### PR TITLE
NAS-136279 / 25.10 / Validate API method schema class names

### DIFF
--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -302,10 +302,10 @@ def single_argument_result(klass, klass_name=None):
     return model
 
 
-def query_result(item):
+def query_result(item, name=None):
     result_item = query_result_item(item)
     return create_model(
-        item.__name__.removesuffix("Entry") + "QueryResult",
+        name or item.__name__.removesuffix("Entry") + "QueryResult",
         __base__=(BaseModel,),
         __module__=item.__module__,
         result=Annotated[list[result_item] | result_item | int, Field()],

--- a/src/middlewared/middlewared/api/v24_10/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v24_10/cloud_sync.py
@@ -4,10 +4,10 @@ from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdate
                                   single_argument_args, single_argument_result)
 
 __all__ = ["CloudCredentialEntry",
-           "CloudCredentialCreateArgs", "CloudCredentialCreateResult",
-           "CloudCredentialUpdateArgs", "CloudCredentialUpdateResult",
-           "CloudCredentialDeleteArgs", "CloudCredentialDeleteResult",
-           "CloudCredentialVerifyArgs", "CloudCredentialVerifyResult"]
+           "CredentialsCreateArgs", "CredentialsCreateResult",
+           "CredentialsUpdateArgs", "CredentialsUpdateResult",
+           "CredentialsDeleteArgs", "CredentialsDeleteResult",
+           "CredentialsVerifyArgs", "CredentialsVerifyResult"]
 
 
 class CloudCredentialEntry(BaseModel):
@@ -25,39 +25,39 @@ class CloudCredentialUpdate(CloudCredentialCreate, metaclass=ForUpdateMetaclass)
     pass
 
 
-class CloudCredentialCreateArgs(BaseModel):
+class CredentialsCreateArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialCreate
 
 
-class CloudCredentialCreateResult(BaseModel):
+class CredentialsCreateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialUpdateArgs(BaseModel):
+class CredentialsUpdateArgs(BaseModel):
     id: int
     cloud_sync_credentials_update: CloudCredentialUpdate
 
 
-class CloudCredentialUpdateResult(BaseModel):
+class CredentialsUpdateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialDeleteArgs(BaseModel):
+class CredentialsDeleteArgs(BaseModel):
     id: int
 
 
-class CloudCredentialDeleteResult(BaseModel):
+class CredentialsDeleteResult(BaseModel):
     result: bool
 
 
 @single_argument_args("cloud_sync_credentials_create")
-class CloudCredentialVerifyArgs(BaseModel):
+class CredentialsVerifyArgs(BaseModel):
     provider: str
     attributes: Secret[dict]
 
 
 @single_argument_result
-class CloudCredentialVerifyResult(BaseModel):
+class CredentialsVerifyResult(BaseModel):
     valid: bool
     error: LongString | None = None
     excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acl.py
@@ -26,12 +26,12 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'AclTemplateEntry',
-    'AclTemplateByPathArgs', 'AclTemplateByPathResult',
-    'AclTemplateCreateArgs', 'AclTemplateCreateResult',
-    'AclTemplateUpdateArgs', 'AclTemplateUpdateResult',
-    'AclTemplateDeleteArgs', 'AclTemplateDeleteResult',
-    'FilesystemGetAclArgs', 'FilesystemGetAclResult',
-    'FilesystemSetAclArgs', 'FilesystemSetAclResult',
+    'ACLTemplateByPathArgs', 'ACLTemplateByPathResult',
+    'ACLTemplateCreateArgs', 'ACLTemplateCreateResult',
+    'ACLTemplateUpdateArgs', 'ACLTemplateUpdateResult',
+    'ACLTemplateDeleteArgs', 'ACLTemplateDeleteResult',
+    'FilesystemGetaclArgs', 'FilesystemGetaclResult',
+    'FilesystemSetaclArgs', 'FilesystemSetaclResult',
     'NFS4ACE', 'POSIXACE',
 ]
 
@@ -207,7 +207,7 @@ class DISABLED_ACL(AclBaseInfo):
     trivial: Literal[True]
 
 
-class FilesystemGetAclArgs(BaseModel):
+class FilesystemGetaclArgs(BaseModel):
     path: NonEmptyString
     simplified: bool = True
     resolve_ids: bool = False
@@ -231,7 +231,7 @@ class DISABLED_ACLResult(DISABLED_ACL, AclBaseResult):
     pass
 
 
-class FilesystemGetAclResult(BaseModel):
+class FilesystemGetaclResult(BaseModel):
     result: NFS4ACLResult | POSIXACLResult | DISABLED_ACLResult
 
 
@@ -244,7 +244,7 @@ class FilesystemSetAclOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class FilesystemSetAclArgs(BaseModel):
+class FilesystemSetaclArgs(BaseModel):
     path: NonEmptyString
     dacl: list[NFS4ACE] | list[POSIXACE]
     options: FilesystemSetAclOptions = Field(default=FilesystemSetAclOptions())
@@ -267,7 +267,7 @@ class FilesystemSetAclArgs(BaseModel):
         return self
 
 
-class FilesystemSetAclResult(FilesystemGetAclResult):
+class FilesystemSetaclResult(FilesystemGetaclResult):
     pass
 
 
@@ -285,11 +285,11 @@ class AclTemplateCreate(AclTemplateEntry):
     builtin: Excluded = excluded_field()
 
 
-class AclTemplateCreateArgs(BaseModel):
+class ACLTemplateCreateArgs(BaseModel):
     acltemplate_create: AclTemplateCreate
 
 
-class AclTemplateCreateResult(BaseModel):
+class ACLTemplateCreateResult(BaseModel):
     result: AclTemplateEntry
 
 
@@ -297,20 +297,20 @@ class AclTemplateUpdate(AclTemplateCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class AclTemplateUpdateArgs(BaseModel):
+class ACLTemplateUpdateArgs(BaseModel):
     id: int
     acltemplate_update: AclTemplateUpdate
 
 
-class AclTemplateUpdateResult(BaseModel):
+class ACLTemplateUpdateResult(BaseModel):
     result: AclTemplateEntry
 
 
-class AclTemplateDeleteArgs(BaseModel):
+class ACLTemplateDeleteArgs(BaseModel):
     id: int
 
 
-class AclTemplateDeleteResult(BaseModel):
+class ACLTemplateDeleteResult(BaseModel):
     result: Literal[True]
 
 
@@ -321,12 +321,12 @@ class AclTemplateFormatOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class AclTemplateByPathArgs(BaseModel):
+class ACLTemplateByPathArgs(BaseModel):
     path: str = ""
     query_filters: QueryFilters = Field(alias='query-filters', default=[])
     query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
     format_options: AclTemplateFormatOptions = Field(alias='format-options', default=AclTemplateFormatOptions())
 
 
-class AclTemplateByPathResult(BaseModel):
+class ACLTemplateByPathResult(BaseModel):
     result: list[AclTemplateEntry]

--- a/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
@@ -10,9 +10,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ACMEDNSAuthenticatorEntry', 'ACMEDNSAuthenticatorCreateArgs', 'ACMEDNSAuthenticatorCreateResult',
-    'ACMEDNSAuthenticatorUpdateArgs', 'ACMEDNSAuthenticatorUpdateResult', 'ACMEDNSAuthenticatorDeleteArgs',
-    'ACMEDNSAuthenticatorDeleteResult', 'ACMEDNSAuthenticatorSchemasArgs', 'ACMEDNSAuthenticatorSchemasResult',
+    'ACMEDNSAuthenticatorEntry', 'DNSAuthenticatorCreateArgs', 'DNSAuthenticatorCreateResult',
+    'DNSAuthenticatorUpdateArgs', 'DNSAuthenticatorUpdateResult', 'DNSAuthenticatorDeleteArgs',
+    'DNSAuthenticatorDeleteResult', 'DNSAuthenticatorAuthenticatorSchemasArgs', 'DNSAuthenticatorAuthenticatorSchemasResult',
     'Route53SchemaArgs', 'ACMECustomDNSAuthenticatorReturns', 'CloudFlareSchemaArgs', 'DigitalOceanSchemaArgs',
     'OVHSchemaArgs', 'ShellSchemaArgs', 'TrueNASConnectSchemaArgs',
 ]
@@ -121,11 +121,11 @@ class ACMEDNSAuthenticatorCreate(BaseModel):
 
 
 @single_argument_args('dns_authenticator_create')
-class ACMEDNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
+class DNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
     pass
 
 
-class ACMEDNSAuthenticatorCreateResult(BaseModel):
+class DNSAuthenticatorCreateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
@@ -133,20 +133,20 @@ class ACMEDNSAuthenticatorUpdate(ACMEDNSAuthenticatorCreate, metaclass=ForUpdate
     pass
 
 
-class ACMEDNSAuthenticatorUpdateArgs(BaseModel):
+class DNSAuthenticatorUpdateArgs(BaseModel):
     id: int
     dns_authenticator_update: ACMEDNSAuthenticatorUpdate
 
 
-class ACMEDNSAuthenticatorUpdateResult(BaseModel):
+class DNSAuthenticatorUpdateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
-class ACMEDNSAuthenticatorDeleteArgs(BaseModel):
+class DNSAuthenticatorDeleteArgs(BaseModel):
     id: int
 
 
-class ACMEDNSAuthenticatorDeleteResult(BaseModel):
+class DNSAuthenticatorDeleteResult(BaseModel):
     result: bool
 
 
@@ -163,9 +163,9 @@ class ACMEDNSAuthenticatorSchema(BaseModel):
     schema_: ACMEDNSAuthenticatorAttributeSchema = Field(alias='schema')
 
 
-class ACMEDNSAuthenticatorSchemasArgs(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasArgs(BaseModel):
     pass
 
 
-class ACMEDNSAuthenticatorSchemasResult(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasResult(BaseModel):
     result: list[ACMEDNSAuthenticatorSchema]

--- a/src/middlewared/middlewared/api/v25_04_0/app.py
+++ b/src/middlewared/middlewared/api/v25_04_0/app.py
@@ -8,14 +8,14 @@ from .catalog import CatalogAppInfo
 
 
 __all__ = [
-    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableResponse',
+    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableItem',
     'AppEntry', 'AppCreateArgs', 'AppCreateResult', 'AppUpdateArgs', 'AppUpdateResult', 'AppDeleteArgs',
     'AppDeleteResult', 'AppConfigArgs', 'AppConfigResult', 'AppConvertToCustomArgs', 'AppConvertToCustomResult',
     'AppStopArgs', 'AppStopResult', 'AppStartArgs', 'AppStartResult', 'AppRedeployArgs', 'AppRedeployResult',
     'AppOutdatedDockerImagesArgs', 'AppOutdatedDockerImagesResult', 'AppPullImagesArgs', 'AppPullImagesResult',
-    'AppContainerIDArgs', 'AppContainerIDResult', 'AppContainerConsoleChoiceArgs', 'AppContainerConsoleChoiceResult',
+    'AppContainerIdsArgs', 'AppContainerIdsResult', 'AppContainerConsoleChoicesArgs', 'AppContainerConsoleChoicesResult',
     'AppCertificateChoicesArgs', 'AppCertificateChoicesResult', 'AppCertificateAuthorityArgs',
-    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIPChoicesArgs', 'AppIPChoicesResult',
+    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIpChoicesArgs', 'AppIpChoicesResult',
     'AppAvailableSpaceArgs', 'AppAvailableSpaceResult', 'AppGpuChoicesArgs', 'AppGpuChoicesResult', 'AppRollbackArgs',
     'AppRollbackResult', 'AppRollbackVersionsArgs', 'AppRollbackVersionsResult', 'AppUpgradeArgs', 'AppUpgradeResult',
     'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult',
@@ -207,7 +207,7 @@ class AppContainerIDOptions(BaseModel):
     alive_only: bool = True
 
 
-class AppContainerIDArgs(BaseModel):
+class AppContainerIdsArgs(BaseModel):
     app_name: NonEmptyString
     options: AppContainerIDOptions = AppContainerIDOptions()
 
@@ -223,15 +223,15 @@ class AppContainerResponse(RootModel[dict[str, ContainerDetails]]):
     pass
 
 
-class AppContainerIDResult(BaseModel):
+class AppContainerIdsResult(BaseModel):
     result: AppContainerResponse
 
 
-class AppContainerConsoleChoiceArgs(BaseModel):
+class AppContainerConsoleChoicesArgs(BaseModel):
     app_name: NonEmptyString
 
 
-class AppContainerConsoleChoiceResult(BaseModel):
+class AppContainerConsoleChoicesResult(BaseModel):
     result: AppContainerResponse
 
 
@@ -264,11 +264,11 @@ class AppUsedPortsResult(BaseModel):
     result: list[int]
 
 
-class AppIPChoicesArgs(BaseModel):
+class AppIpChoicesArgs(BaseModel):
     pass
 
 
-class AppIPChoicesResult(BaseModel):
+class AppIpChoicesResult(BaseModel):
     result: dict[NonEmptyString, NonEmptyString]
 
 
@@ -369,7 +369,7 @@ class AppUpgradeSummaryResult(BaseModel):
     changelog: LongString | None
 
 
-class AppAvailableResponse(CatalogAppInfo):
+class AppAvailableItem(CatalogAppInfo):
     catalog: NonEmptyString
     installed: bool
     train: NonEmptyString
@@ -389,4 +389,8 @@ class AppSimilarArgs(BaseModel):
 
 
 class AppSimilarResult(BaseModel):
-    result: list[AppAvailableResponse]
+    result: list[AppAvailableItem]
+
+
+class AppLatestItem(AppAvailableItem):
+    pass

--- a/src/middlewared/middlewared/api/v25_04_0/app_image.py
+++ b/src/middlewared/middlewared/api/v25_04_0/app_image.py
@@ -3,7 +3,7 @@ from typing import Literal
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
 __all__ = [
-    'AppImageEntry', 'AppImageDockerhubRateLimitArgs', 'AppImageDockerhubRateLimitResult',
+    'AppImageEntry', 'ContainerImagesDockerhubRateLimitArgs', 'ContainerImagesDockerhubRateLimitResult',
     'AppImagePullArgs', 'AppImagePullResult', 'AppImageDeleteArgs', 'AppImageDeleteResult',
 ]
 
@@ -30,12 +30,12 @@ class AppImageEntry(BaseModel):
     parsed_repo_tags: list[AppImageParsedRepoTags] | None = None
 
 
-class AppImageDockerhubRateLimitArgs(BaseModel):
+class ContainerImagesDockerhubRateLimitArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class AppImageDockerhubRateLimitResult(BaseModel):
+class ContainerImagesDockerhubRateLimitResult(BaseModel):
     total_pull_limit: int | None = None
     '''Total pull limit for Docker Hub registry'''
     total_time_limit_in_secs: int | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/app_ix_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/app_ix_volume.py
@@ -1,17 +1,17 @@
 from middlewared.api.base import BaseModel, NonEmptyString
 
 
-__all__ = ['AppIXVolumeEntry', 'AppIXVolumeExistsArgs', 'AppIXVolumeExistsResult']
+__all__ = ['AppsIxVolumeEntry', 'AppsIxVolumeExistsArgs', 'AppsIxVolumeExistsResult']
 
 
-class AppIXVolumeEntry(BaseModel):
+class AppsIxVolumeEntry(BaseModel):
     app_name: NonEmptyString
     name: NonEmptyString
 
 
-class AppIXVolumeExistsArgs(BaseModel):
+class AppsIxVolumeExistsArgs(BaseModel):
     name: NonEmptyString
 
 
-class AppIXVolumeExistsResult(BaseModel):
+class AppsIxVolumeExistsResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -109,11 +109,11 @@ class AuthLoginExResult(BaseModel):
     result: AuthRespSuccess | AuthRespAuthErr | AuthRespExpired | AuthRespOTPRequired | AuthRespAuthRedirect
 
 
-class AuthMechChoicesArgs(BaseModel):
+class AuthMechanismChoicesArgs(BaseModel):
     pass
 
 
-class AuthMechChoicesResult(BaseModel):
+class AuthMechanismChoicesResult(BaseModel):
     result: list[str]
 
 
@@ -152,7 +152,7 @@ class TokenCredentialData(BaseCredentialData):
     username: str | None
 
 
-class AuthSessionEntry(BaseModel):
+class AuthSessionsEntry(BaseModel):
     id: str
     current: bool
     internal: bool
@@ -187,11 +187,11 @@ class AuthTerminateOtherSessionsResult(AuthTerminateSessionResult):
     result: Literal[True]
 
 
-class AuthSessionLogoutArgs(BaseModel):
+class AuthLogoutArgs(BaseModel):
     pass
 
 
-class AuthSessionLogoutResult(BaseModel):
+class AuthLogoutResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/catalog.py
+++ b/src/middlewared/middlewared/api/v25_04_0/catalog.py
@@ -8,7 +8,7 @@ from middlewared.api.base import BaseModel, ForUpdateMetaclass, NonEmptyString, 
 __all__ = [
     'CatalogEntry', 'CatalogUpdateArgs', 'CatalogUpdateResult', 'CatalogTrainsArgs', 'CatalogTrainsResult',
     'CatalogSyncArgs', 'CatalogSyncResult', 'CatalogAppInfo', 'CatalogAppsArgs', 'CatalogAppsResult',
-    'CatalogAppDetailsArgs', 'CatalogAppDetailsResult',
+    'CatalogGetAppDetailsArgs', 'CatalogGetAppDetailsResult',
 ]
 
 
@@ -115,10 +115,10 @@ class CatalogAppVersionDetails(BaseModel):
     train: NonEmptyString
 
 
-class CatalogAppDetailsArgs(BaseModel):
+class CatalogGetAppDetailsArgs(BaseModel):
     app_name: NonEmptyString
     app_version_details: CatalogAppVersionDetails
 
 
-class CatalogAppDetailsResult(BaseModel):
+class CatalogGetAppDetailsResult(BaseModel):
     result: CatalogAppInfo

--- a/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
@@ -7,10 +7,10 @@ from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdate
 from .cloud_sync_providers import CloudCredentialProvider
 
 __all__ = ["CloudCredentialEntry",
-           "CloudCredentialCreateArgs", "CloudCredentialCreateResult",
-           "CloudCredentialUpdateArgs", "CloudCredentialUpdateResult",
-           "CloudCredentialDeleteArgs", "CloudCredentialDeleteResult",
-           "CloudCredentialVerifyArgs", "CloudCredentialVerifyResult",
+           "CredentialsCreateArgs", "CredentialsCreateResult",
+           "CredentialsUpdateArgs", "CredentialsUpdateResult",
+           "CredentialsDeleteArgs", "CredentialsDeleteResult",
+           "CredentialsVerifyArgs", "CredentialsVerifyResult",
            "CloudSyncOneDriveListDrivesArgs", "CloudSyncOneDriveListDrivesResult"]
 
 
@@ -45,32 +45,32 @@ class CloudCredentialUpdate(CloudCredentialCreate, metaclass=ForUpdateMetaclass)
     pass
 
 
-class CloudCredentialCreateArgs(BaseModel):
+class CredentialsCreateArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialCreate
 
 
-class CloudCredentialCreateResult(BaseModel):
+class CredentialsCreateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialUpdateArgs(BaseModel):
+class CredentialsUpdateArgs(BaseModel):
     id: int
     cloud_sync_credentials_update: CloudCredentialUpdate
 
 
-class CloudCredentialUpdateResult(BaseModel):
+class CredentialsUpdateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialDeleteArgs(BaseModel):
+class CredentialsDeleteArgs(BaseModel):
     id: int
 
 
-class CloudCredentialDeleteResult(BaseModel):
+class CredentialsDeleteResult(BaseModel):
     result: bool
 
 
-class CloudCredentialVerifyArgs(BaseModel):
+class CredentialsVerifyArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialProvider
 
     @classmethod
@@ -84,7 +84,7 @@ class CloudCredentialVerifyArgs(BaseModel):
 
 
 @single_argument_result
-class CloudCredentialVerifyResult(BaseModel):
+class CredentialsVerifyResult(BaseModel):
     valid: bool
     error: LongString | None = None
     excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/crypto_cert_info.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_cert_info.py
@@ -1,22 +1,22 @@
 from middlewared.api.base import BaseModel
 
 __all__ = (
-    'CertificateCountryChoicesArgs',
-    'CertificateCountryChoicesResult',
+    'SystemGeneralCountryChoicesArgs',
+    'SystemGeneralCountryChoicesResult',
     'CertificateAcmeServerChoicesArgs',
     'CertificateAcmeServerChoicesResult',
-    'CertificateECCurveChoicesArgs',
-    'CertificateECCurveChoicesResult',
+    'CertificateEcCurveChoicesArgs',
+    'CertificateEcCurveChoicesResult',
     'CertificateExtendedKeyUsageChoicesArgs',
     'CertificateExtendedKeyUsageChoicesResult',
 )
 
 
-class CertificateCountryChoicesArgs(BaseModel):
+class SystemGeneralCountryChoicesArgs(BaseModel):
     pass
 
 
-class CertificateCountryChoicesResult(BaseModel):
+class SystemGeneralCountryChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -28,11 +28,11 @@ class CertificateAcmeServerChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class CertificateECCurveChoicesArgs(BaseModel):
+class CertificateEcCurveChoicesArgs(BaseModel):
     pass
 
 
-class CertificateECCurveChoicesResult(BaseModel):
+class CertificateEcCurveChoicesResult(BaseModel):
     result: dict[str, str]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
@@ -8,9 +8,9 @@ __all__ = (
     "CertProfilesArgs",
     "CertProfilesModel",
     "CertProfilesResult",
-    "CSRProfilesArgs",
+    "WebUICryptoCsrProfilesArgs",
     "CSRProfilesModel",
-    "CSRProfilesResult",
+    "WebUICryptoCsrProfilesResult",
 )
 
 
@@ -167,10 +167,10 @@ class CSRProfilesModel(BaseModel):
     )
 
 
-class CSRProfilesArgs(BaseModel):
+class WebUICryptoCsrProfilesArgs(BaseModel):
     pass
 
 
 @final
-class CSRProfilesResult(BaseModel):
+class WebUICryptoCsrProfilesResult(BaseModel):
     result: CSRProfilesModel = CSRProfilesModel()

--- a/src/middlewared/middlewared/api/v25_04_0/docker.py
+++ b/src/middlewared/middlewared/api/v25_04_0/docker.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'DockerEntry', 'DockerUpdateArgs', 'DockerUpdateResult', 'DockerStatusArgs', 'DockerStatusResult',
     'DockerNvidiaPresentArgs', 'DockerNvidiaPresentResult', 'DockerBackupArgs', 'DockerBackupResult',
-    'DockerListBackupArgs', 'DockerListBackupResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
+    'DockerListBackupsArgs', 'DockerListBackupsResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
     'DockerDeleteBackupArgs', 'DockerDeleteBackupResult',
 ]
 
@@ -102,7 +102,7 @@ class DockerBackupResult(BaseModel):
     result: NonEmptyString
 
 
-class DockerListBackupArgs(BaseModel):
+class DockerListBackupsArgs(BaseModel):
     pass
 
 
@@ -124,7 +124,7 @@ class DockerBackupInfo(RootModel[dict[str, BackupInfo]]):
     pass
 
 
-class DockerListBackupResult(BaseModel):
+class DockerListBackupsResult(BaseModel):
     result: DockerBackupInfo
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/enclosure_label.py
+++ b/src/middlewared/middlewared/api/v25_04_0/enclosure_label.py
@@ -1,6 +1,6 @@
 from middlewared.api.base import BaseModel
 
-__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelUpdateResult"]
+__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelSetResult"]
 
 
 class EnclosureLabelSetArgs(BaseModel):
@@ -8,5 +8,5 @@ class EnclosureLabelSetArgs(BaseModel):
     label: str
 
 
-class EnclosureLabelUpdateResult(BaseModel):
+class EnclosureLabelSetResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_0/fcport.py
+++ b/src/middlewared/middlewared/api/v25_04_0/fcport.py
@@ -56,11 +56,11 @@ class FCPortChoiceEntry(BaseModel):
     wwpn_b: WWPN | None
 
 
-class FCPortChoicesArgs(BaseModel):
+class FCPortPortChoicesArgs(BaseModel):
     include_used: bool = True
 
 
-class FCPortChoicesResult(BaseModel):
+class FCPortPortChoicesResult(BaseModel):
     result: Dict[FibreChannelPortAlias, FCPortChoiceEntry] = Field(examples=[
         {
             'fc0': {

--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -18,15 +18,15 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'FilesystemChownArgs', 'FilesystemChownResult',
-    'FilesystemSetPermArgs', 'FilesystemSetPermResult',
+    'FilesystemSetpermArgs', 'FilesystemSetpermResult',
     'FilesystemListdirArgs', 'FilesystemListdirResult',
     'FilesystemMkdirArgs', 'FilesystemMkdirResult',
     'FilesystemStatArgs', 'FilesystemStatResult',
     'FilesystemStatfsArgs', 'FilesystemStatfsResult',
-    'FilesystemSetZfsAttrsArgs', 'FilesystemSetZfsAttrsResult',
-    'FilesystemGetZfsAttrsArgs', 'FilesystemGetZfsAttrsResult',
-    'FilesystemGetFileArgs', 'FilesystemGetFileResult',
-    'FilesystemPutFileArgs', 'FilesystemPutFileResult',
+    'FilesystemSetZfsAttributesArgs', 'FilesystemSetZfsAttributesResult',
+    'FilesystemGetZfsAttributesArgs', 'FilesystemGetZfsAttributesResult',
+    'FilesystemGetArgs', 'FilesystemGetResult',
+    'FilesystemPutArgs', 'FilesystemPutResult',
 ]
 
 
@@ -74,7 +74,7 @@ class FilesystemChownResult(BaseModel):
 
 
 @single_argument_args('filesystem_setperm')
-class FilesystemSetPermArgs(FilesystemPermChownBase):
+class FilesystemSetpermArgs(FilesystemPermChownBase):
     mode: UnixPerm | None = None
     options: FilesystemSetpermOptions = Field(default=FilesystemSetpermOptions())
 
@@ -90,7 +90,7 @@ class FilesystemSetPermArgs(FilesystemPermChownBase):
         return self
 
 
-class FilesystemSetPermResult(BaseModel):
+class FilesystemSetpermResult(BaseModel):
     result: Literal[None]
 
 
@@ -330,28 +330,28 @@ class ZFSFileAttrsData(BaseModel):
 
 
 @single_argument_args('set_zfs_file_attributes')
-class FilesystemSetZfsAttrsArgs(BaseModel):
+class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
     zfs_file_attributes: ZFSFileAttrsData
 
 
-class FilesystemSetZfsAttrsResult(BaseModel):
+class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetZfsAttrsArgs(BaseModel):
+class FilesystemGetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetZfsAttrsResult(BaseModel):
+class FilesystemGetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetFileArgs(BaseModel):
+class FilesystemGetArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetFileResult(BaseModel):
+class FilesystemGetResult(BaseModel):
     result: Literal[None]
 
 
@@ -360,10 +360,10 @@ class FilesystemPutOptions(BaseModel):
     mode: int | None = None
 
 
-class FilesystemPutFileArgs(BaseModel):
+class FilesystemPutArgs(BaseModel):
     path: NonEmptyString
     options: FilesystemPutOptions = FilesystemPutOptions()
 
 
-class FilesystemPutFileResult(BaseModel):
+class FilesystemPutResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/ftp.py
+++ b/src/middlewared/middlewared/api/v25_04_0/ftp.py
@@ -12,7 +12,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["FtpEntry",
-           "FtpUpdateArgs", "FtpUpdateResult"]
+           "FTPUpdateArgs", "FTPUpdateResult"]
 
 TLS_PolicyOptions = Literal[
     "", "on", "off", "data", "!data", "auth", "ctrl", "ctrl+data", "ctrl+!data", "auth+data", "auth+!data"
@@ -74,9 +74,9 @@ class FtpEntry(BaseModel):
 
 
 @single_argument_args('ftp_update')
-class FtpUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
+class FTPUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class FtpUpdateResult(BaseModel):
+class FTPUpdateResult(BaseModel):
     result: FtpEntry

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_auth.py
@@ -6,12 +6,12 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiAuthEntry",
-    "IscsiAuthCreateArgs",
-    "IscsiAuthCreateResult",
-    "IscsiAuthUpdateArgs",
-    "IscsiAuthUpdateResult",
-    "IscsiAuthDeleteArgs",
-    "IscsiAuthDeleteResult",
+    "iSCSITargetAuthCredentialCreateArgs",
+    "iSCSITargetAuthCredentialCreateResult",
+    "iSCSITargetAuthCredentialUpdateArgs",
+    "iSCSITargetAuthCredentialUpdateResult",
+    "iSCSITargetAuthCredentialDeleteArgs",
+    "iSCSITargetAuthCredentialDeleteResult",
 ]
 
 
@@ -29,11 +29,11 @@ class IscsiAuthCreate(IscsiAuthEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiAuthCreateArgs(BaseModel):
+class iSCSITargetAuthCredentialCreateArgs(BaseModel):
     data: IscsiAuthCreate
 
 
-class IscsiAuthCreateResult(BaseModel):
+class iSCSITargetAuthCredentialCreateResult(BaseModel):
     result: IscsiAuthEntry
 
 
@@ -41,18 +41,18 @@ class IscsiAuthUpdate(IscsiAuthCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiAuthUpdateArgs(BaseModel):
+class iSCSITargetAuthCredentialUpdateArgs(BaseModel):
     id: int
     data: IscsiAuthUpdate
 
 
-class IscsiAuthUpdateResult(BaseModel):
+class iSCSITargetAuthCredentialUpdateResult(BaseModel):
     result: IscsiAuthEntry
 
 
-class IscsiAuthDeleteArgs(BaseModel):
+class iSCSITargetAuthCredentialDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiAuthDeleteResult(BaseModel):
+class iSCSITargetAuthCredentialDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
@@ -8,14 +8,14 @@ from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, Iscsi
 
 __all__ = [
     "IscsiExtentEntry",
-    "IscsiExtentCreateArgs",
-    "IscsiExtentCreateResult",
-    "IscsiExtentUpdateArgs",
-    "IscsiExtentUpdateResult",
-    "IscsiExtentDeleteArgs",
-    "IscsiExtentDeleteResult",
-    "IscsiExtentDiskChoicesArgs",
-    "IscsiExtentDiskChoicesResult",
+    "iSCSITargetExtentCreateArgs",
+    "iSCSITargetExtentCreateResult",
+    "iSCSITargetExtentUpdateArgs",
+    "iSCSITargetExtentUpdateResult",
+    "iSCSITargetExtentDeleteArgs",
+    "iSCSITargetExtentDeleteResult",
+    "iSCSITargetExtentDiskChoicesArgs",
+    "iSCSITargetExtentDiskChoicesResult",
 ]
 
 
@@ -48,11 +48,11 @@ class IscsiExtentCreate(IscsiExtentEntry):
     locked: Excluded = excluded_field()
 
 
-class IscsiExtentCreateArgs(BaseModel):
+class iSCSITargetExtentCreateArgs(BaseModel):
     iscsi_extent_create: IscsiExtentCreate
 
 
-class IscsiExtentCreateResult(BaseModel):
+class iSCSITargetExtentCreateResult(BaseModel):
     result: IscsiExtentEntry
 
 
@@ -60,28 +60,28 @@ class IscsiExtentUpdate(IscsiExtentCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiExtentUpdateArgs(BaseModel):
+class iSCSITargetExtentUpdateArgs(BaseModel):
     id: int
     iscsi_extent_update: IscsiExtentUpdate
 
 
-class IscsiExtentUpdateResult(BaseModel):
+class iSCSITargetExtentUpdateResult(BaseModel):
     result: IscsiExtentEntry
 
 
-class IscsiExtentDeleteArgs(BaseModel):
+class iSCSITargetExtentDeleteArgs(BaseModel):
     id: int
     remove: bool = False
     force: bool = False
 
 
-class IscsiExtentDeleteResult(BaseModel):
+class iSCSITargetExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class IscsiExtentDiskChoicesArgs(BaseModel):
+class iSCSITargetExtentDiskChoicesArgs(BaseModel):
     pass
 
 
-class IscsiExtentDiskChoicesResult(BaseModel):
+class iSCSITargetExtentDiskChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
@@ -6,16 +6,16 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     "IscsiGlobalEntry",
-    "IscsiGlobalUpdateArgs",
-    "IscsiGlobalUpdateResult",
-    "IscsiGlobalAluaEnabledArgs",
-    "IscsiGlobalAluaEnabledResult",
-    "IscsiGlobalISEREnabledArgs",
-    "IscsiGlobalISEREnabledResult",
-    "IscsiGlobalClientCountArgs",
-    "IscsiGlobalClientCountResult",
-    "IscsiGlobalSessionsArgs",
-    "IscsiGlobalSessionsResult"
+    "ISCSIGlobalUpdateArgs",
+    "ISCSIGlobalUpdateResult",
+    "ISCSIGlobalAluaEnabledArgs",
+    "ISCSIGlobalAluaEnabledResult",
+    "ISCSIGlobalIserEnabledArgs",
+    "ISCSIGlobalIserEnabledResult",
+    "ISCSIGlobalClientCountArgs",
+    "ISCSIGlobalClientCountResult",
+    "ISCSIGlobalSessionsArgs",
+    "ISCSIGlobalSessionsResult"
 ]
 
 
@@ -30,35 +30,35 @@ class IscsiGlobalEntry(BaseModel):
 
 
 @single_argument_args('iscsi_update')
-class IscsiGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
+class ISCSIGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class IscsiGlobalUpdateResult(BaseModel):
+class ISCSIGlobalUpdateResult(BaseModel):
     result: IscsiGlobalEntry
 
 
-class IscsiGlobalAluaEnabledArgs(BaseModel):
+class ISCSIGlobalAluaEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalAluaEnabledResult(BaseModel):
+class ISCSIGlobalAluaEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalISEREnabledArgs(BaseModel):
+class ISCSIGlobalIserEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalISEREnabledResult(BaseModel):
+class ISCSIGlobalIserEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalClientCountArgs(BaseModel):
+class ISCSIGlobalClientCountArgs(BaseModel):
     pass
 
 
-class IscsiGlobalClientCountResult(BaseModel):
+class ISCSIGlobalClientCountResult(BaseModel):
     result: int
 
 
@@ -80,9 +80,9 @@ class IscsiSession(BaseModel):
     offload: bool
 
 
-class IscsiGlobalSessionsArgs(BaseModel):
+class ISCSIGlobalSessionsArgs(BaseModel):
     query_filters: QueryFilters = []
     query_options: QueryOptions = QueryOptions()
 
 
-IscsiGlobalSessionsResult = query_result(IscsiSession)
+ISCSIGlobalSessionsResult = query_result(IscsiSession)

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_initiator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_initiator.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiInitiatorEntry",
-    "IscsiInitiatorCreateArgs",
-    "IscsiInitiatorCreateResult",
-    "IscsiInitiatorUpdateArgs",
-    "IscsiInitiatorUpdateResult",
-    "IscsiInitiatorDeleteArgs",
-    "IscsiInitiatorDeleteResult",
+    "iSCSITargetAuthorizedInitiatorCreateArgs",
+    "iSCSITargetAuthorizedInitiatorCreateResult",
+    "iSCSITargetAuthorizedInitiatorUpdateArgs",
+    "iSCSITargetAuthorizedInitiatorUpdateResult",
+    "iSCSITargetAuthorizedInitiatorDeleteArgs",
+    "iSCSITargetAuthorizedInitiatorDeleteResult",
 ]
 
 
@@ -23,11 +23,11 @@ class IscsiInitiatorCreate(IscsiInitiatorEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiInitiatorCreateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateArgs(BaseModel):
     iscsi_initiator_create: IscsiInitiatorCreate
 
 
-class IscsiInitiatorCreateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
@@ -35,18 +35,18 @@ class IscsiInitiatorUpdate(IscsiInitiatorEntry, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiInitiatorUpdateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateArgs(BaseModel):
     id: int
     iscsi_initiator_update: IscsiInitiatorUpdate
 
 
-class IscsiInitiatorUpdateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
-class IscsiInitiatorDeleteArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiInitiatorDeleteResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_portal.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_portal.py
@@ -6,14 +6,14 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiPortalEntry",
-    "IscsiPortalListenIPChoicesArgs",
-    "IscsiPortalListenIPChoicesResult",
-    "IscsiPortalCreateArgs",
-    "IscsiPortalCreateResult",
-    "IscsiPortalUpdateArgs",
-    "IscsiPortalUpdateResult",
-    "IscsiPortalDeleteArgs",
-    "IscsiPortalDeleteResult",
+    "ISCSIPortalListenIpChoicesArgs",
+    "ISCSIPortalListenIpChoicesResult",
+    "ISCSIPortalCreateArgs",
+    "ISCSIPortalCreateResult",
+    "ISCSIPortalUpdateArgs",
+    "ISCSIPortalUpdateResult",
+    "ISCSIPortalDeleteArgs",
+    "ISCSIPortalDeleteResult",
 ]
 
 
@@ -38,11 +38,11 @@ class IscsiPortalEntry(BaseModel):
     comment: str = ''
 
 
-class IscsiPortalListenIPChoicesArgs(BaseModel):
+class ISCSIPortalListenIpChoicesArgs(BaseModel):
     pass
 
 
-class IscsiPortalListenIPChoicesResult(BaseModel):
+class ISCSIPortalListenIpChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -52,11 +52,11 @@ class IscsiPortalCreate(IscsiPortalEntry):
     listen: list[IscsiPortalIP]
 
 
-class IscsiPortalCreateArgs(BaseModel):
+class ISCSIPortalCreateArgs(BaseModel):
     iscsi_portal_create: IscsiPortalCreate
 
 
-class IscsiPortalCreateResult(BaseModel):
+class ISCSIPortalCreateResult(BaseModel):
     result: IscsiPortalEntry
 
 
@@ -64,18 +64,18 @@ class IscsiPortalUpdate(IscsiPortalCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiPortalUpdateArgs(BaseModel):
+class ISCSIPortalUpdateArgs(BaseModel):
     id: int
     iscsi_portal_update: IscsiPortalUpdate
 
 
-class IscsiPortalUpdateResult(BaseModel):
+class ISCSIPortalUpdateResult(BaseModel):
     result: IscsiPortalEntry
 
 
-class IscsiPortalDeleteArgs(BaseModel):
+class ISCSIPortalDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiPortalDeleteResult(BaseModel):
+class ISCSIPortalDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
@@ -11,14 +11,14 @@ RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 
 __all__ = [
     "IscsiTargetEntry",
-    "IscsiTargetValidateNameArgs",
-    "IscsiTargetValidateNameResult",
-    "IscsiTargetCreateArgs",
-    "IscsiTargetCreateResult",
-    "IscsiTargetUpdateArgs",
-    "IscsiTargetUpdateResult",
-    "IscsiTargetDeleteArgs",
-    "IscsiTargetDeleteResult",
+    "iSCSITargetValidateNameArgs",
+    "iSCSITargetValidateNameResult",
+    "iSCSITargetCreateArgs",
+    "iSCSITargetCreateResult",
+    "iSCSITargetUpdateArgs",
+    "iSCSITargetUpdateResult",
+    "iSCSITargetDeleteArgs",
+    "iSCSITargetDeleteResult",
 ]
 
 
@@ -51,12 +51,12 @@ class IscsiTargetEntry(BaseModel):
     iscsi_parameters: IscsiTargetParameters | None = None
 
 
-class IscsiTargetValidateNameArgs(BaseModel):
+class iSCSITargetValidateNameArgs(BaseModel):
     name: str
     existing_id: int | None = None
 
 
-class IscsiTargetValidateNameResult(BaseModel):
+class iSCSITargetValidateNameResult(BaseModel):
     result: str | None
 
 
@@ -65,11 +65,11 @@ class IscsiTargetCreate(IscsiTargetEntry):
     rel_tgt_id: Excluded = excluded_field()
 
 
-class IscsiTargetCreateArgs(BaseModel):
+class iSCSITargetCreateArgs(BaseModel):
     iscsi_target_create: IscsiTargetCreate
 
 
-class IscsiTargetCreateResult(BaseModel):
+class iSCSITargetCreateResult(BaseModel):
     result: IscsiTargetEntry
 
 
@@ -77,20 +77,20 @@ class IscsiTargetUpdate(IscsiTargetCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiTargetUpdateArgs(BaseModel):
+class iSCSITargetUpdateArgs(BaseModel):
     id: int
     iscsi_target_update: IscsiTargetUpdate
 
 
-class IscsiTargetUpdateResult(BaseModel):
+class iSCSITargetUpdateResult(BaseModel):
     result: IscsiTargetEntry
 
 
-class IscsiTargetDeleteArgs(BaseModel):
+class iSCSITargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
     delete_extents: bool = False
 
 
-class IscsiTargetDeleteResult(BaseModel):
+class iSCSITargetDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_target_to_extent.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiTargetToExtentEntry",
-    "IscsiTargetToExtentCreateArgs",
-    "IscsiTargetToExtentCreateResult",
-    "IscsiTargetToExtentUpdateArgs",
-    "IscsiTargetToExtentUpdateResult",
-    "IscsiTargetToExtentDeleteArgs",
-    "IscsiTargetToExtentDeleteResult",
+    "iSCSITargetToExtentCreateArgs",
+    "iSCSITargetToExtentCreateResult",
+    "iSCSITargetToExtentUpdateArgs",
+    "iSCSITargetToExtentUpdateResult",
+    "iSCSITargetToExtentDeleteArgs",
+    "iSCSITargetToExtentDeleteResult",
 ]
 
 
@@ -25,11 +25,11 @@ class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
     lunid: int | None = None
 
 
-class IscsiTargetToExtentCreateArgs(BaseModel):
+class iSCSITargetToExtentCreateArgs(BaseModel):
     iscsi_target_to_extent_create: IscsiTargetToExtentCreate
 
 
-class IscsiTargetToExtentCreateResult(BaseModel):
+class iSCSITargetToExtentCreateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
@@ -37,21 +37,21 @@ class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMet
     pass
 
 
-class IscsiTargetToExtentUpdateArgs(BaseModel):
+class iSCSITargetToExtentUpdateArgs(BaseModel):
     id: int
     iscsi_target_to_extent_update: IscsiTargetToExtentUpdate
 
 
-class IscsiTargetToExtentUpdateResult(BaseModel):
+class iSCSITargetToExtentUpdateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
-class IscsiTargetToExtentDeleteArgs(BaseModel):
+class iSCSITargetToExtentDeleteArgs(BaseModel):
     id: int
     force: bool = False
 
 
-class IscsiTargetToExtentDeleteResult(BaseModel):
+class iSCSITargetToExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/k8s_to_docker.py
+++ b/src/middlewared/middlewared/api/v25_04_0/k8s_to_docker.py
@@ -4,11 +4,11 @@ from middlewared.api.base import BaseModel, single_argument_result
 
 
 __all__ = [
-    'K8sToDockerListBackupsArgs', 'K8sToDockerListBackupsResult', 'K8sToDockerMigrateArgs', 'K8sToDockerMigrateResult',
+    'K8stoDockerMigrationListBackupsArgs', 'K8stoDockerMigrationListBackupsResult', 'K8stoDockerMigrationMigrateArgs', 'K8stoDockerMigrationMigrateResult',
 ]
 
 
-class K8sToDockerListBackupsArgs(BaseModel):
+class K8stoDockerMigrationListBackupsArgs(BaseModel):
     kubernetes_pool: str
 
 
@@ -37,7 +37,7 @@ class Backups(RootModel[dict[str, BackupDetails]]):
 
 
 @single_argument_result
-class K8sToDockerListBackupsResult(BaseModel):
+class K8stoDockerMigrationListBackupsResult(BaseModel):
     error: str | None
     backups: Backups
 
@@ -46,7 +46,7 @@ class MigrateOptions(BaseModel):
     backup_name: str | None = None
 
 
-class K8sToDockerMigrateArgs(BaseModel):
+class K8stoDockerMigrationMigrateArgs(BaseModel):
     kubernetes_pool: str
     options: MigrateOptions = MigrateOptions()
 
@@ -57,5 +57,5 @@ class AppMigrationDetails(BaseModel):
     error: str | None
 
 
-class K8sToDockerMigrateResult(BaseModel):
+class K8stoDockerMigrationMigrateResult(BaseModel):
     result: list[AppMigrationDetails]

--- a/src/middlewared/middlewared/api/v25_04_0/keychain.py
+++ b/src/middlewared/middlewared/api/v25_04_0/keychain.py
@@ -11,10 +11,10 @@ __all__ = ["KeychainCredentialEntry", "SSHKeyPairEntry", "SSHCredentialsEntry",
            "KeychainCredentialUpdateArgs", "KeychainCredentialUpdateResult",
            "KeychainCredentialDeleteArgs", "KeychainCredentialDeleteResult",
            "KeychainCredentialUsedByArgs", "KeychainCredentialUsedByResult",
-           "KeychainCredentialGenerateSSHKeyPairArgs", "KeychainCredentialGenerateSSHKeyPairResult",
-           "KeychainCredentialRemoteSSHHostKeyScanArgs", "KeychainCredentialRemoteSSHHostKeyScanResult",
-           "KeychainCredentialRemoteSSHSemiautomaticSetupArgs", "KeychainCredentialRemoteSSHSemiautomaticSetupResult",
-           "KeychainCredentialSetupSSHConnectionArgs", "KeychainCredentialSetupSSHConnectionResult"]
+           "KeychainCredentialGenerateSshKeyPairArgs", "KeychainCredentialGenerateSshKeyPairResult",
+           "KeychainCredentialRemoteSshHostKeyScanArgs", "KeychainCredentialRemoteSshHostKeyScanResult",
+           "KeychainCredentialRemoteSshSemiautomaticSetupArgs", "KeychainCredentialRemoteSshSemiautomaticSetupResult",
+           "KeychainCredentialSetupSshConnectionArgs", "KeychainCredentialSetupSshConnectionResult"]
 
 
 class SSHKeyPair(BaseModel):
@@ -119,24 +119,24 @@ class KeychainCredentialUsedByResult(BaseModel):
     result: list[UsedKeychainCredential]
 
 
-class KeychainCredentialGenerateSSHKeyPairArgs(BaseModel):
+class KeychainCredentialGenerateSshKeyPairArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class KeychainCredentialGenerateSSHKeyPairResult(BaseModel):
+class KeychainCredentialGenerateSshKeyPairResult(BaseModel):
     private_key: LongString
     public_key: LongString
 
 
 @single_argument_args("keychain_remote_ssh_host_key_scan")
-class KeychainCredentialRemoteSSHHostKeyScanArgs(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanArgs(BaseModel):
     host: NonEmptyString
     port: int = 22
     connect_timeout: int = 10
 
 
-class KeychainCredentialRemoteSSHHostKeyScanResult(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanResult(BaseModel):
     result: LongString
 
 
@@ -154,11 +154,11 @@ class KeychainCredentialRemoteSSHSemiautomaticSetup(BaseModel):
     sudo: bool = False
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupArgs(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupArgs(BaseModel):
     data: KeychainCredentialRemoteSSHSemiautomaticSetup
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupResult(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupResult(BaseModel):
     result: SSHCredentialsEntry
 
 
@@ -197,12 +197,12 @@ class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
     manual_setup: Excluded = excluded_field()
 
 
-class KeychainCredentialSetupSSHConnectionArgs(BaseModel):
+class KeychainCredentialSetupSshConnectionArgs(BaseModel):
     options: Annotated[
         Union[SetupSSHConnectionManual, SetupSSHConnectionSemiautomatic],
         Discriminator("setup_type"),
     ]
 
 
-class KeychainCredentialSetupSSHConnectionResult(BaseModel):
+class KeychainCredentialSetupSshConnectionResult(BaseModel):
     result: SSHCredentialsEntry

--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -11,12 +11,12 @@ from middlewared.api.base import (
 )
 
 __all__ = ["NfsEntry",
-           "NfsUpdateArgs", "NfsUpdateResult",
-           "NfsBindipChoicesArgs", "NfsBindipChoicesResult",
+           "NFSUpdateArgs", "NFSUpdateResult",
+           "NFSBindipChoicesArgs", "NFSBindipChoicesResult",
            "NfsShareEntry",
-           "NfsShareCreateArgs", "NfsShareCreateResult",
-           "NfsShareUpdateArgs", "NfsShareUpdateResult",
-           "NfsShareDeleteArgs", "NfsShareDeleteResult"]
+           "SharingNFSCreateArgs", "SharingNFSCreateResult",
+           "SharingNFSUpdateArgs", "SharingNFSUpdateResult",
+           "SharingNFSDeleteArgs", "SharingNFSDeleteResult"]
 
 MAX_NUM_NFS_NETWORKS = 42
 MAX_NUM_NFS_HOSTS = 42
@@ -64,22 +64,22 @@ class NfsEntry(BaseModel):
 
 
 @single_argument_args('nfs_update')
-class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
+class NFSUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     managed_nfsd: Excluded = excluded_field()
     v4_krb_enabled: Excluded = excluded_field()
     keytab_has_nfs_spn: Excluded = excluded_field()
 
 
-class NfsUpdateResult(BaseModel):
+class NFSUpdateResult(BaseModel):
     result: NfsEntry
 
 
-class NfsBindipChoicesArgs(BaseModel):
+class NFSBindipChoicesArgs(BaseModel):
     pass
 
 
-class NfsBindipChoicesResult(BaseModel):
+class NFSBindipChoicesResult(BaseModel):
     """ Return a dictionary of IP addresses """
     result: dict[str, str]
 
@@ -128,11 +128,11 @@ class NfsShareCreate(NfsShareEntry):
     locked: Excluded = excluded_field()
 
 
-class NfsShareCreateArgs(BaseModel):
+class SharingNFSCreateArgs(BaseModel):
     data: NfsShareCreate
 
 
-class NfsShareCreateResult(BaseModel):
+class SharingNFSCreateResult(BaseModel):
     result: NfsShareEntry
 
 
@@ -140,18 +140,18 @@ class NfsShareUpdate(NfsShareCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class NfsShareUpdateArgs(BaseModel):
+class SharingNFSUpdateArgs(BaseModel):
     id: int
     data: NfsShareUpdate
 
 
-class NfsShareUpdateResult(BaseModel):
+class SharingNFSUpdateResult(BaseModel):
     result: NfsShareEntry
 
 
-class NfsShareDeleteArgs(BaseModel):
+class SharingNFSDeleteArgs(BaseModel):
     id: int
 
 
-class NfsShareDeleteResult(BaseModel):
+class SharingNFSDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool.py
@@ -6,19 +6,19 @@ from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 
 
 @single_argument_args('options')
-class DDTPruneArgs(BaseModel):
+class PoolDdtPruneArgs(BaseModel):
     pool_name: NonEmptyString
     percentage: Annotated[int | None, Field(ge=1, le=100, default=None)]
     days: Annotated[int | None, Field(ge=1, default=None)]
 
 
-class DDTPruneResult(BaseModel):
+class PoolDdtPruneResult(BaseModel):
     result: None
 
 
-class DDTPrefetchArgs(BaseModel):
+class PoolDdtPrefetchArgs(BaseModel):
     pool_name: NonEmptyString
 
 
-class DDTPrefetchResult(BaseModel):
+class PoolDdtPrefetchResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_0/pool_dataset_details.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool_dataset_details.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel
 
 # from pydantic import ConfigDict, Field
 
-__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResults")
+__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResult")
 
 """
 FIXME: We need to fix the return validation
@@ -102,7 +102,7 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[PoolDatasetDetailsEntry]
 """
 
@@ -111,5 +111,5 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[dict]

--- a/src/middlewared/middlewared/api/v25_04_0/pool_snapshot_count.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool_snapshot_count.py
@@ -5,5 +5,5 @@ class PoolDatasetSnapshotCountArgs(BaseModel):
     dataset: str
 
 
-class PoolDatasetSnapshotCountResults(BaseModel):
+class PoolDatasetSnapshotCountResult(BaseModel):
     result: int

--- a/src/middlewared/middlewared/api/v25_04_0/pool_snapshottask.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool_snapshottask.py
@@ -7,13 +7,13 @@ from .common import CronModel
 
 
 __all__ = [
-    "PoolSnapshotTaskEntry", "PoolSnapshotTaskCreateArgs", "PoolSnapshotTaskCreateResult",
-    "PoolSnapshotTaskUpdateArgs", "PoolSnapshotTaskUpdateResult", "PoolSnapshotTaskDeleteArgs",
-    "PoolSnapshotTaskDeleteResult", "PoolSnapshotTaskMaxCountArgs", "PoolSnapshotTaskMaxCountResult",
-    "PoolSnapshotTaskMaxTotalCountArgs", "PoolSnapshotTaskMaxTotalCountResult", "PoolSnapshotTaskRunArgs",
-    "PoolSnapshotTaskRunResult", "PoolSnapshotTaskUpdateWillChangeRetentionForArgs",
-    "PoolSnapshotTaskUpdateWillChangeRetentionForResult", "PoolSnapshotTaskDeleteWillChangeRetentionForArgs",
-    "PoolSnapshotTaskDeleteWillChangeRetentionForResult"
+    "PoolSnapshotTaskEntry", "PeriodicSnapshotTaskCreateArgs", "PeriodicSnapshotTaskCreateResult",
+    "PeriodicSnapshotTaskUpdateArgs", "PeriodicSnapshotTaskUpdateResult", "PeriodicSnapshotTaskDeleteArgs",
+    "PeriodicSnapshotTaskDeleteResult", "PeriodicSnapshotTaskMaxCountArgs", "PeriodicSnapshotTaskMaxCountResult",
+    "PeriodicSnapshotTaskMaxTotalCountArgs", "PeriodicSnapshotTaskMaxTotalCountResult", "PeriodicSnapshotTaskRunArgs",
+    "PeriodicSnapshotTaskRunResult", "PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskUpdateWillChangeRetentionForResult", "PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskDeleteWillChangeRetentionForResult"
 ]
 
 
@@ -53,68 +53,68 @@ class PoolSnapshotTaskEntry(PoolSnapshotTaskCreate):
     state: Any
 
 
-class PoolSnapshotTaskCreateArgs(BaseModel):
+class PeriodicSnapshotTaskCreateArgs(BaseModel):
     data: PoolSnapshotTaskCreate
 
 
-class PoolSnapshotTaskCreateResult(BaseModel):
+class PeriodicSnapshotTaskCreateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskUpdateArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdate
 
 
-class PoolSnapshotTaskUpdateResult(BaseModel):
+class PeriodicSnapshotTaskUpdateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskDeleteArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteArgs(BaseModel):
     id: int
     options: PoolSnapshotTaskDeleteOptions = Field(default_factory=PoolSnapshotTaskDeleteOptions)
 
 
-class PoolSnapshotTaskDeleteResult(BaseModel):
+class PeriodicSnapshotTaskDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class PoolSnapshotTaskMaxCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskMaxTotalCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxTotalCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskRunArgs(BaseModel):
+class PeriodicSnapshotTaskRunArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskRunResult(BaseModel):
+class PeriodicSnapshotTaskRunResult(BaseModel):
     result: None
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdateWillChangeRetentionFor
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]

--- a/src/middlewared/middlewared/api/v25_04_0/privilege.py
+++ b/src/middlewared/middlewared/api/v25_04_0/privilege.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 from middlewared.utils.security import STIGType
 from .group import GroupEntry
 
-__all__ = ["PrivilegeEntry", "PrivilegeRoleEntry",
+__all__ = ["PrivilegeEntry", "PrivilegeRolesEntry",
            "PrivilegeCreateArgs", "PrivilegeCreateResult",
            "PrivilegeUpdateArgs", "PrivilegeUpdateResult",
            "PrivilegeDeleteArgs", "PrivilegeDeleteResult"]
@@ -60,7 +60,7 @@ class PrivilegeDeleteResult(BaseModel):
     result: bool
 
 
-class PrivilegeRoleEntry(BaseModel):
+class PrivilegeRolesEntry(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     includes: list[NonEmptyString]

--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -3,8 +3,8 @@ from typing import Literal
 
 __all__ = [
     "RdmaLinkConfig",
-    "RdmaCardConfigArgs", "RdmaCardConfigResult",
-    "RdmaCapableProtocolsArgs", "RdmaCapableProtocolsResult"
+    "RDMAGetCardChoicesArgs", "RDMAGetCardChoicesResult",
+    "RDMACapableProtocolsArgs", "RDMACapableProtocolsResult"
 ]
 
 
@@ -13,7 +13,7 @@ class RdmaLinkConfig(BaseModel):
     netdev: str
 
 
-class RdmaCardConfigArgs(BaseModel):
+class RDMAGetCardChoicesArgs(BaseModel):
     pass
 
 
@@ -25,13 +25,13 @@ class RdmaCardConfig(BaseModel):
     links: list[RdmaLinkConfig]
 
 
-class RdmaCardConfigResult(BaseModel):
+class RDMAGetCardChoicesResult(BaseModel):
     result: list[RdmaCardConfig]
 
 
-class RdmaCapableProtocolsArgs(BaseModel):
+class RDMACapableProtocolsArgs(BaseModel):
     pass
 
 
-class RdmaCapableProtocolsResult(BaseModel):
+class RDMACapableProtocolsResult(BaseModel):
     result: list[Literal["ISER", "NFS"]]

--- a/src/middlewared/middlewared/api/v25_04_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting.py
@@ -8,8 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraph', 'ReportingGetDataArgs',
-    'ReportingGetDataResult', 'ReportingGraphArgs', 'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult',
+    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraphsItem',
+    'ReportingNetdataGetDataArgs', 'ReportingNetdataGraphResult', 'ReportingNetdataGraphArgs',
+    'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult', 'ReportingNetdataGraphsItem',
 ]
 
 
@@ -49,7 +50,7 @@ class GraphIdentifier(BaseModel):
     identifier: NonEmptyString | None = None
 
 
-class ReportingGetDataArgs(BaseModel):
+class ReportingNetdataGetDataArgs(BaseModel):
     graphs: list[GraphIdentifier] = Field(min_length=1)
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 
@@ -70,18 +71,25 @@ class ReportingGetDataResponse(BaseModel):
     legend: list[str]
 
 
-class ReportingGetDataResult(BaseModel):
+class ReportingNetdataGraphResult(BaseModel):
     result: list[ReportingGetDataResponse]
 
 
-class ReportingGraph(BaseModel):
+class ReportingGraphsItem(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     vertical_label: NonEmptyString
     identifiers: list[str] | None
 
 
-class ReportingGraphArgs(BaseModel):
+class ReportingNetdataGraphsItem(BaseModel):
+    name: NonEmptyString
+    title: NonEmptyString
+    vertical_label: NonEmptyString
+    identifiers: list[str] | None
+
+
+class ReportingNetdataGraphArgs(BaseModel):
     str: NonEmptyString
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 

--- a/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
@@ -8,9 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingExporterEntry', 'ReportingExporterCreateArgs', 'ReportingExporterCreateResult', 'GraphiteExporter',
-    'ReportingExporterUpdateArgs', 'ReportingExporterUpdateResult', 'ReportingExporterDeleteArgs',
-    'ReportingExporterDeleteResult', 'ReportingExporterSchemasArgs', 'ReportingExporterSchemasResult',
+    'ReportingExporterEntry', 'ReportingExportsCreateArgs', 'ReportingExportsCreateResult', 'GraphiteExporter',
+    'ReportingExportsUpdateArgs', 'ReportingExportsUpdateResult', 'ReportingExportsDeleteArgs',
+    'ReportingExportsDeleteResult', 'ReportingExportsExporterSchemasArgs', 'ReportingExportsExporterSchemasResult',
 ]
 
 
@@ -41,11 +41,11 @@ class ReportingExporterEntry(BaseModel):
 
 
 @single_argument_args('reporting_exporter_create')
-class ReportingExporterCreateArgs(ReportingExporterEntry):
+class ReportingExportsCreateArgs(ReportingExporterEntry):
     id: Excluded = excluded_field()
 
 
-class ReportingExporterCreateResult(BaseModel):
+class ReportingExportsCreateResult(BaseModel):
     result: ReportingExporterEntry
 
 
@@ -53,24 +53,24 @@ class ReportingExporterUpdate(ReportingExporterEntry, metaclass=ForUpdateMetacla
     id: Excluded = excluded_field()
 
 
-class ReportingExporterUpdateArgs(BaseModel):
+class ReportingExportsUpdateArgs(BaseModel):
     id: int
     reporting_exporter_update: ReportingExporterUpdate
 
 
-class ReportingExporterUpdateResult(BaseModel):
+class ReportingExportsUpdateResult(BaseModel):
     result: ReportingExporterEntry
 
 
-class ReportingExporterDeleteArgs(BaseModel):
+class ReportingExportsDeleteArgs(BaseModel):
     id: int
 
 
-class ReportingExporterDeleteResult(BaseModel):
+class ReportingExportsDeleteResult(BaseModel):
     result: bool
 
 
-class ReportingExporterSchemasArgs(BaseModel):
+class ReportingExportsExporterSchemasArgs(BaseModel):
     pass
 
 
@@ -87,5 +87,5 @@ class ReportingExporterSchema(BaseModel):
     schema_: list[ReportingExporterAttributeSchema] = Field(alias='schema')
 
 
-class ReportingExporterSchemasResult(BaseModel):
+class ReportingExportsExporterSchemasResult(BaseModel):
     result: list[ReportingExporterSchema]

--- a/src/middlewared/middlewared/api/v25_04_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_04_0/smb.py
@@ -15,12 +15,12 @@ from pydantic import Field, field_validator, IPvAnyInterface, model_validator
 from typing import Literal, Self
 
 __all__ = [
-    'GetSmbAclArgs', 'GetSmbAclResult',
-    'SetSmbAclArgs', 'SetSmbAclResult',
-    'SmbServiceEntry', 'SmbServiceUpdateArgs', 'SmbServiceUpdateResult',
-    'SmbServiceUnixCharsetChoicesArgs', 'SmbServiceUnixCharsetChoicesResult',
-    'SmbServiceBindIPChoicesArgs', 'SmbServiceBindIPChoicesResult',
-    'SmbSharePresetsArgs', 'SmbSharePresetsResult',
+    'SharingSMBGetaclArgs', 'SharingSMBGetaclResult',
+    'SharingSMBSetaclArgs', 'SharingSMBSetaclResult',
+    'SmbServiceEntry', 'SMBUpdateArgs', 'SMBUpdateResult',
+    'SMBUnixcharsetChoicesArgs', 'SMBUnixcharsetChoicesResult',
+    'SMBBindipChoicesArgs', 'SMBBindipChoicesResult',
+    'SharingSMBPresetsArgs', 'SharingSMBPresetsResult',
 ]
 
 EMPTY_STRING = ''
@@ -88,20 +88,20 @@ class SMBShareAcl(BaseModel):
 
 
 @single_argument_args('smb_setacl')
-class SetSmbAclArgs(SMBShareAcl):
+class SharingSMBSetaclArgs(SMBShareAcl):
     pass
 
 
-class SetSmbAclResult(BaseModel):
+class SharingSMBSetaclResult(BaseModel):
     result: SMBShareAcl
 
 
 @single_argument_args('smb_getacl')
-class GetSmbAclArgs(BaseModel):
+class SharingSMBGetaclArgs(BaseModel):
     share_name: NonEmptyString
 
 
-class GetSmbAclResult(SetSmbAclResult):
+class SharingSMBGetaclResult(SharingSMBSetaclResult):
     pass
 
 
@@ -171,33 +171,33 @@ class SmbServiceEntry(BaseModel):
 
 
 @single_argument_args('smb_update')
-class SmbServiceUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
+class SMBUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SmbServiceUpdateResult(BaseModel):
+class SMBUpdateResult(BaseModel):
     result: SmbServiceEntry
 
 
-class SmbServiceUnixCharsetChoicesArgs(BaseModel):
+class SMBUnixcharsetChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceUnixCharsetChoicesResult(BaseModel):
+class SMBUnixcharsetChoicesResult(BaseModel):
     result: dict[str, SMBCharsetType]
 
 
-class SmbServiceBindIPChoicesArgs(BaseModel):
+class SMBBindipChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceBindIPChoicesResult(BaseModel):
+class SMBBindipChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SmbSharePresetsArgs(BaseModel):
+class SharingSMBPresetsArgs(BaseModel):
     pass
 
 
-class SmbSharePresetsResult(BaseModel):
+class SharingSMBPresetsResult(BaseModel):
     result: dict[str, dict]

--- a/src/middlewared/middlewared/api/v25_04_0/snmp.py
+++ b/src/middlewared/middlewared/api/v25_04_0/snmp.py
@@ -8,7 +8,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["SnmpEntry",
-           "SnmpUpdateArgs", "SnmpUpdateResult"]
+           "SNMPUpdateArgs", "SNMPUpdateResult"]
 
 
 class SnmpEntry(BaseModel):
@@ -29,9 +29,9 @@ class SnmpEntry(BaseModel):
 
 
 @single_argument_args('snmp_update')
-class SnmpUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
+class SNMPUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SnmpUpdateResult(BaseModel):
+class SNMPUpdateResult(BaseModel):
     result: SnmpEntry

--- a/src/middlewared/middlewared/api/v25_04_0/system_security.py
+++ b/src/middlewared/middlewared/api/v25_04_0/system_security.py
@@ -8,8 +8,8 @@ from middlewared.api.base import (
 
 __all__ = [
     'SystemSecurityEntry', 'SystemSecurityUpdateArgs', 'SystemSecurityUpdateResult',
-    'SystemSecurityFipsAvailableArgs', 'SystemSecurityFipsAvailableResult',
-    'SystemSecurityFipsEnabledArgs', 'SystemSecurityFipsEnabledResult',
+    'SystemSecurityInfoFipsAvailableArgs', 'SystemSecurityInfoFipsAvailableResult',
+    'SystemSecurityInfoFipsEnabledArgs', 'SystemSecurityInfoFipsEnabledResult',
 ]
 
 
@@ -30,17 +30,17 @@ class SystemSecurityUpdateResult(BaseModel):
     result: SystemSecurityEntry
 
 
-class SystemSecurityFipsAvailableArgs(BaseModel):
+class SystemSecurityInfoFipsAvailableArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsAvailableResult(BaseModel):
+class SystemSecurityInfoFipsAvailableResult(BaseModel):
     result: bool
 
 
-class SystemSecurityFipsEnabledArgs(BaseModel):
+class SystemSecurityInfoFipsEnabledArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsEnabledResult(BaseModel):
+class SystemSecurityInfoFipsEnabledResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_04_0/tn_connect.py
@@ -5,8 +5,8 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TNCGetRegistrationURIArgs', 'TNCGetRegistrationURIResult', 'TNCUpdateArgs', 'TNCUpdateResult',
-    'TNCGenerateClaimTokenArgs', 'TNCGenerateClaimTokenResult', 'TNCIPChoicesArgs', 'TNCIPChoicesResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult', 'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
+    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult', 'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 
 
@@ -25,7 +25,7 @@ class TNCEntry(BaseModel):
 
 
 @single_argument_args('tn_connect_update')
-class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
+class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
     account_service_base_url: HttpsOnlyURL
@@ -34,29 +34,29 @@ class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     heartbeat_url: HttpsOnlyURL
 
 
-class TNCUpdateResult(BaseModel):
+class TrueNASConnectUpdateResult(BaseModel):
     result: TNCEntry
 
 
-class TNCGetRegistrationURIArgs(BaseModel):
+class TrueNASConnectGetRegistrationUriArgs(BaseModel):
     pass
 
 
-class TNCGetRegistrationURIResult(BaseModel):
+class TrueNASConnectGetRegistrationUriResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCGenerateClaimTokenArgs(BaseModel):
+class TrueNASConnectGenerateClaimTokenArgs(BaseModel):
     pass
 
 
-class TNCGenerateClaimTokenResult(BaseModel):
+class TrueNASConnectGenerateClaimTokenResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCIPChoicesArgs(BaseModel):
+class TrueNASConnectIpChoicesArgs(BaseModel):
     pass
 
 
-class TNCIPChoicesResult(BaseModel):
+class TrueNASConnectIpChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_0/truenas.py
+++ b/src/middlewared/middlewared/api/v25_04_0/truenas.py
@@ -4,10 +4,10 @@ from middlewared.api.base import BaseModel, LongString
 __all__ = [
     'TrueNASSetProductionArgs', 'TrueNASSetProductionResult',
     'TrueNASIsProductionArgs', 'TrueNASIsProductionResult',
-    'TrueNASAcceptEULAArgs', 'TrueNASAcceptEULAResult',
-    'TrueNASIsEULAAcceptedArgs', 'TrueNASIsEULAAcceptedResult',
-    'TrueNASGetEULAArgs', 'TrueNASGetEULAResult',
-    'TrueNASIsIXHardwareArgs', 'TrueNASIsIXHardwareResult',
+    'TrueNASAcceptEulaArgs', 'TrueNASAcceptEulaResult',
+    'TrueNASIsEulaAcceptedArgs', 'TrueNASIsEulaAcceptedResult',
+    'TrueNASGetEulaArgs', 'TrueNASGetEulaResult',
+    'TrueNASIsIxHardwareArgs', 'TrueNASIsIxHardwareResult',
     'TrueNASGetChassisHardwareArgs', 'TrueNASGetChassisHardwareResult',
     'TrueNASManagedByTruecommandArgs', 'TrueNASManagedByTruecommandResult'
 ]
@@ -29,35 +29,35 @@ class TrueNASGetChassisHardwareResult(BaseModel):
     result: str
 
 
-class TrueNASIsIXHardwareArgs(BaseModel):
+class TrueNASIsIxHardwareArgs(BaseModel):
     pass
 
 
-class TrueNASIsIXHardwareResult(BaseModel):
+class TrueNASIsIxHardwareResult(BaseModel):
     result: bool
 
 
-class TrueNASGetEULAArgs(BaseModel):
+class TrueNASGetEulaArgs(BaseModel):
     pass
 
 
-class TrueNASGetEULAResult(BaseModel):
+class TrueNASGetEulaResult(BaseModel):
     result: LongString | None
 
 
-class TrueNASIsEULAAcceptedArgs(BaseModel):
+class TrueNASIsEulaAcceptedArgs(BaseModel):
     pass
 
 
-class TrueNASIsEULAAcceptedResult(BaseModel):
+class TrueNASIsEulaAcceptedResult(BaseModel):
     result: bool
 
 
-class TrueNASAcceptEULAArgs(BaseModel):
+class TrueNASAcceptEulaArgs(BaseModel):
     pass
 
 
-class TrueNASAcceptEULAResult(BaseModel):
+class TrueNASAcceptEulaResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_device.py
@@ -6,11 +6,11 @@ from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, 
 
 
 __all__ = [
-    'DeviceType', 'InstanceType', 'VirtDeviceUSBChoicesArgs', 'VirtDeviceUSBChoicesResult',
-    'VirtDeviceGPUChoicesArgs', 'VirtDeviceGPUChoicesResult', 'VirtDeviceDiskChoicesArgs',
-    'VirtDeviceDiskChoicesResult', 'VirtDeviceNICChoicesArgs', 'VirtDeviceNICChoicesResult',
+    'DeviceType', 'InstanceType', 'VirtDeviceUsbChoicesArgs', 'VirtDeviceUsbChoicesResult',
+    'VirtDeviceGpuChoicesArgs', 'VirtDeviceGpuChoicesResult', 'VirtDeviceDiskChoicesArgs',
+    'VirtDeviceDiskChoicesResult', 'VirtDeviceNicChoicesArgs', 'VirtDeviceNicChoicesResult',
     'VirtDeviceExportDiskImageArgs', 'VirtDeviceExportDiskImageResult', 'VirtDeviceImportDiskImageArgs',
-    'VirtDeviceImportDiskImageResult', 'VirtDevicePCIChoicesArgs', 'VirtDevicePCIChoicesResult',
+    'VirtDeviceImportDiskImageResult', 'VirtDevicePciChoicesArgs', 'VirtDevicePciChoicesResult',
 ]
 
 
@@ -120,7 +120,7 @@ DeviceType: TypeAlias = Annotated[
 ]
 
 
-class VirtDeviceUSBChoicesArgs(BaseModel):
+class VirtDeviceUsbChoicesArgs(BaseModel):
     pass
 
 
@@ -133,11 +133,11 @@ class USBChoice(BaseModel):
     manufacturer: str | None
 
 
-class VirtDeviceUSBChoicesResult(BaseModel):
+class VirtDeviceUsbChoicesResult(BaseModel):
     result: dict[str, USBChoice]
 
 
-class VirtDeviceGPUChoicesArgs(BaseModel):
+class VirtDeviceGpuChoicesArgs(BaseModel):
     gpu_type: GPUType
 
 
@@ -149,7 +149,7 @@ class GPUChoice(BaseModel):
     pci: str
 
 
-class VirtDeviceGPUChoicesResult(BaseModel):
+class VirtDeviceGpuChoicesResult(BaseModel):
     result: dict[str, GPUChoice]
 
 
@@ -161,11 +161,11 @@ class VirtDeviceDiskChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class VirtDeviceNICChoicesArgs(BaseModel):
+class VirtDeviceNicChoicesArgs(BaseModel):
     nic_type: NicType
 
 
-class VirtDeviceNICChoicesResult(BaseModel):
+class VirtDeviceNicChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -190,9 +190,9 @@ class VirtDeviceExportDiskImageResult(BaseModel):
     result: bool
 
 
-class VirtDevicePCIChoicesArgs(BaseModel):
+class VirtDevicePciChoicesArgs(BaseModel):
     pass
 
 
-class VirtDevicePCIChoicesResult(BaseModel):
+class VirtDevicePciChoicesResult(BaseModel):
     result: dict

--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -14,9 +14,9 @@ __all__ = [
     'VirtInstanceUpdateResult', 'VirtInstanceDeleteArgs', 'VirtInstanceDeleteResult',
     'VirtInstanceStartArgs', 'VirtInstanceStartResult', 'VirtInstanceStopArgs', 'VirtInstanceStopResult',
     'VirtInstanceRestartArgs', 'VirtInstanceRestartResult', 'VirtInstanceImageChoicesArgs',
-    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceListArgs', 'VirtInstanceDeviceListResult',
-    'VirtInstanceDeviceAddArgs', 'VirtInstanceDeviceAddResult', 'VirtInstanceDeviceUpdateArgs',
-    'VirtInstanceDeviceUpdateResult', 'VirtInstanceDeviceDeleteArgs', 'VirtInstanceDeviceDeleteResult',
+    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceDeviceListArgs', 'VirtInstanceDeviceDeviceListResult',
+    'VirtInstanceDeviceDeviceAddArgs', 'VirtInstanceDeviceDeviceAddResult', 'VirtInstanceDeviceDeviceUpdateArgs',
+    'VirtInstanceDeviceDeviceUpdateResult', 'VirtInstanceDeviceDeviceDeleteArgs', 'VirtInstanceDeviceDeviceDeleteResult',
 ]
 
 
@@ -278,36 +278,36 @@ class VirtInstanceImageChoicesResult(BaseModel):
     result: dict[str, ImageChoiceItem]
 
 
-class VirtInstanceDeviceListArgs(BaseModel):
+class VirtInstanceDeviceDeviceListArgs(BaseModel):
     id: str
 
 
-class VirtInstanceDeviceListResult(BaseModel):
+class VirtInstanceDeviceDeviceListResult(BaseModel):
     result: list[DeviceType]
 
 
-class VirtInstanceDeviceAddArgs(BaseModel):
+class VirtInstanceDeviceDeviceAddArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceAddResult(BaseModel):
+class VirtInstanceDeviceDeviceAddResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceUpdateArgs(BaseModel):
+class VirtInstanceDeviceDeviceUpdateArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceUpdateResult(BaseModel):
+class VirtInstanceDeviceDeviceUpdateResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceDeleteArgs(BaseModel):
+class VirtInstanceDeviceDeviceDeleteArgs(BaseModel):
     id: str
     name: str
 
 
-class VirtInstanceDeviceDeleteResult(BaseModel):
+class VirtInstanceDeviceDeviceDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
-    'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+    'VirtVolumeDeleteResult', 'VirtVolumeImportIsoArgs', 'VirtVolumeImportIsoResult',
     'VirtVolumeImportZvolArgs', 'VirtVolumeImportZvolResult',
 ]
 
@@ -80,7 +80,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 
 @single_argument_args('virt_volume_import_iso')
-class VirtVolumeImportISOArgs(BaseModel):
+class VirtVolumeImportIsoArgs(BaseModel):
     name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
@@ -93,7 +93,7 @@ class VirtVolumeImportISOArgs(BaseModel):
     '''
 
 
-class VirtVolumeImportISOResult(BaseModel):
+class VirtVolumeImportIsoResult(BaseModel):
     result: VirtVolumeEntry
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acl.py
@@ -26,12 +26,12 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'AclTemplateEntry',
-    'AclTemplateByPathArgs', 'AclTemplateByPathResult',
-    'AclTemplateCreateArgs', 'AclTemplateCreateResult',
-    'AclTemplateUpdateArgs', 'AclTemplateUpdateResult',
-    'AclTemplateDeleteArgs', 'AclTemplateDeleteResult',
-    'FilesystemGetAclArgs', 'FilesystemGetAclResult',
-    'FilesystemSetAclArgs', 'FilesystemSetAclResult',
+    'ACLTemplateByPathArgs', 'ACLTemplateByPathResult',
+    'ACLTemplateCreateArgs', 'ACLTemplateCreateResult',
+    'ACLTemplateUpdateArgs', 'ACLTemplateUpdateResult',
+    'ACLTemplateDeleteArgs', 'ACLTemplateDeleteResult',
+    'FilesystemGetaclArgs', 'FilesystemGetaclResult',
+    'FilesystemSetaclArgs', 'FilesystemSetaclResult',
     'NFS4ACE', 'POSIXACE',
 ]
 
@@ -207,7 +207,7 @@ class DISABLED_ACL(AclBaseInfo):
     trivial: Literal[True]
 
 
-class FilesystemGetAclArgs(BaseModel):
+class FilesystemGetaclArgs(BaseModel):
     path: NonEmptyString
     simplified: bool = True
     resolve_ids: bool = False
@@ -231,7 +231,7 @@ class DISABLED_ACLResult(DISABLED_ACL, AclBaseResult):
     pass
 
 
-class FilesystemGetAclResult(BaseModel):
+class FilesystemGetaclResult(BaseModel):
     result: NFS4ACLResult | POSIXACLResult | DISABLED_ACLResult
 
 
@@ -244,7 +244,7 @@ class FilesystemSetAclOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class FilesystemSetAclArgs(BaseModel):
+class FilesystemSetaclArgs(BaseModel):
     path: NonEmptyString
     dacl: list[NFS4ACE] | list[POSIXACE]
     options: FilesystemSetAclOptions = Field(default=FilesystemSetAclOptions())
@@ -267,7 +267,7 @@ class FilesystemSetAclArgs(BaseModel):
         return self
 
 
-class FilesystemSetAclResult(FilesystemGetAclResult):
+class FilesystemSetaclResult(FilesystemGetaclResult):
     pass
 
 
@@ -285,11 +285,11 @@ class AclTemplateCreate(AclTemplateEntry):
     builtin: Excluded = excluded_field()
 
 
-class AclTemplateCreateArgs(BaseModel):
+class ACLTemplateCreateArgs(BaseModel):
     acltemplate_create: AclTemplateCreate
 
 
-class AclTemplateCreateResult(BaseModel):
+class ACLTemplateCreateResult(BaseModel):
     result: AclTemplateEntry
 
 
@@ -297,20 +297,20 @@ class AclTemplateUpdate(AclTemplateCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class AclTemplateUpdateArgs(BaseModel):
+class ACLTemplateUpdateArgs(BaseModel):
     id: int
     acltemplate_update: AclTemplateUpdate
 
 
-class AclTemplateUpdateResult(BaseModel):
+class ACLTemplateUpdateResult(BaseModel):
     result: AclTemplateEntry
 
 
-class AclTemplateDeleteArgs(BaseModel):
+class ACLTemplateDeleteArgs(BaseModel):
     id: int
 
 
-class AclTemplateDeleteResult(BaseModel):
+class ACLTemplateDeleteResult(BaseModel):
     result: Literal[True]
 
 
@@ -321,12 +321,12 @@ class AclTemplateFormatOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class AclTemplateByPathArgs(BaseModel):
+class ACLTemplateByPathArgs(BaseModel):
     path: str = ""
     query_filters: QueryFilters = Field(alias='query-filters', default=[])
     query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
     format_options: AclTemplateFormatOptions = Field(alias='format-options', default=AclTemplateFormatOptions())
 
 
-class AclTemplateByPathResult(BaseModel):
+class ACLTemplateByPathResult(BaseModel):
     result: list[AclTemplateEntry]

--- a/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
@@ -10,9 +10,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ACMEDNSAuthenticatorEntry', 'ACMEDNSAuthenticatorCreateArgs', 'ACMEDNSAuthenticatorCreateResult',
-    'ACMEDNSAuthenticatorUpdateArgs', 'ACMEDNSAuthenticatorUpdateResult', 'ACMEDNSAuthenticatorDeleteArgs',
-    'ACMEDNSAuthenticatorDeleteResult', 'ACMEDNSAuthenticatorSchemasArgs', 'ACMEDNSAuthenticatorSchemasResult',
+    'ACMEDNSAuthenticatorEntry', 'DNSAuthenticatorCreateArgs', 'DNSAuthenticatorCreateResult',
+    'DNSAuthenticatorUpdateArgs', 'DNSAuthenticatorUpdateResult', 'DNSAuthenticatorDeleteArgs',
+    'DNSAuthenticatorDeleteResult', 'DNSAuthenticatorAuthenticatorSchemasArgs', 'DNSAuthenticatorAuthenticatorSchemasResult',
     'Route53SchemaArgs', 'ACMECustomDNSAuthenticatorReturns', 'CloudFlareSchemaArgs', 'DigitalOceanSchemaArgs',
     'OVHSchemaArgs', 'ShellSchemaArgs', 'TrueNASConnectSchemaArgs',
 ]
@@ -121,11 +121,11 @@ class ACMEDNSAuthenticatorCreate(BaseModel):
 
 
 @single_argument_args('dns_authenticator_create')
-class ACMEDNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
+class DNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
     pass
 
 
-class ACMEDNSAuthenticatorCreateResult(BaseModel):
+class DNSAuthenticatorCreateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
@@ -133,20 +133,20 @@ class ACMEDNSAuthenticatorUpdate(ACMEDNSAuthenticatorCreate, metaclass=ForUpdate
     pass
 
 
-class ACMEDNSAuthenticatorUpdateArgs(BaseModel):
+class DNSAuthenticatorUpdateArgs(BaseModel):
     id: int
     dns_authenticator_update: ACMEDNSAuthenticatorUpdate
 
 
-class ACMEDNSAuthenticatorUpdateResult(BaseModel):
+class DNSAuthenticatorUpdateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
-class ACMEDNSAuthenticatorDeleteArgs(BaseModel):
+class DNSAuthenticatorDeleteArgs(BaseModel):
     id: int
 
 
-class ACMEDNSAuthenticatorDeleteResult(BaseModel):
+class DNSAuthenticatorDeleteResult(BaseModel):
     result: bool
 
 
@@ -163,9 +163,9 @@ class ACMEDNSAuthenticatorSchema(BaseModel):
     schema_: ACMEDNSAuthenticatorAttributeSchema = Field(alias='schema')
 
 
-class ACMEDNSAuthenticatorSchemasArgs(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasArgs(BaseModel):
     pass
 
 
-class ACMEDNSAuthenticatorSchemasResult(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasResult(BaseModel):
     result: list[ACMEDNSAuthenticatorSchema]

--- a/src/middlewared/middlewared/api/v25_04_1/app.py
+++ b/src/middlewared/middlewared/api/v25_04_1/app.py
@@ -8,17 +8,17 @@ from .catalog import CatalogAppInfo
 
 
 __all__ = [
-    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableResponse',
+    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableItem',
     'AppEntry', 'AppCreateArgs', 'AppCreateResult', 'AppUpdateArgs', 'AppUpdateResult', 'AppDeleteArgs',
     'AppDeleteResult', 'AppConfigArgs', 'AppConfigResult', 'AppConvertToCustomArgs', 'AppConvertToCustomResult',
     'AppStopArgs', 'AppStopResult', 'AppStartArgs', 'AppStartResult', 'AppRedeployArgs', 'AppRedeployResult',
     'AppOutdatedDockerImagesArgs', 'AppOutdatedDockerImagesResult', 'AppPullImagesArgs', 'AppPullImagesResult',
-    'AppContainerIDArgs', 'AppContainerIDResult', 'AppContainerConsoleChoiceArgs', 'AppContainerConsoleChoiceResult',
+    'AppContainerIdsArgs', 'AppContainerIdsResult', 'AppContainerConsoleChoicesArgs', 'AppContainerConsoleChoicesResult',
     'AppCertificateChoicesArgs', 'AppCertificateChoicesResult', 'AppCertificateAuthorityArgs',
-    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIPChoicesArgs', 'AppIPChoicesResult',
+    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIpChoicesArgs', 'AppIpChoicesResult',
     'AppAvailableSpaceArgs', 'AppAvailableSpaceResult', 'AppGpuChoicesArgs', 'AppGpuChoicesResult', 'AppRollbackArgs',
     'AppRollbackResult', 'AppRollbackVersionsArgs', 'AppRollbackVersionsResult', 'AppUpgradeArgs', 'AppUpgradeResult',
-    'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult',
+    'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult', 'AppLatestItem',
 ]
 
 
@@ -207,7 +207,7 @@ class AppContainerIDOptions(BaseModel):
     alive_only: bool = True
 
 
-class AppContainerIDArgs(BaseModel):
+class AppContainerIdsArgs(BaseModel):
     app_name: NonEmptyString
     options: AppContainerIDOptions = AppContainerIDOptions()
 
@@ -223,15 +223,15 @@ class AppContainerResponse(RootModel[dict[str, ContainerDetails]]):
     pass
 
 
-class AppContainerIDResult(BaseModel):
+class AppContainerIdsResult(BaseModel):
     result: AppContainerResponse
 
 
-class AppContainerConsoleChoiceArgs(BaseModel):
+class AppContainerConsoleChoicesArgs(BaseModel):
     app_name: NonEmptyString
 
 
-class AppContainerConsoleChoiceResult(BaseModel):
+class AppContainerConsoleChoicesResult(BaseModel):
     result: AppContainerResponse
 
 
@@ -264,11 +264,11 @@ class AppUsedPortsResult(BaseModel):
     result: list[int]
 
 
-class AppIPChoicesArgs(BaseModel):
+class AppIpChoicesArgs(BaseModel):
     pass
 
 
-class AppIPChoicesResult(BaseModel):
+class AppIpChoicesResult(BaseModel):
     result: dict[NonEmptyString, NonEmptyString]
 
 
@@ -369,7 +369,7 @@ class AppUpgradeSummaryResult(BaseModel):
     changelog: LongString | None
 
 
-class AppAvailableResponse(CatalogAppInfo):
+class AppAvailableItem(CatalogAppInfo):
     catalog: NonEmptyString
     installed: bool
     train: NonEmptyString
@@ -389,4 +389,8 @@ class AppSimilarArgs(BaseModel):
 
 
 class AppSimilarResult(BaseModel):
-    result: list[AppAvailableResponse]
+    result: list[AppAvailableItem]
+
+
+class AppLatestItem(AppAvailableItem):
+    pass

--- a/src/middlewared/middlewared/api/v25_04_1/app_image.py
+++ b/src/middlewared/middlewared/api/v25_04_1/app_image.py
@@ -3,7 +3,7 @@ from typing import Literal
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
 __all__ = [
-    'AppImageEntry', 'AppImageDockerhubRateLimitArgs', 'AppImageDockerhubRateLimitResult',
+    'AppImageEntry', 'ContainerImagesDockerhubRateLimitArgs', 'ContainerImagesDockerhubRateLimitResult',
     'AppImagePullArgs', 'AppImagePullResult', 'AppImageDeleteArgs', 'AppImageDeleteResult',
 ]
 
@@ -30,12 +30,12 @@ class AppImageEntry(BaseModel):
     parsed_repo_tags: list[AppImageParsedRepoTags] | None = None
 
 
-class AppImageDockerhubRateLimitArgs(BaseModel):
+class ContainerImagesDockerhubRateLimitArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class AppImageDockerhubRateLimitResult(BaseModel):
+class ContainerImagesDockerhubRateLimitResult(BaseModel):
     total_pull_limit: int | None = None
     '''Total pull limit for Docker Hub registry'''
     total_time_limit_in_secs: int | None = None

--- a/src/middlewared/middlewared/api/v25_04_1/app_ix_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_1/app_ix_volume.py
@@ -1,17 +1,17 @@
 from middlewared.api.base import BaseModel, NonEmptyString
 
 
-__all__ = ['AppIXVolumeEntry', 'AppIXVolumeExistsArgs', 'AppIXVolumeExistsResult']
+__all__ = ['AppsIxVolumeEntry', 'AppsIxVolumeExistsArgs', 'AppsIxVolumeExistsResult']
 
 
-class AppIXVolumeEntry(BaseModel):
+class AppsIxVolumeEntry(BaseModel):
     app_name: NonEmptyString
     name: NonEmptyString
 
 
-class AppIXVolumeExistsArgs(BaseModel):
+class AppsIxVolumeExistsArgs(BaseModel):
     name: NonEmptyString
 
 
-class AppIXVolumeExistsResult(BaseModel):
+class AppsIxVolumeExistsResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_1/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_1/auth.py
@@ -109,11 +109,11 @@ class AuthLoginExResult(BaseModel):
     result: AuthRespSuccess | AuthRespAuthErr | AuthRespExpired | AuthRespOTPRequired | AuthRespAuthRedirect
 
 
-class AuthMechChoicesArgs(BaseModel):
+class AuthMechanismChoicesArgs(BaseModel):
     pass
 
 
-class AuthMechChoicesResult(BaseModel):
+class AuthMechanismChoicesResult(BaseModel):
     result: list[str]
 
 
@@ -152,7 +152,7 @@ class TokenCredentialData(BaseCredentialData):
     username: str | None
 
 
-class AuthSessionEntry(BaseModel):
+class AuthSessionsEntry(BaseModel):
     id: str
     current: bool
     internal: bool
@@ -187,11 +187,11 @@ class AuthTerminateOtherSessionsResult(AuthTerminateSessionResult):
     result: Literal[True]
 
 
-class AuthSessionLogoutArgs(BaseModel):
+class AuthLogoutArgs(BaseModel):
     pass
 
 
-class AuthSessionLogoutResult(BaseModel):
+class AuthLogoutResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/catalog.py
+++ b/src/middlewared/middlewared/api/v25_04_1/catalog.py
@@ -8,7 +8,7 @@ from middlewared.api.base import BaseModel, ForUpdateMetaclass, NonEmptyString, 
 __all__ = [
     'CatalogEntry', 'CatalogUpdateArgs', 'CatalogUpdateResult', 'CatalogTrainsArgs', 'CatalogTrainsResult',
     'CatalogSyncArgs', 'CatalogSyncResult', 'CatalogAppInfo', 'CatalogAppsArgs', 'CatalogAppsResult',
-    'CatalogAppDetailsArgs', 'CatalogAppDetailsResult',
+    'CatalogGetAppDetailsArgs', 'CatalogGetAppDetailsResult',
 ]
 
 
@@ -115,10 +115,10 @@ class CatalogAppVersionDetails(BaseModel):
     train: NonEmptyString
 
 
-class CatalogAppDetailsArgs(BaseModel):
+class CatalogGetAppDetailsArgs(BaseModel):
     app_name: NonEmptyString
     app_version_details: CatalogAppVersionDetails
 
 
-class CatalogAppDetailsResult(BaseModel):
+class CatalogGetAppDetailsResult(BaseModel):
     result: CatalogAppInfo

--- a/src/middlewared/middlewared/api/v25_04_1/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_04_1/cloud_sync.py
@@ -7,10 +7,10 @@ from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdate
 from .cloud_sync_providers import CloudCredentialProvider
 
 __all__ = ["CloudCredentialEntry",
-           "CloudCredentialCreateArgs", "CloudCredentialCreateResult",
-           "CloudCredentialUpdateArgs", "CloudCredentialUpdateResult",
-           "CloudCredentialDeleteArgs", "CloudCredentialDeleteResult",
-           "CloudCredentialVerifyArgs", "CloudCredentialVerifyResult",
+           "CredentialsCreateArgs", "CredentialsCreateResult",
+           "CredentialsUpdateArgs", "CredentialsUpdateResult",
+           "CredentialsDeleteArgs", "CredentialsDeleteResult",
+           "CredentialsVerifyArgs", "CredentialsVerifyResult",
            "CloudSyncOneDriveListDrivesArgs", "CloudSyncOneDriveListDrivesResult"]
 
 
@@ -28,37 +28,37 @@ class CloudCredentialUpdate(CloudCredentialCreate, metaclass=ForUpdateMetaclass)
     pass
 
 
-class CloudCredentialCreateArgs(BaseModel):
+class CredentialsCreateArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialCreate
 
 
-class CloudCredentialCreateResult(BaseModel):
+class CredentialsCreateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialUpdateArgs(BaseModel):
+class CredentialsUpdateArgs(BaseModel):
     id: int
     cloud_sync_credentials_update: CloudCredentialUpdate
 
 
-class CloudCredentialUpdateResult(BaseModel):
+class CredentialsUpdateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialDeleteArgs(BaseModel):
+class CredentialsDeleteArgs(BaseModel):
     id: int
 
 
-class CloudCredentialDeleteResult(BaseModel):
+class CredentialsDeleteResult(BaseModel):
     result: bool
 
 
-class CloudCredentialVerifyArgs(BaseModel):
+class CredentialsVerifyArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialProvider
 
 
 @single_argument_result
-class CloudCredentialVerifyResult(BaseModel):
+class CredentialsVerifyResult(BaseModel):
     valid: bool
     error: LongString | None = None
     excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_04_1/crypto_cert_info.py
+++ b/src/middlewared/middlewared/api/v25_04_1/crypto_cert_info.py
@@ -1,22 +1,22 @@
 from middlewared.api.base import BaseModel
 
 __all__ = (
-    'CertificateCountryChoicesArgs',
-    'CertificateCountryChoicesResult',
+    'SystemGeneralCountryChoicesArgs',
+    'SystemGeneralCountryChoicesResult',
     'CertificateAcmeServerChoicesArgs',
     'CertificateAcmeServerChoicesResult',
-    'CertificateECCurveChoicesArgs',
-    'CertificateECCurveChoicesResult',
+    'CertificateEcCurveChoicesArgs',
+    'CertificateEcCurveChoicesResult',
     'CertificateExtendedKeyUsageChoicesArgs',
     'CertificateExtendedKeyUsageChoicesResult',
 )
 
 
-class CertificateCountryChoicesArgs(BaseModel):
+class SystemGeneralCountryChoicesArgs(BaseModel):
     pass
 
 
-class CertificateCountryChoicesResult(BaseModel):
+class SystemGeneralCountryChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -28,11 +28,11 @@ class CertificateAcmeServerChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class CertificateECCurveChoicesArgs(BaseModel):
+class CertificateEcCurveChoicesArgs(BaseModel):
     pass
 
 
-class CertificateECCurveChoicesResult(BaseModel):
+class CertificateEcCurveChoicesResult(BaseModel):
     result: dict[str, str]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_1/crypto_cert_profiles.py
@@ -8,9 +8,9 @@ __all__ = (
     "CertProfilesArgs",
     "CertProfilesModel",
     "CertProfilesResult",
-    "CSRProfilesArgs",
+    "WebUICryptoCsrProfilesArgs",
     "CSRProfilesModel",
-    "CSRProfilesResult",
+    "WebUICryptoCsrProfilesResult",
 )
 
 
@@ -167,10 +167,10 @@ class CSRProfilesModel(BaseModel):
     )
 
 
-class CSRProfilesArgs(BaseModel):
+class WebUICryptoCsrProfilesArgs(BaseModel):
     pass
 
 
 @final
-class CSRProfilesResult(BaseModel):
+class WebUICryptoCsrProfilesResult(BaseModel):
     result: CSRProfilesModel = CSRProfilesModel()

--- a/src/middlewared/middlewared/api/v25_04_1/docker.py
+++ b/src/middlewared/middlewared/api/v25_04_1/docker.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'DockerEntry', 'DockerUpdateArgs', 'DockerUpdateResult', 'DockerStatusArgs', 'DockerStatusResult',
     'DockerNvidiaPresentArgs', 'DockerNvidiaPresentResult', 'DockerBackupArgs', 'DockerBackupResult',
-    'DockerListBackupArgs', 'DockerListBackupResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
+    'DockerListBackupsArgs', 'DockerListBackupsResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
     'DockerDeleteBackupArgs', 'DockerDeleteBackupResult',
 ]
 
@@ -95,7 +95,7 @@ class DockerBackupResult(BaseModel):
     result: NonEmptyString
 
 
-class DockerListBackupArgs(BaseModel):
+class DockerListBackupsArgs(BaseModel):
     pass
 
 
@@ -117,7 +117,7 @@ class DockerBackupInfo(RootModel[dict[str, BackupInfo]]):
     pass
 
 
-class DockerListBackupResult(BaseModel):
+class DockerListBackupsResult(BaseModel):
     result: DockerBackupInfo
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/enclosure_label.py
+++ b/src/middlewared/middlewared/api/v25_04_1/enclosure_label.py
@@ -1,6 +1,6 @@
 from middlewared.api.base import BaseModel
 
-__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelUpdateResult"]
+__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelSetResult"]
 
 
 class EnclosureLabelSetArgs(BaseModel):
@@ -8,5 +8,5 @@ class EnclosureLabelSetArgs(BaseModel):
     label: str
 
 
-class EnclosureLabelUpdateResult(BaseModel):
+class EnclosureLabelSetResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_1/fcport.py
+++ b/src/middlewared/middlewared/api/v25_04_1/fcport.py
@@ -56,11 +56,11 @@ class FCPortChoiceEntry(BaseModel):
     wwpn_b: WWPN | None
 
 
-class FCPortChoicesArgs(BaseModel):
+class FCPortPortChoicesArgs(BaseModel):
     include_used: bool = True
 
 
-class FCPortChoicesResult(BaseModel):
+class FCPortPortChoicesResult(BaseModel):
     result: Dict[FibreChannelPortAlias, FCPortChoiceEntry] = Field(examples=[
         {
             'fc0': {

--- a/src/middlewared/middlewared/api/v25_04_1/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_1/filesystem.py
@@ -18,15 +18,15 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'FilesystemChownArgs', 'FilesystemChownResult',
-    'FilesystemSetPermArgs', 'FilesystemSetPermResult',
+    'FilesystemSetpermArgs', 'FilesystemSetpermResult',
     'FilesystemListdirArgs', 'FilesystemListdirResult',
     'FilesystemMkdirArgs', 'FilesystemMkdirResult',
     'FilesystemStatArgs', 'FilesystemStatResult',
     'FilesystemStatfsArgs', 'FilesystemStatfsResult',
-    'FilesystemSetZfsAttrsArgs', 'FilesystemSetZfsAttrsResult',
-    'FilesystemGetZfsAttrsArgs', 'FilesystemGetZfsAttrsResult',
-    'FilesystemGetFileArgs', 'FilesystemGetFileResult',
-    'FilesystemPutFileArgs', 'FilesystemPutFileResult',
+    'FilesystemSetZfsAttributesArgs', 'FilesystemSetZfsAttributesResult',
+    'FilesystemGetZfsAttributesArgs', 'FilesystemGetZfsAttributesResult',
+    'FilesystemGetArgs', 'FilesystemGetResult',
+    'FilesystemPutArgs', 'FilesystemPutResult',
 ]
 
 
@@ -74,7 +74,7 @@ class FilesystemChownResult(BaseModel):
 
 
 @single_argument_args('filesystem_setperm')
-class FilesystemSetPermArgs(FilesystemPermChownBase):
+class FilesystemSetpermArgs(FilesystemPermChownBase):
     mode: UnixPerm | None = None
     options: FilesystemSetpermOptions = Field(default=FilesystemSetpermOptions())
 
@@ -90,7 +90,7 @@ class FilesystemSetPermArgs(FilesystemPermChownBase):
         return self
 
 
-class FilesystemSetPermResult(BaseModel):
+class FilesystemSetpermResult(BaseModel):
     result: Literal[None]
 
 
@@ -330,28 +330,28 @@ class ZFSFileAttrsData(BaseModel):
 
 
 @single_argument_args('set_zfs_file_attributes')
-class FilesystemSetZfsAttrsArgs(BaseModel):
+class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
     zfs_file_attributes: ZFSFileAttrsData
 
 
-class FilesystemSetZfsAttrsResult(BaseModel):
+class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetZfsAttrsArgs(BaseModel):
+class FilesystemGetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetZfsAttrsResult(BaseModel):
+class FilesystemGetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetFileArgs(BaseModel):
+class FilesystemGetArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetFileResult(BaseModel):
+class FilesystemGetResult(BaseModel):
     result: Literal[None]
 
 
@@ -360,10 +360,10 @@ class FilesystemPutOptions(BaseModel):
     mode: int | None = None
 
 
-class FilesystemPutFileArgs(BaseModel):
+class FilesystemPutArgs(BaseModel):
     path: NonEmptyString
     options: FilesystemPutOptions = FilesystemPutOptions()
 
 
-class FilesystemPutFileResult(BaseModel):
+class FilesystemPutResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/ftp.py
+++ b/src/middlewared/middlewared/api/v25_04_1/ftp.py
@@ -12,7 +12,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["FtpEntry",
-           "FtpUpdateArgs", "FtpUpdateResult"]
+           "FTPUpdateArgs", "FTPUpdateResult"]
 
 TLS_PolicyOptions = Literal[
     "", "on", "off", "data", "!data", "auth", "ctrl", "ctrl+data", "ctrl+!data", "auth+data", "auth+!data"
@@ -74,9 +74,9 @@ class FtpEntry(BaseModel):
 
 
 @single_argument_args('ftp_update')
-class FtpUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
+class FTPUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class FtpUpdateResult(BaseModel):
+class FTPUpdateResult(BaseModel):
     result: FtpEntry

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_auth.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_auth.py
@@ -6,12 +6,12 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiAuthEntry",
-    "IscsiAuthCreateArgs",
-    "IscsiAuthCreateResult",
-    "IscsiAuthUpdateArgs",
-    "IscsiAuthUpdateResult",
-    "IscsiAuthDeleteArgs",
-    "IscsiAuthDeleteResult",
+    "iSCSITargetAuthCredentialCreateArgs",
+    "iSCSITargetAuthCredentialCreateResult",
+    "iSCSITargetAuthCredentialUpdateArgs",
+    "iSCSITargetAuthCredentialUpdateResult",
+    "iSCSITargetAuthCredentialDeleteArgs",
+    "iSCSITargetAuthCredentialDeleteResult",
 ]
 
 
@@ -29,11 +29,11 @@ class IscsiAuthCreate(IscsiAuthEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiAuthCreateArgs(BaseModel):
+class iSCSITargetAuthCredentialCreateArgs(BaseModel):
     data: IscsiAuthCreate
 
 
-class IscsiAuthCreateResult(BaseModel):
+class iSCSITargetAuthCredentialCreateResult(BaseModel):
     result: IscsiAuthEntry
 
 
@@ -41,18 +41,18 @@ class IscsiAuthUpdate(IscsiAuthCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiAuthUpdateArgs(BaseModel):
+class iSCSITargetAuthCredentialUpdateArgs(BaseModel):
     id: int
     data: IscsiAuthUpdate
 
 
-class IscsiAuthUpdateResult(BaseModel):
+class iSCSITargetAuthCredentialUpdateResult(BaseModel):
     result: IscsiAuthEntry
 
 
-class IscsiAuthDeleteArgs(BaseModel):
+class iSCSITargetAuthCredentialDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiAuthDeleteResult(BaseModel):
+class iSCSITargetAuthCredentialDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_extent.py
@@ -8,14 +8,14 @@ from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, Iscsi
 
 __all__ = [
     "IscsiExtentEntry",
-    "IscsiExtentCreateArgs",
-    "IscsiExtentCreateResult",
-    "IscsiExtentUpdateArgs",
-    "IscsiExtentUpdateResult",
-    "IscsiExtentDeleteArgs",
-    "IscsiExtentDeleteResult",
-    "IscsiExtentDiskChoicesArgs",
-    "IscsiExtentDiskChoicesResult",
+    "iSCSITargetExtentCreateArgs",
+    "iSCSITargetExtentCreateResult",
+    "iSCSITargetExtentUpdateArgs",
+    "iSCSITargetExtentUpdateResult",
+    "iSCSITargetExtentDeleteArgs",
+    "iSCSITargetExtentDeleteResult",
+    "iSCSITargetExtentDiskChoicesArgs",
+    "iSCSITargetExtentDiskChoicesResult",
 ]
 
 
@@ -48,11 +48,11 @@ class IscsiExtentCreate(IscsiExtentEntry):
     locked: Excluded = excluded_field()
 
 
-class IscsiExtentCreateArgs(BaseModel):
+class iSCSITargetExtentCreateArgs(BaseModel):
     iscsi_extent_create: IscsiExtentCreate
 
 
-class IscsiExtentCreateResult(BaseModel):
+class iSCSITargetExtentCreateResult(BaseModel):
     result: IscsiExtentEntry
 
 
@@ -60,28 +60,28 @@ class IscsiExtentUpdate(IscsiExtentCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiExtentUpdateArgs(BaseModel):
+class iSCSITargetExtentUpdateArgs(BaseModel):
     id: int
     iscsi_extent_update: IscsiExtentUpdate
 
 
-class IscsiExtentUpdateResult(BaseModel):
+class iSCSITargetExtentUpdateResult(BaseModel):
     result: IscsiExtentEntry
 
 
-class IscsiExtentDeleteArgs(BaseModel):
+class iSCSITargetExtentDeleteArgs(BaseModel):
     id: int
     remove: bool = False
     force: bool = False
 
 
-class IscsiExtentDeleteResult(BaseModel):
+class iSCSITargetExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class IscsiExtentDiskChoicesArgs(BaseModel):
+class iSCSITargetExtentDiskChoicesArgs(BaseModel):
     pass
 
 
-class IscsiExtentDiskChoicesResult(BaseModel):
+class iSCSITargetExtentDiskChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_global.py
@@ -6,16 +6,16 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     "IscsiGlobalEntry",
-    "IscsiGlobalUpdateArgs",
-    "IscsiGlobalUpdateResult",
-    "IscsiGlobalAluaEnabledArgs",
-    "IscsiGlobalAluaEnabledResult",
-    "IscsiGlobalISEREnabledArgs",
-    "IscsiGlobalISEREnabledResult",
-    "IscsiGlobalClientCountArgs",
-    "IscsiGlobalClientCountResult",
-    "IscsiGlobalSessionsArgs",
-    "IscsiGlobalSessionsResult"
+    "ISCSIGlobalUpdateArgs",
+    "ISCSIGlobalUpdateResult",
+    "ISCSIGlobalAluaEnabledArgs",
+    "ISCSIGlobalAluaEnabledResult",
+    "ISCSIGlobalIserEnabledArgs",
+    "ISCSIGlobalIserEnabledResult",
+    "ISCSIGlobalClientCountArgs",
+    "ISCSIGlobalClientCountResult",
+    "ISCSIGlobalSessionsArgs",
+    "ISCSIGlobalSessionsResult"
 ]
 
 
@@ -30,35 +30,35 @@ class IscsiGlobalEntry(BaseModel):
 
 
 @single_argument_args('iscsi_update')
-class IscsiGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
+class ISCSIGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class IscsiGlobalUpdateResult(BaseModel):
+class ISCSIGlobalUpdateResult(BaseModel):
     result: IscsiGlobalEntry
 
 
-class IscsiGlobalAluaEnabledArgs(BaseModel):
+class ISCSIGlobalAluaEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalAluaEnabledResult(BaseModel):
+class ISCSIGlobalAluaEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalISEREnabledArgs(BaseModel):
+class ISCSIGlobalIserEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalISEREnabledResult(BaseModel):
+class ISCSIGlobalIserEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalClientCountArgs(BaseModel):
+class ISCSIGlobalClientCountArgs(BaseModel):
     pass
 
 
-class IscsiGlobalClientCountResult(BaseModel):
+class ISCSIGlobalClientCountResult(BaseModel):
     result: int
 
 
@@ -80,9 +80,9 @@ class IscsiSession(BaseModel):
     offload: bool
 
 
-class IscsiGlobalSessionsArgs(BaseModel):
+class ISCSIGlobalSessionsArgs(BaseModel):
     query_filters: QueryFilters = []
     query_options: QueryOptions = QueryOptions()
 
 
-IscsiGlobalSessionsResult = query_result(IscsiSession)
+ISCSIGlobalSessionsResult = query_result(IscsiSession)

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_initiator.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_initiator.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiInitiatorEntry",
-    "IscsiInitiatorCreateArgs",
-    "IscsiInitiatorCreateResult",
-    "IscsiInitiatorUpdateArgs",
-    "IscsiInitiatorUpdateResult",
-    "IscsiInitiatorDeleteArgs",
-    "IscsiInitiatorDeleteResult",
+    "iSCSITargetAuthorizedInitiatorCreateArgs",
+    "iSCSITargetAuthorizedInitiatorCreateResult",
+    "iSCSITargetAuthorizedInitiatorUpdateArgs",
+    "iSCSITargetAuthorizedInitiatorUpdateResult",
+    "iSCSITargetAuthorizedInitiatorDeleteArgs",
+    "iSCSITargetAuthorizedInitiatorDeleteResult",
 ]
 
 
@@ -23,11 +23,11 @@ class IscsiInitiatorCreate(IscsiInitiatorEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiInitiatorCreateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateArgs(BaseModel):
     iscsi_initiator_create: IscsiInitiatorCreate
 
 
-class IscsiInitiatorCreateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
@@ -35,18 +35,18 @@ class IscsiInitiatorUpdate(IscsiInitiatorEntry, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiInitiatorUpdateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateArgs(BaseModel):
     id: int
     iscsi_initiator_update: IscsiInitiatorUpdate
 
 
-class IscsiInitiatorUpdateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
-class IscsiInitiatorDeleteArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiInitiatorDeleteResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_portal.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_portal.py
@@ -6,14 +6,14 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiPortalEntry",
-    "IscsiPortalListenIPChoicesArgs",
-    "IscsiPortalListenIPChoicesResult",
-    "IscsiPortalCreateArgs",
-    "IscsiPortalCreateResult",
-    "IscsiPortalUpdateArgs",
-    "IscsiPortalUpdateResult",
-    "IscsiPortalDeleteArgs",
-    "IscsiPortalDeleteResult",
+    "ISCSIPortalListenIpChoicesArgs",
+    "ISCSIPortalListenIpChoicesResult",
+    "ISCSIPortalCreateArgs",
+    "ISCSIPortalCreateResult",
+    "ISCSIPortalUpdateArgs",
+    "ISCSIPortalUpdateResult",
+    "ISCSIPortalDeleteArgs",
+    "ISCSIPortalDeleteResult",
 ]
 
 
@@ -38,11 +38,11 @@ class IscsiPortalEntry(BaseModel):
     comment: str = ''
 
 
-class IscsiPortalListenIPChoicesArgs(BaseModel):
+class ISCSIPortalListenIpChoicesArgs(BaseModel):
     pass
 
 
-class IscsiPortalListenIPChoicesResult(BaseModel):
+class ISCSIPortalListenIpChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -52,11 +52,11 @@ class IscsiPortalCreate(IscsiPortalEntry):
     listen: list[IscsiPortalIP]
 
 
-class IscsiPortalCreateArgs(BaseModel):
+class ISCSIPortalCreateArgs(BaseModel):
     iscsi_portal_create: IscsiPortalCreate
 
 
-class IscsiPortalCreateResult(BaseModel):
+class ISCSIPortalCreateResult(BaseModel):
     result: IscsiPortalEntry
 
 
@@ -64,18 +64,18 @@ class IscsiPortalUpdate(IscsiPortalCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiPortalUpdateArgs(BaseModel):
+class ISCSIPortalUpdateArgs(BaseModel):
     id: int
     iscsi_portal_update: IscsiPortalUpdate
 
 
-class IscsiPortalUpdateResult(BaseModel):
+class ISCSIPortalUpdateResult(BaseModel):
     result: IscsiPortalEntry
 
 
-class IscsiPortalDeleteArgs(BaseModel):
+class ISCSIPortalDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiPortalDeleteResult(BaseModel):
+class ISCSIPortalDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_target.py
@@ -11,14 +11,14 @@ RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 
 __all__ = [
     "IscsiTargetEntry",
-    "IscsiTargetValidateNameArgs",
-    "IscsiTargetValidateNameResult",
-    "IscsiTargetCreateArgs",
-    "IscsiTargetCreateResult",
-    "IscsiTargetUpdateArgs",
-    "IscsiTargetUpdateResult",
-    "IscsiTargetDeleteArgs",
-    "IscsiTargetDeleteResult",
+    "iSCSITargetValidateNameArgs",
+    "iSCSITargetValidateNameResult",
+    "iSCSITargetCreateArgs",
+    "iSCSITargetCreateResult",
+    "iSCSITargetUpdateArgs",
+    "iSCSITargetUpdateResult",
+    "iSCSITargetDeleteArgs",
+    "iSCSITargetDeleteResult",
 ]
 
 
@@ -51,12 +51,12 @@ class IscsiTargetEntry(BaseModel):
     iscsi_parameters: IscsiTargetParameters | None = None
 
 
-class IscsiTargetValidateNameArgs(BaseModel):
+class iSCSITargetValidateNameArgs(BaseModel):
     name: str
     existing_id: int | None = None
 
 
-class IscsiTargetValidateNameResult(BaseModel):
+class iSCSITargetValidateNameResult(BaseModel):
     result: str | None
 
 
@@ -65,11 +65,11 @@ class IscsiTargetCreate(IscsiTargetEntry):
     rel_tgt_id: Excluded = excluded_field()
 
 
-class IscsiTargetCreateArgs(BaseModel):
+class iSCSITargetCreateArgs(BaseModel):
     iscsi_target_create: IscsiTargetCreate
 
 
-class IscsiTargetCreateResult(BaseModel):
+class iSCSITargetCreateResult(BaseModel):
     result: IscsiTargetEntry
 
 
@@ -77,20 +77,20 @@ class IscsiTargetUpdate(IscsiTargetCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiTargetUpdateArgs(BaseModel):
+class iSCSITargetUpdateArgs(BaseModel):
     id: int
     iscsi_target_update: IscsiTargetUpdate
 
 
-class IscsiTargetUpdateResult(BaseModel):
+class iSCSITargetUpdateResult(BaseModel):
     result: IscsiTargetEntry
 
 
-class IscsiTargetDeleteArgs(BaseModel):
+class iSCSITargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
     delete_extents: bool = False
 
 
-class IscsiTargetDeleteResult(BaseModel):
+class iSCSITargetDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_1/iscsi_target_to_extent.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiTargetToExtentEntry",
-    "IscsiTargetToExtentCreateArgs",
-    "IscsiTargetToExtentCreateResult",
-    "IscsiTargetToExtentUpdateArgs",
-    "IscsiTargetToExtentUpdateResult",
-    "IscsiTargetToExtentDeleteArgs",
-    "IscsiTargetToExtentDeleteResult",
+    "iSCSITargetToExtentCreateArgs",
+    "iSCSITargetToExtentCreateResult",
+    "iSCSITargetToExtentUpdateArgs",
+    "iSCSITargetToExtentUpdateResult",
+    "iSCSITargetToExtentDeleteArgs",
+    "iSCSITargetToExtentDeleteResult",
 ]
 
 
@@ -25,11 +25,11 @@ class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
     lunid: int | None = None
 
 
-class IscsiTargetToExtentCreateArgs(BaseModel):
+class iSCSITargetToExtentCreateArgs(BaseModel):
     iscsi_target_to_extent_create: IscsiTargetToExtentCreate
 
 
-class IscsiTargetToExtentCreateResult(BaseModel):
+class iSCSITargetToExtentCreateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
@@ -37,21 +37,21 @@ class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMet
     pass
 
 
-class IscsiTargetToExtentUpdateArgs(BaseModel):
+class iSCSITargetToExtentUpdateArgs(BaseModel):
     id: int
     iscsi_target_to_extent_update: IscsiTargetToExtentUpdate
 
 
-class IscsiTargetToExtentUpdateResult(BaseModel):
+class iSCSITargetToExtentUpdateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
-class IscsiTargetToExtentDeleteArgs(BaseModel):
+class iSCSITargetToExtentDeleteArgs(BaseModel):
     id: int
     force: bool = False
 
 
-class IscsiTargetToExtentDeleteResult(BaseModel):
+class iSCSITargetToExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/k8s_to_docker.py
+++ b/src/middlewared/middlewared/api/v25_04_1/k8s_to_docker.py
@@ -4,11 +4,11 @@ from middlewared.api.base import BaseModel, single_argument_result
 
 
 __all__ = [
-    'K8sToDockerListBackupsArgs', 'K8sToDockerListBackupsResult', 'K8sToDockerMigrateArgs', 'K8sToDockerMigrateResult',
+    'K8stoDockerMigrationListBackupsArgs', 'K8stoDockerMigrationListBackupsResult', 'K8stoDockerMigrationMigrateArgs', 'K8stoDockerMigrationMigrateResult',
 ]
 
 
-class K8sToDockerListBackupsArgs(BaseModel):
+class K8stoDockerMigrationListBackupsArgs(BaseModel):
     kubernetes_pool: str
 
 
@@ -37,7 +37,7 @@ class Backups(RootModel[dict[str, BackupDetails]]):
 
 
 @single_argument_result
-class K8sToDockerListBackupsResult(BaseModel):
+class K8stoDockerMigrationListBackupsResult(BaseModel):
     error: str | None
     backups: Backups
 
@@ -46,7 +46,7 @@ class MigrateOptions(BaseModel):
     backup_name: str | None = None
 
 
-class K8sToDockerMigrateArgs(BaseModel):
+class K8stoDockerMigrationMigrateArgs(BaseModel):
     kubernetes_pool: str
     options: MigrateOptions = MigrateOptions()
 
@@ -57,5 +57,5 @@ class AppMigrationDetails(BaseModel):
     error: str | None
 
 
-class K8sToDockerMigrateResult(BaseModel):
+class K8stoDockerMigrationMigrateResult(BaseModel):
     result: list[AppMigrationDetails]

--- a/src/middlewared/middlewared/api/v25_04_1/keychain.py
+++ b/src/middlewared/middlewared/api/v25_04_1/keychain.py
@@ -11,10 +11,10 @@ __all__ = ["KeychainCredentialEntry", "SSHKeyPairEntry", "SSHCredentialsEntry",
            "KeychainCredentialUpdateArgs", "KeychainCredentialUpdateResult",
            "KeychainCredentialDeleteArgs", "KeychainCredentialDeleteResult",
            "KeychainCredentialUsedByArgs", "KeychainCredentialUsedByResult",
-           "KeychainCredentialGenerateSSHKeyPairArgs", "KeychainCredentialGenerateSSHKeyPairResult",
-           "KeychainCredentialRemoteSSHHostKeyScanArgs", "KeychainCredentialRemoteSSHHostKeyScanResult",
-           "KeychainCredentialRemoteSSHSemiautomaticSetupArgs", "KeychainCredentialRemoteSSHSemiautomaticSetupResult",
-           "KeychainCredentialSetupSSHConnectionArgs", "KeychainCredentialSetupSSHConnectionResult"]
+           "KeychainCredentialGenerateSshKeyPairArgs", "KeychainCredentialGenerateSshKeyPairResult",
+           "KeychainCredentialRemoteSshHostKeyScanArgs", "KeychainCredentialRemoteSshHostKeyScanResult",
+           "KeychainCredentialRemoteSshSemiautomaticSetupArgs", "KeychainCredentialRemoteSshSemiautomaticSetupResult",
+           "KeychainCredentialSetupSshConnectionArgs", "KeychainCredentialSetupSshConnectionResult"]
 
 
 class SSHKeyPair(BaseModel):
@@ -119,24 +119,24 @@ class KeychainCredentialUsedByResult(BaseModel):
     result: list[UsedKeychainCredential]
 
 
-class KeychainCredentialGenerateSSHKeyPairArgs(BaseModel):
+class KeychainCredentialGenerateSshKeyPairArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class KeychainCredentialGenerateSSHKeyPairResult(BaseModel):
+class KeychainCredentialGenerateSshKeyPairResult(BaseModel):
     private_key: LongString
     public_key: LongString
 
 
 @single_argument_args("keychain_remote_ssh_host_key_scan")
-class KeychainCredentialRemoteSSHHostKeyScanArgs(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanArgs(BaseModel):
     host: NonEmptyString
     port: int = 22
     connect_timeout: int = 10
 
 
-class KeychainCredentialRemoteSSHHostKeyScanResult(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanResult(BaseModel):
     result: LongString
 
 
@@ -154,11 +154,11 @@ class KeychainCredentialRemoteSSHSemiautomaticSetup(BaseModel):
     sudo: bool = False
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupArgs(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupArgs(BaseModel):
     data: KeychainCredentialRemoteSSHSemiautomaticSetup
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupResult(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupResult(BaseModel):
     result: SSHCredentialsEntry
 
 
@@ -197,12 +197,12 @@ class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
     manual_setup: Excluded = excluded_field()
 
 
-class KeychainCredentialSetupSSHConnectionArgs(BaseModel):
+class KeychainCredentialSetupSshConnectionArgs(BaseModel):
     options: Annotated[
         Union[SetupSSHConnectionManual, SetupSSHConnectionSemiautomatic],
         Discriminator("setup_type"),
     ]
 
 
-class KeychainCredentialSetupSSHConnectionResult(BaseModel):
+class KeychainCredentialSetupSshConnectionResult(BaseModel):
     result: SSHCredentialsEntry

--- a/src/middlewared/middlewared/api/v25_04_1/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_1/nfs.py
@@ -11,12 +11,12 @@ from middlewared.api.base import (
 )
 
 __all__ = ["NfsEntry",
-           "NfsUpdateArgs", "NfsUpdateResult",
-           "NfsBindipChoicesArgs", "NfsBindipChoicesResult",
+           "NFSUpdateArgs", "NFSUpdateResult",
+           "NFSBindipChoicesArgs", "NFSBindipChoicesResult",
            "NfsShareEntry",
-           "NfsShareCreateArgs", "NfsShareCreateResult",
-           "NfsShareUpdateArgs", "NfsShareUpdateResult",
-           "NfsShareDeleteArgs", "NfsShareDeleteResult"]
+           "SharingNFSCreateArgs", "SharingNFSCreateResult",
+           "SharingNFSUpdateArgs", "SharingNFSUpdateResult",
+           "SharingNFSDeleteArgs", "SharingNFSDeleteResult"]
 
 MAX_NUM_NFS_NETWORKS = 42
 MAX_NUM_NFS_HOSTS = 42
@@ -64,22 +64,22 @@ class NfsEntry(BaseModel):
 
 
 @single_argument_args('nfs_update')
-class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
+class NFSUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     managed_nfsd: Excluded = excluded_field()
     v4_krb_enabled: Excluded = excluded_field()
     keytab_has_nfs_spn: Excluded = excluded_field()
 
 
-class NfsUpdateResult(BaseModel):
+class NFSUpdateResult(BaseModel):
     result: NfsEntry
 
 
-class NfsBindipChoicesArgs(BaseModel):
+class NFSBindipChoicesArgs(BaseModel):
     pass
 
 
-class NfsBindipChoicesResult(BaseModel):
+class NFSBindipChoicesResult(BaseModel):
     """ Return a dictionary of IP addresses """
     result: dict[str, str]
 
@@ -128,11 +128,11 @@ class NfsShareCreate(NfsShareEntry):
     locked: Excluded = excluded_field()
 
 
-class NfsShareCreateArgs(BaseModel):
+class SharingNFSCreateArgs(BaseModel):
     data: NfsShareCreate
 
 
-class NfsShareCreateResult(BaseModel):
+class SharingNFSCreateResult(BaseModel):
     result: NfsShareEntry
 
 
@@ -140,18 +140,18 @@ class NfsShareUpdate(NfsShareCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class NfsShareUpdateArgs(BaseModel):
+class SharingNFSUpdateArgs(BaseModel):
     id: int
     data: NfsShareUpdate
 
 
-class NfsShareUpdateResult(BaseModel):
+class SharingNFSUpdateResult(BaseModel):
     result: NfsShareEntry
 
 
-class NfsShareDeleteArgs(BaseModel):
+class SharingNFSDeleteArgs(BaseModel):
     id: int
 
 
-class NfsShareDeleteResult(BaseModel):
+class SharingNFSDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/pool.py
+++ b/src/middlewared/middlewared/api/v25_04_1/pool.py
@@ -6,19 +6,19 @@ from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 
 
 @single_argument_args('options')
-class DDTPruneArgs(BaseModel):
+class PoolDdtPruneArgs(BaseModel):
     pool_name: NonEmptyString
     percentage: Annotated[int | None, Field(ge=1, le=100, default=None)]
     days: Annotated[int | None, Field(ge=1, default=None)]
 
 
-class DDTPruneResult(BaseModel):
+class PoolDdtPruneResult(BaseModel):
     result: None
 
 
-class DDTPrefetchArgs(BaseModel):
+class PoolDdtPrefetchArgs(BaseModel):
     pool_name: NonEmptyString
 
 
-class DDTPrefetchResult(BaseModel):
+class PoolDdtPrefetchResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_1/pool_dataset_details.py
+++ b/src/middlewared/middlewared/api/v25_04_1/pool_dataset_details.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel
 
 # from pydantic import ConfigDict, Field
 
-__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResults")
+__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResult")
 
 """
 FIXME: We need to fix the return validation
@@ -102,7 +102,7 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[PoolDatasetDetailsEntry]
 """
 
@@ -111,5 +111,5 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[dict]

--- a/src/middlewared/middlewared/api/v25_04_1/pool_snapshot_count.py
+++ b/src/middlewared/middlewared/api/v25_04_1/pool_snapshot_count.py
@@ -5,5 +5,5 @@ class PoolDatasetSnapshotCountArgs(BaseModel):
     dataset: str
 
 
-class PoolDatasetSnapshotCountResults(BaseModel):
+class PoolDatasetSnapshotCountResult(BaseModel):
     result: int

--- a/src/middlewared/middlewared/api/v25_04_1/pool_snapshottask.py
+++ b/src/middlewared/middlewared/api/v25_04_1/pool_snapshottask.py
@@ -7,13 +7,13 @@ from .common import CronModel
 
 
 __all__ = [
-    "PoolSnapshotTaskEntry", "PoolSnapshotTaskCreateArgs", "PoolSnapshotTaskCreateResult",
-    "PoolSnapshotTaskUpdateArgs", "PoolSnapshotTaskUpdateResult", "PoolSnapshotTaskDeleteArgs",
-    "PoolSnapshotTaskDeleteResult", "PoolSnapshotTaskMaxCountArgs", "PoolSnapshotTaskMaxCountResult",
-    "PoolSnapshotTaskMaxTotalCountArgs", "PoolSnapshotTaskMaxTotalCountResult", "PoolSnapshotTaskRunArgs",
-    "PoolSnapshotTaskRunResult", "PoolSnapshotTaskUpdateWillChangeRetentionForArgs",
-    "PoolSnapshotTaskUpdateWillChangeRetentionForResult", "PoolSnapshotTaskDeleteWillChangeRetentionForArgs",
-    "PoolSnapshotTaskDeleteWillChangeRetentionForResult"
+    "PoolSnapshotTaskEntry", "PeriodicSnapshotTaskCreateArgs", "PeriodicSnapshotTaskCreateResult",
+    "PeriodicSnapshotTaskUpdateArgs", "PeriodicSnapshotTaskUpdateResult", "PeriodicSnapshotTaskDeleteArgs",
+    "PeriodicSnapshotTaskDeleteResult", "PeriodicSnapshotTaskMaxCountArgs", "PeriodicSnapshotTaskMaxCountResult",
+    "PeriodicSnapshotTaskMaxTotalCountArgs", "PeriodicSnapshotTaskMaxTotalCountResult", "PeriodicSnapshotTaskRunArgs",
+    "PeriodicSnapshotTaskRunResult", "PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskUpdateWillChangeRetentionForResult", "PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskDeleteWillChangeRetentionForResult"
 ]
 
 
@@ -53,68 +53,68 @@ class PoolSnapshotTaskEntry(PoolSnapshotTaskCreate):
     state: Any
 
 
-class PoolSnapshotTaskCreateArgs(BaseModel):
+class PeriodicSnapshotTaskCreateArgs(BaseModel):
     data: PoolSnapshotTaskCreate
 
 
-class PoolSnapshotTaskCreateResult(BaseModel):
+class PeriodicSnapshotTaskCreateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskUpdateArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdate
 
 
-class PoolSnapshotTaskUpdateResult(BaseModel):
+class PeriodicSnapshotTaskUpdateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskDeleteArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteArgs(BaseModel):
     id: int
     options: PoolSnapshotTaskDeleteOptions = Field(default_factory=PoolSnapshotTaskDeleteOptions)
 
 
-class PoolSnapshotTaskDeleteResult(BaseModel):
+class PeriodicSnapshotTaskDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class PoolSnapshotTaskMaxCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskMaxTotalCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxTotalCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskRunArgs(BaseModel):
+class PeriodicSnapshotTaskRunArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskRunResult(BaseModel):
+class PeriodicSnapshotTaskRunResult(BaseModel):
     result: None
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdateWillChangeRetentionFor
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]

--- a/src/middlewared/middlewared/api/v25_04_1/privilege.py
+++ b/src/middlewared/middlewared/api/v25_04_1/privilege.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 from middlewared.utils.security import STIGType
 from .group import GroupEntry
 
-__all__ = ["PrivilegeEntry", "PrivilegeRoleEntry",
+__all__ = ["PrivilegeEntry", "PrivilegeRolesEntry",
            "PrivilegeCreateArgs", "PrivilegeCreateResult",
            "PrivilegeUpdateArgs", "PrivilegeUpdateResult",
            "PrivilegeDeleteArgs", "PrivilegeDeleteResult"]
@@ -60,7 +60,7 @@ class PrivilegeDeleteResult(BaseModel):
     result: bool
 
 
-class PrivilegeRoleEntry(BaseModel):
+class PrivilegeRolesEntry(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     includes: list[NonEmptyString]

--- a/src/middlewared/middlewared/api/v25_04_1/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_1/rdma.py
@@ -3,8 +3,8 @@ from typing import Literal
 
 __all__ = [
     "RdmaLinkConfig",
-    "RdmaCardConfigArgs", "RdmaCardConfigResult",
-    "RdmaCapableProtocolsArgs", "RdmaCapableProtocolsResult"
+    "RDMAGetCardChoicesArgs", "RDMAGetCardChoicesResult",
+    "RDMACapableProtocolsArgs", "RDMACapableProtocolsResult"
 ]
 
 
@@ -13,7 +13,7 @@ class RdmaLinkConfig(BaseModel):
     netdev: str
 
 
-class RdmaCardConfigArgs(BaseModel):
+class RDMAGetCardChoicesArgs(BaseModel):
     pass
 
 
@@ -25,13 +25,13 @@ class RdmaCardConfig(BaseModel):
     links: list[RdmaLinkConfig]
 
 
-class RdmaCardConfigResult(BaseModel):
+class RDMAGetCardChoicesResult(BaseModel):
     result: list[RdmaCardConfig]
 
 
-class RdmaCapableProtocolsArgs(BaseModel):
+class RDMACapableProtocolsArgs(BaseModel):
     pass
 
 
-class RdmaCapableProtocolsResult(BaseModel):
+class RDMACapableProtocolsResult(BaseModel):
     result: list[Literal["ISER", "NFS"]]

--- a/src/middlewared/middlewared/api/v25_04_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting.py
@@ -8,8 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraph', 'ReportingGetDataArgs',
-    'ReportingGetDataResult', 'ReportingGraphArgs', 'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult',
+    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraphsItem',
+    'ReportingNetdataGetDataArgs', 'ReportingNetdataGraphResult', 'ReportingNetdataGraphArgs',
+    'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult', 'ReportingNetdataGraphsItem',
 ]
 
 
@@ -49,7 +50,7 @@ class GraphIdentifier(BaseModel):
     identifier: NonEmptyString | None = None
 
 
-class ReportingGetDataArgs(BaseModel):
+class ReportingNetdataGetDataArgs(BaseModel):
     graphs: list[GraphIdentifier] = Field(min_length=1)
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 
@@ -70,18 +71,25 @@ class ReportingGetDataResponse(BaseModel):
     legend: list[str]
 
 
-class ReportingGetDataResult(BaseModel):
+class ReportingNetdataGraphResult(BaseModel):
     result: list[ReportingGetDataResponse]
 
 
-class ReportingGraph(BaseModel):
+class ReportingGraphsItem(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     vertical_label: NonEmptyString
     identifiers: list[str] | None
 
 
-class ReportingGraphArgs(BaseModel):
+class ReportingNetdataGraphsItem(BaseModel):
+    name: NonEmptyString
+    title: NonEmptyString
+    vertical_label: NonEmptyString
+    identifiers: list[str] | None
+
+
+class ReportingNetdataGraphArgs(BaseModel):
     str: NonEmptyString
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 

--- a/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
@@ -8,9 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingExporterEntry', 'ReportingExporterCreateArgs', 'ReportingExporterCreateResult', 'GraphiteExporter',
-    'ReportingExporterUpdateArgs', 'ReportingExporterUpdateResult', 'ReportingExporterDeleteArgs',
-    'ReportingExporterDeleteResult', 'ReportingExporterSchemasArgs', 'ReportingExporterSchemasResult',
+    'ReportingExporterEntry', 'ReportingExportsCreateArgs', 'ReportingExportsCreateResult', 'GraphiteExporter',
+    'ReportingExportsUpdateArgs', 'ReportingExportsUpdateResult', 'ReportingExportsDeleteArgs',
+    'ReportingExportsDeleteResult', 'ReportingExportsExporterSchemasArgs', 'ReportingExportsExporterSchemasResult',
 ]
 
 
@@ -41,11 +41,11 @@ class ReportingExporterEntry(BaseModel):
 
 
 @single_argument_args('reporting_exporter_create')
-class ReportingExporterCreateArgs(ReportingExporterEntry):
+class ReportingExportsCreateArgs(ReportingExporterEntry):
     id: Excluded = excluded_field()
 
 
-class ReportingExporterCreateResult(BaseModel):
+class ReportingExportsCreateResult(BaseModel):
     result: ReportingExporterEntry
 
 
@@ -53,24 +53,24 @@ class ReportingExporterUpdate(ReportingExporterEntry, metaclass=ForUpdateMetacla
     id: Excluded = excluded_field()
 
 
-class ReportingExporterUpdateArgs(BaseModel):
+class ReportingExportsUpdateArgs(BaseModel):
     id: int
     reporting_exporter_update: ReportingExporterUpdate
 
 
-class ReportingExporterUpdateResult(BaseModel):
+class ReportingExportsUpdateResult(BaseModel):
     result: ReportingExporterEntry
 
 
-class ReportingExporterDeleteArgs(BaseModel):
+class ReportingExportsDeleteArgs(BaseModel):
     id: int
 
 
-class ReportingExporterDeleteResult(BaseModel):
+class ReportingExportsDeleteResult(BaseModel):
     result: bool
 
 
-class ReportingExporterSchemasArgs(BaseModel):
+class ReportingExportsExporterSchemasArgs(BaseModel):
     pass
 
 
@@ -87,5 +87,5 @@ class ReportingExporterSchema(BaseModel):
     schema_: list[ReportingExporterAttributeSchema] = Field(alias='schema')
 
 
-class ReportingExporterSchemasResult(BaseModel):
+class ReportingExportsExporterSchemasResult(BaseModel):
     result: list[ReportingExporterSchema]

--- a/src/middlewared/middlewared/api/v25_04_1/smb.py
+++ b/src/middlewared/middlewared/api/v25_04_1/smb.py
@@ -15,12 +15,12 @@ from pydantic import Field, field_validator, IPvAnyInterface, model_validator
 from typing import Literal, Self
 
 __all__ = [
-    'GetSmbAclArgs', 'GetSmbAclResult',
-    'SetSmbAclArgs', 'SetSmbAclResult',
-    'SmbServiceEntry', 'SmbServiceUpdateArgs', 'SmbServiceUpdateResult',
-    'SmbServiceUnixCharsetChoicesArgs', 'SmbServiceUnixCharsetChoicesResult',
-    'SmbServiceBindIPChoicesArgs', 'SmbServiceBindIPChoicesResult',
-    'SmbSharePresetsArgs', 'SmbSharePresetsResult',
+    'SharingSMBGetaclArgs', 'SharingSMBGetaclResult',
+    'SharingSMBSetaclArgs', 'SharingSMBSetaclResult',
+    'SmbServiceEntry', 'SMBUpdateArgs', 'SMBUpdateResult',
+    'SMBUnixcharsetChoicesArgs', 'SMBUnixcharsetChoicesResult',
+    'SMBBindipChoicesArgs', 'SMBBindipChoicesResult',
+    'SharingSMBPresetsArgs', 'SharingSMBPresetsResult',
 ]
 
 EMPTY_STRING = ''
@@ -88,20 +88,20 @@ class SMBShareAcl(BaseModel):
 
 
 @single_argument_args('smb_setacl')
-class SetSmbAclArgs(SMBShareAcl):
+class SharingSMBSetaclArgs(SMBShareAcl):
     pass
 
 
-class SetSmbAclResult(BaseModel):
+class SharingSMBSetaclResult(BaseModel):
     result: SMBShareAcl
 
 
 @single_argument_args('smb_getacl')
-class GetSmbAclArgs(BaseModel):
+class SharingSMBGetaclArgs(BaseModel):
     share_name: NonEmptyString
 
 
-class GetSmbAclResult(SetSmbAclResult):
+class SharingSMBGetaclResult(SharingSMBSetaclResult):
     pass
 
 
@@ -171,33 +171,33 @@ class SmbServiceEntry(BaseModel):
 
 
 @single_argument_args('smb_update')
-class SmbServiceUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
+class SMBUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SmbServiceUpdateResult(BaseModel):
+class SMBUpdateResult(BaseModel):
     result: SmbServiceEntry
 
 
-class SmbServiceUnixCharsetChoicesArgs(BaseModel):
+class SMBUnixcharsetChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceUnixCharsetChoicesResult(BaseModel):
+class SMBUnixcharsetChoicesResult(BaseModel):
     result: dict[str, SMBCharsetType]
 
 
-class SmbServiceBindIPChoicesArgs(BaseModel):
+class SMBBindipChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceBindIPChoicesResult(BaseModel):
+class SMBBindipChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SmbSharePresetsArgs(BaseModel):
+class SharingSMBPresetsArgs(BaseModel):
     pass
 
 
-class SmbSharePresetsResult(BaseModel):
+class SharingSMBPresetsResult(BaseModel):
     result: dict[str, dict]

--- a/src/middlewared/middlewared/api/v25_04_1/snmp.py
+++ b/src/middlewared/middlewared/api/v25_04_1/snmp.py
@@ -8,7 +8,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["SnmpEntry",
-           "SnmpUpdateArgs", "SnmpUpdateResult"]
+           "SNMPUpdateArgs", "SNMPUpdateResult"]
 
 
 class SnmpEntry(BaseModel):
@@ -29,9 +29,9 @@ class SnmpEntry(BaseModel):
 
 
 @single_argument_args('snmp_update')
-class SnmpUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
+class SNMPUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SnmpUpdateResult(BaseModel):
+class SNMPUpdateResult(BaseModel):
     result: SnmpEntry

--- a/src/middlewared/middlewared/api/v25_04_1/system_security.py
+++ b/src/middlewared/middlewared/api/v25_04_1/system_security.py
@@ -13,8 +13,8 @@ from annotated_types import Ge, Le
 
 __all__ = [
     'SystemSecurityEntry', 'SystemSecurityUpdateArgs', 'SystemSecurityUpdateResult',
-    'SystemSecurityFipsAvailableArgs', 'SystemSecurityFipsAvailableResult',
-    'SystemSecurityFipsEnabledArgs', 'SystemSecurityFipsEnabledResult',
+    'SystemSecurityInfoFipsAvailableArgs', 'SystemSecurityInfoFipsAvailableResult',
+    'SystemSecurityInfoFipsEnabledArgs', 'SystemSecurityInfoFipsEnabledResult',
 ]
 
 
@@ -78,17 +78,17 @@ class SystemSecurityUpdateResult(BaseModel):
     result: SystemSecurityEntry
 
 
-class SystemSecurityFipsAvailableArgs(BaseModel):
+class SystemSecurityInfoFipsAvailableArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsAvailableResult(BaseModel):
+class SystemSecurityInfoFipsAvailableResult(BaseModel):
     result: bool
 
 
-class SystemSecurityFipsEnabledArgs(BaseModel):
+class SystemSecurityInfoFipsEnabledArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsEnabledResult(BaseModel):
+class SystemSecurityInfoFipsEnabledResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_1/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_04_1/tn_connect.py
@@ -5,8 +5,8 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TNCGetRegistrationURIArgs', 'TNCGetRegistrationURIResult', 'TNCUpdateArgs', 'TNCUpdateResult',
-    'TNCGenerateClaimTokenArgs', 'TNCGenerateClaimTokenResult', 'TNCIPChoicesArgs', 'TNCIPChoicesResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult', 'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
+    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult', 'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 
 
@@ -25,7 +25,7 @@ class TNCEntry(BaseModel):
 
 
 @single_argument_args('tn_connect_update')
-class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
+class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
     account_service_base_url: HttpsOnlyURL
@@ -34,29 +34,29 @@ class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     heartbeat_url: HttpsOnlyURL
 
 
-class TNCUpdateResult(BaseModel):
+class TrueNASConnectUpdateResult(BaseModel):
     result: TNCEntry
 
 
-class TNCGetRegistrationURIArgs(BaseModel):
+class TrueNASConnectGetRegistrationUriArgs(BaseModel):
     pass
 
 
-class TNCGetRegistrationURIResult(BaseModel):
+class TrueNASConnectGetRegistrationUriResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCGenerateClaimTokenArgs(BaseModel):
+class TrueNASConnectGenerateClaimTokenArgs(BaseModel):
     pass
 
 
-class TNCGenerateClaimTokenResult(BaseModel):
+class TrueNASConnectGenerateClaimTokenResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCIPChoicesArgs(BaseModel):
+class TrueNASConnectIpChoicesArgs(BaseModel):
     pass
 
 
-class TNCIPChoicesResult(BaseModel):
+class TrueNASConnectIpChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_1/truenas.py
+++ b/src/middlewared/middlewared/api/v25_04_1/truenas.py
@@ -4,10 +4,10 @@ from middlewared.api.base import BaseModel, LongString
 __all__ = [
     'TrueNASSetProductionArgs', 'TrueNASSetProductionResult',
     'TrueNASIsProductionArgs', 'TrueNASIsProductionResult',
-    'TrueNASAcceptEULAArgs', 'TrueNASAcceptEULAResult',
-    'TrueNASIsEULAAcceptedArgs', 'TrueNASIsEULAAcceptedResult',
-    'TrueNASGetEULAArgs', 'TrueNASGetEULAResult',
-    'TrueNASIsIXHardwareArgs', 'TrueNASIsIXHardwareResult',
+    'TrueNASAcceptEulaArgs', 'TrueNASAcceptEulaResult',
+    'TrueNASIsEulaAcceptedArgs', 'TrueNASIsEulaAcceptedResult',
+    'TrueNASGetEulaArgs', 'TrueNASGetEulaResult',
+    'TrueNASIsIxHardwareArgs', 'TrueNASIsIxHardwareResult',
     'TrueNASGetChassisHardwareArgs', 'TrueNASGetChassisHardwareResult',
     'TrueNASManagedByTruecommandArgs', 'TrueNASManagedByTruecommandResult'
 ]
@@ -29,35 +29,35 @@ class TrueNASGetChassisHardwareResult(BaseModel):
     result: str
 
 
-class TrueNASIsIXHardwareArgs(BaseModel):
+class TrueNASIsIxHardwareArgs(BaseModel):
     pass
 
 
-class TrueNASIsIXHardwareResult(BaseModel):
+class TrueNASIsIxHardwareResult(BaseModel):
     result: bool
 
 
-class TrueNASGetEULAArgs(BaseModel):
+class TrueNASGetEulaArgs(BaseModel):
     pass
 
 
-class TrueNASGetEULAResult(BaseModel):
+class TrueNASGetEulaResult(BaseModel):
     result: LongString | None
 
 
-class TrueNASIsEULAAcceptedArgs(BaseModel):
+class TrueNASIsEulaAcceptedArgs(BaseModel):
     pass
 
 
-class TrueNASIsEULAAcceptedResult(BaseModel):
+class TrueNASIsEulaAcceptedResult(BaseModel):
     result: bool
 
 
-class TrueNASAcceptEULAArgs(BaseModel):
+class TrueNASAcceptEulaArgs(BaseModel):
     pass
 
 
-class TrueNASAcceptEULAResult(BaseModel):
+class TrueNASAcceptEulaResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_1/virt_device.py
@@ -6,11 +6,11 @@ from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, 
 
 
 __all__ = [
-    'DeviceType', 'InstanceType', 'VirtDeviceUSBChoicesArgs', 'VirtDeviceUSBChoicesResult',
-    'VirtDeviceGPUChoicesArgs', 'VirtDeviceGPUChoicesResult', 'VirtDeviceDiskChoicesArgs',
-    'VirtDeviceDiskChoicesResult', 'VirtDeviceNICChoicesArgs', 'VirtDeviceNICChoicesResult',
+    'DeviceType', 'InstanceType', 'VirtDeviceUsbChoicesArgs', 'VirtDeviceUsbChoicesResult',
+    'VirtDeviceGpuChoicesArgs', 'VirtDeviceGpuChoicesResult', 'VirtDeviceDiskChoicesArgs',
+    'VirtDeviceDiskChoicesResult', 'VirtDeviceNicChoicesArgs', 'VirtDeviceNicChoicesResult',
     'VirtDeviceExportDiskImageArgs', 'VirtDeviceExportDiskImageResult', 'VirtDeviceImportDiskImageArgs',
-    'VirtDeviceImportDiskImageResult', 'VirtDevicePCIChoicesArgs', 'VirtDevicePCIChoicesResult',
+    'VirtDeviceImportDiskImageResult', 'VirtDevicePciChoicesArgs', 'VirtDevicePciChoicesResult',
 ]
 
 
@@ -120,7 +120,7 @@ DeviceType: TypeAlias = Annotated[
 ]
 
 
-class VirtDeviceUSBChoicesArgs(BaseModel):
+class VirtDeviceUsbChoicesArgs(BaseModel):
     pass
 
 
@@ -133,11 +133,11 @@ class USBChoice(BaseModel):
     manufacturer: str | None
 
 
-class VirtDeviceUSBChoicesResult(BaseModel):
+class VirtDeviceUsbChoicesResult(BaseModel):
     result: dict[str, USBChoice]
 
 
-class VirtDeviceGPUChoicesArgs(BaseModel):
+class VirtDeviceGpuChoicesArgs(BaseModel):
     gpu_type: GPUType
 
 
@@ -149,7 +149,7 @@ class GPUChoice(BaseModel):
     pci: str
 
 
-class VirtDeviceGPUChoicesResult(BaseModel):
+class VirtDeviceGpuChoicesResult(BaseModel):
     result: dict[str, GPUChoice]
 
 
@@ -161,11 +161,11 @@ class VirtDeviceDiskChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class VirtDeviceNICChoicesArgs(BaseModel):
+class VirtDeviceNicChoicesArgs(BaseModel):
     nic_type: NicType
 
 
-class VirtDeviceNICChoicesResult(BaseModel):
+class VirtDeviceNicChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -190,9 +190,9 @@ class VirtDeviceExportDiskImageResult(BaseModel):
     result: bool
 
 
-class VirtDevicePCIChoicesArgs(BaseModel):
+class VirtDevicePciChoicesArgs(BaseModel):
     pass
 
 
-class VirtDevicePCIChoicesResult(BaseModel):
+class VirtDevicePciChoicesResult(BaseModel):
     result: dict

--- a/src/middlewared/middlewared/api/v25_04_1/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_1/virt_instance.py
@@ -14,9 +14,9 @@ __all__ = [
     'VirtInstanceUpdateResult', 'VirtInstanceDeleteArgs', 'VirtInstanceDeleteResult',
     'VirtInstanceStartArgs', 'VirtInstanceStartResult', 'VirtInstanceStopArgs', 'VirtInstanceStopResult',
     'VirtInstanceRestartArgs', 'VirtInstanceRestartResult', 'VirtInstanceImageChoicesArgs',
-    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceListArgs', 'VirtInstanceDeviceListResult',
-    'VirtInstanceDeviceAddArgs', 'VirtInstanceDeviceAddResult', 'VirtInstanceDeviceUpdateArgs',
-    'VirtInstanceDeviceUpdateResult', 'VirtInstanceDeviceDeleteArgs', 'VirtInstanceDeviceDeleteResult',
+    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceDeviceListArgs', 'VirtInstanceDeviceDeviceListResult',
+    'VirtInstanceDeviceDeviceAddArgs', 'VirtInstanceDeviceDeviceAddResult', 'VirtInstanceDeviceDeviceUpdateArgs',
+    'VirtInstanceDeviceDeviceUpdateResult', 'VirtInstanceDeviceDeviceDeleteArgs', 'VirtInstanceDeviceDeviceDeleteResult',
 ]
 
 
@@ -278,36 +278,36 @@ class VirtInstanceImageChoicesResult(BaseModel):
     result: dict[str, ImageChoiceItem]
 
 
-class VirtInstanceDeviceListArgs(BaseModel):
+class VirtInstanceDeviceDeviceListArgs(BaseModel):
     id: str
 
 
-class VirtInstanceDeviceListResult(BaseModel):
+class VirtInstanceDeviceDeviceListResult(BaseModel):
     result: list[DeviceType]
 
 
-class VirtInstanceDeviceAddArgs(BaseModel):
+class VirtInstanceDeviceDeviceAddArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceAddResult(BaseModel):
+class VirtInstanceDeviceDeviceAddResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceUpdateArgs(BaseModel):
+class VirtInstanceDeviceDeviceUpdateArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceUpdateResult(BaseModel):
+class VirtInstanceDeviceDeviceUpdateResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceDeleteArgs(BaseModel):
+class VirtInstanceDeviceDeviceDeleteArgs(BaseModel):
     id: str
     name: str
 
 
-class VirtInstanceDeviceDeleteResult(BaseModel):
+class VirtInstanceDeviceDeviceDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_1/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_1/virt_volume.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
-    'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+    'VirtVolumeDeleteResult', 'VirtVolumeImportIsoArgs', 'VirtVolumeImportIsoResult',
     'VirtVolumeImportZvolArgs', 'VirtVolumeImportZvolResult',
 ]
 
@@ -80,7 +80,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 
 @single_argument_args('virt_volume_import_iso')
-class VirtVolumeImportISOArgs(BaseModel):
+class VirtVolumeImportIsoArgs(BaseModel):
     name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
@@ -93,7 +93,7 @@ class VirtVolumeImportISOArgs(BaseModel):
     '''
 
 
-class VirtVolumeImportISOResult(BaseModel):
+class VirtVolumeImportIsoResult(BaseModel):
     result: VirtVolumeEntry
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acl.py
@@ -26,12 +26,12 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'AclTemplateEntry',
-    'AclTemplateByPathArgs', 'AclTemplateByPathResult',
-    'AclTemplateCreateArgs', 'AclTemplateCreateResult',
-    'AclTemplateUpdateArgs', 'AclTemplateUpdateResult',
-    'AclTemplateDeleteArgs', 'AclTemplateDeleteResult',
-    'FilesystemGetAclArgs', 'FilesystemGetAclResult',
-    'FilesystemSetAclArgs', 'FilesystemSetAclResult',
+    'ACLTemplateByPathArgs', 'ACLTemplateByPathResult',
+    'ACLTemplateCreateArgs', 'ACLTemplateCreateResult',
+    'ACLTemplateUpdateArgs', 'ACLTemplateUpdateResult',
+    'ACLTemplateDeleteArgs', 'ACLTemplateDeleteResult',
+    'FilesystemGetaclArgs', 'FilesystemGetaclResult',
+    'FilesystemSetaclArgs', 'FilesystemSetaclResult',
     'NFS4ACE', 'POSIXACE',
 ]
 
@@ -207,7 +207,7 @@ class DISABLED_ACL(AclBaseInfo):
     trivial: Literal[True]
 
 
-class FilesystemGetAclArgs(BaseModel):
+class FilesystemGetaclArgs(BaseModel):
     path: NonEmptyString
     simplified: bool = True
     resolve_ids: bool = False
@@ -231,7 +231,7 @@ class DISABLED_ACLResult(DISABLED_ACL, AclBaseResult):
     pass
 
 
-class FilesystemGetAclResult(BaseModel):
+class FilesystemGetaclResult(BaseModel):
     result: NFS4ACLResult | POSIXACLResult | DISABLED_ACLResult
 
 
@@ -244,7 +244,7 @@ class FilesystemSetAclOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class FilesystemSetAclArgs(BaseModel):
+class FilesystemSetaclArgs(BaseModel):
     path: NonEmptyString
     dacl: list[NFS4ACE] | list[POSIXACE]
     options: FilesystemSetAclOptions = Field(default=FilesystemSetAclOptions())
@@ -267,7 +267,7 @@ class FilesystemSetAclArgs(BaseModel):
         return self
 
 
-class FilesystemSetAclResult(FilesystemGetAclResult):
+class FilesystemSetaclResult(FilesystemGetaclResult):
     pass
 
 
@@ -285,11 +285,11 @@ class AclTemplateCreate(AclTemplateEntry):
     builtin: Excluded = excluded_field()
 
 
-class AclTemplateCreateArgs(BaseModel):
+class ACLTemplateCreateArgs(BaseModel):
     acltemplate_create: AclTemplateCreate
 
 
-class AclTemplateCreateResult(BaseModel):
+class ACLTemplateCreateResult(BaseModel):
     result: AclTemplateEntry
 
 
@@ -297,20 +297,20 @@ class AclTemplateUpdate(AclTemplateCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class AclTemplateUpdateArgs(BaseModel):
+class ACLTemplateUpdateArgs(BaseModel):
     id: int
     acltemplate_update: AclTemplateUpdate
 
 
-class AclTemplateUpdateResult(BaseModel):
+class ACLTemplateUpdateResult(BaseModel):
     result: AclTemplateEntry
 
 
-class AclTemplateDeleteArgs(BaseModel):
+class ACLTemplateDeleteArgs(BaseModel):
     id: int
 
 
-class AclTemplateDeleteResult(BaseModel):
+class ACLTemplateDeleteResult(BaseModel):
     result: Literal[True]
 
 
@@ -321,12 +321,12 @@ class AclTemplateFormatOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class AclTemplateByPathArgs(BaseModel):
+class ACLTemplateByPathArgs(BaseModel):
     path: str = ""
     query_filters: QueryFilters = Field(alias='query-filters', default=[])
     query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
     format_options: AclTemplateFormatOptions = Field(alias='format-options', default=AclTemplateFormatOptions())
 
 
-class AclTemplateByPathResult(BaseModel):
+class ACLTemplateByPathResult(BaseModel):
     result: list[AclTemplateEntry]

--- a/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
@@ -10,9 +10,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ACMEDNSAuthenticatorEntry', 'ACMEDNSAuthenticatorCreateArgs', 'ACMEDNSAuthenticatorCreateResult',
-    'ACMEDNSAuthenticatorUpdateArgs', 'ACMEDNSAuthenticatorUpdateResult', 'ACMEDNSAuthenticatorDeleteArgs',
-    'ACMEDNSAuthenticatorDeleteResult', 'ACMEDNSAuthenticatorSchemasArgs', 'ACMEDNSAuthenticatorSchemasResult',
+    'ACMEDNSAuthenticatorEntry', 'DNSAuthenticatorCreateArgs', 'DNSAuthenticatorCreateResult',
+    'DNSAuthenticatorUpdateArgs', 'DNSAuthenticatorUpdateResult', 'DNSAuthenticatorDeleteArgs',
+    'DNSAuthenticatorDeleteResult', 'DNSAuthenticatorAuthenticatorSchemasArgs', 'DNSAuthenticatorAuthenticatorSchemasResult',
     'Route53SchemaArgs', 'ACMECustomDNSAuthenticatorReturns', 'CloudFlareSchemaArgs', 'DigitalOceanSchemaArgs',
     'OVHSchemaArgs', 'ShellSchemaArgs', 'TrueNASConnectSchemaArgs',
 ]
@@ -121,11 +121,11 @@ class ACMEDNSAuthenticatorCreate(BaseModel):
 
 
 @single_argument_args('dns_authenticator_create')
-class ACMEDNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
+class DNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
     pass
 
 
-class ACMEDNSAuthenticatorCreateResult(BaseModel):
+class DNSAuthenticatorCreateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
@@ -133,20 +133,20 @@ class ACMEDNSAuthenticatorUpdate(ACMEDNSAuthenticatorCreate, metaclass=ForUpdate
     pass
 
 
-class ACMEDNSAuthenticatorUpdateArgs(BaseModel):
+class DNSAuthenticatorUpdateArgs(BaseModel):
     id: int
     dns_authenticator_update: ACMEDNSAuthenticatorUpdate
 
 
-class ACMEDNSAuthenticatorUpdateResult(BaseModel):
+class DNSAuthenticatorUpdateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
-class ACMEDNSAuthenticatorDeleteArgs(BaseModel):
+class DNSAuthenticatorDeleteArgs(BaseModel):
     id: int
 
 
-class ACMEDNSAuthenticatorDeleteResult(BaseModel):
+class DNSAuthenticatorDeleteResult(BaseModel):
     result: bool
 
 
@@ -163,9 +163,9 @@ class ACMEDNSAuthenticatorSchema(BaseModel):
     schema_: ACMEDNSAuthenticatorAttributeSchema = Field(alias='schema')
 
 
-class ACMEDNSAuthenticatorSchemasArgs(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasArgs(BaseModel):
     pass
 
 
-class ACMEDNSAuthenticatorSchemasResult(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasResult(BaseModel):
     result: list[ACMEDNSAuthenticatorSchema]

--- a/src/middlewared/middlewared/api/v25_04_2/app.py
+++ b/src/middlewared/middlewared/api/v25_04_2/app.py
@@ -8,17 +8,17 @@ from .catalog import CatalogAppInfo
 
 
 __all__ = [
-    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableResponse',
+    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableItem',
     'AppEntry', 'AppCreateArgs', 'AppCreateResult', 'AppUpdateArgs', 'AppUpdateResult', 'AppDeleteArgs',
     'AppDeleteResult', 'AppConfigArgs', 'AppConfigResult', 'AppConvertToCustomArgs', 'AppConvertToCustomResult',
     'AppStopArgs', 'AppStopResult', 'AppStartArgs', 'AppStartResult', 'AppRedeployArgs', 'AppRedeployResult',
     'AppOutdatedDockerImagesArgs', 'AppOutdatedDockerImagesResult', 'AppPullImagesArgs', 'AppPullImagesResult',
-    'AppContainerIDArgs', 'AppContainerIDResult', 'AppContainerConsoleChoiceArgs', 'AppContainerConsoleChoiceResult',
+    'AppContainerIdsArgs', 'AppContainerIdsResult', 'AppContainerConsoleChoicesArgs', 'AppContainerConsoleChoicesResult',
     'AppCertificateChoicesArgs', 'AppCertificateChoicesResult', 'AppCertificateAuthorityArgs',
-    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIPChoicesArgs', 'AppIPChoicesResult',
+    'AppCertificateAuthorityResult', 'AppUsedPortsArgs', 'AppUsedPortsResult', 'AppIpChoicesArgs', 'AppIpChoicesResult',
     'AppAvailableSpaceArgs', 'AppAvailableSpaceResult', 'AppGpuChoicesArgs', 'AppGpuChoicesResult', 'AppRollbackArgs',
     'AppRollbackResult', 'AppRollbackVersionsArgs', 'AppRollbackVersionsResult', 'AppUpgradeArgs', 'AppUpgradeResult',
-    'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult',
+    'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult', 'AppLatestItem',
 ]
 
 
@@ -207,7 +207,7 @@ class AppContainerIDOptions(BaseModel):
     alive_only: bool = True
 
 
-class AppContainerIDArgs(BaseModel):
+class AppContainerIdsArgs(BaseModel):
     app_name: NonEmptyString
     options: AppContainerIDOptions = AppContainerIDOptions()
 
@@ -223,15 +223,15 @@ class AppContainerResponse(RootModel[dict[str, ContainerDetails]]):
     pass
 
 
-class AppContainerIDResult(BaseModel):
+class AppContainerIdsResult(BaseModel):
     result: AppContainerResponse
 
 
-class AppContainerConsoleChoiceArgs(BaseModel):
+class AppContainerConsoleChoicesArgs(BaseModel):
     app_name: NonEmptyString
 
 
-class AppContainerConsoleChoiceResult(BaseModel):
+class AppContainerConsoleChoicesResult(BaseModel):
     result: AppContainerResponse
 
 
@@ -264,11 +264,11 @@ class AppUsedPortsResult(BaseModel):
     result: list[int]
 
 
-class AppIPChoicesArgs(BaseModel):
+class AppIpChoicesArgs(BaseModel):
     pass
 
 
-class AppIPChoicesResult(BaseModel):
+class AppIpChoicesResult(BaseModel):
     result: dict[NonEmptyString, NonEmptyString]
 
 
@@ -369,10 +369,14 @@ class AppUpgradeSummaryResult(BaseModel):
     changelog: LongString | None
 
 
-class AppAvailableResponse(CatalogAppInfo):
+class AppAvailableItem(CatalogAppInfo):
     catalog: NonEmptyString
     installed: bool
     train: NonEmptyString
+
+
+class AppLatestItem(AppAvailableItem):
+    pass
 
 
 class AppCategoriesArgs(BaseModel):
@@ -389,4 +393,4 @@ class AppSimilarArgs(BaseModel):
 
 
 class AppSimilarResult(BaseModel):
-    result: list[AppAvailableResponse]
+    result: list[AppAvailableItem]

--- a/src/middlewared/middlewared/api/v25_04_2/app_image.py
+++ b/src/middlewared/middlewared/api/v25_04_2/app_image.py
@@ -3,7 +3,7 @@ from typing import Literal
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
 __all__ = [
-    'AppImageEntry', 'AppImageDockerhubRateLimitArgs', 'AppImageDockerhubRateLimitResult',
+    'AppImageEntry', 'ContainerImagesDockerhubRateLimitArgs', 'ContainerImagesDockerhubRateLimitResult',
     'AppImagePullArgs', 'AppImagePullResult', 'AppImageDeleteArgs', 'AppImageDeleteResult',
 ]
 
@@ -30,12 +30,12 @@ class AppImageEntry(BaseModel):
     parsed_repo_tags: list[AppImageParsedRepoTags] | None = None
 
 
-class AppImageDockerhubRateLimitArgs(BaseModel):
+class ContainerImagesDockerhubRateLimitArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class AppImageDockerhubRateLimitResult(BaseModel):
+class ContainerImagesDockerhubRateLimitResult(BaseModel):
     total_pull_limit: int | None = None
     '''Total pull limit for Docker Hub registry'''
     total_time_limit_in_secs: int | None = None

--- a/src/middlewared/middlewared/api/v25_04_2/app_ix_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_2/app_ix_volume.py
@@ -1,17 +1,17 @@
 from middlewared.api.base import BaseModel, NonEmptyString
 
 
-__all__ = ['AppIXVolumeEntry', 'AppIXVolumeExistsArgs', 'AppIXVolumeExistsResult']
+__all__ = ['AppsIxVolumeEntry', 'AppsIxVolumeExistsArgs', 'AppsIxVolumeExistsResult']
 
 
-class AppIXVolumeEntry(BaseModel):
+class AppsIxVolumeEntry(BaseModel):
     app_name: NonEmptyString
     name: NonEmptyString
 
 
-class AppIXVolumeExistsArgs(BaseModel):
+class AppsIxVolumeExistsArgs(BaseModel):
     name: NonEmptyString
 
 
-class AppIXVolumeExistsResult(BaseModel):
+class AppsIxVolumeExistsResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_2/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_2/auth.py
@@ -109,11 +109,11 @@ class AuthLoginExResult(BaseModel):
     result: AuthRespSuccess | AuthRespAuthErr | AuthRespExpired | AuthRespOTPRequired | AuthRespAuthRedirect
 
 
-class AuthMechChoicesArgs(BaseModel):
+class AuthMechanismChoicesArgs(BaseModel):
     pass
 
 
-class AuthMechChoicesResult(BaseModel):
+class AuthMechanismChoicesResult(BaseModel):
     result: list[str]
 
 
@@ -152,7 +152,7 @@ class TokenCredentialData(BaseCredentialData):
     username: str | None
 
 
-class AuthSessionEntry(BaseModel):
+class AuthSessionsEntry(BaseModel):
     id: str
     current: bool
     internal: bool
@@ -187,11 +187,11 @@ class AuthTerminateOtherSessionsResult(AuthTerminateSessionResult):
     result: Literal[True]
 
 
-class AuthSessionLogoutArgs(BaseModel):
+class AuthLogoutArgs(BaseModel):
     pass
 
 
-class AuthSessionLogoutResult(BaseModel):
+class AuthLogoutResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/catalog.py
+++ b/src/middlewared/middlewared/api/v25_04_2/catalog.py
@@ -8,7 +8,7 @@ from middlewared.api.base import BaseModel, ForUpdateMetaclass, NonEmptyString, 
 __all__ = [
     'CatalogEntry', 'CatalogUpdateArgs', 'CatalogUpdateResult', 'CatalogTrainsArgs', 'CatalogTrainsResult',
     'CatalogSyncArgs', 'CatalogSyncResult', 'CatalogAppInfo', 'CatalogAppsArgs', 'CatalogAppsResult',
-    'CatalogAppDetailsArgs', 'CatalogAppDetailsResult',
+    'CatalogGetAppDetailsArgs', 'CatalogGetAppDetailsResult',
 ]
 
 
@@ -115,10 +115,10 @@ class CatalogAppVersionDetails(BaseModel):
     train: NonEmptyString
 
 
-class CatalogAppDetailsArgs(BaseModel):
+class CatalogGetAppDetailsArgs(BaseModel):
     app_name: NonEmptyString
     app_version_details: CatalogAppVersionDetails
 
 
-class CatalogAppDetailsResult(BaseModel):
+class CatalogGetAppDetailsResult(BaseModel):
     result: CatalogAppInfo

--- a/src/middlewared/middlewared/api/v25_04_2/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_04_2/cloud_sync.py
@@ -7,10 +7,10 @@ from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdate
 from .cloud_sync_providers import CloudCredentialProvider
 
 __all__ = ["CloudCredentialEntry",
-           "CloudCredentialCreateArgs", "CloudCredentialCreateResult",
-           "CloudCredentialUpdateArgs", "CloudCredentialUpdateResult",
-           "CloudCredentialDeleteArgs", "CloudCredentialDeleteResult",
-           "CloudCredentialVerifyArgs", "CloudCredentialVerifyResult",
+           "CredentialsCreateArgs", "CredentialsCreateResult",
+           "CredentialsUpdateArgs", "CredentialsUpdateResult",
+           "CredentialsDeleteArgs", "CredentialsDeleteResult",
+           "CredentialsVerifyArgs", "CredentialsVerifyResult",
            "CloudSyncOneDriveListDrivesArgs", "CloudSyncOneDriveListDrivesResult"]
 
 
@@ -28,37 +28,37 @@ class CloudCredentialUpdate(CloudCredentialCreate, metaclass=ForUpdateMetaclass)
     pass
 
 
-class CloudCredentialCreateArgs(BaseModel):
+class CredentialsCreateArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialCreate
 
 
-class CloudCredentialCreateResult(BaseModel):
+class CredentialsCreateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialUpdateArgs(BaseModel):
+class CredentialsUpdateArgs(BaseModel):
     id: int
     cloud_sync_credentials_update: CloudCredentialUpdate
 
 
-class CloudCredentialUpdateResult(BaseModel):
+class CredentialsUpdateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialDeleteArgs(BaseModel):
+class CredentialsDeleteArgs(BaseModel):
     id: int
 
 
-class CloudCredentialDeleteResult(BaseModel):
+class CredentialsDeleteResult(BaseModel):
     result: bool
 
 
-class CloudCredentialVerifyArgs(BaseModel):
+class CredentialsVerifyArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialProvider
 
 
 @single_argument_result
-class CloudCredentialVerifyResult(BaseModel):
+class CredentialsVerifyResult(BaseModel):
     valid: bool
     error: LongString | None = None
     excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_04_2/crypto_cert_info.py
+++ b/src/middlewared/middlewared/api/v25_04_2/crypto_cert_info.py
@@ -1,22 +1,22 @@
 from middlewared.api.base import BaseModel
 
 __all__ = (
-    'CertificateCountryChoicesArgs',
-    'CertificateCountryChoicesResult',
+    'SystemGeneralCountryChoicesArgs',
+    'SystemGeneralCountryChoicesResult',
     'CertificateAcmeServerChoicesArgs',
     'CertificateAcmeServerChoicesResult',
-    'CertificateECCurveChoicesArgs',
-    'CertificateECCurveChoicesResult',
+    'CertificateEcCurveChoicesArgs',
+    'CertificateEcCurveChoicesResult',
     'CertificateExtendedKeyUsageChoicesArgs',
     'CertificateExtendedKeyUsageChoicesResult',
 )
 
 
-class CertificateCountryChoicesArgs(BaseModel):
+class SystemGeneralCountryChoicesArgs(BaseModel):
     pass
 
 
-class CertificateCountryChoicesResult(BaseModel):
+class SystemGeneralCountryChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -28,11 +28,11 @@ class CertificateAcmeServerChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class CertificateECCurveChoicesArgs(BaseModel):
+class CertificateEcCurveChoicesArgs(BaseModel):
     pass
 
 
-class CertificateECCurveChoicesResult(BaseModel):
+class CertificateEcCurveChoicesResult(BaseModel):
     result: dict[str, str]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_2/crypto_cert_profiles.py
@@ -8,9 +8,9 @@ __all__ = (
     "CertProfilesArgs",
     "CertProfilesModel",
     "CertProfilesResult",
-    "CSRProfilesArgs",
+    "WebUICryptoCsrProfilesArgs",
     "CSRProfilesModel",
-    "CSRProfilesResult",
+    "WebUICryptoCsrProfilesResult",
 )
 
 
@@ -167,10 +167,10 @@ class CSRProfilesModel(BaseModel):
     )
 
 
-class CSRProfilesArgs(BaseModel):
+class WebUICryptoCsrProfilesArgs(BaseModel):
     pass
 
 
 @final
-class CSRProfilesResult(BaseModel):
+class WebUICryptoCsrProfilesResult(BaseModel):
     result: CSRProfilesModel = CSRProfilesModel()

--- a/src/middlewared/middlewared/api/v25_04_2/docker.py
+++ b/src/middlewared/middlewared/api/v25_04_2/docker.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'DockerEntry', 'DockerUpdateArgs', 'DockerUpdateResult', 'DockerStatusArgs', 'DockerStatusResult',
     'DockerNvidiaPresentArgs', 'DockerNvidiaPresentResult', 'DockerBackupArgs', 'DockerBackupResult',
-    'DockerListBackupArgs', 'DockerListBackupResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
+    'DockerListBackupsArgs', 'DockerListBackupsResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
     'DockerDeleteBackupArgs', 'DockerDeleteBackupResult',
 ]
 
@@ -95,7 +95,7 @@ class DockerBackupResult(BaseModel):
     result: NonEmptyString
 
 
-class DockerListBackupArgs(BaseModel):
+class DockerListBackupsArgs(BaseModel):
     pass
 
 
@@ -117,7 +117,7 @@ class DockerBackupInfo(RootModel[dict[str, BackupInfo]]):
     pass
 
 
-class DockerListBackupResult(BaseModel):
+class DockerListBackupsResult(BaseModel):
     result: DockerBackupInfo
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/enclosure_label.py
+++ b/src/middlewared/middlewared/api/v25_04_2/enclosure_label.py
@@ -1,6 +1,6 @@
 from middlewared.api.base import BaseModel
 
-__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelUpdateResult"]
+__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelSetResult"]
 
 
 class EnclosureLabelSetArgs(BaseModel):
@@ -8,5 +8,5 @@ class EnclosureLabelSetArgs(BaseModel):
     label: str
 
 
-class EnclosureLabelUpdateResult(BaseModel):
+class EnclosureLabelSetResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_2/fcport.py
+++ b/src/middlewared/middlewared/api/v25_04_2/fcport.py
@@ -56,11 +56,11 @@ class FCPortChoiceEntry(BaseModel):
     wwpn_b: WWPN | None
 
 
-class FCPortChoicesArgs(BaseModel):
+class FCPortPortChoicesArgs(BaseModel):
     include_used: bool = True
 
 
-class FCPortChoicesResult(BaseModel):
+class FCPortPortChoicesResult(BaseModel):
     result: Dict[FibreChannelPortAlias, FCPortChoiceEntry] = Field(examples=[
         {
             'fc0': {

--- a/src/middlewared/middlewared/api/v25_04_2/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_2/filesystem.py
@@ -18,15 +18,15 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'FilesystemChownArgs', 'FilesystemChownResult',
-    'FilesystemSetPermArgs', 'FilesystemSetPermResult',
+    'FilesystemSetpermArgs', 'FilesystemSetpermResult',
     'FilesystemListdirArgs', 'FilesystemListdirResult',
     'FilesystemMkdirArgs', 'FilesystemMkdirResult',
     'FilesystemStatArgs', 'FilesystemStatResult',
     'FilesystemStatfsArgs', 'FilesystemStatfsResult',
-    'FilesystemSetZfsAttrsArgs', 'FilesystemSetZfsAttrsResult',
-    'FilesystemGetZfsAttrsArgs', 'FilesystemGetZfsAttrsResult',
-    'FilesystemGetFileArgs', 'FilesystemGetFileResult',
-    'FilesystemPutFileArgs', 'FilesystemPutFileResult',
+    'FilesystemSetZfsAttributesArgs', 'FilesystemSetZfsAttributesResult',
+    'FilesystemGetZfsAttributesArgs', 'FilesystemGetZfsAttributesResult',
+    'FilesystemGetArgs', 'FilesystemGetResult',
+    'FilesystemPutArgs', 'FilesystemPutResult',
 ]
 
 
@@ -74,7 +74,7 @@ class FilesystemChownResult(BaseModel):
 
 
 @single_argument_args('filesystem_setperm')
-class FilesystemSetPermArgs(FilesystemPermChownBase):
+class FilesystemSetpermArgs(FilesystemPermChownBase):
     mode: UnixPerm | None = None
     options: FilesystemSetpermOptions = Field(default=FilesystemSetpermOptions())
 
@@ -90,7 +90,7 @@ class FilesystemSetPermArgs(FilesystemPermChownBase):
         return self
 
 
-class FilesystemSetPermResult(BaseModel):
+class FilesystemSetpermResult(BaseModel):
     result: Literal[None]
 
 
@@ -330,28 +330,28 @@ class ZFSFileAttrsData(BaseModel):
 
 
 @single_argument_args('set_zfs_file_attributes')
-class FilesystemSetZfsAttrsArgs(BaseModel):
+class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
     zfs_file_attributes: ZFSFileAttrsData
 
 
-class FilesystemSetZfsAttrsResult(BaseModel):
+class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetZfsAttrsArgs(BaseModel):
+class FilesystemGetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetZfsAttrsResult(BaseModel):
+class FilesystemGetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetFileArgs(BaseModel):
+class FilesystemGetArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetFileResult(BaseModel):
+class FilesystemGetResult(BaseModel):
     result: Literal[None]
 
 
@@ -360,10 +360,10 @@ class FilesystemPutOptions(BaseModel):
     mode: int | None = None
 
 
-class FilesystemPutFileArgs(BaseModel):
+class FilesystemPutArgs(BaseModel):
     path: NonEmptyString
     options: FilesystemPutOptions = FilesystemPutOptions()
 
 
-class FilesystemPutFileResult(BaseModel):
+class FilesystemPutResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/ftp.py
+++ b/src/middlewared/middlewared/api/v25_04_2/ftp.py
@@ -12,7 +12,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["FtpEntry",
-           "FtpUpdateArgs", "FtpUpdateResult"]
+           "FTPUpdateArgs", "FTPUpdateResult"]
 
 TLS_PolicyOptions = Literal[
     "", "on", "off", "data", "!data", "auth", "ctrl", "ctrl+data", "ctrl+!data", "auth+data", "auth+!data"
@@ -74,9 +74,9 @@ class FtpEntry(BaseModel):
 
 
 @single_argument_args('ftp_update')
-class FtpUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
+class FTPUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class FtpUpdateResult(BaseModel):
+class FTPUpdateResult(BaseModel):
     result: FtpEntry

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_auth.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_auth.py
@@ -6,12 +6,12 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiAuthEntry",
-    "IscsiAuthCreateArgs",
-    "IscsiAuthCreateResult",
-    "IscsiAuthUpdateArgs",
-    "IscsiAuthUpdateResult",
-    "IscsiAuthDeleteArgs",
-    "IscsiAuthDeleteResult",
+    "iSCSITargetAuthCredentialCreateArgs",
+    "iSCSITargetAuthCredentialCreateResult",
+    "iSCSITargetAuthCredentialUpdateArgs",
+    "iSCSITargetAuthCredentialUpdateResult",
+    "iSCSITargetAuthCredentialDeleteArgs",
+    "iSCSITargetAuthCredentialDeleteResult",
 ]
 
 
@@ -29,11 +29,11 @@ class IscsiAuthCreate(IscsiAuthEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiAuthCreateArgs(BaseModel):
+class iSCSITargetAuthCredentialCreateArgs(BaseModel):
     data: IscsiAuthCreate
 
 
-class IscsiAuthCreateResult(BaseModel):
+class iSCSITargetAuthCredentialCreateResult(BaseModel):
     result: IscsiAuthEntry
 
 
@@ -41,18 +41,18 @@ class IscsiAuthUpdate(IscsiAuthCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiAuthUpdateArgs(BaseModel):
+class iSCSITargetAuthCredentialUpdateArgs(BaseModel):
     id: int
     data: IscsiAuthUpdate
 
 
-class IscsiAuthUpdateResult(BaseModel):
+class iSCSITargetAuthCredentialUpdateResult(BaseModel):
     result: IscsiAuthEntry
 
 
-class IscsiAuthDeleteArgs(BaseModel):
+class iSCSITargetAuthCredentialDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiAuthDeleteResult(BaseModel):
+class iSCSITargetAuthCredentialDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_extent.py
@@ -8,14 +8,14 @@ from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, Iscsi
 
 __all__ = [
     "IscsiExtentEntry",
-    "IscsiExtentCreateArgs",
-    "IscsiExtentCreateResult",
-    "IscsiExtentUpdateArgs",
-    "IscsiExtentUpdateResult",
-    "IscsiExtentDeleteArgs",
-    "IscsiExtentDeleteResult",
-    "IscsiExtentDiskChoicesArgs",
-    "IscsiExtentDiskChoicesResult",
+    "iSCSITargetExtentCreateArgs",
+    "iSCSITargetExtentCreateResult",
+    "iSCSITargetExtentUpdateArgs",
+    "iSCSITargetExtentUpdateResult",
+    "iSCSITargetExtentDeleteArgs",
+    "iSCSITargetExtentDeleteResult",
+    "iSCSITargetExtentDiskChoicesArgs",
+    "iSCSITargetExtentDiskChoicesResult",
 ]
 
 
@@ -48,11 +48,11 @@ class IscsiExtentCreate(IscsiExtentEntry):
     locked: Excluded = excluded_field()
 
 
-class IscsiExtentCreateArgs(BaseModel):
+class iSCSITargetExtentCreateArgs(BaseModel):
     iscsi_extent_create: IscsiExtentCreate
 
 
-class IscsiExtentCreateResult(BaseModel):
+class iSCSITargetExtentCreateResult(BaseModel):
     result: IscsiExtentEntry
 
 
@@ -60,28 +60,28 @@ class IscsiExtentUpdate(IscsiExtentCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiExtentUpdateArgs(BaseModel):
+class iSCSITargetExtentUpdateArgs(BaseModel):
     id: int
     iscsi_extent_update: IscsiExtentUpdate
 
 
-class IscsiExtentUpdateResult(BaseModel):
+class iSCSITargetExtentUpdateResult(BaseModel):
     result: IscsiExtentEntry
 
 
-class IscsiExtentDeleteArgs(BaseModel):
+class iSCSITargetExtentDeleteArgs(BaseModel):
     id: int
     remove: bool = False
     force: bool = False
 
 
-class IscsiExtentDeleteResult(BaseModel):
+class iSCSITargetExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class IscsiExtentDiskChoicesArgs(BaseModel):
+class iSCSITargetExtentDiskChoicesArgs(BaseModel):
     pass
 
 
-class IscsiExtentDiskChoicesResult(BaseModel):
+class iSCSITargetExtentDiskChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_global.py
@@ -6,16 +6,16 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     "IscsiGlobalEntry",
-    "IscsiGlobalUpdateArgs",
-    "IscsiGlobalUpdateResult",
-    "IscsiGlobalAluaEnabledArgs",
-    "IscsiGlobalAluaEnabledResult",
-    "IscsiGlobalISEREnabledArgs",
-    "IscsiGlobalISEREnabledResult",
-    "IscsiGlobalClientCountArgs",
-    "IscsiGlobalClientCountResult",
-    "IscsiGlobalSessionsArgs",
-    "IscsiGlobalSessionsResult"
+    "ISCSIGlobalUpdateArgs",
+    "ISCSIGlobalUpdateResult",
+    "ISCSIGlobalAluaEnabledArgs",
+    "ISCSIGlobalAluaEnabledResult",
+    "ISCSIGlobalIserEnabledArgs",
+    "ISCSIGlobalIserEnabledResult",
+    "ISCSIGlobalClientCountArgs",
+    "ISCSIGlobalClientCountResult",
+    "ISCSIGlobalSessionsArgs",
+    "ISCSIGlobalSessionsResult"
 ]
 
 
@@ -30,35 +30,35 @@ class IscsiGlobalEntry(BaseModel):
 
 
 @single_argument_args('iscsi_update')
-class IscsiGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
+class ISCSIGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class IscsiGlobalUpdateResult(BaseModel):
+class ISCSIGlobalUpdateResult(BaseModel):
     result: IscsiGlobalEntry
 
 
-class IscsiGlobalAluaEnabledArgs(BaseModel):
+class ISCSIGlobalAluaEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalAluaEnabledResult(BaseModel):
+class ISCSIGlobalAluaEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalISEREnabledArgs(BaseModel):
+class ISCSIGlobalIserEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalISEREnabledResult(BaseModel):
+class ISCSIGlobalIserEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalClientCountArgs(BaseModel):
+class ISCSIGlobalClientCountArgs(BaseModel):
     pass
 
 
-class IscsiGlobalClientCountResult(BaseModel):
+class ISCSIGlobalClientCountResult(BaseModel):
     result: int
 
 
@@ -80,9 +80,9 @@ class IscsiSession(BaseModel):
     offload: bool
 
 
-class IscsiGlobalSessionsArgs(BaseModel):
+class ISCSIGlobalSessionsArgs(BaseModel):
     query_filters: QueryFilters = []
     query_options: QueryOptions = QueryOptions()
 
 
-IscsiGlobalSessionsResult = query_result(IscsiSession)
+ISCSIGlobalSessionsResult = query_result(IscsiSession)

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_initiator.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_initiator.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiInitiatorEntry",
-    "IscsiInitiatorCreateArgs",
-    "IscsiInitiatorCreateResult",
-    "IscsiInitiatorUpdateArgs",
-    "IscsiInitiatorUpdateResult",
-    "IscsiInitiatorDeleteArgs",
-    "IscsiInitiatorDeleteResult",
+    "iSCSITargetAuthorizedInitiatorCreateArgs",
+    "iSCSITargetAuthorizedInitiatorCreateResult",
+    "iSCSITargetAuthorizedInitiatorUpdateArgs",
+    "iSCSITargetAuthorizedInitiatorUpdateResult",
+    "iSCSITargetAuthorizedInitiatorDeleteArgs",
+    "iSCSITargetAuthorizedInitiatorDeleteResult",
 ]
 
 
@@ -23,11 +23,11 @@ class IscsiInitiatorCreate(IscsiInitiatorEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiInitiatorCreateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateArgs(BaseModel):
     iscsi_initiator_create: IscsiInitiatorCreate
 
 
-class IscsiInitiatorCreateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
@@ -35,18 +35,18 @@ class IscsiInitiatorUpdate(IscsiInitiatorEntry, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiInitiatorUpdateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateArgs(BaseModel):
     id: int
     iscsi_initiator_update: IscsiInitiatorUpdate
 
 
-class IscsiInitiatorUpdateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
-class IscsiInitiatorDeleteArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiInitiatorDeleteResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_portal.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_portal.py
@@ -6,14 +6,14 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiPortalEntry",
-    "IscsiPortalListenIPChoicesArgs",
-    "IscsiPortalListenIPChoicesResult",
-    "IscsiPortalCreateArgs",
-    "IscsiPortalCreateResult",
-    "IscsiPortalUpdateArgs",
-    "IscsiPortalUpdateResult",
-    "IscsiPortalDeleteArgs",
-    "IscsiPortalDeleteResult",
+    "ISCSIPortalListenIpChoicesArgs",
+    "ISCSIPortalListenIpChoicesResult",
+    "ISCSIPortalCreateArgs",
+    "ISCSIPortalCreateResult",
+    "ISCSIPortalUpdateArgs",
+    "ISCSIPortalUpdateResult",
+    "ISCSIPortalDeleteArgs",
+    "ISCSIPortalDeleteResult",
 ]
 
 
@@ -38,11 +38,11 @@ class IscsiPortalEntry(BaseModel):
     comment: str = ''
 
 
-class IscsiPortalListenIPChoicesArgs(BaseModel):
+class ISCSIPortalListenIpChoicesArgs(BaseModel):
     pass
 
 
-class IscsiPortalListenIPChoicesResult(BaseModel):
+class ISCSIPortalListenIpChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -52,11 +52,11 @@ class IscsiPortalCreate(IscsiPortalEntry):
     listen: list[IscsiPortalIP]
 
 
-class IscsiPortalCreateArgs(BaseModel):
+class ISCSIPortalCreateArgs(BaseModel):
     iscsi_portal_create: IscsiPortalCreate
 
 
-class IscsiPortalCreateResult(BaseModel):
+class ISCSIPortalCreateResult(BaseModel):
     result: IscsiPortalEntry
 
 
@@ -64,18 +64,18 @@ class IscsiPortalUpdate(IscsiPortalCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiPortalUpdateArgs(BaseModel):
+class ISCSIPortalUpdateArgs(BaseModel):
     id: int
     iscsi_portal_update: IscsiPortalUpdate
 
 
-class IscsiPortalUpdateResult(BaseModel):
+class ISCSIPortalUpdateResult(BaseModel):
     result: IscsiPortalEntry
 
 
-class IscsiPortalDeleteArgs(BaseModel):
+class ISCSIPortalDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiPortalDeleteResult(BaseModel):
+class ISCSIPortalDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_target.py
@@ -11,14 +11,14 @@ RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 
 __all__ = [
     "IscsiTargetEntry",
-    "IscsiTargetValidateNameArgs",
-    "IscsiTargetValidateNameResult",
-    "IscsiTargetCreateArgs",
-    "IscsiTargetCreateResult",
-    "IscsiTargetUpdateArgs",
-    "IscsiTargetUpdateResult",
-    "IscsiTargetDeleteArgs",
-    "IscsiTargetDeleteResult",
+    "iSCSITargetValidateNameArgs",
+    "iSCSITargetValidateNameResult",
+    "iSCSITargetCreateArgs",
+    "iSCSITargetCreateResult",
+    "iSCSITargetUpdateArgs",
+    "iSCSITargetUpdateResult",
+    "iSCSITargetDeleteArgs",
+    "iSCSITargetDeleteResult",
 ]
 
 
@@ -51,12 +51,12 @@ class IscsiTargetEntry(BaseModel):
     iscsi_parameters: IscsiTargetParameters | None = None
 
 
-class IscsiTargetValidateNameArgs(BaseModel):
+class iSCSITargetValidateNameArgs(BaseModel):
     name: str
     existing_id: int | None = None
 
 
-class IscsiTargetValidateNameResult(BaseModel):
+class iSCSITargetValidateNameResult(BaseModel):
     result: str | None
 
 
@@ -65,11 +65,11 @@ class IscsiTargetCreate(IscsiTargetEntry):
     rel_tgt_id: Excluded = excluded_field()
 
 
-class IscsiTargetCreateArgs(BaseModel):
+class iSCSITargetCreateArgs(BaseModel):
     iscsi_target_create: IscsiTargetCreate
 
 
-class IscsiTargetCreateResult(BaseModel):
+class iSCSITargetCreateResult(BaseModel):
     result: IscsiTargetEntry
 
 
@@ -77,20 +77,20 @@ class IscsiTargetUpdate(IscsiTargetCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiTargetUpdateArgs(BaseModel):
+class iSCSITargetUpdateArgs(BaseModel):
     id: int
     iscsi_target_update: IscsiTargetUpdate
 
 
-class IscsiTargetUpdateResult(BaseModel):
+class iSCSITargetUpdateResult(BaseModel):
     result: IscsiTargetEntry
 
 
-class IscsiTargetDeleteArgs(BaseModel):
+class iSCSITargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
     delete_extents: bool = False
 
 
-class IscsiTargetDeleteResult(BaseModel):
+class iSCSITargetDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_2/iscsi_target_to_extent.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiTargetToExtentEntry",
-    "IscsiTargetToExtentCreateArgs",
-    "IscsiTargetToExtentCreateResult",
-    "IscsiTargetToExtentUpdateArgs",
-    "IscsiTargetToExtentUpdateResult",
-    "IscsiTargetToExtentDeleteArgs",
-    "IscsiTargetToExtentDeleteResult",
+    "iSCSITargetToExtentCreateArgs",
+    "iSCSITargetToExtentCreateResult",
+    "iSCSITargetToExtentUpdateArgs",
+    "iSCSITargetToExtentUpdateResult",
+    "iSCSITargetToExtentDeleteArgs",
+    "iSCSITargetToExtentDeleteResult",
 ]
 
 
@@ -25,11 +25,11 @@ class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
     lunid: int | None = None
 
 
-class IscsiTargetToExtentCreateArgs(BaseModel):
+class iSCSITargetToExtentCreateArgs(BaseModel):
     iscsi_target_to_extent_create: IscsiTargetToExtentCreate
 
 
-class IscsiTargetToExtentCreateResult(BaseModel):
+class iSCSITargetToExtentCreateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
@@ -37,21 +37,21 @@ class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMet
     pass
 
 
-class IscsiTargetToExtentUpdateArgs(BaseModel):
+class iSCSITargetToExtentUpdateArgs(BaseModel):
     id: int
     iscsi_target_to_extent_update: IscsiTargetToExtentUpdate
 
 
-class IscsiTargetToExtentUpdateResult(BaseModel):
+class iSCSITargetToExtentUpdateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
-class IscsiTargetToExtentDeleteArgs(BaseModel):
+class iSCSITargetToExtentDeleteArgs(BaseModel):
     id: int
     force: bool = False
 
 
-class IscsiTargetToExtentDeleteResult(BaseModel):
+class iSCSITargetToExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/k8s_to_docker.py
+++ b/src/middlewared/middlewared/api/v25_04_2/k8s_to_docker.py
@@ -4,11 +4,11 @@ from middlewared.api.base import BaseModel, single_argument_result
 
 
 __all__ = [
-    'K8sToDockerListBackupsArgs', 'K8sToDockerListBackupsResult', 'K8sToDockerMigrateArgs', 'K8sToDockerMigrateResult',
+    'K8stoDockerMigrationListBackupsArgs', 'K8stoDockerMigrationListBackupsResult', 'K8stoDockerMigrationMigrateArgs', 'K8stoDockerMigrationMigrateResult',
 ]
 
 
-class K8sToDockerListBackupsArgs(BaseModel):
+class K8stoDockerMigrationListBackupsArgs(BaseModel):
     kubernetes_pool: str
 
 
@@ -37,7 +37,7 @@ class Backups(RootModel[dict[str, BackupDetails]]):
 
 
 @single_argument_result
-class K8sToDockerListBackupsResult(BaseModel):
+class K8stoDockerMigrationListBackupsResult(BaseModel):
     error: str | None
     backups: Backups
 
@@ -46,7 +46,7 @@ class MigrateOptions(BaseModel):
     backup_name: str | None = None
 
 
-class K8sToDockerMigrateArgs(BaseModel):
+class K8stoDockerMigrationMigrateArgs(BaseModel):
     kubernetes_pool: str
     options: MigrateOptions = MigrateOptions()
 
@@ -57,5 +57,5 @@ class AppMigrationDetails(BaseModel):
     error: str | None
 
 
-class K8sToDockerMigrateResult(BaseModel):
+class K8stoDockerMigrationMigrateResult(BaseModel):
     result: list[AppMigrationDetails]

--- a/src/middlewared/middlewared/api/v25_04_2/keychain.py
+++ b/src/middlewared/middlewared/api/v25_04_2/keychain.py
@@ -11,10 +11,10 @@ __all__ = ["KeychainCredentialEntry", "SSHKeyPairEntry", "SSHCredentialsEntry",
            "KeychainCredentialUpdateArgs", "KeychainCredentialUpdateResult",
            "KeychainCredentialDeleteArgs", "KeychainCredentialDeleteResult",
            "KeychainCredentialUsedByArgs", "KeychainCredentialUsedByResult",
-           "KeychainCredentialGenerateSSHKeyPairArgs", "KeychainCredentialGenerateSSHKeyPairResult",
-           "KeychainCredentialRemoteSSHHostKeyScanArgs", "KeychainCredentialRemoteSSHHostKeyScanResult",
-           "KeychainCredentialRemoteSSHSemiautomaticSetupArgs", "KeychainCredentialRemoteSSHSemiautomaticSetupResult",
-           "KeychainCredentialSetupSSHConnectionArgs", "KeychainCredentialSetupSSHConnectionResult"]
+           "KeychainCredentialGenerateSshKeyPairArgs", "KeychainCredentialGenerateSshKeyPairResult",
+           "KeychainCredentialRemoteSshHostKeyScanArgs", "KeychainCredentialRemoteSshHostKeyScanResult",
+           "KeychainCredentialRemoteSshSemiautomaticSetupArgs", "KeychainCredentialRemoteSshSemiautomaticSetupResult",
+           "KeychainCredentialSetupSshConnectionArgs", "KeychainCredentialSetupSshConnectionResult"]
 
 
 class SSHKeyPair(BaseModel):
@@ -119,24 +119,24 @@ class KeychainCredentialUsedByResult(BaseModel):
     result: list[UsedKeychainCredential]
 
 
-class KeychainCredentialGenerateSSHKeyPairArgs(BaseModel):
+class KeychainCredentialGenerateSshKeyPairArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class KeychainCredentialGenerateSSHKeyPairResult(BaseModel):
+class KeychainCredentialGenerateSshKeyPairResult(BaseModel):
     private_key: LongString
     public_key: LongString
 
 
 @single_argument_args("keychain_remote_ssh_host_key_scan")
-class KeychainCredentialRemoteSSHHostKeyScanArgs(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanArgs(BaseModel):
     host: NonEmptyString
     port: int = 22
     connect_timeout: int = 10
 
 
-class KeychainCredentialRemoteSSHHostKeyScanResult(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanResult(BaseModel):
     result: LongString
 
 
@@ -154,11 +154,11 @@ class KeychainCredentialRemoteSSHSemiautomaticSetup(BaseModel):
     sudo: bool = False
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupArgs(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupArgs(BaseModel):
     data: KeychainCredentialRemoteSSHSemiautomaticSetup
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupResult(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupResult(BaseModel):
     result: SSHCredentialsEntry
 
 
@@ -197,12 +197,12 @@ class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
     manual_setup: Excluded = excluded_field()
 
 
-class KeychainCredentialSetupSSHConnectionArgs(BaseModel):
+class KeychainCredentialSetupSshConnectionArgs(BaseModel):
     options: Annotated[
         Union[SetupSSHConnectionManual, SetupSSHConnectionSemiautomatic],
         Discriminator("setup_type"),
     ]
 
 
-class KeychainCredentialSetupSSHConnectionResult(BaseModel):
+class KeychainCredentialSetupSshConnectionResult(BaseModel):
     result: SSHCredentialsEntry

--- a/src/middlewared/middlewared/api/v25_04_2/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_2/nfs.py
@@ -11,12 +11,12 @@ from middlewared.api.base import (
 )
 
 __all__ = ["NfsEntry",
-           "NfsUpdateArgs", "NfsUpdateResult",
-           "NfsBindipChoicesArgs", "NfsBindipChoicesResult",
+           "NFSUpdateArgs", "NFSUpdateResult",
+           "NFSBindipChoicesArgs", "NFSBindipChoicesResult",
            "NfsShareEntry",
-           "NfsShareCreateArgs", "NfsShareCreateResult",
-           "NfsShareUpdateArgs", "NfsShareUpdateResult",
-           "NfsShareDeleteArgs", "NfsShareDeleteResult"]
+           "SharingNFSCreateArgs", "SharingNFSCreateResult",
+           "SharingNFSUpdateArgs", "SharingNFSUpdateResult",
+           "SharingNFSDeleteArgs", "SharingNFSDeleteResult"]
 
 MAX_NUM_NFS_NETWORKS = 42
 MAX_NUM_NFS_HOSTS = 42
@@ -64,22 +64,22 @@ class NfsEntry(BaseModel):
 
 
 @single_argument_args('nfs_update')
-class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
+class NFSUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     managed_nfsd: Excluded = excluded_field()
     v4_krb_enabled: Excluded = excluded_field()
     keytab_has_nfs_spn: Excluded = excluded_field()
 
 
-class NfsUpdateResult(BaseModel):
+class NFSUpdateResult(BaseModel):
     result: NfsEntry
 
 
-class NfsBindipChoicesArgs(BaseModel):
+class NFSBindipChoicesArgs(BaseModel):
     pass
 
 
-class NfsBindipChoicesResult(BaseModel):
+class NFSBindipChoicesResult(BaseModel):
     """ Return a dictionary of IP addresses """
     result: dict[str, str]
 
@@ -128,11 +128,11 @@ class NfsShareCreate(NfsShareEntry):
     locked: Excluded = excluded_field()
 
 
-class NfsShareCreateArgs(BaseModel):
+class SharingNFSCreateArgs(BaseModel):
     data: NfsShareCreate
 
 
-class NfsShareCreateResult(BaseModel):
+class SharingNFSCreateResult(BaseModel):
     result: NfsShareEntry
 
 
@@ -140,18 +140,18 @@ class NfsShareUpdate(NfsShareCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class NfsShareUpdateArgs(BaseModel):
+class SharingNFSUpdateArgs(BaseModel):
     id: int
     data: NfsShareUpdate
 
 
-class NfsShareUpdateResult(BaseModel):
+class SharingNFSUpdateResult(BaseModel):
     result: NfsShareEntry
 
 
-class NfsShareDeleteArgs(BaseModel):
+class SharingNFSDeleteArgs(BaseModel):
     id: int
 
 
-class NfsShareDeleteResult(BaseModel):
+class SharingNFSDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/pool.py
+++ b/src/middlewared/middlewared/api/v25_04_2/pool.py
@@ -6,19 +6,19 @@ from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 
 
 @single_argument_args('options')
-class DDTPruneArgs(BaseModel):
+class PoolDdtPruneArgs(BaseModel):
     pool_name: NonEmptyString
     percentage: Annotated[int | None, Field(ge=1, le=100, default=None)]
     days: Annotated[int | None, Field(ge=1, default=None)]
 
 
-class DDTPruneResult(BaseModel):
+class PoolDdtPruneResult(BaseModel):
     result: None
 
 
-class DDTPrefetchArgs(BaseModel):
+class PoolDdtPrefetchArgs(BaseModel):
     pool_name: NonEmptyString
 
 
-class DDTPrefetchResult(BaseModel):
+class PoolDdtPrefetchResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_04_2/pool_dataset_details.py
+++ b/src/middlewared/middlewared/api/v25_04_2/pool_dataset_details.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel
 
 # from pydantic import ConfigDict, Field
 
-__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResults")
+__all__ = ("PoolDatasetDetailsArgs", "PoolDatasetDetailsResult")
 
 """
 FIXME: We need to fix the return validation
@@ -102,7 +102,7 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[PoolDatasetDetailsEntry]
 """
 
@@ -111,5 +111,5 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[dict]

--- a/src/middlewared/middlewared/api/v25_04_2/pool_snapshot_count.py
+++ b/src/middlewared/middlewared/api/v25_04_2/pool_snapshot_count.py
@@ -5,5 +5,5 @@ class PoolDatasetSnapshotCountArgs(BaseModel):
     dataset: str
 
 
-class PoolDatasetSnapshotCountResults(BaseModel):
+class PoolDatasetSnapshotCountResult(BaseModel):
     result: int

--- a/src/middlewared/middlewared/api/v25_04_2/pool_snapshottask.py
+++ b/src/middlewared/middlewared/api/v25_04_2/pool_snapshottask.py
@@ -7,13 +7,13 @@ from .common import CronModel
 
 
 __all__ = [
-    "PoolSnapshotTaskEntry", "PoolSnapshotTaskCreateArgs", "PoolSnapshotTaskCreateResult",
-    "PoolSnapshotTaskUpdateArgs", "PoolSnapshotTaskUpdateResult", "PoolSnapshotTaskDeleteArgs",
-    "PoolSnapshotTaskDeleteResult", "PoolSnapshotTaskMaxCountArgs", "PoolSnapshotTaskMaxCountResult",
-    "PoolSnapshotTaskMaxTotalCountArgs", "PoolSnapshotTaskMaxTotalCountResult", "PoolSnapshotTaskRunArgs",
-    "PoolSnapshotTaskRunResult", "PoolSnapshotTaskUpdateWillChangeRetentionForArgs",
-    "PoolSnapshotTaskUpdateWillChangeRetentionForResult", "PoolSnapshotTaskDeleteWillChangeRetentionForArgs",
-    "PoolSnapshotTaskDeleteWillChangeRetentionForResult"
+    "PoolSnapshotTaskEntry", "PeriodicSnapshotTaskCreateArgs", "PeriodicSnapshotTaskCreateResult",
+    "PeriodicSnapshotTaskUpdateArgs", "PeriodicSnapshotTaskUpdateResult", "PeriodicSnapshotTaskDeleteArgs",
+    "PeriodicSnapshotTaskDeleteResult", "PeriodicSnapshotTaskMaxCountArgs", "PeriodicSnapshotTaskMaxCountResult",
+    "PeriodicSnapshotTaskMaxTotalCountArgs", "PeriodicSnapshotTaskMaxTotalCountResult", "PeriodicSnapshotTaskRunArgs",
+    "PeriodicSnapshotTaskRunResult", "PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskUpdateWillChangeRetentionForResult", "PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskDeleteWillChangeRetentionForResult"
 ]
 
 
@@ -53,68 +53,68 @@ class PoolSnapshotTaskEntry(PoolSnapshotTaskCreate):
     state: Any
 
 
-class PoolSnapshotTaskCreateArgs(BaseModel):
+class PeriodicSnapshotTaskCreateArgs(BaseModel):
     data: PoolSnapshotTaskCreate
 
 
-class PoolSnapshotTaskCreateResult(BaseModel):
+class PeriodicSnapshotTaskCreateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskUpdateArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdate
 
 
-class PoolSnapshotTaskUpdateResult(BaseModel):
+class PeriodicSnapshotTaskUpdateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskDeleteArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteArgs(BaseModel):
     id: int
     options: PoolSnapshotTaskDeleteOptions = Field(default_factory=PoolSnapshotTaskDeleteOptions)
 
 
-class PoolSnapshotTaskDeleteResult(BaseModel):
+class PeriodicSnapshotTaskDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class PoolSnapshotTaskMaxCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskMaxTotalCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxTotalCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskRunArgs(BaseModel):
+class PeriodicSnapshotTaskRunArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskRunResult(BaseModel):
+class PeriodicSnapshotTaskRunResult(BaseModel):
     result: None
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdateWillChangeRetentionFor
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]

--- a/src/middlewared/middlewared/api/v25_04_2/privilege.py
+++ b/src/middlewared/middlewared/api/v25_04_2/privilege.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 from middlewared.utils.security import STIGType
 from .group import GroupEntry
 
-__all__ = ["PrivilegeEntry", "PrivilegeRoleEntry",
+__all__ = ["PrivilegeEntry", "PrivilegeRolesEntry",
            "PrivilegeCreateArgs", "PrivilegeCreateResult",
            "PrivilegeUpdateArgs", "PrivilegeUpdateResult",
            "PrivilegeDeleteArgs", "PrivilegeDeleteResult"]
@@ -60,7 +60,7 @@ class PrivilegeDeleteResult(BaseModel):
     result: bool
 
 
-class PrivilegeRoleEntry(BaseModel):
+class PrivilegeRolesEntry(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     includes: list[NonEmptyString]

--- a/src/middlewared/middlewared/api/v25_04_2/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_2/rdma.py
@@ -3,8 +3,8 @@ from typing import Literal
 
 __all__ = [
     "RdmaLinkConfig",
-    "RdmaCardConfigArgs", "RdmaCardConfigResult",
-    "RdmaCapableProtocolsArgs", "RdmaCapableProtocolsResult"
+    "RDMAGetCardChoicesArgs", "RDMAGetCardChoicesResult",
+    "RDMACapableProtocolsArgs", "RDMACapableProtocolsResult"
 ]
 
 
@@ -13,7 +13,7 @@ class RdmaLinkConfig(BaseModel):
     netdev: str
 
 
-class RdmaCardConfigArgs(BaseModel):
+class RDMAGetCardChoicesArgs(BaseModel):
     pass
 
 
@@ -25,13 +25,13 @@ class RdmaCardConfig(BaseModel):
     links: list[RdmaLinkConfig]
 
 
-class RdmaCardConfigResult(BaseModel):
+class RDMAGetCardChoicesResult(BaseModel):
     result: list[RdmaCardConfig]
 
 
-class RdmaCapableProtocolsArgs(BaseModel):
+class RDMACapableProtocolsArgs(BaseModel):
     pass
 
 
-class RdmaCapableProtocolsResult(BaseModel):
+class RDMACapableProtocolsResult(BaseModel):
     result: list[Literal["ISER", "NFS"]]

--- a/src/middlewared/middlewared/api/v25_04_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting.py
@@ -8,8 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraph', 'ReportingGetDataArgs',
-    'ReportingGetDataResult', 'ReportingGraphArgs', 'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult',
+    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraphsItem',
+    'ReportingNetdataGetDataArgs', 'ReportingNetdataGraphResult', 'ReportingNetdataGraphArgs',
+    'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult', 'ReportingNetdataGraphsItem',
 ]
 
 
@@ -49,7 +50,7 @@ class GraphIdentifier(BaseModel):
     identifier: NonEmptyString | None = None
 
 
-class ReportingGetDataArgs(BaseModel):
+class ReportingNetdataGetDataArgs(BaseModel):
     graphs: list[GraphIdentifier] = Field(min_length=1)
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 
@@ -70,18 +71,25 @@ class ReportingGetDataResponse(BaseModel):
     legend: list[str]
 
 
-class ReportingGetDataResult(BaseModel):
+class ReportingNetdataGraphResult(BaseModel):
     result: list[ReportingGetDataResponse]
 
 
-class ReportingGraph(BaseModel):
+class ReportingGraphsItem(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     vertical_label: NonEmptyString
     identifiers: list[str] | None
 
 
-class ReportingGraphArgs(BaseModel):
+class ReportingNetdataGraphsItem(BaseModel):
+    name: NonEmptyString
+    title: NonEmptyString
+    vertical_label: NonEmptyString
+    identifiers: list[str] | None
+
+
+class ReportingNetdataGraphArgs(BaseModel):
     str: NonEmptyString
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 

--- a/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
@@ -8,9 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingExporterEntry', 'ReportingExporterCreateArgs', 'ReportingExporterCreateResult', 'GraphiteExporter',
-    'ReportingExporterUpdateArgs', 'ReportingExporterUpdateResult', 'ReportingExporterDeleteArgs',
-    'ReportingExporterDeleteResult', 'ReportingExporterSchemasArgs', 'ReportingExporterSchemasResult',
+    'ReportingExporterEntry', 'ReportingExportsCreateArgs', 'ReportingExportsCreateResult', 'GraphiteExporter',
+    'ReportingExportsUpdateArgs', 'ReportingExportsUpdateResult', 'ReportingExportsDeleteArgs',
+    'ReportingExportsDeleteResult', 'ReportingExportsExporterSchemasArgs', 'ReportingExportsExporterSchemasResult',
 ]
 
 
@@ -41,11 +41,11 @@ class ReportingExporterEntry(BaseModel):
 
 
 @single_argument_args('reporting_exporter_create')
-class ReportingExporterCreateArgs(ReportingExporterEntry):
+class ReportingExportsCreateArgs(ReportingExporterEntry):
     id: Excluded = excluded_field()
 
 
-class ReportingExporterCreateResult(BaseModel):
+class ReportingExportsCreateResult(BaseModel):
     result: ReportingExporterEntry
 
 
@@ -53,24 +53,24 @@ class ReportingExporterUpdate(ReportingExporterEntry, metaclass=ForUpdateMetacla
     id: Excluded = excluded_field()
 
 
-class ReportingExporterUpdateArgs(BaseModel):
+class ReportingExportsUpdateArgs(BaseModel):
     id: int
     reporting_exporter_update: ReportingExporterUpdate
 
 
-class ReportingExporterUpdateResult(BaseModel):
+class ReportingExportsUpdateResult(BaseModel):
     result: ReportingExporterEntry
 
 
-class ReportingExporterDeleteArgs(BaseModel):
+class ReportingExportsDeleteArgs(BaseModel):
     id: int
 
 
-class ReportingExporterDeleteResult(BaseModel):
+class ReportingExportsDeleteResult(BaseModel):
     result: bool
 
 
-class ReportingExporterSchemasArgs(BaseModel):
+class ReportingExportsExporterSchemasArgs(BaseModel):
     pass
 
 
@@ -87,5 +87,5 @@ class ReportingExporterSchema(BaseModel):
     schema_: list[ReportingExporterAttributeSchema] = Field(alias='schema')
 
 
-class ReportingExporterSchemasResult(BaseModel):
+class ReportingExportsExporterSchemasResult(BaseModel):
     result: list[ReportingExporterSchema]

--- a/src/middlewared/middlewared/api/v25_04_2/smb.py
+++ b/src/middlewared/middlewared/api/v25_04_2/smb.py
@@ -15,12 +15,12 @@ from pydantic import Field, field_validator, IPvAnyInterface, model_validator
 from typing import Literal, Self
 
 __all__ = [
-    'GetSmbAclArgs', 'GetSmbAclResult',
-    'SetSmbAclArgs', 'SetSmbAclResult',
-    'SmbServiceEntry', 'SmbServiceUpdateArgs', 'SmbServiceUpdateResult',
-    'SmbServiceUnixCharsetChoicesArgs', 'SmbServiceUnixCharsetChoicesResult',
-    'SmbServiceBindIPChoicesArgs', 'SmbServiceBindIPChoicesResult',
-    'SmbSharePresetsArgs', 'SmbSharePresetsResult',
+    'SharingSMBGetaclArgs', 'SharingSMBGetaclResult',
+    'SharingSMBSetaclArgs', 'SharingSMBSetaclResult',
+    'SmbServiceEntry', 'SMBUpdateArgs', 'SMBUpdateResult',
+    'SMBUnixcharsetChoicesArgs', 'SMBUnixcharsetChoicesResult',
+    'SMBBindipChoicesArgs', 'SMBBindipChoicesResult',
+    'SharingSMBPresetsArgs', 'SharingSMBPresetsResult',
 ]
 
 EMPTY_STRING = ''
@@ -88,20 +88,20 @@ class SMBShareAcl(BaseModel):
 
 
 @single_argument_args('smb_setacl')
-class SetSmbAclArgs(SMBShareAcl):
+class SharingSMBSetaclArgs(SMBShareAcl):
     pass
 
 
-class SetSmbAclResult(BaseModel):
+class SharingSMBSetaclResult(BaseModel):
     result: SMBShareAcl
 
 
 @single_argument_args('smb_getacl')
-class GetSmbAclArgs(BaseModel):
+class SharingSMBGetaclArgs(BaseModel):
     share_name: NonEmptyString
 
 
-class GetSmbAclResult(SetSmbAclResult):
+class SharingSMBGetaclResult(SharingSMBSetaclResult):
     pass
 
 
@@ -171,33 +171,33 @@ class SmbServiceEntry(BaseModel):
 
 
 @single_argument_args('smb_update')
-class SmbServiceUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
+class SMBUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SmbServiceUpdateResult(BaseModel):
+class SMBUpdateResult(BaseModel):
     result: SmbServiceEntry
 
 
-class SmbServiceUnixCharsetChoicesArgs(BaseModel):
+class SMBUnixcharsetChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceUnixCharsetChoicesResult(BaseModel):
+class SMBUnixcharsetChoicesResult(BaseModel):
     result: dict[str, SMBCharsetType]
 
 
-class SmbServiceBindIPChoicesArgs(BaseModel):
+class SMBBindipChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceBindIPChoicesResult(BaseModel):
+class SMBBindipChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SmbSharePresetsArgs(BaseModel):
+class SharingSMBPresetsArgs(BaseModel):
     pass
 
 
-class SmbSharePresetsResult(BaseModel):
+class SharingSMBPresetsResult(BaseModel):
     result: dict[str, dict]

--- a/src/middlewared/middlewared/api/v25_04_2/snmp.py
+++ b/src/middlewared/middlewared/api/v25_04_2/snmp.py
@@ -8,7 +8,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["SnmpEntry",
-           "SnmpUpdateArgs", "SnmpUpdateResult"]
+           "SNMPUpdateArgs", "SNMPUpdateResult"]
 
 
 class SnmpEntry(BaseModel):
@@ -29,9 +29,9 @@ class SnmpEntry(BaseModel):
 
 
 @single_argument_args('snmp_update')
-class SnmpUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
+class SNMPUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SnmpUpdateResult(BaseModel):
+class SNMPUpdateResult(BaseModel):
     result: SnmpEntry

--- a/src/middlewared/middlewared/api/v25_04_2/system_security.py
+++ b/src/middlewared/middlewared/api/v25_04_2/system_security.py
@@ -13,8 +13,8 @@ from annotated_types import Ge, Le
 
 __all__ = [
     'SystemSecurityEntry', 'SystemSecurityUpdateArgs', 'SystemSecurityUpdateResult',
-    'SystemSecurityFipsAvailableArgs', 'SystemSecurityFipsAvailableResult',
-    'SystemSecurityFipsEnabledArgs', 'SystemSecurityFipsEnabledResult',
+    'SystemSecurityInfoFipsAvailableArgs', 'SystemSecurityInfoFipsAvailableResult',
+    'SystemSecurityInfoFipsEnabledArgs', 'SystemSecurityInfoFipsEnabledResult',
 ]
 
 
@@ -78,17 +78,17 @@ class SystemSecurityUpdateResult(BaseModel):
     result: SystemSecurityEntry
 
 
-class SystemSecurityFipsAvailableArgs(BaseModel):
+class SystemSecurityInfoFipsAvailableArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsAvailableResult(BaseModel):
+class SystemSecurityInfoFipsAvailableResult(BaseModel):
     result: bool
 
 
-class SystemSecurityFipsEnabledArgs(BaseModel):
+class SystemSecurityInfoFipsEnabledArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsEnabledResult(BaseModel):
+class SystemSecurityInfoFipsEnabledResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_04_2/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_04_2/tn_connect.py
@@ -5,8 +5,8 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TNCGetRegistrationURIArgs', 'TNCGetRegistrationURIResult', 'TNCUpdateArgs', 'TNCUpdateResult',
-    'TNCGenerateClaimTokenArgs', 'TNCGenerateClaimTokenResult', 'TNCIPChoicesArgs', 'TNCIPChoicesResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult', 'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
+    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult', 'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 
 
@@ -25,7 +25,7 @@ class TNCEntry(BaseModel):
 
 
 @single_argument_args('tn_connect_update')
-class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
+class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
     account_service_base_url: HttpsOnlyURL
@@ -34,29 +34,29 @@ class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     heartbeat_url: HttpsOnlyURL
 
 
-class TNCUpdateResult(BaseModel):
+class TrueNASConnectUpdateResult(BaseModel):
     result: TNCEntry
 
 
-class TNCGetRegistrationURIArgs(BaseModel):
+class TrueNASConnectGetRegistrationUriArgs(BaseModel):
     pass
 
 
-class TNCGetRegistrationURIResult(BaseModel):
+class TrueNASConnectGetRegistrationUriResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCGenerateClaimTokenArgs(BaseModel):
+class TrueNASConnectGenerateClaimTokenArgs(BaseModel):
     pass
 
 
-class TNCGenerateClaimTokenResult(BaseModel):
+class TrueNASConnectGenerateClaimTokenResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCIPChoicesArgs(BaseModel):
+class TrueNASConnectIpChoicesArgs(BaseModel):
     pass
 
 
-class TNCIPChoicesResult(BaseModel):
+class TrueNASConnectIpChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_04_2/truenas.py
+++ b/src/middlewared/middlewared/api/v25_04_2/truenas.py
@@ -4,10 +4,10 @@ from middlewared.api.base import BaseModel, LongString
 __all__ = [
     'TrueNASSetProductionArgs', 'TrueNASSetProductionResult',
     'TrueNASIsProductionArgs', 'TrueNASIsProductionResult',
-    'TrueNASAcceptEULAArgs', 'TrueNASAcceptEULAResult',
-    'TrueNASIsEULAAcceptedArgs', 'TrueNASIsEULAAcceptedResult',
-    'TrueNASGetEULAArgs', 'TrueNASGetEULAResult',
-    'TrueNASIsIXHardwareArgs', 'TrueNASIsIXHardwareResult',
+    'TrueNASAcceptEulaArgs', 'TrueNASAcceptEulaResult',
+    'TrueNASIsEulaAcceptedArgs', 'TrueNASIsEulaAcceptedResult',
+    'TrueNASGetEulaArgs', 'TrueNASGetEulaResult',
+    'TrueNASIsIxHardwareArgs', 'TrueNASIsIxHardwareResult',
     'TrueNASGetChassisHardwareArgs', 'TrueNASGetChassisHardwareResult',
     'TrueNASManagedByTruecommandArgs', 'TrueNASManagedByTruecommandResult'
 ]
@@ -29,35 +29,35 @@ class TrueNASGetChassisHardwareResult(BaseModel):
     result: str
 
 
-class TrueNASIsIXHardwareArgs(BaseModel):
+class TrueNASIsIxHardwareArgs(BaseModel):
     pass
 
 
-class TrueNASIsIXHardwareResult(BaseModel):
+class TrueNASIsIxHardwareResult(BaseModel):
     result: bool
 
 
-class TrueNASGetEULAArgs(BaseModel):
+class TrueNASGetEulaArgs(BaseModel):
     pass
 
 
-class TrueNASGetEULAResult(BaseModel):
+class TrueNASGetEulaResult(BaseModel):
     result: LongString | None
 
 
-class TrueNASIsEULAAcceptedArgs(BaseModel):
+class TrueNASIsEulaAcceptedArgs(BaseModel):
     pass
 
 
-class TrueNASIsEULAAcceptedResult(BaseModel):
+class TrueNASIsEulaAcceptedResult(BaseModel):
     result: bool
 
 
-class TrueNASAcceptEULAArgs(BaseModel):
+class TrueNASAcceptEulaArgs(BaseModel):
     pass
 
 
-class TrueNASAcceptEULAResult(BaseModel):
+class TrueNASAcceptEulaResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_2/virt_device.py
@@ -6,11 +6,11 @@ from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, 
 
 
 __all__ = [
-    'DeviceType', 'InstanceType', 'VirtDeviceUSBChoicesArgs', 'VirtDeviceUSBChoicesResult',
-    'VirtDeviceGPUChoicesArgs', 'VirtDeviceGPUChoicesResult', 'VirtDeviceDiskChoicesArgs',
-    'VirtDeviceDiskChoicesResult', 'VirtDeviceNICChoicesArgs', 'VirtDeviceNICChoicesResult',
+    'DeviceType', 'InstanceType', 'VirtDeviceUsbChoicesArgs', 'VirtDeviceUsbChoicesResult',
+    'VirtDeviceGpuChoicesArgs', 'VirtDeviceGpuChoicesResult', 'VirtDeviceDiskChoicesArgs',
+    'VirtDeviceDiskChoicesResult', 'VirtDeviceNicChoicesArgs', 'VirtDeviceNicChoicesResult',
     'VirtDeviceExportDiskImageArgs', 'VirtDeviceExportDiskImageResult', 'VirtDeviceImportDiskImageArgs',
-    'VirtDeviceImportDiskImageResult', 'VirtDevicePCIChoicesArgs', 'VirtDevicePCIChoicesResult',
+    'VirtDeviceImportDiskImageResult', 'VirtDevicePciChoicesArgs', 'VirtDevicePciChoicesResult',
 ]
 
 
@@ -120,7 +120,7 @@ DeviceType: TypeAlias = Annotated[
 ]
 
 
-class VirtDeviceUSBChoicesArgs(BaseModel):
+class VirtDeviceUsbChoicesArgs(BaseModel):
     pass
 
 
@@ -133,11 +133,11 @@ class USBChoice(BaseModel):
     manufacturer: str | None
 
 
-class VirtDeviceUSBChoicesResult(BaseModel):
+class VirtDeviceUsbChoicesResult(BaseModel):
     result: dict[str, USBChoice]
 
 
-class VirtDeviceGPUChoicesArgs(BaseModel):
+class VirtDeviceGpuChoicesArgs(BaseModel):
     gpu_type: GPUType
 
 
@@ -149,7 +149,7 @@ class GPUChoice(BaseModel):
     pci: str
 
 
-class VirtDeviceGPUChoicesResult(BaseModel):
+class VirtDeviceGpuChoicesResult(BaseModel):
     result: dict[str, GPUChoice]
 
 
@@ -161,11 +161,11 @@ class VirtDeviceDiskChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class VirtDeviceNICChoicesArgs(BaseModel):
+class VirtDeviceNicChoicesArgs(BaseModel):
     nic_type: NicType
 
 
-class VirtDeviceNICChoicesResult(BaseModel):
+class VirtDeviceNicChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -190,9 +190,9 @@ class VirtDeviceExportDiskImageResult(BaseModel):
     result: bool
 
 
-class VirtDevicePCIChoicesArgs(BaseModel):
+class VirtDevicePciChoicesArgs(BaseModel):
     pass
 
 
-class VirtDevicePCIChoicesResult(BaseModel):
+class VirtDevicePciChoicesResult(BaseModel):
     result: dict

--- a/src/middlewared/middlewared/api/v25_04_2/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_2/virt_instance.py
@@ -14,9 +14,9 @@ __all__ = [
     'VirtInstanceUpdateResult', 'VirtInstanceDeleteArgs', 'VirtInstanceDeleteResult',
     'VirtInstanceStartArgs', 'VirtInstanceStartResult', 'VirtInstanceStopArgs', 'VirtInstanceStopResult',
     'VirtInstanceRestartArgs', 'VirtInstanceRestartResult', 'VirtInstanceImageChoicesArgs',
-    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceListArgs', 'VirtInstanceDeviceListResult',
-    'VirtInstanceDeviceAddArgs', 'VirtInstanceDeviceAddResult', 'VirtInstanceDeviceUpdateArgs',
-    'VirtInstanceDeviceUpdateResult', 'VirtInstanceDeviceDeleteArgs', 'VirtInstanceDeviceDeleteResult',
+    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceDeviceListArgs', 'VirtInstanceDeviceDeviceListResult',
+    'VirtInstanceDeviceDeviceAddArgs', 'VirtInstanceDeviceDeviceAddResult', 'VirtInstanceDeviceDeviceUpdateArgs',
+    'VirtInstanceDeviceDeviceUpdateResult', 'VirtInstanceDeviceDeviceDeleteArgs', 'VirtInstanceDeviceDeviceDeleteResult',
 ]
 
 
@@ -278,36 +278,36 @@ class VirtInstanceImageChoicesResult(BaseModel):
     result: dict[str, ImageChoiceItem]
 
 
-class VirtInstanceDeviceListArgs(BaseModel):
+class VirtInstanceDeviceDeviceListArgs(BaseModel):
     id: str
 
 
-class VirtInstanceDeviceListResult(BaseModel):
+class VirtInstanceDeviceDeviceListResult(BaseModel):
     result: list[DeviceType]
 
 
-class VirtInstanceDeviceAddArgs(BaseModel):
+class VirtInstanceDeviceDeviceAddArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceAddResult(BaseModel):
+class VirtInstanceDeviceDeviceAddResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceUpdateArgs(BaseModel):
+class VirtInstanceDeviceDeviceUpdateArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceUpdateResult(BaseModel):
+class VirtInstanceDeviceDeviceUpdateResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceDeleteArgs(BaseModel):
+class VirtInstanceDeviceDeviceDeleteArgs(BaseModel):
     id: str
     name: str
 
 
-class VirtInstanceDeviceDeleteResult(BaseModel):
+class VirtInstanceDeviceDeviceDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_2/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_2/virt_volume.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
-    'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+    'VirtVolumeDeleteResult', 'VirtVolumeImportIsoArgs', 'VirtVolumeImportIsoResult',
     'VirtVolumeImportZvolArgs', 'VirtVolumeImportZvolResult',
 ]
 
@@ -80,7 +80,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 
 @single_argument_args('virt_volume_import_iso')
-class VirtVolumeImportISOArgs(BaseModel):
+class VirtVolumeImportIsoArgs(BaseModel):
     name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
@@ -93,7 +93,7 @@ class VirtVolumeImportISOArgs(BaseModel):
     '''
 
 
-class VirtVolumeImportISOResult(BaseModel):
+class VirtVolumeImportIsoResult(BaseModel):
     result: VirtVolumeEntry
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -25,12 +25,12 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'AclTemplateEntry',
-    'AclTemplateByPathArgs', 'AclTemplateByPathResult',
-    'AclTemplateCreateArgs', 'AclTemplateCreateResult',
-    'AclTemplateUpdateArgs', 'AclTemplateUpdateResult',
-    'AclTemplateDeleteArgs', 'AclTemplateDeleteResult',
-    'FilesystemGetAclArgs', 'FilesystemGetAclResult',
-    'FilesystemSetAclArgs', 'FilesystemSetAclResult',
+    'ACLTemplateByPathArgs', 'ACLTemplateByPathResult',
+    'ACLTemplateCreateArgs', 'ACLTemplateCreateResult',
+    'ACLTemplateUpdateArgs', 'ACLTemplateUpdateResult',
+    'ACLTemplateDeleteArgs', 'ACLTemplateDeleteResult',
+    'FilesystemGetaclArgs', 'FilesystemGetaclResult',
+    'FilesystemSetaclArgs', 'FilesystemSetaclResult',
     'NFS4ACE', 'POSIXACE',
 ]
 
@@ -206,7 +206,7 @@ class DISABLED_ACL(AclBaseInfo):
     trivial: Literal[True]
 
 
-class FilesystemGetAclArgs(BaseModel):
+class FilesystemGetaclArgs(BaseModel):
     path: NonEmptyString
     simplified: bool = True
     resolve_ids: bool = False
@@ -230,7 +230,7 @@ class DISABLED_ACLResult(DISABLED_ACL, AclBaseResult):
     pass
 
 
-class FilesystemGetAclResult(BaseModel):
+class FilesystemGetaclResult(BaseModel):
     result: NFS4ACLResult | POSIXACLResult | DISABLED_ACLResult
 
 
@@ -243,7 +243,7 @@ class FilesystemSetAclOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class FilesystemSetAclArgs(BaseModel):
+class FilesystemSetaclArgs(BaseModel):
     path: NonEmptyString
     dacl: list[NFS4ACE] | list[POSIXACE]
     options: FilesystemSetAclOptions = Field(default=FilesystemSetAclOptions())
@@ -266,7 +266,7 @@ class FilesystemSetAclArgs(BaseModel):
         return self
 
 
-class FilesystemSetAclResult(FilesystemGetAclResult):
+class FilesystemSetaclResult(FilesystemGetaclResult):
     pass
 
 
@@ -284,11 +284,11 @@ class AclTemplateCreate(AclTemplateEntry):
     builtin: Excluded = excluded_field()
 
 
-class AclTemplateCreateArgs(BaseModel):
+class ACLTemplateCreateArgs(BaseModel):
     acltemplate_create: AclTemplateCreate
 
 
-class AclTemplateCreateResult(BaseModel):
+class ACLTemplateCreateResult(BaseModel):
     result: AclTemplateEntry
 
 
@@ -296,20 +296,20 @@ class AclTemplateUpdate(AclTemplateCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class AclTemplateUpdateArgs(BaseModel):
+class ACLTemplateUpdateArgs(BaseModel):
     id: int
     acltemplate_update: AclTemplateUpdate
 
 
-class AclTemplateUpdateResult(BaseModel):
+class ACLTemplateUpdateResult(BaseModel):
     result: AclTemplateEntry
 
 
-class AclTemplateDeleteArgs(BaseModel):
+class ACLTemplateDeleteArgs(BaseModel):
     id: int
 
 
-class AclTemplateDeleteResult(BaseModel):
+class ACLTemplateDeleteResult(BaseModel):
     result: Literal[True]
 
 
@@ -320,12 +320,12 @@ class AclTemplateFormatOptions(BaseModel):
 
 
 @single_argument_args('filesystem_acl')
-class AclTemplateByPathArgs(BaseModel):
+class ACLTemplateByPathArgs(BaseModel):
     path: str = ""
     query_filters: QueryFilters = Field(alias='query-filters', default=[])
     query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
     format_options: AclTemplateFormatOptions = Field(alias='format-options', default=AclTemplateFormatOptions())
 
 
-class AclTemplateByPathResult(BaseModel):
+class ACLTemplateByPathResult(BaseModel):
     result: list[AclTemplateEntry]

--- a/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
@@ -10,9 +10,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ACMEDNSAuthenticatorEntry', 'ACMEDNSAuthenticatorCreateArgs', 'ACMEDNSAuthenticatorCreateResult',
-    'ACMEDNSAuthenticatorUpdateArgs', 'ACMEDNSAuthenticatorUpdateResult', 'ACMEDNSAuthenticatorDeleteArgs',
-    'ACMEDNSAuthenticatorDeleteResult', 'ACMEDNSAuthenticatorSchemasArgs', 'ACMEDNSAuthenticatorSchemasResult',
+    'ACMEDNSAuthenticatorEntry', 'DNSAuthenticatorCreateArgs', 'DNSAuthenticatorCreateResult',
+    'DNSAuthenticatorUpdateArgs', 'DNSAuthenticatorUpdateResult', 'DNSAuthenticatorDeleteArgs',
+    'DNSAuthenticatorDeleteResult', 'DNSAuthenticatorAuthenticatorSchemasArgs', 'DNSAuthenticatorAuthenticatorSchemasResult',
     'Route53SchemaArgs', 'ACMECustomDNSAuthenticatorReturns', 'CloudFlareSchemaArgs', 'DigitalOceanSchemaArgs',
     'OVHSchemaArgs', 'ShellSchemaArgs', 'TrueNASConnectSchemaArgs',
 ]
@@ -135,11 +135,11 @@ class ACMEDNSAuthenticatorCreate(BaseModel):
 
 
 @single_argument_args('dns_authenticator_create')
-class ACMEDNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
+class DNSAuthenticatorCreateArgs(ACMEDNSAuthenticatorCreate):
     pass
 
 
-class ACMEDNSAuthenticatorCreateResult(BaseModel):
+class DNSAuthenticatorCreateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
@@ -147,20 +147,20 @@ class ACMEDNSAuthenticatorUpdate(ACMEDNSAuthenticatorCreate, metaclass=ForUpdate
     pass
 
 
-class ACMEDNSAuthenticatorUpdateArgs(BaseModel):
+class DNSAuthenticatorUpdateArgs(BaseModel):
     id: int
     dns_authenticator_update: ACMEDNSAuthenticatorUpdate
 
 
-class ACMEDNSAuthenticatorUpdateResult(BaseModel):
+class DNSAuthenticatorUpdateResult(BaseModel):
     result: ACMEDNSAuthenticatorEntry
 
 
-class ACMEDNSAuthenticatorDeleteArgs(BaseModel):
+class DNSAuthenticatorDeleteArgs(BaseModel):
     id: int
 
 
-class ACMEDNSAuthenticatorDeleteResult(BaseModel):
+class DNSAuthenticatorDeleteResult(BaseModel):
     result: bool
 
 
@@ -177,9 +177,9 @@ class ACMEDNSAuthenticatorSchema(BaseModel):
     schema_: ACMEDNSAuthenticatorAttributeSchema = Field(alias='schema')
 
 
-class ACMEDNSAuthenticatorSchemasArgs(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasArgs(BaseModel):
     pass
 
 
-class ACMEDNSAuthenticatorSchemasResult(BaseModel):
+class DNSAuthenticatorAuthenticatorSchemasResult(BaseModel):
     result: list[ACMEDNSAuthenticatorSchema]

--- a/src/middlewared/middlewared/api/v25_10_0/app.py
+++ b/src/middlewared/middlewared/api/v25_10_0/app.py
@@ -8,18 +8,19 @@ from .catalog import CatalogAppInfo
 
 
 __all__ = [
-    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableResponse',
+    'AppCategoriesArgs', 'AppCategoriesResult', 'AppSimilarArgs', 'AppSimilarResult', 'AppAvailableItem',
     'AppEntry', 'AppCreateArgs', 'AppCreateResult', 'AppUpdateArgs', 'AppUpdateResult', 'AppDeleteArgs',
     'AppDeleteResult', 'AppConfigArgs', 'AppConfigResult', 'AppConvertToCustomArgs', 'AppConvertToCustomResult',
     'AppStopArgs', 'AppStopResult', 'AppStartArgs', 'AppStartResult', 'AppRedeployArgs', 'AppRedeployResult',
     'AppOutdatedDockerImagesArgs', 'AppOutdatedDockerImagesResult', 'AppPullImagesArgs', 'AppPullImagesResult',
-    'AppContainerIDArgs', 'AppContainerIDResult', 'AppContainerConsoleChoiceArgs', 'AppContainerConsoleChoiceResult',
+    'AppContainerIdsArgs', 'AppContainerIdsResult', 'AppContainerConsoleChoicesArgs', 'AppContainerConsoleChoicesResult',
     'AppCertificateChoicesArgs', 'AppCertificateChoicesResult', 'AppUsedPortsArgs', 'AppUsedPortsResult',
-    'AppIPChoicesArgs', 'AppIPChoicesResult', 'AppAvailableSpaceArgs', 'AppAvailableSpaceResult',
+    'AppIpChoicesArgs', 'AppIpChoicesResult', 'AppAvailableSpaceArgs', 'AppAvailableSpaceResult',
     'AppGpuChoicesArgs', 'AppGpuChoicesResult', 'AppRollbackArgs',
     'AppRollbackResult', 'AppRollbackVersionsArgs', 'AppRollbackVersionsResult', 'AppUpgradeArgs', 'AppUpgradeResult',
     'AppUpgradeSummaryArgs', 'AppUpgradeSummaryResult', 'AppContainerLogsFollowTailEventSourceArgs',
     'AppContainerLogsFollowTailEventSourceEvent', 'AppStatsEventSourceArgs', 'AppStatsEventSourceEvent',
+    'AppLatestItem',
 ]
 
 
@@ -208,7 +209,7 @@ class AppContainerIDOptions(BaseModel):
     alive_only: bool = True
 
 
-class AppContainerIDArgs(BaseModel):
+class AppContainerIdsArgs(BaseModel):
     app_name: NonEmptyString
     options: AppContainerIDOptions = AppContainerIDOptions()
 
@@ -224,15 +225,15 @@ class AppContainerResponse(RootModel[dict[str, ContainerDetails]]):
     pass
 
 
-class AppContainerIDResult(BaseModel):
+class AppContainerIdsResult(BaseModel):
     result: AppContainerResponse
 
 
-class AppContainerConsoleChoiceArgs(BaseModel):
+class AppContainerConsoleChoicesArgs(BaseModel):
     app_name: NonEmptyString
 
 
-class AppContainerConsoleChoiceResult(BaseModel):
+class AppContainerConsoleChoicesResult(BaseModel):
     result: AppContainerResponse
 
 
@@ -257,11 +258,11 @@ class AppUsedPortsResult(BaseModel):
     result: list[int]
 
 
-class AppIPChoicesArgs(BaseModel):
+class AppIpChoicesArgs(BaseModel):
     pass
 
 
-class AppIPChoicesResult(BaseModel):
+class AppIpChoicesResult(BaseModel):
     result: dict[NonEmptyString, NonEmptyString]
 
 
@@ -362,11 +363,15 @@ class AppUpgradeSummaryResult(BaseModel):
     changelog: LongString | None
 
 
-class AppAvailableResponse(CatalogAppInfo):
+class AppAvailableItem(CatalogAppInfo):
     catalog: NonEmptyString
     installed: bool
     train: NonEmptyString
     popularity_rank: int | None
+
+
+class AppLatestItem(AppAvailableItem):
+    pass
 
 
 class AppCategoriesArgs(BaseModel):
@@ -383,7 +388,7 @@ class AppSimilarArgs(BaseModel):
 
 
 class AppSimilarResult(BaseModel):
-    result: list[AppAvailableResponse]
+    result: list[AppAvailableItem]
 
 
 class AppContainerLogsFollowTailEventSourceArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/app_image.py
+++ b/src/middlewared/middlewared/api/v25_10_0/app_image.py
@@ -3,7 +3,7 @@ from typing import Literal
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
 __all__ = [
-    'AppImageEntry', 'AppImageDockerhubRateLimitArgs', 'AppImageDockerhubRateLimitResult',
+    'AppImageEntry', 'ContainerImagesDockerhubRateLimitArgs', 'ContainerImagesDockerhubRateLimitResult',
     'AppImagePullArgs', 'AppImagePullResult', 'AppImageDeleteArgs', 'AppImageDeleteResult',
 ]
 
@@ -30,12 +30,12 @@ class AppImageEntry(BaseModel):
     parsed_repo_tags: list[AppImageParsedRepoTags] | None = None
 
 
-class AppImageDockerhubRateLimitArgs(BaseModel):
+class ContainerImagesDockerhubRateLimitArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class AppImageDockerhubRateLimitResult(BaseModel):
+class ContainerImagesDockerhubRateLimitResult(BaseModel):
     total_pull_limit: int | None = None
     '''Total pull limit for Docker Hub registry'''
     total_time_limit_in_secs: int | None = None

--- a/src/middlewared/middlewared/api/v25_10_0/app_ix_volume.py
+++ b/src/middlewared/middlewared/api/v25_10_0/app_ix_volume.py
@@ -1,17 +1,17 @@
 from middlewared.api.base import BaseModel, NonEmptyString
 
 
-__all__ = ['AppIXVolumeEntry', 'AppIXVolumeExistsArgs', 'AppIXVolumeExistsResult']
+__all__ = ['AppsIxVolumeEntry', 'AppsIxVolumeExistsArgs', 'AppsIxVolumeExistsResult']
 
 
-class AppIXVolumeEntry(BaseModel):
+class AppsIxVolumeEntry(BaseModel):
     app_name: NonEmptyString
     name: NonEmptyString
 
 
-class AppIXVolumeExistsArgs(BaseModel):
+class AppsIxVolumeExistsArgs(BaseModel):
     name: NonEmptyString
 
 
-class AppIXVolumeExistsResult(BaseModel):
+class AppsIxVolumeExistsResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_10_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_10_0/auth.py
@@ -9,11 +9,11 @@ from .user import UserGetUserObj
 
 
 __all__ = [
-    'AuthSessionEntry', 'AuthGenerateOnetimePasswordArgs', 'AuthGenerateOnetimePasswordResult',
+    'AuthSessionsEntry', 'AuthGenerateOnetimePasswordArgs', 'AuthGenerateOnetimePasswordResult',
     'AuthGenerateTokenArgs', 'AuthGenerateTokenResult', 'AuthLoginArgs', 'AuthLoginResult', 'AuthLoginExArgs',
     'AuthLoginExResult', 'AuthLoginExContinueArgs', 'AuthLoginExContinueResult', 'AuthLoginWithApiKeyArgs',
     'AuthLoginWithApiKeyResult', 'AuthLoginWithTokenArgs', 'AuthLoginWithTokenResult', 'AuthMeArgs', 'AuthMeResult',
-    'AuthMechChoicesArgs', 'AuthMechChoicesResult', 'AuthSessionLogoutArgs', 'AuthSessionLogoutResult',
+    'AuthMechanismChoicesArgs', 'AuthMechanismChoicesResult', 'AuthLogoutArgs', 'AuthLogoutResult',
     'AuthSetAttributeArgs', 'AuthSetAttributeResult', 'AuthTerminateOtherSessionsArgs',
     'AuthTerminateOtherSessionsResult', 'AuthTerminateSessionArgs', 'AuthTerminateSessionResult',
 ]
@@ -42,7 +42,7 @@ class TokenCredentialData(BaseCredentialData):
     username: str | None
 
 
-class AuthSessionEntry(BaseModel):
+class AuthSessionsEntry(BaseModel):
     id: str
     current: bool
     internal: bool
@@ -212,19 +212,19 @@ class AuthMeResult(AuthUserInfo):
     pass
 
 
-class AuthMechChoicesArgs(BaseModel):
+class AuthMechanismChoicesArgs(BaseModel):
     pass
 
 
-class AuthMechChoicesResult(BaseModel):
+class AuthMechanismChoicesResult(BaseModel):
     result: list[str]
 
 
-class AuthSessionLogoutArgs(BaseModel):
+class AuthLogoutArgs(BaseModel):
     pass
 
 
-class AuthSessionLogoutResult(BaseModel):
+class AuthLogoutResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/catalog.py
+++ b/src/middlewared/middlewared/api/v25_10_0/catalog.py
@@ -8,7 +8,7 @@ from middlewared.api.base import BaseModel, ForUpdateMetaclass, NonEmptyString, 
 __all__ = [
     'CatalogEntry', 'CatalogUpdateArgs', 'CatalogUpdateResult', 'CatalogTrainsArgs', 'CatalogTrainsResult',
     'CatalogSyncArgs', 'CatalogSyncResult', 'CatalogAppInfo', 'CatalogAppsArgs', 'CatalogAppsResult',
-    'CatalogAppDetailsArgs', 'CatalogAppDetailsResult',
+    'CatalogGetAppDetailsArgs', 'CatalogGetAppDetailsResult',
 ]
 
 
@@ -115,10 +115,10 @@ class CatalogAppVersionDetails(BaseModel):
     train: NonEmptyString
 
 
-class CatalogAppDetailsArgs(BaseModel):
+class CatalogGetAppDetailsArgs(BaseModel):
     app_name: NonEmptyString
     app_version_details: CatalogAppVersionDetails
 
 
-class CatalogAppDetailsResult(BaseModel):
+class CatalogGetAppDetailsResult(BaseModel):
     result: CatalogAppInfo

--- a/src/middlewared/middlewared/api/v25_10_0/cloud_credential.py
+++ b/src/middlewared/middlewared/api/v25_10_0/cloud_credential.py
@@ -3,10 +3,10 @@ from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdate
 from .cloud_sync_providers import CloudCredentialProvider
 
 __all__ = ["CloudCredentialEntry",
-           "CloudCredentialCreateArgs", "CloudCredentialCreateResult",
-           "CloudCredentialUpdateArgs", "CloudCredentialUpdateResult",
-           "CloudCredentialDeleteArgs", "CloudCredentialDeleteResult",
-           "CloudCredentialVerifyArgs", "CloudCredentialVerifyResult"]
+           "CredentialsCreateArgs", "CredentialsCreateResult",
+           "CredentialsUpdateArgs", "CredentialsUpdateResult",
+           "CredentialsDeleteArgs", "CredentialsDeleteResult",
+           "CredentialsVerifyArgs", "CredentialsVerifyResult"]
 
 
 class CloudCredentialEntry(BaseModel):
@@ -23,37 +23,37 @@ class CloudCredentialUpdate(CloudCredentialCreate, metaclass=ForUpdateMetaclass)
     pass
 
 
-class CloudCredentialCreateArgs(BaseModel):
+class CredentialsCreateArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialCreate
 
 
-class CloudCredentialCreateResult(BaseModel):
+class CredentialsCreateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialUpdateArgs(BaseModel):
+class CredentialsUpdateArgs(BaseModel):
     id: int
     cloud_sync_credentials_update: CloudCredentialUpdate
 
 
-class CloudCredentialUpdateResult(BaseModel):
+class CredentialsUpdateResult(BaseModel):
     result: CloudCredentialEntry
 
 
-class CloudCredentialDeleteArgs(BaseModel):
+class CredentialsDeleteArgs(BaseModel):
     id: int
 
 
-class CloudCredentialDeleteResult(BaseModel):
+class CredentialsDeleteResult(BaseModel):
     result: bool
 
 
-class CloudCredentialVerifyArgs(BaseModel):
+class CredentialsVerifyArgs(BaseModel):
     cloud_sync_credentials_create: CloudCredentialProvider
 
 
 @single_argument_result
-class CloudCredentialVerifyResult(BaseModel):
+class CredentialsVerifyResult(BaseModel):
     valid: bool
     error: LongString | None = None
     excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_10_0/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_10_0/cloud_sync.py
@@ -19,8 +19,8 @@ __all__ = [
     "CloudSyncEntry",
     "CloudSyncCreateArgs",
     "CloudSyncCreateResult",
-    "CloudSyncCrudRestoreArgs",
-    "CloudSyncCrudRestoreResult",
+    "CloudSyncRestoreArgs",
+    "CloudSyncRestoreResult",
     "CloudSyncUpdateArgs",
     "CloudSyncUpdateResult",
     "CloudSyncDeleteArgs",
@@ -33,8 +33,8 @@ __all__ = [
     "CloudSyncListDirectoryResult",
     "CloudSyncSyncArgs",
     "CloudSyncSyncResult",
-    "CloudSyncSyncOneTimeArgs",
-    "CloudSyncSyncOneTimeResult",
+    "CloudSyncSyncOnetimeArgs",
+    "CloudSyncSyncOnetimeResult",
     "CloudSyncAbortArgs",
     "CloudSyncAbortResult",
     "CloudSyncProvidersArgs",
@@ -87,12 +87,12 @@ class RestoreOpts(BaseModel):
     path: NonEmptyString
 
 
-class CloudSyncCrudRestoreArgs(BaseModel):
+class CloudSyncRestoreArgs(BaseModel):
     id: int
     opts: RestoreOpts
 
 
-class CloudSyncCrudRestoreResult(BaseModel):
+class CloudSyncRestoreResult(BaseModel):
     result: CloudSyncEntry
 
 
@@ -164,14 +164,14 @@ class CloudSyncSyncResult(BaseModel):
     result: None
 
 
-class CloudSyncSyncOneTimeArgs(BaseModel):
+class CloudSyncSyncOnetimeArgs(BaseModel):
     cloud_sync_sync_onetime: CloudSyncCreate
     cloud_sync_sync_onetime_options: CloudSyncSyncOptions = Field(
         default_factory=CloudSyncSyncOptions
     )
 
 
-class CloudSyncSyncOneTimeResult(BaseModel):
+class CloudSyncSyncOnetimeResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/crypto_cert_info.py
+++ b/src/middlewared/middlewared/api/v25_10_0/crypto_cert_info.py
@@ -5,8 +5,8 @@ __all__ = (
     'CertificateCountryChoicesResult',
     'CertificateAcmeServerChoicesArgs',
     'CertificateAcmeServerChoicesResult',
-    'CertificateECCurveChoicesArgs',
-    'CertificateECCurveChoicesResult',
+    'CertificateEcCurveChoicesArgs',
+    'CertificateEcCurveChoicesResult',
     'CertificateExtendedKeyUsageChoicesArgs',
     'CertificateExtendedKeyUsageChoicesResult',
 )
@@ -28,11 +28,11 @@ class CertificateAcmeServerChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class CertificateECCurveChoicesArgs(BaseModel):
+class CertificateEcCurveChoicesArgs(BaseModel):
     pass
 
 
-class CertificateECCurveChoicesResult(BaseModel):
+class CertificateEcCurveChoicesResult(BaseModel):
     result: dict[str, str]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_10_0/crypto_cert_profiles.py
@@ -5,9 +5,9 @@ from middlewared.api.base import BaseModel
 from pydantic import Field
 
 __all__ = (
-    "CSRProfilesArgs",
+    "WebUICryptoCsrProfilesArgs",
     "CSRProfilesModel",
-    "CSRProfilesResult",
+    "WebUICryptoCsrProfilesResult",
 )
 
 
@@ -104,10 +104,10 @@ class CSRProfilesModel(BaseModel):
     )
 
 
-class CSRProfilesArgs(BaseModel):
+class WebUICryptoCsrProfilesArgs(BaseModel):
     pass
 
 
 @final
-class CSRProfilesResult(BaseModel):
+class WebUICryptoCsrProfilesResult(BaseModel):
     result: CSRProfilesModel = CSRProfilesModel()

--- a/src/middlewared/middlewared/api/v25_10_0/docker.py
+++ b/src/middlewared/middlewared/api/v25_10_0/docker.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'DockerEntry', 'DockerUpdateArgs', 'DockerUpdateResult', 'DockerStatusArgs', 'DockerStatusResult',
     'DockerNvidiaPresentArgs', 'DockerNvidiaPresentResult', 'DockerBackupArgs', 'DockerBackupResult',
-    'DockerListBackupArgs', 'DockerListBackupResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
+    'DockerListBackupsArgs', 'DockerListBackupsResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
     'DockerDeleteBackupArgs', 'DockerDeleteBackupResult', 'DockerBackupToPoolArgs', 'DockerBackupToPoolResult',
 ]
 
@@ -102,7 +102,7 @@ class DockerBackupResult(BaseModel):
     result: NonEmptyString
 
 
-class DockerListBackupArgs(BaseModel):
+class DockerListBackupsArgs(BaseModel):
     pass
 
 
@@ -124,7 +124,7 @@ class DockerBackupInfo(RootModel[dict[str, BackupInfo]]):
     pass
 
 
-class DockerListBackupResult(BaseModel):
+class DockerListBackupsResult(BaseModel):
     result: DockerBackupInfo
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/enclosure_label.py
+++ b/src/middlewared/middlewared/api/v25_10_0/enclosure_label.py
@@ -1,6 +1,6 @@
 from middlewared.api.base import BaseModel
 
-__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelUpdateResult"]
+__all__ = ["EnclosureLabelSetArgs", "EnclosureLabelSetResult"]
 
 
 class EnclosureLabelSetArgs(BaseModel):
@@ -8,5 +8,5 @@ class EnclosureLabelSetArgs(BaseModel):
     label: str
 
 
-class EnclosureLabelUpdateResult(BaseModel):
+class EnclosureLabelSetResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_10_0/failover_disabled_reasons.py
+++ b/src/middlewared/middlewared/api/v25_10_0/failover_disabled_reasons.py
@@ -1,12 +1,12 @@
 from middlewared.api.base import BaseModel
 
 
-__all__ = ["FailoverDisabledReasonsArgs", "FailoverDisabledReasonsResult"]
+__all__ = ["FailoverDisabledReasonsReasonsArgs", "FailoverDisabledReasonsReasonsResult"]
 
 
-class FailoverDisabledReasonsArgs(BaseModel):
+class FailoverDisabledReasonsReasonsArgs(BaseModel):
     pass
 
 
-class FailoverDisabledReasonsResult(BaseModel):
+class FailoverDisabledReasonsReasonsResult(BaseModel):
     result: list[str]

--- a/src/middlewared/middlewared/api/v25_10_0/fcport.py
+++ b/src/middlewared/middlewared/api/v25_10_0/fcport.py
@@ -8,7 +8,7 @@ from .common import QueryArgs
 
 __all__ = [
     "FCPortEntry", "FCPortCreateArgs", "FCPortCreateResult", "FCPortUpdateArgs", "FCPortUpdateResult",
-    "FCPortDeleteArgs", "FCPortDeleteResult", "FCPortChoicesArgs", "FCPortChoicesResult", "FCPortStatusArgs",
+    "FCPortDeleteArgs", "FCPortDeleteResult", "FCPortPortChoicesArgs", "FCPortPortChoicesResult", "FCPortStatusArgs",
     "FCPortStatusResult",
 ]
 
@@ -63,11 +63,11 @@ class FCPortChoiceEntry(BaseModel):
     wwpn_b: WWPN | None
 
 
-class FCPortChoicesArgs(BaseModel):
+class FCPortPortChoicesArgs(BaseModel):
     include_used: bool = True
 
 
-class FCPortChoicesResult(BaseModel):
+class FCPortPortChoicesResult(BaseModel):
     result: dict[FibreChannelPortAlias, FCPortChoiceEntry] = Field(examples=[
         {
             'fc0': {

--- a/src/middlewared/middlewared/api/v25_10_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_10_0/filesystem.py
@@ -19,15 +19,15 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'FilesystemChownArgs', 'FilesystemChownResult',
-    'FilesystemSetPermArgs', 'FilesystemSetPermResult',
+    'FilesystemSetpermArgs', 'FilesystemSetpermResult',
     'FilesystemListdirArgs', 'FilesystemListdirResult',
     'FilesystemMkdirArgs', 'FilesystemMkdirResult',
     'FilesystemStatArgs', 'FilesystemStatResult',
     'FilesystemStatfsArgs', 'FilesystemStatfsResult',
-    'FilesystemSetZfsAttrsArgs', 'FilesystemSetZfsAttrsResult',
-    'FilesystemGetZfsAttrsArgs', 'FilesystemGetZfsAttrsResult',
-    'FilesystemGetFileArgs', 'FilesystemGetFileResult',
-    'FilesystemPutFileArgs', 'FilesystemPutFileResult',
+    'FilesystemSetZfsAttributesArgs', 'FilesystemSetZfsAttributesResult',
+    'FilesystemGetZfsAttributesArgs', 'FilesystemGetZfsAttributesResult',
+    'FilesystemGetArgs', 'FilesystemGetResult',
+    'FilesystemPutArgs', 'FilesystemPutResult',
     'FileFollowTailEventSourceArgs', 'FileFollowTailEventSourceEvent',
 ]
 
@@ -76,7 +76,7 @@ class FilesystemChownResult(BaseModel):
 
 
 @single_argument_args('filesystem_setperm')
-class FilesystemSetPermArgs(FilesystemPermChownBase):
+class FilesystemSetpermArgs(FilesystemPermChownBase):
     mode: UnixPerm | None = None
     options: FilesystemSetpermOptions = Field(default=FilesystemSetpermOptions())
 
@@ -92,7 +92,7 @@ class FilesystemSetPermArgs(FilesystemPermChownBase):
         return self
 
 
-class FilesystemSetPermResult(BaseModel):
+class FilesystemSetpermResult(BaseModel):
     result: Literal[None]
 
 
@@ -176,7 +176,7 @@ class FilesystemListdirArgs(BaseModel):
     query_options: QueryOptions = QueryOptions()
 
 
-FilesystemListdirResult = query_result(FilesystemDirEntry)
+FilesystemListdirResult = query_result(FilesystemDirEntry, "FilesystemListdirResult")
 
 
 class FilesystemMkdirOptions(BaseModel):
@@ -332,28 +332,28 @@ class ZFSFileAttrsData(BaseModel):
 
 
 @single_argument_args('set_zfs_file_attributes')
-class FilesystemSetZfsAttrsArgs(BaseModel):
+class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
     zfs_file_attributes: ZFSFileAttrsData
 
 
-class FilesystemSetZfsAttrsResult(BaseModel):
+class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetZfsAttrsArgs(BaseModel):
+class FilesystemGetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetZfsAttrsResult(BaseModel):
+class FilesystemGetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
 
 
-class FilesystemGetFileArgs(BaseModel):
+class FilesystemGetArgs(BaseModel):
     path: NonEmptyString
 
 
-class FilesystemGetFileResult(BaseModel):
+class FilesystemGetResult(BaseModel):
     result: Literal[None]
 
 
@@ -362,12 +362,12 @@ class FilesystemPutOptions(BaseModel):
     mode: int | None = None
 
 
-class FilesystemPutFileArgs(BaseModel):
+class FilesystemPutArgs(BaseModel):
     path: NonEmptyString
     options: FilesystemPutOptions = FilesystemPutOptions()
 
 
-class FilesystemPutFileResult(BaseModel):
+class FilesystemPutResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/ftp.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ftp.py
@@ -12,7 +12,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["FtpEntry",
-           "FtpUpdateArgs", "FtpUpdateResult"]
+           "FTPUpdateArgs", "FTPUpdateResult"]
 
 TLS_PolicyOptions = Literal[
     "", "on", "off", "data", "!data", "auth", "ctrl", "ctrl+data", "ctrl+!data", "auth+data", "auth+!data"
@@ -74,9 +74,9 @@ class FtpEntry(BaseModel):
 
 
 @single_argument_args('ftp_update')
-class FtpUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
+class FTPUpdateArgs(FtpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class FtpUpdateResult(BaseModel):
+class FTPUpdateResult(BaseModel):
     result: FtpEntry

--- a/src/middlewared/middlewared/api/v25_10_0/idmap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/idmap.py
@@ -3,13 +3,13 @@ from typing import Literal
 
 
 __all__ = [
-    'IdmapCacheClearArgs', 'IdmapCacheClearResult',
+    'IdmapDomainClearIdmapCacheArgs', 'IdmapDomainClearIdmapCacheResult',
 ]
 
 
-class IdmapCacheClearArgs(BaseModel):
+class IdmapDomainClearIdmapCacheArgs(BaseModel):
     pass
 
 
-class IdmapCacheClearResult(BaseModel):
+class IdmapDomainClearIdmapCacheResult(BaseModel):
     result: Literal[None]

--- a/src/middlewared/middlewared/api/v25_10_0/interface.py
+++ b/src/middlewared/middlewared/api/v25_10_0/interface.py
@@ -15,14 +15,14 @@ __all__ = [
     "InterfaceCommitArgs", "InterfaceCommitResult", "InterfaceCreateArgs", "InterfaceCreateResult",
     "InterfaceDefaultRouteWillBeRemovedArgs", "InterfaceDefaultRouteWillBeRemovedResult", "InterfaceDeleteArgs",
     "InterfaceDeleteResult", "InterfaceHasPendingChangesArgs", "InterfaceHasPendingChangesResult",
-    "InterfaceIPInUseArgs", "InterfaceIPInUseResult", "InterfaceLacpduRateChoicesArgs",
+    "InterfaceIpInUseArgs", "InterfaceIpInUseResult", "InterfaceLacpduRateChoicesArgs",
     "InterfaceLacpduRateChoicesResult", "InterfaceLagPortsChoicesArgs", "InterfaceLagPortsChoicesResult",
     "InterfaceRollbackArgs", "InterfaceRollbackResult", "InterfaceSaveDefaultRouteArgs",
     "InterfaceSaveDefaultRouteResult", "InterfaceServicesRestartedOnSyncArgs",
     "InterfaceServicesRestartedOnSyncResult", "InterfaceUpdateArgs", "InterfaceUpdateResult",
-    "InterfaceVLANParentInterfaceChoicesArgs", "InterfaceVLANParentInterfaceChoicesResult",
-    "InterfaceWebsocketInterfaceArgs", "InterfaceWebsocketInterfaceResult", "InterfaceWebsocketLocalIPArgs",
-    "InterfaceWebsocketLocalIPResult", "InterfaceXmitHashPolicyChoicesArgs", "InterfaceXmitHashPolicyChoicesResult",
+    "InterfaceVlanParentInterfaceChoicesArgs", "InterfaceVlanParentInterfaceChoicesResult",
+    "InterfaceWebsocketInterfaceArgs", "InterfaceWebsocketInterfaceResult", "InterfaceWebsocketLocalIpArgs",
+    "InterfaceWebsocketLocalIpResult", "InterfaceXmitHashPolicyChoicesArgs", "InterfaceXmitHashPolicyChoicesResult",
 ]
 
 
@@ -274,11 +274,11 @@ class InterfaceHasPendingChangesResult(BaseModel):
     result: bool
 
 
-class InterfaceIPInUseArgs(BaseModel):
+class InterfaceIpInUseArgs(BaseModel):
     options: InterfaceIPInUseOptions = Field(default_factory=InterfaceIPInUseOptions)
 
 
-class InterfaceIPInUseResult(BaseModel):
+class InterfaceIpInUseResult(BaseModel):
     result: list[InterfaceIPInUseItem] = Field(examples=[[
         {
             "type": "INET6",
@@ -347,11 +347,11 @@ class InterfaceUpdateResult(BaseModel):
     result: InterfaceEntry
 
 
-class InterfaceVLANParentInterfaceChoicesArgs(BaseModel):
+class InterfaceVlanParentInterfaceChoicesArgs(BaseModel):
     pass
 
 
-class InterfaceVLANParentInterfaceChoicesResult(BaseModel):
+class InterfaceVlanParentInterfaceChoicesResult(BaseModel):
     result: dict[str, str]
     """Names and descriptions of available interfaces for `vlan_parent_interface` attribute."""
 
@@ -364,11 +364,11 @@ class InterfaceWebsocketInterfaceResult(BaseModel):
     result: InterfaceEntry | None
 
 
-class InterfaceWebsocketLocalIPArgs(BaseModel):
+class InterfaceWebsocketLocalIpArgs(BaseModel):
     pass
 
 
-class InterfaceWebsocketLocalIPResult(BaseModel):
+class InterfaceWebsocketLocalIpResult(BaseModel):
     result: IPvAnyAddress | None
     """The local IP address for the current websocket session or `null`."""
 

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_chassis.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_chassis.py
@@ -5,7 +5,7 @@ from middlewared.api.base import BaseModel
 from pydantic import Field
 
 
-__all__ = ["IPMIChassisIdentifyArgs", "IPMIChassisIdentifyResult", "IPMIChassisInfoArgs", "IPMIChassisInfoResult"]
+__all__ = ["IpmiChassisIdentifyArgs", "IpmiChassisIdentifyResult", "IpmiChassisInfoArgs", "IpmiChassisInfoResult"]
 
 
 class IPMIChassisInfo(BaseModel):
@@ -23,17 +23,17 @@ class IPMIChassisInfo(BaseModel):
     chassis_identify_state: str
 
 
-class IPMIChassisIdentifyArgs(BaseModel):
+class IpmiChassisIdentifyArgs(BaseModel):
     verb: Literal["ON", "OFF"] = "ON"
 
 
-class IPMIChassisIdentifyResult(BaseModel):
+class IpmiChassisIdentifyResult(BaseModel):
     result: None
 
 
-class IPMIChassisInfoArgs(BaseModel):
+class IpmiChassisInfoArgs(BaseModel):
     pass
 
 
-class IPMIChassisInfoResult(BaseModel):
+class IpmiChassisInfoResult(BaseModel):
     result: IPMIChassisInfo | dict

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_sel.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_sel.py
@@ -1,10 +1,10 @@
 from middlewared.api.base import BaseModel
 
 
-__all__ = ["IPMISELElistEntry", "IPMISELClearArgs", "IPMISELClearResult", "IPMISELInfoArgs", "IPMISELInfoResult",]
+__all__ = ["IpmiSelElistEntry", "IpmiSelClearArgs", "IpmiSelClearResult", "IpmiSelInfoArgs", "IpmiSelInfoResult",]
 
 
-class IPMISELElistEntry(BaseModel):
+class IpmiSelElistEntry(BaseModel):
     id: str
     date: str
     time: str
@@ -31,17 +31,17 @@ class IPMISELInfo(BaseModel):
     maximum_record_size: str
 
 
-class IPMISELClearArgs(BaseModel):
+class IpmiSelClearArgs(BaseModel):
     pass
 
 
-class IPMISELClearResult(BaseModel):
+class IpmiSelClearResult(BaseModel):
     result: None
 
 
-class IPMISELInfoArgs(BaseModel):
+class IpmiSelInfoArgs(BaseModel):
     pass
 
 
-class IPMISELInfoResult(BaseModel):
+class IpmiSelInfoResult(BaseModel):
     result: IPMISELInfo | dict

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_auth.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_auth.py
@@ -6,12 +6,12 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiAuthEntry",
-    "IscsiAuthCreateArgs",
-    "IscsiAuthCreateResult",
-    "IscsiAuthUpdateArgs",
-    "IscsiAuthUpdateResult",
-    "IscsiAuthDeleteArgs",
-    "IscsiAuthDeleteResult",
+    "iSCSITargetAuthCredentialCreateArgs",
+    "iSCSITargetAuthCredentialCreateResult",
+    "iSCSITargetAuthCredentialUpdateArgs",
+    "iSCSITargetAuthCredentialUpdateResult",
+    "iSCSITargetAuthCredentialDeleteArgs",
+    "iSCSITargetAuthCredentialDeleteResult",
 ]
 
 
@@ -29,11 +29,11 @@ class IscsiAuthCreate(IscsiAuthEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiAuthCreateArgs(BaseModel):
+class iSCSITargetAuthCredentialCreateArgs(BaseModel):
     data: IscsiAuthCreate
 
 
-class IscsiAuthCreateResult(BaseModel):
+class iSCSITargetAuthCredentialCreateResult(BaseModel):
     result: IscsiAuthEntry
 
 
@@ -41,18 +41,18 @@ class IscsiAuthUpdate(IscsiAuthCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiAuthUpdateArgs(BaseModel):
+class iSCSITargetAuthCredentialUpdateArgs(BaseModel):
     id: int
     data: IscsiAuthUpdate
 
 
-class IscsiAuthUpdateResult(BaseModel):
+class iSCSITargetAuthCredentialUpdateResult(BaseModel):
     result: IscsiAuthEntry
 
 
-class IscsiAuthDeleteArgs(BaseModel):
+class iSCSITargetAuthCredentialDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiAuthDeleteResult(BaseModel):
+class iSCSITargetAuthCredentialDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
@@ -9,14 +9,14 @@ from middlewared.api.base import (
 
 __all__ = [
     "IscsiExtentEntry",
-    "IscsiExtentCreateArgs",
-    "IscsiExtentCreateResult",
-    "IscsiExtentUpdateArgs",
-    "IscsiExtentUpdateResult",
-    "IscsiExtentDeleteArgs",
-    "IscsiExtentDeleteResult",
-    "IscsiExtentDiskChoicesArgs",
-    "IscsiExtentDiskChoicesResult",
+    "iSCSITargetExtentCreateArgs",
+    "iSCSITargetExtentCreateResult",
+    "iSCSITargetExtentUpdateArgs",
+    "iSCSITargetExtentUpdateResult",
+    "iSCSITargetExtentDeleteArgs",
+    "iSCSITargetExtentDeleteResult",
+    "iSCSITargetExtentDiskChoicesArgs",
+    "iSCSITargetExtentDiskChoicesResult",
 ]
 
 
@@ -49,11 +49,11 @@ class IscsiExtentCreate(IscsiExtentEntry):
     locked: Excluded = excluded_field()
 
 
-class IscsiExtentCreateArgs(BaseModel):
+class iSCSITargetExtentCreateArgs(BaseModel):
     iscsi_extent_create: IscsiExtentCreate
 
 
-class IscsiExtentCreateResult(BaseModel):
+class iSCSITargetExtentCreateResult(BaseModel):
     result: IscsiExtentEntry
 
 
@@ -61,28 +61,28 @@ class IscsiExtentUpdate(IscsiExtentCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiExtentUpdateArgs(BaseModel):
+class iSCSITargetExtentUpdateArgs(BaseModel):
     id: int
     iscsi_extent_update: IscsiExtentUpdate
 
 
-class IscsiExtentUpdateResult(BaseModel):
+class iSCSITargetExtentUpdateResult(BaseModel):
     result: IscsiExtentEntry
 
 
-class IscsiExtentDeleteArgs(BaseModel):
+class iSCSITargetExtentDeleteArgs(BaseModel):
     id: int
     remove: bool = False
     force: bool = False
 
 
-class IscsiExtentDeleteResult(BaseModel):
+class iSCSITargetExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class IscsiExtentDiskChoicesArgs(BaseModel):
+class iSCSITargetExtentDiskChoicesArgs(BaseModel):
     pass
 
 
-class IscsiExtentDiskChoicesResult(BaseModel):
+class iSCSITargetExtentDiskChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_global.py
@@ -5,16 +5,16 @@ from .common import QueryFilters, QueryOptions
 
 __all__ = [
     "IscsiGlobalEntry",
-    "IscsiGlobalUpdateArgs",
-    "IscsiGlobalUpdateResult",
-    "IscsiGlobalAluaEnabledArgs",
-    "IscsiGlobalAluaEnabledResult",
-    "IscsiGlobalISEREnabledArgs",
-    "IscsiGlobalISEREnabledResult",
-    "IscsiGlobalClientCountArgs",
-    "IscsiGlobalClientCountResult",
-    "IscsiGlobalSessionsArgs",
-    "IscsiGlobalSessionsResult"
+    "ISCSIGlobalUpdateArgs",
+    "ISCSIGlobalUpdateResult",
+    "ISCSIGlobalAluaEnabledArgs",
+    "ISCSIGlobalAluaEnabledResult",
+    "ISCSIGlobalIserEnabledArgs",
+    "ISCSIGlobalIserEnabledResult",
+    "ISCSIGlobalClientCountArgs",
+    "ISCSIGlobalClientCountResult",
+    "ISCSIGlobalSessionsArgs",
+    "ISCSIGlobalSessionsResult"
 ]
 
 
@@ -29,35 +29,35 @@ class IscsiGlobalEntry(BaseModel):
 
 
 @single_argument_args('iscsi_update')
-class IscsiGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
+class ISCSIGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class IscsiGlobalUpdateResult(BaseModel):
+class ISCSIGlobalUpdateResult(BaseModel):
     result: IscsiGlobalEntry
 
 
-class IscsiGlobalAluaEnabledArgs(BaseModel):
+class ISCSIGlobalAluaEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalAluaEnabledResult(BaseModel):
+class ISCSIGlobalAluaEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalISEREnabledArgs(BaseModel):
+class ISCSIGlobalIserEnabledArgs(BaseModel):
     pass
 
 
-class IscsiGlobalISEREnabledResult(BaseModel):
+class ISCSIGlobalIserEnabledResult(BaseModel):
     result: bool
 
 
-class IscsiGlobalClientCountArgs(BaseModel):
+class ISCSIGlobalClientCountArgs(BaseModel):
     pass
 
 
-class IscsiGlobalClientCountResult(BaseModel):
+class ISCSIGlobalClientCountResult(BaseModel):
     result: int
 
 
@@ -79,10 +79,10 @@ class IscsiSession(BaseModel):
     offload: bool
 
 
-class IscsiGlobalSessionsArgs(BaseModel):
+class ISCSIGlobalSessionsArgs(BaseModel):
     query_filters: QueryFilters = []
     query_options: QueryOptions = QueryOptions()
 
 
-class IscsiGlobalSessionsResult(BaseModel):
+class ISCSIGlobalSessionsResult(BaseModel):
     result: list[IscsiSession]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_initiator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_initiator.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiInitiatorEntry",
-    "IscsiInitiatorCreateArgs",
-    "IscsiInitiatorCreateResult",
-    "IscsiInitiatorUpdateArgs",
-    "IscsiInitiatorUpdateResult",
-    "IscsiInitiatorDeleteArgs",
-    "IscsiInitiatorDeleteResult",
+    "iSCSITargetAuthorizedInitiatorCreateArgs",
+    "iSCSITargetAuthorizedInitiatorCreateResult",
+    "iSCSITargetAuthorizedInitiatorUpdateArgs",
+    "iSCSITargetAuthorizedInitiatorUpdateResult",
+    "iSCSITargetAuthorizedInitiatorDeleteArgs",
+    "iSCSITargetAuthorizedInitiatorDeleteResult",
 ]
 
 
@@ -23,11 +23,11 @@ class IscsiInitiatorCreate(IscsiInitiatorEntry):
     id: Excluded = excluded_field()
 
 
-class IscsiInitiatorCreateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateArgs(BaseModel):
     iscsi_initiator_create: IscsiInitiatorCreate
 
 
-class IscsiInitiatorCreateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorCreateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
@@ -35,18 +35,18 @@ class IscsiInitiatorUpdate(IscsiInitiatorEntry, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiInitiatorUpdateArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateArgs(BaseModel):
     id: int
     iscsi_initiator_update: IscsiInitiatorUpdate
 
 
-class IscsiInitiatorUpdateResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorUpdateResult(BaseModel):
     result: IscsiInitiatorEntry
 
 
-class IscsiInitiatorDeleteArgs(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiInitiatorDeleteResult(BaseModel):
+class iSCSITargetAuthorizedInitiatorDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_portal.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_portal.py
@@ -6,14 +6,14 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 __all__ = [
     "IscsiPortalEntry",
-    "IscsiPortalListenIPChoicesArgs",
-    "IscsiPortalListenIPChoicesResult",
-    "IscsiPortalCreateArgs",
-    "IscsiPortalCreateResult",
-    "IscsiPortalUpdateArgs",
-    "IscsiPortalUpdateResult",
-    "IscsiPortalDeleteArgs",
-    "IscsiPortalDeleteResult",
+    "ISCSIPortalListenIpChoicesArgs",
+    "ISCSIPortalListenIpChoicesResult",
+    "ISCSIPortalCreateArgs",
+    "ISCSIPortalCreateResult",
+    "ISCSIPortalUpdateArgs",
+    "ISCSIPortalUpdateResult",
+    "ISCSIPortalDeleteArgs",
+    "ISCSIPortalDeleteResult",
 ]
 
 
@@ -38,11 +38,11 @@ class IscsiPortalEntry(BaseModel):
     comment: str = ''
 
 
-class IscsiPortalListenIPChoicesArgs(BaseModel):
+class ISCSIPortalListenIpChoicesArgs(BaseModel):
     pass
 
 
-class IscsiPortalListenIPChoicesResult(BaseModel):
+class ISCSIPortalListenIpChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -52,11 +52,11 @@ class IscsiPortalCreate(IscsiPortalEntry):
     listen: list[IscsiPortalIP]
 
 
-class IscsiPortalCreateArgs(BaseModel):
+class ISCSIPortalCreateArgs(BaseModel):
     iscsi_portal_create: IscsiPortalCreate
 
 
-class IscsiPortalCreateResult(BaseModel):
+class ISCSIPortalCreateResult(BaseModel):
     result: IscsiPortalEntry
 
 
@@ -64,18 +64,18 @@ class IscsiPortalUpdate(IscsiPortalCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiPortalUpdateArgs(BaseModel):
+class ISCSIPortalUpdateArgs(BaseModel):
     id: int
     iscsi_portal_update: IscsiPortalUpdate
 
 
-class IscsiPortalUpdateResult(BaseModel):
+class ISCSIPortalUpdateResult(BaseModel):
     result: IscsiPortalEntry
 
 
-class IscsiPortalDeleteArgs(BaseModel):
+class ISCSIPortalDeleteArgs(BaseModel):
     id: int
 
 
-class IscsiPortalDeleteResult(BaseModel):
+class ISCSIPortalDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_target.py
@@ -11,14 +11,14 @@ RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 
 __all__ = [
     "IscsiTargetEntry",
-    "IscsiTargetValidateNameArgs",
-    "IscsiTargetValidateNameResult",
-    "IscsiTargetCreateArgs",
-    "IscsiTargetCreateResult",
-    "IscsiTargetUpdateArgs",
-    "IscsiTargetUpdateResult",
-    "IscsiTargetDeleteArgs",
-    "IscsiTargetDeleteResult",
+    "iSCSITargetValidateNameArgs",
+    "iSCSITargetValidateNameResult",
+    "iSCSITargetCreateArgs",
+    "iSCSITargetCreateResult",
+    "iSCSITargetUpdateArgs",
+    "iSCSITargetUpdateResult",
+    "iSCSITargetDeleteArgs",
+    "iSCSITargetDeleteResult",
 ]
 
 
@@ -51,12 +51,12 @@ class IscsiTargetEntry(BaseModel):
     iscsi_parameters: IscsiTargetParameters | None = None
 
 
-class IscsiTargetValidateNameArgs(BaseModel):
+class iSCSITargetValidateNameArgs(BaseModel):
     name: str
     existing_id: int | None = None
 
 
-class IscsiTargetValidateNameResult(BaseModel):
+class iSCSITargetValidateNameResult(BaseModel):
     result: str | None
 
 
@@ -65,11 +65,11 @@ class IscsiTargetCreate(IscsiTargetEntry):
     rel_tgt_id: Excluded = excluded_field()
 
 
-class IscsiTargetCreateArgs(BaseModel):
+class iSCSITargetCreateArgs(BaseModel):
     iscsi_target_create: IscsiTargetCreate
 
 
-class IscsiTargetCreateResult(BaseModel):
+class iSCSITargetCreateResult(BaseModel):
     result: IscsiTargetEntry
 
 
@@ -77,20 +77,20 @@ class IscsiTargetUpdate(IscsiTargetCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class IscsiTargetUpdateArgs(BaseModel):
+class iSCSITargetUpdateArgs(BaseModel):
     id: int
     iscsi_target_update: IscsiTargetUpdate
 
 
-class IscsiTargetUpdateResult(BaseModel):
+class iSCSITargetUpdateResult(BaseModel):
     result: IscsiTargetEntry
 
 
-class IscsiTargetDeleteArgs(BaseModel):
+class iSCSITargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
     delete_extents: bool = False
 
 
-class IscsiTargetDeleteResult(BaseModel):
+class iSCSITargetDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_target_to_extent.py
@@ -4,12 +4,12 @@ from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, exclud
 
 __all__ = [
     "IscsiTargetToExtentEntry",
-    "IscsiTargetToExtentCreateArgs",
-    "IscsiTargetToExtentCreateResult",
-    "IscsiTargetToExtentUpdateArgs",
-    "IscsiTargetToExtentUpdateResult",
-    "IscsiTargetToExtentDeleteArgs",
-    "IscsiTargetToExtentDeleteResult",
+    "iSCSITargetToExtentCreateArgs",
+    "iSCSITargetToExtentCreateResult",
+    "iSCSITargetToExtentUpdateArgs",
+    "iSCSITargetToExtentUpdateResult",
+    "iSCSITargetToExtentDeleteArgs",
+    "iSCSITargetToExtentDeleteResult",
 ]
 
 
@@ -25,11 +25,11 @@ class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
     lunid: int | None = None
 
 
-class IscsiTargetToExtentCreateArgs(BaseModel):
+class iSCSITargetToExtentCreateArgs(BaseModel):
     iscsi_target_to_extent_create: IscsiTargetToExtentCreate
 
 
-class IscsiTargetToExtentCreateResult(BaseModel):
+class iSCSITargetToExtentCreateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
@@ -37,21 +37,21 @@ class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMet
     pass
 
 
-class IscsiTargetToExtentUpdateArgs(BaseModel):
+class iSCSITargetToExtentUpdateArgs(BaseModel):
     id: int
     iscsi_target_to_extent_update: IscsiTargetToExtentUpdate
 
 
-class IscsiTargetToExtentUpdateResult(BaseModel):
+class iSCSITargetToExtentUpdateResult(BaseModel):
     result: IscsiTargetToExtentEntry
 
 
-class IscsiTargetToExtentDeleteArgs(BaseModel):
+class iSCSITargetToExtentDeleteArgs(BaseModel):
     id: int
     force: bool = False
 
 
-class IscsiTargetToExtentDeleteResult(BaseModel):
+class iSCSITargetToExtentDeleteResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/k8s_to_docker.py
+++ b/src/middlewared/middlewared/api/v25_10_0/k8s_to_docker.py
@@ -4,11 +4,11 @@ from middlewared.api.base import BaseModel, single_argument_result
 
 
 __all__ = [
-    'K8sToDockerListBackupsArgs', 'K8sToDockerListBackupsResult', 'K8sToDockerMigrateArgs', 'K8sToDockerMigrateResult',
+    'K8stoDockerMigrationListBackupsArgs', 'K8stoDockerMigrationListBackupsResult', 'K8stoDockerMigrationMigrateArgs', 'K8stoDockerMigrationMigrateResult',
 ]
 
 
-class K8sToDockerListBackupsArgs(BaseModel):
+class K8stoDockerMigrationListBackupsArgs(BaseModel):
     kubernetes_pool: str
 
 
@@ -37,7 +37,7 @@ class Backups(RootModel[dict[str, BackupDetails]]):
 
 
 @single_argument_result
-class K8sToDockerListBackupsResult(BaseModel):
+class K8stoDockerMigrationListBackupsResult(BaseModel):
     error: str | None
     backups: Backups
 
@@ -46,7 +46,7 @@ class MigrateOptions(BaseModel):
     backup_name: str | None = None
 
 
-class K8sToDockerMigrateArgs(BaseModel):
+class K8stoDockerMigrationMigrateArgs(BaseModel):
     kubernetes_pool: str
     options: MigrateOptions = MigrateOptions()
 
@@ -57,5 +57,5 @@ class AppMigrationDetails(BaseModel):
     error: str | None
 
 
-class K8sToDockerMigrateResult(BaseModel):
+class K8stoDockerMigrationMigrateResult(BaseModel):
     result: list[AppMigrationDetails]

--- a/src/middlewared/middlewared/api/v25_10_0/keychain.py
+++ b/src/middlewared/middlewared/api/v25_10_0/keychain.py
@@ -11,10 +11,10 @@ __all__ = ["KeychainCredentialEntry", "SSHKeyPairEntry", "SSHCredentialsEntry",
            "KeychainCredentialUpdateArgs", "KeychainCredentialUpdateResult",
            "KeychainCredentialDeleteArgs", "KeychainCredentialDeleteResult",
            "KeychainCredentialUsedByArgs", "KeychainCredentialUsedByResult",
-           "KeychainCredentialGenerateSSHKeyPairArgs", "KeychainCredentialGenerateSSHKeyPairResult",
-           "KeychainCredentialRemoteSSHHostKeyScanArgs", "KeychainCredentialRemoteSSHHostKeyScanResult",
-           "KeychainCredentialRemoteSSHSemiautomaticSetupArgs", "KeychainCredentialRemoteSSHSemiautomaticSetupResult",
-           "KeychainCredentialSetupSSHConnectionArgs", "KeychainCredentialSetupSSHConnectionResult"]
+           "KeychainCredentialGenerateSshKeyPairArgs", "KeychainCredentialGenerateSshKeyPairResult",
+           "KeychainCredentialRemoteSshHostKeyScanArgs", "KeychainCredentialRemoteSshHostKeyScanResult",
+           "KeychainCredentialRemoteSshSemiautomaticSetupArgs", "KeychainCredentialRemoteSshSemiautomaticSetupResult",
+           "KeychainCredentialSetupSshConnectionArgs", "KeychainCredentialSetupSshConnectionResult"]
 
 
 class SSHKeyPair(BaseModel):
@@ -119,24 +119,24 @@ class KeychainCredentialUsedByResult(BaseModel):
     result: list[UsedKeychainCredential]
 
 
-class KeychainCredentialGenerateSSHKeyPairArgs(BaseModel):
+class KeychainCredentialGenerateSshKeyPairArgs(BaseModel):
     pass
 
 
 @single_argument_result
-class KeychainCredentialGenerateSSHKeyPairResult(BaseModel):
+class KeychainCredentialGenerateSshKeyPairResult(BaseModel):
     private_key: LongString
     public_key: LongString
 
 
 @single_argument_args("keychain_remote_ssh_host_key_scan")
-class KeychainCredentialRemoteSSHHostKeyScanArgs(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanArgs(BaseModel):
     host: NonEmptyString
     port: int = 22
     connect_timeout: int = 10
 
 
-class KeychainCredentialRemoteSSHHostKeyScanResult(BaseModel):
+class KeychainCredentialRemoteSshHostKeyScanResult(BaseModel):
     result: LongString
 
 
@@ -154,11 +154,11 @@ class KeychainCredentialRemoteSSHSemiautomaticSetup(BaseModel):
     sudo: bool = False
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupArgs(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupArgs(BaseModel):
     data: KeychainCredentialRemoteSSHSemiautomaticSetup
 
 
-class KeychainCredentialRemoteSSHSemiautomaticSetupResult(BaseModel):
+class KeychainCredentialRemoteSshSemiautomaticSetupResult(BaseModel):
     result: SSHCredentialsEntry
 
 
@@ -197,12 +197,12 @@ class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
     manual_setup: Excluded = excluded_field()
 
 
-class KeychainCredentialSetupSSHConnectionArgs(BaseModel):
+class KeychainCredentialSetupSshConnectionArgs(BaseModel):
     options: Annotated[
         Union[SetupSSHConnectionManual, SetupSSHConnectionSemiautomatic],
         Discriminator("setup_type"),
     ]
 
 
-class KeychainCredentialSetupSSHConnectionResult(BaseModel):
+class KeychainCredentialSetupSshConnectionResult(BaseModel):
     result: SSHCredentialsEntry

--- a/src/middlewared/middlewared/api/v25_10_0/kmip.py
+++ b/src/middlewared/middlewared/api/v25_10_0/kmip.py
@@ -7,9 +7,9 @@ from middlewared.api.base import (
 )
 
 __all__ = [
-    'KmipEntry', 'KmipSyncPendingArgs', 'KmipSyncPendingResult',
-    'KmipSyncKeysArgs', 'KmipSyncKeysResult', 'KmipClearSyncPendingKeysArgs',
-    'KmipClearSyncPendingKeysResult', 'KmipUpdateArgs', 'KmipUpdateResult'
+    'KmipEntry', 'KMIPKmipSyncPendingArgs', 'KMIPKmipSyncPendingResult',
+    'KMIPSyncKeysArgs', 'KMIPSyncKeysResult', 'KMIPClearSyncPendingKeysArgs',
+    'KMIPClearSyncPendingKeysResult', 'KMIPUpdateArgs', 'KMIPUpdateResult'
 ]
 
 
@@ -26,7 +26,7 @@ class KmipEntry(BaseModel):
 
 
 @single_argument_args('kmip_update')
-class KmipUpdateArgs(KmipEntry, metaclass=ForUpdateMetaclass):
+class KMIPUpdateArgs(KmipEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     enabled: bool
     force_clear: bool
@@ -34,29 +34,29 @@ class KmipUpdateArgs(KmipEntry, metaclass=ForUpdateMetaclass):
     validate_: bool = Field(alias='validate')
 
 
-class KmipUpdateResult(BaseModel):
+class KMIPUpdateResult(BaseModel):
     result: KmipEntry
 
 
-class KmipSyncPendingArgs(BaseModel):
+class KMIPKmipSyncPendingArgs(BaseModel):
     pass
 
 
-class KmipSyncPendingResult(BaseModel):
+class KMIPKmipSyncPendingResult(BaseModel):
     result: bool
 
 
-class KmipSyncKeysArgs(BaseModel):
+class KMIPSyncKeysArgs(BaseModel):
     pass
 
 
-class KmipSyncKeysResult(BaseModel):
+class KMIPSyncKeysResult(BaseModel):
     result: None
 
 
-class KmipClearSyncPendingKeysArgs(BaseModel):
+class KMIPClearSyncPendingKeysArgs(BaseModel):
     pass
 
 
-class KmipClearSyncPendingKeysResult(BaseModel):
+class KMIPClearSyncPendingKeysResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_10_0/network_configuration.py
+++ b/src/middlewared/middlewared/api/v25_10_0/network_configuration.py
@@ -5,7 +5,7 @@ from middlewared.api.base.types.network import IPvAnyAddress, Hostname, Domain
 
 
 __all__ = [
-    "NetworkConfigurationEntry", "NetWorkConfigurationUpdateArgs", "NetworkConfigurationUpdateResult",
+    "NetworkConfigurationEntry", "NetworkConfigurationUpdateArgs", "NetworkConfigurationUpdateResult",
     "NetworkConfigurationActivityChoicesArgs", "NetworkConfigurationActivityChoicesResult",
 ]
 
@@ -74,7 +74,7 @@ class NetworkConfigurationActivityChoicesResult(BaseModel):
     result: list[list[str]]
 
 
-class NetWorkConfigurationUpdateArgs(BaseModel):
+class NetworkConfigurationUpdateArgs(BaseModel):
     data: NetWorkConfigurationUpdate
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nfs.py
@@ -15,22 +15,22 @@ from middlewared.api.base import (
 )
 
 __all__ = [
-    "GetNFSv3ClientsEntry",
-    "GetNFSv4ClientsEntry",
+    "NFSGetNfs3ClientsEntry",
+    "NFSGetNfs4ClientsEntry",
     "NfsEntry",
-    "NfsBindipChoicesArgs",
-    "NfsBindipChoicesResult",
-    "NfsClientCountArgs",
-    "NfsClientCountResult",
+    "NFSBindipChoicesArgs",
+    "NFSBindipChoicesResult",
+    "NFSClientCountArgs",
+    "NFSClientCountResult",
     "NfsShareEntry",
-    "NfsShareCreateArgs",
-    "NfsShareCreateResult",
-    "NfsShareUpdateArgs",
-    "NfsShareUpdateResult",
-    "NfsShareDeleteArgs",
-    "NfsShareDeleteResult",
-    "NfsUpdateArgs",
-    "NfsUpdateResult",
+    "SharingNFSCreateArgs",
+    "SharingNFSCreateResult",
+    "SharingNFSUpdateArgs",
+    "SharingNFSUpdateResult",
+    "SharingNFSDeleteArgs",
+    "SharingNFSDeleteResult",
+    "NFSUpdateArgs",
+    "NFSUpdateResult",
 ]
 
 MAX_NUM_NFS_NETWORKS = 42
@@ -43,12 +43,12 @@ NfsTcpPort: TypeAlias = Annotated[
 ]
 
 
-class GetNFSv3ClientsEntry(BaseModel):
+class NFSGetNfs3ClientsEntry(BaseModel):
     ip: str
     export: str
 
 
-class GetNFSv4ClientsEntry(BaseModel):
+class NFSGetNfs4ClientsEntry(BaseModel):
     id: str
     info: dict
     states: list[dict]
@@ -92,32 +92,32 @@ class NfsEntry(BaseModel):
 
 
 @single_argument_args("nfs_update")
-class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
+class NFSUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     managed_nfsd: Excluded = excluded_field()
     v4_krb_enabled: Excluded = excluded_field()
     keytab_has_nfs_spn: Excluded = excluded_field()
 
 
-class NfsUpdateResult(BaseModel):
+class NFSUpdateResult(BaseModel):
     result: NfsEntry
 
 
-class NfsBindipChoicesArgs(BaseModel):
+class NFSBindipChoicesArgs(BaseModel):
     pass
 
 
-class NfsBindipChoicesResult(BaseModel):
+class NFSBindipChoicesResult(BaseModel):
     """Return a dictionary of IP addresses"""
 
     result: dict[str, str]
 
 
-class NfsClientCountArgs(BaseModel):
+class NFSClientCountArgs(BaseModel):
     pass
 
 
-class NfsClientCountResult(BaseModel):
+class NFSClientCountResult(BaseModel):
     result: int
 
 
@@ -167,11 +167,11 @@ class NfsShareCreate(NfsShareEntry):
     locked: Excluded = excluded_field()
 
 
-class NfsShareCreateArgs(BaseModel):
+class SharingNFSCreateArgs(BaseModel):
     data: NfsShareCreate
 
 
-class NfsShareCreateResult(BaseModel):
+class SharingNFSCreateResult(BaseModel):
     result: NfsShareEntry
 
 
@@ -179,18 +179,18 @@ class NfsShareUpdate(NfsShareCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class NfsShareUpdateArgs(BaseModel):
+class SharingNFSUpdateArgs(BaseModel):
     id: int
     data: NfsShareUpdate
 
 
-class NfsShareUpdateResult(BaseModel):
+class SharingNFSUpdateResult(BaseModel):
     result: NfsShareEntry
 
 
-class NfsShareDeleteArgs(BaseModel):
+class SharingNFSDeleteArgs(BaseModel):
     id: int
 
 
-class NfsShareDeleteResult(BaseModel):
+class SharingNFSDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_global.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_global.py
@@ -6,9 +6,9 @@ __all__ = [
     "NVMetGlobalUpdateResult",
     "NVMetGlobalAnaEnabledArgs",
     "NVMetGlobalAnaEnabledResult",
-    "NVMetGlobalRDMAEnabledArgs",
-    "NVMetGlobalRDMAEnabledResult",
-    "NVMetSession"
+    "NVMetGlobalRdmaEnabledArgs",
+    "NVMetGlobalRdmaEnabledResult",
+    "NVMetGlobalSessionsItem"
 ]
 
 
@@ -62,16 +62,16 @@ class NVMetGlobalAnaEnabledResult(BaseModel):
     """ `True` if Asymmetric Namespace Access (ANA) is enabled. """
 
 
-class NVMetGlobalRDMAEnabledArgs(BaseModel):
+class NVMetGlobalRdmaEnabledArgs(BaseModel):
     pass
 
 
-class NVMetGlobalRDMAEnabledResult(BaseModel):
+class NVMetGlobalRdmaEnabledResult(BaseModel):
     result: bool
     """ `True` if Remote Direct Memory Access (RDMA) is enabled for NVMe-oF. """
 
 
-class NVMetSession(BaseModel):
+class NVMetGlobalSessionsItem(BaseModel):
     host_traddr: str
     """ Address of the connected host. For example an IP address."""
     hostnqn: str

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_host.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_host.py
@@ -14,10 +14,10 @@ __all__ = [
     "NVMetHostDeleteResult",
     "NVMetHostGenerateKeyArgs",
     "NVMetHostGenerateKeyResult",
-    "NVMetHostDHChapDHGroupChoicesArgs",
-    "NVMetHostDHChapDHGroupChoicesResult",
-    "NVMetHostDHChapHashChoicesArgs",
-    "NVMetHostDHChapHashChoicesResult",
+    "NVMetHostDhchapDhgroupChoicesArgs",
+    "NVMetHostDhchapDhgroupChoicesResult",
+    "NVMetHostDhchapHashChoicesArgs",
+    "NVMetHostDhchapHashChoicesResult",
 ]
 
 DHChapHashType: TypeAlias = Literal['SHA-256', 'SHA-384', 'SHA-512']
@@ -107,17 +107,17 @@ class NVMetHostGenerateKeyResult(BaseModel):
     result: str
 
 
-class NVMetHostDHChapDHGroupChoicesArgs(BaseModel):
+class NVMetHostDhchapDhgroupChoicesArgs(BaseModel):
     pass
 
 
-class NVMetHostDHChapDHGroupChoicesResult(BaseModel):
+class NVMetHostDhchapDhgroupChoicesResult(BaseModel):
     result: list[DHChapDHGroupType]
 
 
-class NVMetHostDHChapHashChoicesArgs(BaseModel):
+class NVMetHostDhchapHashChoicesArgs(BaseModel):
     pass
 
 
-class NVMetHostDHChapHashChoicesResult(BaseModel):
+class NVMetHostDhchapHashChoicesResult(BaseModel):
     result: list[DHChapHashType]

--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    "PoolEntry", "DDTPruneArgs", "DDTPruneResult", "DDTPrefetchArgs", "DDTPrefetchResult", "PoolAttachArgs",
+    "PoolEntry", "PoolDdtPruneArgs", "PoolDdtPruneResult", "PoolDdtPrefetchArgs", "PoolDdtPrefetchResult", "PoolAttachArgs",
     "PoolAttachResult", "PoolAttachmentsArgs", "PoolAttachmentsResult", "PoolCreateArgs", "PoolCreateResult",
     "PoolDetachArgs", "PoolDetachResult", "PoolExpandArgs", "PoolExpandResult", "PoolExportArgs", "PoolExportResult",
     "PoolFilesystemChoicesArgs", "PoolFilesystemChoicesResult", "PoolGetDisksArgs", "PoolGetDisksResult",
@@ -276,21 +276,21 @@ class PoolUpdate(PoolCreate, metaclass=ForUpdateMetaclass):
 
 
 @single_argument_args("options")
-class DDTPruneArgs(BaseModel):
+class PoolDdtPruneArgs(BaseModel):
     pool_name: NonEmptyString
     percentage: Annotated[int, Field(ge=1, le=100)] | None = None
     days: Annotated[int, Field(ge=1)] | None = None
 
 
-class DDTPruneResult(BaseModel):
+class PoolDdtPruneResult(BaseModel):
     result: None
 
 
-class DDTPrefetchArgs(BaseModel):
+class PoolDdtPrefetchArgs(BaseModel):
     pool_name: NonEmptyString
 
 
-class DDTPrefetchResult(BaseModel):
+class PoolDdtPrefetchResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
@@ -14,7 +14,7 @@ from .pool import PoolAttachment, PoolCreateEncryptionOptions, PoolProcess
 
 __all__ = [
     "PoolDatasetEntry", "PoolDatasetAttachmentsArgs", "PoolDatasetAttachmentsResult", "PoolDatasetCreateArgs",
-    "PoolDatasetCreateResult", "PoolDatasetDetailsArgs", "PoolDatasetDetailsResults",
+    "PoolDatasetCreateResult", "PoolDatasetDetailsArgs", "PoolDatasetDetailsResult",
     "PoolDatasetEncryptionSummaryArgs", "PoolDatasetEncryptionSummaryResult", "PoolDatasetExportKeysArgs",
     "PoolDatasetExportKeysResult", "PoolDatasetExportKeysForReplicationArgs",
     "PoolDatasetExportKeysForReplicationResult", "PoolDatasetExportKeyArgs", "PoolDatasetExportKeyResult",
@@ -24,9 +24,9 @@ __all__ = [
     "PoolDatasetInheritParentEncryptionPropertiesResult", "PoolDatasetChecksumChoicesArgs",
     "PoolDatasetChecksumChoicesResult", "PoolDatasetCompressionChoicesArgs", "PoolDatasetCompressionChoicesResult",
     "PoolDatasetEncryptionAlgorithmChoicesArgs", "PoolDatasetEncryptionAlgorithmChoicesResult",
-    "PoolDatasetRecommendedZVolBlockSizeArgs", "PoolDatasetRecommendedZVolBlockSizeResult", "PoolDatasetProcessesArgs",
+    "PoolDatasetRecommendedZvolBlocksizeArgs", "PoolDatasetRecommendedZvolBlocksizeResult", "PoolDatasetProcessesArgs",
     "PoolDatasetProcessesResult", "PoolDatasetGetQuotaArgs", "PoolDatasetGetQuotaResult", "PoolDatasetSetQuotaArgs",
-    "PoolDatasetSetQuotaResult", "PoolDatasetRecordSizeChoicesArgs", "PoolDatasetRecordSizeChoicesResult",
+    "PoolDatasetSetQuotaResult", "PoolDatasetRecordsizeChoicesArgs", "PoolDatasetRecordsizeChoicesResult",
     "PoolDatasetUpdateArgs", "PoolDatasetUpdateResult", "PoolDatasetDeleteArgs", "PoolDatasetDeleteResult",
     "PoolDatasetDestroySnapshotsArgs", "PoolDatasetDestroySnapshotsResult", "PoolDatasetPromoteArgs",
     "PoolDatasetPromoteResult", "PoolDatasetRenameArgs", "PoolDatasetRenameResult",
@@ -418,7 +418,7 @@ class PoolDatasetDetailsArgs(BaseModel):
     pass
 
 
-class PoolDatasetDetailsResults(BaseModel):
+class PoolDatasetDetailsResult(BaseModel):
     result: list[dict]
 
 
@@ -527,19 +527,19 @@ class PoolDatasetPromoteResult(BaseModel):
     result: None
 
 
-class PoolDatasetRecommendedZVolBlockSizeArgs(BaseModel):
+class PoolDatasetRecommendedZvolBlocksizeArgs(BaseModel):
     pool: str
 
 
-class PoolDatasetRecommendedZVolBlockSizeResult(BaseModel):
+class PoolDatasetRecommendedZvolBlocksizeResult(BaseModel):
     result: str
 
 
-class PoolDatasetRecordSizeChoicesArgs(BaseModel):
+class PoolDatasetRecordsizeChoicesArgs(BaseModel):
     pool_name: str | None = None
 
 
-class PoolDatasetRecordSizeChoicesResult(BaseModel):
+class PoolDatasetRecordsizeChoicesResult(BaseModel):
     result: list[str]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_snapshot_count.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_snapshot_count.py
@@ -1,12 +1,12 @@
 from middlewared.api.base import BaseModel
 
 
-__all__ = ["PoolDatasetSnapshotCountArgs", "PoolDatasetSnapshotCountResults",]
+__all__ = ["PoolDatasetSnapshotCountArgs", "PoolDatasetSnapshotCountResult",]
 
 
 class PoolDatasetSnapshotCountArgs(BaseModel):
     dataset: str
 
 
-class PoolDatasetSnapshotCountResults(BaseModel):
+class PoolDatasetSnapshotCountResult(BaseModel):
     result: int

--- a/src/middlewared/middlewared/api/v25_10_0/pool_snapshottask.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_snapshottask.py
@@ -7,13 +7,13 @@ from .common import CronModel
 
 
 __all__ = [
-    "PoolSnapshotTaskDBEntry", "PoolSnapshotTaskEntry", "PoolSnapshotTaskCreateArgs", "PoolSnapshotTaskCreateResult",
-    "PoolSnapshotTaskUpdateArgs", "PoolSnapshotTaskUpdateResult", "PoolSnapshotTaskDeleteArgs",
-    "PoolSnapshotTaskDeleteResult", "PoolSnapshotTaskMaxCountArgs", "PoolSnapshotTaskMaxCountResult",
-    "PoolSnapshotTaskMaxTotalCountArgs", "PoolSnapshotTaskMaxTotalCountResult", "PoolSnapshotTaskRunArgs",
-    "PoolSnapshotTaskRunResult", "PoolSnapshotTaskUpdateWillChangeRetentionForArgs",
-    "PoolSnapshotTaskUpdateWillChangeRetentionForResult", "PoolSnapshotTaskDeleteWillChangeRetentionForArgs",
-    "PoolSnapshotTaskDeleteWillChangeRetentionForResult"
+    "PoolSnapshotTaskDBEntry", "PoolSnapshotTaskEntry", "PeriodicSnapshotTaskCreateArgs", "PeriodicSnapshotTaskCreateResult",
+    "PeriodicSnapshotTaskUpdateArgs", "PeriodicSnapshotTaskUpdateResult", "PeriodicSnapshotTaskDeleteArgs",
+    "PeriodicSnapshotTaskDeleteResult", "PeriodicSnapshotTaskMaxCountArgs", "PeriodicSnapshotTaskMaxCountResult",
+    "PeriodicSnapshotTaskMaxTotalCountArgs", "PeriodicSnapshotTaskMaxTotalCountResult", "PeriodicSnapshotTaskRunArgs",
+    "PeriodicSnapshotTaskRunResult", "PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskUpdateWillChangeRetentionForResult", "PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs",
+    "PeriodicSnapshotTaskDeleteWillChangeRetentionForResult"
 ]
 
 
@@ -57,68 +57,68 @@ class PoolSnapshotTaskEntry(PoolSnapshotTaskDBEntry):
     state: Any
 
 
-class PoolSnapshotTaskCreateArgs(BaseModel):
+class PeriodicSnapshotTaskCreateArgs(BaseModel):
     data: PoolSnapshotTaskCreate
 
 
-class PoolSnapshotTaskCreateResult(BaseModel):
+class PeriodicSnapshotTaskCreateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskUpdateArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdate
 
 
-class PoolSnapshotTaskUpdateResult(BaseModel):
+class PeriodicSnapshotTaskUpdateResult(BaseModel):
     result: PoolSnapshotTaskEntry
 
 
-class PoolSnapshotTaskDeleteArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteArgs(BaseModel):
     id: int
     options: PoolSnapshotTaskDeleteOptions = Field(default_factory=PoolSnapshotTaskDeleteOptions)
 
 
-class PoolSnapshotTaskDeleteResult(BaseModel):
+class PeriodicSnapshotTaskDeleteResult(BaseModel):
     result: Literal[True]
 
 
-class PoolSnapshotTaskMaxCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskMaxTotalCountArgs(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountArgs(BaseModel):
     pass
 
 
-class PoolSnapshotTaskMaxTotalCountResult(BaseModel):
+class PeriodicSnapshotTaskMaxTotalCountResult(BaseModel):
     result: int
 
 
-class PoolSnapshotTaskRunArgs(BaseModel):
+class PeriodicSnapshotTaskRunArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskRunResult(BaseModel):
+class PeriodicSnapshotTaskRunResult(BaseModel):
     result: None
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs(BaseModel):
     id: int
     data: PoolSnapshotTaskUpdateWillChangeRetentionFor
 
 
-class PoolSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskUpdateWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs(BaseModel):
     id: int
 
 
-class PoolSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
+class PeriodicSnapshotTaskDeleteWillChangeRetentionForResult(BaseModel):
     result: dict[str, list[str]]

--- a/src/middlewared/middlewared/api/v25_10_0/privilege.py
+++ b/src/middlewared/middlewared/api/v25_10_0/privilege.py
@@ -2,7 +2,7 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 from middlewared.utils.security import STIGType
 from .group import GroupEntry
 
-__all__ = ["PrivilegeEntry", "PrivilegeRoleEntry",
+__all__ = ["PrivilegeEntry", "PrivilegeRolesEntry",
            "PrivilegeCreateArgs", "PrivilegeCreateResult",
            "PrivilegeUpdateArgs", "PrivilegeUpdateResult",
            "PrivilegeDeleteArgs", "PrivilegeDeleteResult"]
@@ -60,7 +60,7 @@ class PrivilegeDeleteResult(BaseModel):
     result: bool
 
 
-class PrivilegeRoleEntry(BaseModel):
+class PrivilegeRolesEntry(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     includes: list[NonEmptyString]

--- a/src/middlewared/middlewared/api/v25_10_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_10_0/rdma.py
@@ -3,8 +3,8 @@ from typing import Literal
 
 __all__ = [
     "RdmaLinkConfig",
-    "RdmaCardConfigArgs", "RdmaCardConfigResult",
-    "RdmaCapableProtocolsArgs", "RdmaCapableProtocolsResult"
+    "RDMAGetCardChoicesArgs", "RDMAGetCardChoicesResult",
+    "RDMACapableProtocolsArgs", "RDMACapableProtocolsResult"
 ]
 
 
@@ -13,7 +13,7 @@ class RdmaLinkConfig(BaseModel):
     netdev: str
 
 
-class RdmaCardConfigArgs(BaseModel):
+class RDMAGetCardChoicesArgs(BaseModel):
     pass
 
 
@@ -25,13 +25,13 @@ class RdmaCardConfig(BaseModel):
     links: list[RdmaLinkConfig]
 
 
-class RdmaCardConfigResult(BaseModel):
+class RDMAGetCardChoicesResult(BaseModel):
     result: list[RdmaCardConfig]
 
 
-class RdmaCapableProtocolsArgs(BaseModel):
+class RDMACapableProtocolsArgs(BaseModel):
     pass
 
 
-class RdmaCapableProtocolsResult(BaseModel):
+class RDMACapableProtocolsResult(BaseModel):
     result: list[Literal["ISER", "NFS", "NVMET"]]

--- a/src/middlewared/middlewared/api/v25_10_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting.py
@@ -9,9 +9,11 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraph', 'ReportingGetDataArgs',
-    'ReportingGetDataResult', 'ReportingGraphArgs', 'ReportingGeneratePasswordArgs', 'ReportingGeneratePasswordResult',
-    'ReportingRealtimeEventSourceArgs', 'ReportingRealtimeEventSourceEvent',
+    'ReportingEntry', 'ReportingUpdateArgs', 'ReportingUpdateResult', 'ReportingGraphsItem', 'ReportingNetdataGetDataArgs',
+    'ReportingNetdataGraphResult', 'ReportingNetdataGraphArgs', 'ReportingGeneratePasswordArgs',
+    'ReportingGeneratePasswordResult', 'ReportingRealtimeEventSourceArgs', 'ReportingRealtimeEventSourceEvent',
+    'ReportingGetDataArgs', 'ReportingGetDataResult', 'ReportingGraphArgs', 'ReportingGraphResult',
+    'ReportingNetdataGetDataResult', 'ReportingNetdataGraphsItem',
 ]
 
 
@@ -51,7 +53,7 @@ class GraphIdentifier(BaseModel):
     identifier: NonEmptyString | None = None
 
 
-class ReportingGetDataArgs(BaseModel):
+class ReportingNetdataGetDataArgs(BaseModel):
     graphs: list[GraphIdentifier] = Field(min_length=1)
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 
@@ -72,18 +74,25 @@ class ReportingGetDataResponse(BaseModel):
     legend: list[str]
 
 
-class ReportingGetDataResult(BaseModel):
+class ReportingNetdataGraphResult(BaseModel):
     result: list[ReportingGetDataResponse]
 
 
-class ReportingGraph(BaseModel):
+class ReportingGraphsItem(BaseModel):
     name: NonEmptyString
     title: NonEmptyString
     vertical_label: NonEmptyString
     identifiers: list[str] | None
 
 
-class ReportingGraphArgs(BaseModel):
+class ReportingNetdataGraphsItem(BaseModel):
+    name: NonEmptyString
+    title: NonEmptyString
+    vertical_label: NonEmptyString
+    identifiers: list[str] | None
+
+
+class ReportingNetdataGraphArgs(BaseModel):
     str: NonEmptyString
     query: ReportingQuery = Field(default_factory=lambda: ReportingQuery())
 
@@ -149,3 +158,23 @@ class ReportingRealtimeEventSourceEventZFS(BaseModel):
     l2arc_miss_percentage: int
     bytes_read_per_second_from_the_l2arc: int
     bytes_written_per_second_to_the_l2arc: int
+
+
+class ReportingGetDataArgs(ReportingNetdataGetDataArgs):
+    pass
+
+
+class ReportingGetDataResult(ReportingNetdataGraphResult):
+    pass
+
+
+class ReportingGraphArgs(ReportingNetdataGraphArgs):
+    pass
+
+
+class ReportingGraphResult(ReportingNetdataGraphResult):
+    pass
+
+
+class ReportingNetdataGetDataResult(ReportingNetdataGraphResult):
+    pass

--- a/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
@@ -8,9 +8,9 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    'ReportingExporterEntry', 'ReportingExporterCreateArgs', 'ReportingExporterCreateResult', 'GraphiteExporter',
-    'ReportingExporterUpdateArgs', 'ReportingExporterUpdateResult', 'ReportingExporterDeleteArgs',
-    'ReportingExporterDeleteResult', 'ReportingExporterSchemasArgs', 'ReportingExporterSchemasResult',
+    'ReportingExporterEntry', 'ReportingExportsCreateArgs', 'ReportingExportsCreateResult', 'GraphiteExporter',
+    'ReportingExportsUpdateArgs', 'ReportingExportsUpdateResult', 'ReportingExportsDeleteArgs',
+    'ReportingExportsDeleteResult', 'ReportingExportsExporterSchemasArgs', 'ReportingExportsExporterSchemasResult',
 ]
 
 
@@ -41,11 +41,11 @@ class ReportingExporterEntry(BaseModel):
 
 
 @single_argument_args('reporting_exporter_create')
-class ReportingExporterCreateArgs(ReportingExporterEntry):
+class ReportingExportsCreateArgs(ReportingExporterEntry):
     id: Excluded = excluded_field()
 
 
-class ReportingExporterCreateResult(BaseModel):
+class ReportingExportsCreateResult(BaseModel):
     result: ReportingExporterEntry
 
 
@@ -53,24 +53,24 @@ class ReportingExporterUpdate(ReportingExporterEntry, metaclass=ForUpdateMetacla
     id: Excluded = excluded_field()
 
 
-class ReportingExporterUpdateArgs(BaseModel):
+class ReportingExportsUpdateArgs(BaseModel):
     id: int
     reporting_exporter_update: ReportingExporterUpdate
 
 
-class ReportingExporterUpdateResult(BaseModel):
+class ReportingExportsUpdateResult(BaseModel):
     result: ReportingExporterEntry
 
 
-class ReportingExporterDeleteArgs(BaseModel):
+class ReportingExportsDeleteArgs(BaseModel):
     id: int
 
 
-class ReportingExporterDeleteResult(BaseModel):
+class ReportingExportsDeleteResult(BaseModel):
     result: bool
 
 
-class ReportingExporterSchemasArgs(BaseModel):
+class ReportingExportsExporterSchemasArgs(BaseModel):
     pass
 
 
@@ -87,5 +87,5 @@ class ReportingExporterSchema(BaseModel):
     schema_: list[ReportingExporterAttributeSchema] = Field(alias='schema')
 
 
-class ReportingExporterSchemasResult(BaseModel):
+class ReportingExportsExporterSchemasResult(BaseModel):
     result: list[ReportingExporterSchema]

--- a/src/middlewared/middlewared/api/v25_10_0/route.py
+++ b/src/middlewared/middlewared/api/v25_10_0/route.py
@@ -1,10 +1,10 @@
 from middlewared.api.base import BaseModel, IPvAnyAddress
 
 
-__all__ = ["RouteSystemRoutes", "RouteIPv4gwReachableArgs", "RouteIPv4gwReachableResult",]
+__all__ = ["RouteSystemRoutesItem", "RouteIpv4gwReachableArgs", "RouteIpv4gwReachableResult",]
 
 
-class RouteSystemRoutes(BaseModel):
+class RouteSystemRoutesItem(BaseModel):
     network: IPvAnyAddress
     netmask: IPvAnyAddress
     gateway: IPvAnyAddress | None
@@ -15,9 +15,9 @@ class RouteSystemRoutes(BaseModel):
     preferred_source: str | None
 
 
-class RouteIPv4gwReachableArgs(BaseModel):
+class RouteIpv4gwReachableArgs(BaseModel):
     ipv4_gateway: str
 
 
-class RouteIPv4gwReachableResult(BaseModel):
+class RouteIpv4gwReachableResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_10_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_0/smb.py
@@ -20,16 +20,16 @@ from middlewared.utils.lang import undefined
 from middlewared.utils.smb import SMBUnixCharset, SMBSharePurpose, validate_smb_path_suffix
 
 __all__ = [
-    'GetSmbAclArgs', 'GetSmbAclResult',
-    'SetSmbAclArgs', 'SetSmbAclResult',
-    'SmbServiceEntry', 'SmbServiceUpdateArgs', 'SmbServiceUpdateResult',
-    'SmbServiceUnixCharsetChoicesArgs', 'SmbServiceUnixCharsetChoicesResult',
-    'SmbServiceBindIPChoicesArgs', 'SmbServiceBindIPChoicesResult',
-    'SmbSharePresetsArgs', 'SmbSharePresetsResult',
-    'SmbSharePrecheckArgs', 'SmbSharePrecheckResult',
-    'SmbShareEntry', 'SmbShareCreateArgs', 'SmbShareCreateResult',
-    'SmbShareUpdateArgs', 'SmbShareUpdateResult',
-    'SmbShareDeleteArgs', 'SmbShareDeleteResult',
+    'SharingSMBGetaclArgs', 'SharingSMBGetaclResult',
+    'SharingSMBSetaclArgs', 'SharingSMBSetaclResult',
+    'SmbServiceEntry', 'SMBUpdateArgs', 'SMBUpdateResult',
+    'SMBUnixcharsetChoicesArgs', 'SMBUnixcharsetChoicesResult',
+    'SMBBindipChoicesArgs', 'SMBBindipChoicesResult',
+    'SharingSMBPresetsArgs', 'SharingSMBPresetsResult',
+    'SharingSMBSharePrecheckArgs', 'SharingSMBSharePrecheckResult',
+    'SmbShareEntry', 'SharingSMBCreateArgs', 'SharingSMBCreateResult',
+    'SharingSMBUpdateArgs', 'SharingSMBUpdateResult',
+    'SharingSMBDeleteArgs', 'SharingSMBDeleteResult',
 ]
 
 EMPTY_STRING = ''
@@ -99,20 +99,20 @@ class SMBShareAcl(BaseModel):
 
 
 @single_argument_args('smb_setacl')
-class SetSmbAclArgs(SMBShareAcl):
+class SharingSMBSetaclArgs(SMBShareAcl):
     pass
 
 
-class SetSmbAclResult(BaseModel):
+class SharingSMBSetaclResult(BaseModel):
     result: SMBShareAcl
 
 
 @single_argument_args('smb_getacl')
-class GetSmbAclArgs(BaseModel):
+class SharingSMBGetaclArgs(BaseModel):
     share_name: NonEmptyString
 
 
-class GetSmbAclResult(SetSmbAclResult):
+class SharingSMBGetaclResult(SharingSMBSetaclResult):
     pass
 
 
@@ -183,44 +183,44 @@ class SmbServiceEntry(BaseModel):
 
 
 @single_argument_args('smb_update')
-class SmbServiceUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
+class SMBUpdateArgs(SmbServiceEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SmbServiceUpdateResult(BaseModel):
+class SMBUpdateResult(BaseModel):
     result: SmbServiceEntry
 
 
-class SmbServiceUnixCharsetChoicesArgs(BaseModel):
+class SMBUnixcharsetChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceUnixCharsetChoicesResult(BaseModel):
+class SMBUnixcharsetChoicesResult(BaseModel):
     result: dict[str, SMBCharsetType]
 
 
-class SmbServiceBindIPChoicesArgs(BaseModel):
+class SMBBindipChoicesArgs(BaseModel):
     pass
 
 
-class SmbServiceBindIPChoicesResult(BaseModel):
+class SMBBindipChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SmbSharePresetsArgs(BaseModel):
+class SharingSMBPresetsArgs(BaseModel):
     pass
 
 
-class SmbSharePresetsResult(BaseModel):
+class SharingSMBPresetsResult(BaseModel):
     result: dict[str, dict]
 
 
 @single_argument_args('smb_share_precheck')
-class SmbSharePrecheckArgs(BaseModel):
+class SharingSMBSharePrecheckArgs(BaseModel):
     name: SmbShareName | None = None
 
 
-class SmbSharePrecheckResult(BaseModel):
+class SharingSMBSharePrecheckResult(BaseModel):
     result: None
 
 
@@ -658,11 +658,11 @@ class SmbShareCreate(SmbShareEntry):
         return self
 
 
-class SmbShareCreateArgs(BaseModel):
+class SharingSMBCreateArgs(BaseModel):
     data: SmbShareCreate
 
 
-class SmbShareCreateResult(BaseModel):
+class SharingSMBCreateResult(BaseModel):
     result: SmbShareEntry
 
 
@@ -670,18 +670,18 @@ class SmbShareUpdate(SmbShareCreate, metaclass=ForUpdateMetaclass):
     pass
 
 
-class SmbShareUpdateArgs(BaseModel):
+class SharingSMBUpdateArgs(BaseModel):
     id: int
     data: SmbShareUpdate
 
 
-class SmbShareUpdateResult(BaseModel):
+class SharingSMBUpdateResult(BaseModel):
     result: SmbShareEntry
 
 
-class SmbShareDeleteArgs(BaseModel):
+class SharingSMBDeleteArgs(BaseModel):
     id: int
 
 
-class SmbShareDeleteResult(BaseModel):
+class SharingSMBDeleteResult(BaseModel):
     result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_10_0/snmp.py
+++ b/src/middlewared/middlewared/api/v25_10_0/snmp.py
@@ -8,7 +8,7 @@ from middlewared.api.base import (
 )
 
 __all__ = ["SnmpEntry",
-           "SnmpUpdateArgs", "SnmpUpdateResult"]
+           "SNMPUpdateArgs", "SNMPUpdateResult"]
 
 
 class SnmpEntry(BaseModel):
@@ -29,9 +29,9 @@ class SnmpEntry(BaseModel):
 
 
 @single_argument_args('snmp_update')
-class SnmpUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
+class SNMPUpdateArgs(SnmpEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class SnmpUpdateResult(BaseModel):
+class SNMPUpdateResult(BaseModel):
     result: SnmpEntry

--- a/src/middlewared/middlewared/api/v25_10_0/ssh.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ssh.py
@@ -3,7 +3,7 @@ from typing import Literal
 from middlewared.api.base import BaseModel, LongString, Excluded, excluded_field, ForUpdateMetaclass, TcpPort
 
 
-__all__ = ['SSHEntry', 'SSHBindIfaceChoicesArgs', 'SSHBindIfaceChoicesResult', 'SSHUpdateArgs', 'SSHUpdateResult',]
+__all__ = ['SSHEntry', 'SSHBindifaceChoicesArgs', 'SSHBindifaceChoicesResult', 'SSHUpdateArgs', 'SSHUpdateResult',]
 
 
 class SSHEntry(BaseModel):
@@ -57,11 +57,11 @@ class SSHUpdate(SSHEntry, metaclass=ForUpdateMetaclass):
     host_rsa_key_cert_pub: Excluded = excluded_field()
 
 
-class SSHBindIfaceChoicesArgs(BaseModel):
+class SSHBindifaceChoicesArgs(BaseModel):
     pass
 
 
-class SSHBindIfaceChoicesResult(BaseModel):
+class SSHBindifaceChoicesResult(BaseModel):
     result: dict[str, str]
     """Result of `interface.choices`."""
 

--- a/src/middlewared/middlewared/api/v25_10_0/system.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system.py
@@ -8,8 +8,8 @@ from middlewared.api.base import BaseModel, single_argument_result
 __all__ = [
     "SystemDebugArgs",
     "SystemDebugResult",
-    "SystemHostIDArgs",
-    "SystemHostIDResult",
+    "SystemHostIdArgs",
+    "SystemHostIdResult",
     "SystemInfoArgs",
     "SystemInfoResult",
 ]
@@ -23,11 +23,11 @@ class SystemDebugResult(BaseModel):
     result: None
 
 
-class SystemHostIDArgs(BaseModel):
+class SystemHostIdArgs(BaseModel):
     pass
 
 
-class SystemHostIDResult(BaseModel):
+class SystemHostIdResult(BaseModel):
     result: str
     """The system host identifier."""
 

--- a/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
@@ -8,14 +8,14 @@ from middlewared.api.base import (
 
 
 __all__ = [
-    "SystemAdvancedEntry", "SystemAdvancedGpuChoicesArgs", "SystemAdvancedGpuChoicesResult",
-    "SystemAdvancedLoginBannerArgs", "SystemAdvancedLoginBannerResult", "SystemAdvancedSEDGlobalPasswordArgs",
-    "SystemAdvancedSEDGlobalPasswordResult", "SystemAdvancedSEDGlobalPasswordIsSetArgs",
-    "SystemAdvancedSEDGlobalPasswordIsSetResult", "SystemAdvancedSerialPortChoicesArgs",
+    "SystemAdvancedEntry", "SystemAdvancedGetGpuPciChoicesArgs", "SystemAdvancedGetGpuPciChoicesResult",
+    "SystemAdvancedLoginBannerArgs", "SystemAdvancedLoginBannerResult", "SystemAdvancedSedGlobalPasswordArgs",
+    "SystemAdvancedSedGlobalPasswordResult", "SystemAdvancedSedGlobalPasswordIsSetArgs",
+    "SystemAdvancedSedGlobalPasswordIsSetResult", "SystemAdvancedSerialPortChoicesArgs",
     "SystemAdvancedSerialPortChoicesResult", "SystemAdvancedSyslogCertificateAuthorityChoicesArgs",
     "SystemAdvancedSyslogCertificateAuthorityChoicesResult", "SystemAdvancedSyslogCertificateChoicesArgs",
     "SystemAdvancedSyslogCertificateChoicesResult", "SystemAdvancedUpdateArgs", "SystemAdvancedUpdateResult",
-    "SystemAdvancedUpdateGpuPciIdArgs", "SystemAdvancedUpdateGpuPciIdResult",
+    "SystemAdvancedUpdateGpuPciIdsArgs", "SystemAdvancedUpdateGpuPciIdsResult",
 ]
 
 
@@ -62,11 +62,11 @@ class SystemAdvancedUpdate(SystemAdvancedEntry, metaclass=ForUpdateMetaclass):
     sed_passwd: Secret[str]
 
 
-class SystemAdvancedGpuChoicesArgs(BaseModel):
+class SystemAdvancedGetGpuPciChoicesArgs(BaseModel):
     pass
 
 
-class SystemAdvancedGpuChoicesResult(BaseModel):
+class SystemAdvancedGetGpuPciChoicesResult(BaseModel):
     result: dict
 
 
@@ -78,19 +78,19 @@ class SystemAdvancedLoginBannerResult(BaseModel):
     result: str
 
 
-class SystemAdvancedSEDGlobalPasswordArgs(BaseModel):
+class SystemAdvancedSedGlobalPasswordArgs(BaseModel):
     pass
 
 
-class SystemAdvancedSEDGlobalPasswordResult(BaseModel):
+class SystemAdvancedSedGlobalPasswordResult(BaseModel):
     result: Secret[str]
 
 
-class SystemAdvancedSEDGlobalPasswordIsSetArgs(BaseModel):
+class SystemAdvancedSedGlobalPasswordIsSetArgs(BaseModel):
     pass
 
 
-class SystemAdvancedSEDGlobalPasswordIsSetResult(BaseModel):
+class SystemAdvancedSedGlobalPasswordIsSetResult(BaseModel):
     result: bool
 
 
@@ -127,9 +127,9 @@ class SystemAdvancedUpdateResult(BaseModel):
     result: SystemAdvancedEntry
 
 
-class SystemAdvancedUpdateGpuPciIdArgs(BaseModel):
+class SystemAdvancedUpdateGpuPciIdsArgs(BaseModel):
     data: list[str]
 
 
-class SystemAdvancedUpdateGpuPciIdResult(BaseModel):
+class SystemAdvancedUpdateGpuPciIdsResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/api/v25_10_0/system_general.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_general.py
@@ -20,6 +20,8 @@ __all__ = [
     "SystemGeneralEntry", "SystemGeneralUpdateArgs", "SystemGeneralUpdateResult",
     "SystemGeneralCheckinWaitingArgs", "SystemGeneralCheckinWaitingResult",
     "SystemGeneralCheckinArgs", "SystemGeneralCheckinResult",
+    'SystemGeneralCountryChoicesArgs',
+    'SystemGeneralCountryChoicesResult',
 ]
 
 
@@ -82,3 +84,11 @@ class SystemGeneralCheckinArgs(BaseModel):
 
 class SystemGeneralCheckinResult(BaseModel):
     result: None
+
+
+class SystemGeneralCountryChoicesArgs(BaseModel):
+    pass
+
+
+class SystemGeneralCountryChoicesResult(BaseModel):
+    result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_10_0/system_general_keymap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_general_keymap.py
@@ -1,12 +1,12 @@
 from middlewared.api.base import BaseModel
 
 
-__all__ = ["SystemGeneralKbdMapChoicesArgs", "SystemGeneralKbdMapChoicesResult",]
+__all__ = ["SystemGeneralKbdmapChoicesArgs", "SystemGeneralKbdmapChoicesResult",]
 
 
-class SystemGeneralKbdMapChoicesArgs(BaseModel):
+class SystemGeneralKbdmapChoicesArgs(BaseModel):
     pass
 
 
-class SystemGeneralKbdMapChoicesResult(BaseModel):
+class SystemGeneralKbdmapChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_10_0/system_general_ui.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_general_ui.py
@@ -4,58 +4,58 @@ from pydantic import NonNegativeInt
 
 
 __all__ = [
-    "SystemGeneralUIAddressChoicesArgs", "SystemGeneralUIAddressChoicesResult",
-    "SystemGeneralUICertificateChoicesArgs", "SystemGeneralUICertificateChoicesResult",
-    "SystemGeneralUIHTTPSProtocolChoicesArgs", "SystemGeneralUIHTTPSProtocolChoicesResult",
-    "SystemGeneralUILocalURLArgs", "SystemGeneralUILocalURLResult", "SystemGeneralUIRestartArgs",
-    "SystemGeneralUIRestartResult", "SystemGeneralUIV6AddressChoicesArgs", "SystemGeneralUIV6AddressChoicesResult",
+    "SystemGeneralUiAddressChoicesArgs", "SystemGeneralUiAddressChoicesResult",
+    "SystemGeneralUiCertificateChoicesArgs", "SystemGeneralUiCertificateChoicesResult",
+    "SystemGeneralUiHttpsprotocolsChoicesArgs", "SystemGeneralUiHttpsprotocolsChoicesResult",
+    "SystemGeneralLocalUrlArgs", "SystemGeneralLocalUrlResult", "SystemGeneralUiRestartArgs",
+    "SystemGeneralUiRestartResult", "SystemGeneralUiV6addressChoicesArgs", "SystemGeneralUiV6addressChoicesResult",
 ]
 
 
-class SystemGeneralUIAddressChoicesArgs(BaseModel):
+class SystemGeneralUiAddressChoicesArgs(BaseModel):
     pass
 
 
-class SystemGeneralUIAddressChoicesResult(BaseModel):
+class SystemGeneralUiAddressChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SystemGeneralUICertificateChoicesArgs(BaseModel):
+class SystemGeneralUiCertificateChoicesArgs(BaseModel):
     pass
 
 
-class SystemGeneralUICertificateChoicesResult(BaseModel):
+class SystemGeneralUiCertificateChoicesResult(BaseModel):
     result: dict[int, str]
 
 
-class SystemGeneralUIHTTPSProtocolChoicesArgs(BaseModel):
+class SystemGeneralUiHttpsprotocolsChoicesArgs(BaseModel):
     pass
 
 
-class SystemGeneralUIHTTPSProtocolChoicesResult(BaseModel):
+class SystemGeneralUiHttpsprotocolsChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class SystemGeneralUILocalURLArgs(BaseModel):
+class SystemGeneralLocalUrlArgs(BaseModel):
     pass
 
 
-class SystemGeneralUILocalURLResult(BaseModel):
+class SystemGeneralLocalUrlResult(BaseModel):
     result: str
 
 
-class SystemGeneralUIRestartArgs(BaseModel):
+class SystemGeneralUiRestartArgs(BaseModel):
     delay: NonNegativeInt = 3
     """How long to wait before the UI is restarted"""
 
 
-class SystemGeneralUIRestartResult(BaseModel):
+class SystemGeneralUiRestartResult(BaseModel):
     result: None
 
 
-class SystemGeneralUIV6AddressChoicesArgs(BaseModel):
+class SystemGeneralUiV6addressChoicesArgs(BaseModel):
     pass
 
 
-class SystemGeneralUIV6AddressChoicesResult(BaseModel):
+class SystemGeneralUiV6addressChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_10_0/system_global.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_global.py
@@ -1,11 +1,11 @@
 from middlewared.api.base import BaseModel
 
-__all__ = ("SystemGlobalIdArgs", "SystemGlobalIdResult")
+__all__ = ("SystemGlobalIDIdArgs", "SystemGlobalIDIdResult")
 
 
-class SystemGlobalIdArgs(BaseModel):
+class SystemGlobalIDIdArgs(BaseModel):
     pass
 
 
-class SystemGlobalIdResult(BaseModel):
+class SystemGlobalIDIdResult(BaseModel):
     result: str

--- a/src/middlewared/middlewared/api/v25_10_0/system_ntpserver.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_ntpserver.py
@@ -3,25 +3,11 @@ from typing import Literal
 
 
 __all__ = [
-    'NTPPeerEntry', 'NTPServerEntry',
+    'NTPServerEntry',
     'NTPServerCreateArgs', 'NTPServerCreateResult',
     'NTPServerUpdateArgs', 'NTPServerUpdateResult',
     'NTPServerDeleteArgs', 'NTPServerDeleteResult',
 ]
-
-
-class NTPPeerEntry(BaseModel):
-    mode: Literal['SERVER', 'PEER', 'LOCAL']
-    state: Literal['BEST', 'SELECTED', 'SELECTABLE', 'FALSE_TICKER', 'TOO_VARIABLE', 'NOT_SELECTABLE']
-    remote: str
-    stratum: int
-    poll_interval: int
-    reach: int
-    lastrx: int
-    offset: float
-    offset_measured: float
-    jitter: float
-    active: bool
 
 
 class NTPServerEntry(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/system_product.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_product.py
@@ -4,42 +4,42 @@ from middlewared.api.base import BaseModel, NonEmptyString
 
 
 __all__ = (
-    "SystemProductFeatureEnabledArgs",
-    "SystemProductFeatureEnabledResult",
-    "SystemProductLicenseArgs",
-    "SystemProductLicenseResult",
-    "SystemProductReleaseNotesUrlArgs",
-    "SystemProductReleaseNotesUrlResult",
+    "SystemFeatureEnabledArgs",
+    "SystemFeatureEnabledResult",
+    "SystemLicenseUpdateArgs",
+    "SystemLicenseUpdateResult",
+    "SystemReleaseNotesUrlArgs",
+    "SystemReleaseNotesUrlResult",
     "SystemProductTypeArgs",
     "SystemProductTypeResult",
-    "SystemProductVersionArgs",
-    "SystemProductVersionResult",
-    "SystemProductVersionShortArgs",
-    "SystemProductVersionShortResult",
+    "SystemVersionArgs",
+    "SystemVersionResult",
+    "SystemVersionShortArgs",
+    "SystemVersionShortResult",
 )
 
 
-class SystemProductFeatureEnabledArgs(BaseModel):
+class SystemFeatureEnabledArgs(BaseModel):
     feature: Literal["DEDUP", "FIBRECHANNEL", "VM"]
 
 
-class SystemProductFeatureEnabledResult(BaseModel):
+class SystemFeatureEnabledResult(BaseModel):
     result: bool
 
 
-class SystemProductLicenseArgs(BaseModel):
+class SystemLicenseUpdateArgs(BaseModel):
     license: NonEmptyString
 
 
-class SystemProductLicenseResult(BaseModel):
+class SystemLicenseUpdateResult(BaseModel):
     result: None
 
 
-class SystemProductReleaseNotesUrlArgs(BaseModel):
+class SystemReleaseNotesUrlArgs(BaseModel):
     version_str: NonEmptyString | None = None
 
 
-class SystemProductReleaseNotesUrlResult(BaseModel):
+class SystemReleaseNotesUrlResult(BaseModel):
     result: str
 
 
@@ -51,17 +51,17 @@ class SystemProductTypeResult(BaseModel):
     result: Literal["COMMUNITY_EDITION", "ENTERPRISE"]
 
 
-class SystemProductVersionArgs(BaseModel):
+class SystemVersionArgs(BaseModel):
     pass
 
 
-class SystemProductVersionResult(BaseModel):
+class SystemVersionResult(BaseModel):
     result: str
 
 
-class SystemProductVersionShortArgs(BaseModel):
+class SystemVersionShortArgs(BaseModel):
     pass
 
 
-class SystemProductVersionShortResult(BaseModel):
+class SystemVersionShortResult(BaseModel):
     result: str

--- a/src/middlewared/middlewared/api/v25_10_0/system_security.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_security.py
@@ -14,8 +14,8 @@ from middlewared.utils.security import PasswordComplexity, MAX_PASSWORD_HISTORY
 
 __all__ = [
     'SystemSecurityEntry', 'SystemSecurityUpdateArgs', 'SystemSecurityUpdateResult',
-    'SystemSecurityFipsAvailableArgs', 'SystemSecurityFipsAvailableResult',
-    'SystemSecurityFipsEnabledArgs', 'SystemSecurityFipsEnabledResult',
+    'SystemSecurityInfoFipsAvailableArgs', 'SystemSecurityInfoFipsAvailableResult',
+    'SystemSecurityInfoFipsEnabledArgs', 'SystemSecurityInfoFipsEnabledResult',
 ]
 
 
@@ -79,17 +79,17 @@ class SystemSecurityUpdateResult(BaseModel):
     result: SystemSecurityEntry
 
 
-class SystemSecurityFipsAvailableArgs(BaseModel):
+class SystemSecurityInfoFipsAvailableArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsAvailableResult(BaseModel):
+class SystemSecurityInfoFipsAvailableResult(BaseModel):
     result: bool
 
 
-class SystemSecurityFipsEnabledArgs(BaseModel):
+class SystemSecurityInfoFipsEnabledArgs(BaseModel):
     pass
 
 
-class SystemSecurityFipsEnabledResult(BaseModel):
+class SystemSecurityInfoFipsEnabledResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
@@ -5,8 +5,8 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TNCGetRegistrationURIArgs', 'TNCGetRegistrationURIResult', 'TNCUpdateArgs', 'TNCUpdateResult',
-    'TNCGenerateClaimTokenArgs', 'TNCGenerateClaimTokenResult', 'TNCIPChoicesArgs', 'TNCIPChoicesResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult', 'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
+    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult', 'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 
 
@@ -25,7 +25,7 @@ class TNCEntry(BaseModel):
 
 
 @single_argument_args('tn_connect_update')
-class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
+class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
     account_service_base_url: HttpsOnlyURL
@@ -34,29 +34,29 @@ class TNCUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     heartbeat_url: HttpsOnlyURL
 
 
-class TNCUpdateResult(BaseModel):
+class TrueNASConnectUpdateResult(BaseModel):
     result: TNCEntry
 
 
-class TNCGetRegistrationURIArgs(BaseModel):
+class TrueNASConnectGetRegistrationUriArgs(BaseModel):
     pass
 
 
-class TNCGetRegistrationURIResult(BaseModel):
+class TrueNASConnectGetRegistrationUriResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCGenerateClaimTokenArgs(BaseModel):
+class TrueNASConnectGenerateClaimTokenArgs(BaseModel):
     pass
 
 
-class TNCGenerateClaimTokenResult(BaseModel):
+class TrueNASConnectGenerateClaimTokenResult(BaseModel):
     result: NonEmptyString
 
 
-class TNCIPChoicesArgs(BaseModel):
+class TrueNASConnectIpChoicesArgs(BaseModel):
     pass
 
 
-class TNCIPChoicesResult(BaseModel):
+class TrueNASConnectIpChoicesResult(BaseModel):
     result: dict[str, str]

--- a/src/middlewared/middlewared/api/v25_10_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v25_10_0/truecommand.py
@@ -8,7 +8,7 @@ from middlewared.api.base import BaseModel, ForUpdateMetaclass, single_argument_
 
 __all__ = [
     'TRUECOMMAND_CONNECTING_STATUS_REASON', 'TruecommandStatus', 'TruecommandStatusReason',
-    'TruecommandEntry', 'TruecommandUpdateArgs', 'TrueCommandUpdateResult',
+    'TruecommandEntry', 'TruecommandUpdateArgs', 'TruecommandUpdateResult',
 ]
 
 TRUECOMMAND_CONNECTING_STATUS_REASON = 'Waiting for connection from Truecommand.'
@@ -58,5 +58,5 @@ class TruecommandUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     api_key: Secret[Annotated[str, Field(min_length=16, max_length=16)] | None]
 
 
-class TrueCommandUpdateResult(BaseModel):
+class TruecommandUpdateResult(BaseModel):
     result: TruecommandEntry

--- a/src/middlewared/middlewared/api/v25_10_0/truenas.py
+++ b/src/middlewared/middlewared/api/v25_10_0/truenas.py
@@ -4,10 +4,10 @@ from middlewared.api.base import BaseModel, LongString
 __all__ = [
     'TrueNASSetProductionArgs', 'TrueNASSetProductionResult',
     'TrueNASIsProductionArgs', 'TrueNASIsProductionResult',
-    'TrueNASAcceptEULAArgs', 'TrueNASAcceptEULAResult',
-    'TrueNASIsEULAAcceptedArgs', 'TrueNASIsEULAAcceptedResult',
-    'TrueNASGetEULAArgs', 'TrueNASGetEULAResult',
-    'TrueNASIsIXHardwareArgs', 'TrueNASIsIXHardwareResult',
+    'TrueNASAcceptEulaArgs', 'TrueNASAcceptEulaResult',
+    'TrueNASIsEulaAcceptedArgs', 'TrueNASIsEulaAcceptedResult',
+    'TrueNASGetEulaArgs', 'TrueNASGetEulaResult',
+    'TrueNASIsIxHardwareArgs', 'TrueNASIsIxHardwareResult',
     'TrueNASGetChassisHardwareArgs', 'TrueNASGetChassisHardwareResult',
     'TrueNASManagedByTruecommandArgs', 'TrueNASManagedByTruecommandResult'
 ]
@@ -29,35 +29,35 @@ class TrueNASGetChassisHardwareResult(BaseModel):
     result: str
 
 
-class TrueNASIsIXHardwareArgs(BaseModel):
+class TrueNASIsIxHardwareArgs(BaseModel):
     pass
 
 
-class TrueNASIsIXHardwareResult(BaseModel):
+class TrueNASIsIxHardwareResult(BaseModel):
     result: bool
 
 
-class TrueNASGetEULAArgs(BaseModel):
+class TrueNASGetEulaArgs(BaseModel):
     pass
 
 
-class TrueNASGetEULAResult(BaseModel):
+class TrueNASGetEulaResult(BaseModel):
     result: LongString | None
 
 
-class TrueNASIsEULAAcceptedArgs(BaseModel):
+class TrueNASIsEulaAcceptedArgs(BaseModel):
     pass
 
 
-class TrueNASIsEULAAcceptedResult(BaseModel):
+class TrueNASIsEulaAcceptedResult(BaseModel):
     result: bool
 
 
-class TrueNASAcceptEULAArgs(BaseModel):
+class TrueNASAcceptEulaArgs(BaseModel):
     pass
 
 
-class TrueNASAcceptEULAResult(BaseModel):
+class TrueNASAcceptEulaResult(BaseModel):
     result: None
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_device.py
@@ -7,12 +7,12 @@ from middlewared.validators import RE_MAC_ADDRESS
 
 
 __all__ = [
-    'DeviceType', 'InstanceType', 'VirtDeviceUSBChoicesArgs', 'VirtDeviceUSBChoicesResult',
-    'VirtDeviceGPUChoicesArgs', 'VirtDeviceGPUChoicesResult', 'VirtDeviceDiskChoicesArgs',
-    'VirtDeviceDiskChoicesResult', 'VirtDeviceNICChoicesArgs', 'VirtDeviceNICChoicesResult',
+    'DeviceType', 'InstanceType', 'VirtDeviceUsbChoicesArgs', 'VirtDeviceUsbChoicesResult',
+    'VirtDeviceGpuChoicesArgs', 'VirtDeviceGpuChoicesResult', 'VirtDeviceDiskChoicesArgs',
+    'VirtDeviceDiskChoicesResult', 'VirtDeviceNicChoicesArgs', 'VirtDeviceNicChoicesResult',
     'VirtDeviceExportDiskImageArgs', 'VirtDeviceExportDiskImageResult', 'VirtDeviceImportDiskImageArgs',
-    'VirtDeviceImportDiskImageResult', 'VirtDevicePCIChoicesArgs', 'VirtDevicePCIChoicesResult',
-    'VirtInstanceBootableDiskArgs', 'VirtInstanceBootableDiskResult',
+    'VirtDeviceImportDiskImageResult', 'VirtDevicePciChoicesArgs', 'VirtDevicePciChoicesResult',
+    'VirtInstanceDeviceSetBootableDiskArgs', 'VirtInstanceDeviceSetBootableDiskResult',
 ]
 
 
@@ -138,7 +138,7 @@ DeviceType: TypeAlias = Annotated[
 ]
 
 
-class VirtDeviceUSBChoicesArgs(BaseModel):
+class VirtDeviceUsbChoicesArgs(BaseModel):
     pass
 
 
@@ -151,11 +151,11 @@ class USBChoice(BaseModel):
     manufacturer: str | None
 
 
-class VirtDeviceUSBChoicesResult(BaseModel):
+class VirtDeviceUsbChoicesResult(BaseModel):
     result: dict[str, USBChoice]
 
 
-class VirtDeviceGPUChoicesArgs(BaseModel):
+class VirtDeviceGpuChoicesArgs(BaseModel):
     gpu_type: GPUType
 
 
@@ -167,7 +167,7 @@ class GPUChoice(BaseModel):
     pci: str
 
 
-class VirtDeviceGPUChoicesResult(BaseModel):
+class VirtDeviceGpuChoicesResult(BaseModel):
     result: dict[str, GPUChoice]
 
 
@@ -179,11 +179,11 @@ class VirtDeviceDiskChoicesResult(BaseModel):
     result: dict[str, str]
 
 
-class VirtDeviceNICChoicesArgs(BaseModel):
+class VirtDeviceNicChoicesArgs(BaseModel):
     nic_type: NicType
 
 
-class VirtDeviceNICChoicesResult(BaseModel):
+class VirtDeviceNicChoicesResult(BaseModel):
     result: dict[str, str]
 
 
@@ -208,18 +208,18 @@ class VirtDeviceExportDiskImageResult(BaseModel):
     result: bool
 
 
-class VirtDevicePCIChoicesArgs(BaseModel):
+class VirtDevicePciChoicesArgs(BaseModel):
     pass
 
 
-class VirtDevicePCIChoicesResult(BaseModel):
+class VirtDevicePciChoicesResult(BaseModel):
     result: dict
 
 
-class VirtInstanceBootableDiskArgs(BaseModel):
+class VirtInstanceDeviceSetBootableDiskArgs(BaseModel):
     id: NonEmptyString
     disk: NonEmptyString
 
 
-class VirtInstanceBootableDiskResult(BaseModel):
+class VirtInstanceDeviceSetBootableDiskResult(BaseModel):
     result: bool

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -13,9 +13,9 @@ __all__ = [
     'VirtInstanceUpdateResult', 'VirtInstanceDeleteArgs', 'VirtInstanceDeleteResult',
     'VirtInstanceStartArgs', 'VirtInstanceStartResult', 'VirtInstanceStopArgs', 'VirtInstanceStopResult',
     'VirtInstanceRestartArgs', 'VirtInstanceRestartResult', 'VirtInstanceImageChoicesArgs',
-    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceListArgs', 'VirtInstanceDeviceListResult',
-    'VirtInstanceDeviceAddArgs', 'VirtInstanceDeviceAddResult', 'VirtInstanceDeviceUpdateArgs',
-    'VirtInstanceDeviceUpdateResult', 'VirtInstanceDeviceDeleteArgs', 'VirtInstanceDeviceDeleteResult',
+    'VirtInstanceImageChoicesResult', 'VirtInstanceDeviceDeviceListArgs', 'VirtInstanceDeviceDeviceListResult',
+    'VirtInstanceDeviceDeviceAddArgs', 'VirtInstanceDeviceDeviceAddResult', 'VirtInstanceDeviceDeviceUpdateArgs',
+    'VirtInstanceDeviceDeviceUpdateResult', 'VirtInstanceDeviceDeviceDeleteArgs', 'VirtInstanceDeviceDeviceDeleteResult',
     'VirtInstancesMetricsEventSourceArgs', 'VirtInstancesMetricsEventSourceEvent',
 ]
 
@@ -283,38 +283,38 @@ class VirtInstanceImageChoicesResult(BaseModel):
     result: dict[str, ImageChoiceItem]
 
 
-class VirtInstanceDeviceListArgs(BaseModel):
+class VirtInstanceDeviceDeviceListArgs(BaseModel):
     id: str
 
 
-class VirtInstanceDeviceListResult(BaseModel):
+class VirtInstanceDeviceDeviceListResult(BaseModel):
     result: list[DeviceType]
 
 
-class VirtInstanceDeviceAddArgs(BaseModel):
+class VirtInstanceDeviceDeviceAddArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceAddResult(BaseModel):
+class VirtInstanceDeviceDeviceAddResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceUpdateArgs(BaseModel):
+class VirtInstanceDeviceDeviceUpdateArgs(BaseModel):
     id: str
     device: DeviceType
 
 
-class VirtInstanceDeviceUpdateResult(BaseModel):
+class VirtInstanceDeviceDeviceUpdateResult(BaseModel):
     result: Literal[True]
 
 
-class VirtInstanceDeviceDeleteArgs(BaseModel):
+class VirtInstanceDeviceDeviceDeleteArgs(BaseModel):
     id: str
     name: str
 
 
-class VirtInstanceDeviceDeleteResult(BaseModel):
+class VirtInstanceDeviceDeviceDeleteResult(BaseModel):
     result: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_volume.py
@@ -10,7 +10,7 @@ from middlewared.api.base import (
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
-    'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+    'VirtVolumeDeleteResult', 'VirtVolumeImportIsoArgs', 'VirtVolumeImportIsoResult',
     'VirtVolumeImportZvolArgs', 'VirtVolumeImportZvolResult'
 ]
 
@@ -80,7 +80,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 
 @single_argument_args('virt_volume_import_iso')
-class VirtVolumeImportISOArgs(BaseModel):
+class VirtVolumeImportIsoArgs(BaseModel):
     name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
@@ -93,7 +93,7 @@ class VirtVolumeImportISOArgs(BaseModel):
     '''
 
 
-class VirtVolumeImportISOResult(BaseModel):
+class VirtVolumeImportIsoResult(BaseModel):
     result: VirtVolumeEntry
 
 

--- a/src/middlewared/middlewared/plugins/account_/privilege_roles.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege_roles.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from middlewared.api.current import PrivilegeRoleEntry
+from middlewared.api.current import PrivilegeRolesEntry
 
 from middlewared.role import ROLES
 from middlewared.service import Service, filterable_api_method, filter_list, private
@@ -12,7 +12,7 @@ class PrivilegeService(Service):
         namespace = "privilege"
         cli_namespace = "auth.privilege"
 
-    @filterable_api_method(item=PrivilegeRoleEntry, authorization_required=False)
+    @filterable_api_method(item=PrivilegeRolesEntry, authorization_required=False)
     async def roles(self, filters, options):
         """
         Get all available roles.

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -10,9 +10,9 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from middlewared.api import api_method
 from middlewared.api.base import BaseModel, LongString, single_argument_args
 from middlewared.api.current import (
-    ACMEDNSAuthenticatorEntry, ACMEDNSAuthenticatorCreateArgs, ACMEDNSAuthenticatorCreateResult,
-    ACMEDNSAuthenticatorUpdateArgs, ACMEDNSAuthenticatorUpdateResult, ACMEDNSAuthenticatorDeleteArgs,
-    ACMEDNSAuthenticatorDeleteResult,
+    ACMEDNSAuthenticatorEntry, DNSAuthenticatorCreateArgs, DNSAuthenticatorCreateResult,
+    DNSAuthenticatorUpdateArgs, DNSAuthenticatorUpdateResult, DNSAuthenticatorDeleteArgs,
+    DNSAuthenticatorDeleteResult,
 )
 from middlewared.schema import ValidationErrors
 from middlewared.service import CallError, CRUDService, private
@@ -262,7 +262,7 @@ class DNSAuthenticatorService(CRUDService):
 
         verrors.check()
 
-    @api_method(ACMEDNSAuthenticatorCreateArgs, ACMEDNSAuthenticatorCreateResult)
+    @api_method(DNSAuthenticatorCreateArgs, DNSAuthenticatorCreateResult)
     async def do_create(self, data):
         """
         Create a DNS Authenticator
@@ -299,7 +299,7 @@ class DNSAuthenticatorService(CRUDService):
 
         return await self.get_instance(id_)
 
-    @api_method(ACMEDNSAuthenticatorUpdateArgs, ACMEDNSAuthenticatorUpdateResult)
+    @api_method(DNSAuthenticatorUpdateArgs, DNSAuthenticatorUpdateResult)
     async def do_update(self, id_, data):
         """
         Update DNS Authenticator of `id`
@@ -343,7 +343,7 @@ class DNSAuthenticatorService(CRUDService):
 
         return await self.get_instance(id_)
 
-    @api_method(ACMEDNSAuthenticatorDeleteArgs, ACMEDNSAuthenticatorDeleteResult)
+    @api_method(DNSAuthenticatorDeleteArgs, DNSAuthenticatorDeleteResult)
     async def do_delete(self, id_):
         """
         Delete DNS Authenticator of `id`

--- a/src/middlewared/middlewared/plugins/acme_protocol_/schema.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/schema.py
@@ -1,6 +1,6 @@
 from middlewared.api import api_method
 from middlewared.api.base.jsonschema import get_json_schema
-from middlewared.api.current import ACMEDNSAuthenticatorSchemasArgs, ACMEDNSAuthenticatorSchemasResult
+from middlewared.api.current import DNSAuthenticatorAuthenticatorSchemasArgs, DNSAuthenticatorAuthenticatorSchemasResult
 from middlewared.service import private, Service
 
 from .authenticators.factory import auth_factory
@@ -15,7 +15,7 @@ class DNSAuthenticatorService(Service):
         super(DNSAuthenticatorService, self).__init__(*args, **kwargs)
         self.schemas = self.get_authenticator_schemas()
 
-    @api_method(ACMEDNSAuthenticatorSchemasArgs, ACMEDNSAuthenticatorSchemasResult, roles=['READONLY_ADMIN'])
+    @api_method(DNSAuthenticatorAuthenticatorSchemasArgs, DNSAuthenticatorAuthenticatorSchemasResult, roles=['READONLY_ADMIN'])
     def authenticator_schemas(self):
         """
         Get the schemas for all DNS providers we support for ACME DNS Challenge and the respective attributes

--- a/src/middlewared/middlewared/plugins/apps/ix_volumes.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_volumes.py
@@ -1,7 +1,7 @@
 import collections
 
 from middlewared.api import api_method
-from middlewared.api.current import AppIXVolumeEntry, AppIXVolumeExistsArgs, AppIXVolumeExistsResult
+from middlewared.api.current import AppsIxVolumeEntry, AppsIxVolumeExistsArgs, AppsIxVolumeExistsResult
 from middlewared.service import filterable_api_method, Service
 from middlewared.utils import filter_list
 
@@ -14,9 +14,9 @@ class AppsIxVolumeService(Service):
         namespace = 'app.ix_volume'
         event_send = False
         cli_namespace = 'app.ix_volume'
-        entry = AppIXVolumeEntry
+        entry = AppsIxVolumeEntry
 
-    @filterable_api_method(item=AppIXVolumeEntry, roles=['APPS_READ'])
+    @filterable_api_method(item=AppsIxVolumeEntry, roles=['APPS_READ'])
     async def query(self, filters, options):
         """
         Query ix-volumes with `filters` and `options`.
@@ -45,7 +45,7 @@ class AppsIxVolumeService(Service):
 
         return filter_list(volumes, filters, options)
 
-    @api_method(AppIXVolumeExistsArgs, AppIXVolumeExistsResult, roles=['APPS_READ'])
+    @api_method(AppsIxVolumeExistsArgs, AppsIxVolumeExistsResult, roles=['APPS_READ'])
     async def exists(self, app_name):
         """
         Check if ix-volumes exist for `app_name`.

--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -1,8 +1,8 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    AppContainerIDArgs, AppContainerIDResult, AppContainerConsoleChoiceArgs, AppContainerConsoleChoiceResult,
+    AppContainerIdsArgs, AppContainerIdsResult, AppContainerConsoleChoicesArgs, AppContainerConsoleChoicesResult,
     AppCertificateChoicesArgs, AppCertificateChoicesResult,
-    AppUsedPortsArgs, AppUsedPortsResult, AppIPChoicesArgs, AppIPChoicesResult, AppAvailableSpaceArgs,
+    AppUsedPortsArgs, AppUsedPortsResult, AppIpChoicesArgs, AppIpChoicesResult, AppAvailableSpaceArgs,
     AppAvailableSpaceResult, AppGpuChoicesArgs, AppGpuChoicesResult,
 )
 from middlewared.plugins.zfs_.utils import paths_to_datasets_impl
@@ -20,7 +20,7 @@ class AppService(Service):
         namespace = 'app'
         cli_namespace = 'app'
 
-    @api_method(AppContainerIDArgs, AppContainerIDResult, roles=['APPS_READ'])
+    @api_method(AppContainerIdsArgs, AppContainerIdsResult, roles=['APPS_READ'])
     async def container_ids(self, app_name, options):
         """
         Returns container IDs for `app_name`.
@@ -38,7 +38,7 @@ class AppService(Service):
             )
         }
 
-    @api_method(AppContainerConsoleChoiceArgs, AppContainerConsoleChoiceResult, roles=['APPS_READ'])
+    @api_method(AppContainerConsoleChoicesArgs, AppContainerConsoleChoicesResult, roles=['APPS_READ'])
     async def container_console_choices(self, app_name):
         """
         Returns container console choices for `app_name`.
@@ -67,7 +67,7 @@ class AppService(Service):
             for host_port in port_entry['host_ports']
         })))
 
-    @api_method(AppIPChoicesArgs, AppIPChoicesResult, roles=['APPS_READ'])
+    @api_method(AppIpChoicesArgs, AppIpChoicesResult, roles=['APPS_READ'])
     async def ip_choices(self):
         """
         Returns IP choices which can be used by applications.

--- a/src/middlewared/middlewared/plugins/apps_images/dockerhub_ratelimit.py
+++ b/src/middlewared/middlewared/plugins/apps_images/dockerhub_ratelimit.py
@@ -1,5 +1,5 @@
 from middlewared.api import api_method
-from middlewared.api.current import AppImageDockerhubRateLimitArgs, AppImageDockerhubRateLimitResult
+from middlewared.api.current import ContainerImagesDockerhubRateLimitArgs, ContainerImagesDockerhubRateLimitResult
 from middlewared.service import Service
 
 from .client import ContainerRegistryClientMixin
@@ -11,7 +11,7 @@ class ContainerImagesService(Service):
     class Config:
         namespace = 'app.image'
 
-    @api_method(AppImageDockerhubRateLimitArgs, AppImageDockerhubRateLimitResult, roles=['APPS_READ'])
+    @api_method(ContainerImagesDockerhubRateLimitArgs, ContainerImagesDockerhubRateLimitResult, roles=['APPS_READ'])
     async def dockerhub_rate_limit(self):
         """
         Returns the current rate limit information for Docker Hub registry.

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -14,10 +14,10 @@ from middlewared.api.current import (
     AuthLoginExArgs, AuthLoginExResult,
     AuthLoginExContinueArgs, AuthLoginExContinueResult,
     AuthMeArgs, AuthMeResult,
-    AuthMechChoicesArgs, AuthMechChoicesResult,
-    AuthSessionEntry,
+    AuthMechanismChoicesArgs, AuthMechanismChoicesResult,
+    AuthSessionsEntry,
     AuthGenerateTokenArgs, AuthGenerateTokenResult,
-    AuthSessionLogoutArgs, AuthSessionLogoutResult,
+    AuthLogoutArgs, AuthLogoutResult,
     AuthSetAttributeArgs, AuthSetAttributeResult,
     AuthTerminateSessionArgs, AuthTerminateSessionResult,
     AuthTerminateOtherSessionsArgs, AuthTerminateOtherSessionsResult,
@@ -246,7 +246,7 @@ class AuthService(Service):
         super(AuthService, self).__init__(*args, **kwargs)
         self.session_manager.middleware = self.middleware
 
-    @filterable_api_method(item=AuthSessionEntry, roles=['AUTH_SESSIONS_READ'])
+    @filterable_api_method(item=AuthSessionsEntry, roles=['AUTH_SESSIONS_READ'])
     @pass_app(require=True)
     def sessions(self, app, filters, options):
         """
@@ -624,7 +624,7 @@ class AuthService(Service):
                 errno.EOPNOTSUPP
             )
 
-    @api_method(AuthMechChoicesArgs, AuthMechChoicesResult, authentication_required=False)
+    @api_method(AuthMechanismChoicesArgs, AuthMechanismChoicesResult, authentication_required=False)
     async def mechanism_choices(self) -> list:
         """ Get list of available authentication mechanisms available for auth.login_ex """
         aal = CURRENT_AAL.level
@@ -1178,7 +1178,7 @@ class AuthService(Service):
         return resp['response_type'] == AuthResp.SUCCESS
 
     @cli_private
-    @api_method(AuthSessionLogoutArgs, AuthSessionLogoutResult, authorization_required=False)
+    @api_method(AuthLogoutArgs, AuthLogoutResult, authorization_required=False)
     @pass_app()
     async def logout(self, app):
         """

--- a/src/middlewared/middlewared/plugins/catalog/app_version.py
+++ b/src/middlewared/middlewared/plugins/catalog/app_version.py
@@ -5,7 +5,7 @@ import stat
 from catalog_reader.train_utils import get_train_path
 
 from middlewared.api import api_method
-from middlewared.api.current import CatalogAppDetailsArgs, CatalogAppDetailsResult
+from middlewared.api.current import CatalogGetAppDetailsArgs, CatalogGetAppDetailsResult
 from middlewared.service import CallError, Service
 
 from .apps_util import get_app_details
@@ -16,7 +16,7 @@ class CatalogService(Service):
     class Config:
         cli_namespace = 'app.catalog'
 
-    @api_method(CatalogAppDetailsArgs, CatalogAppDetailsResult, roles=['CATALOG_READ'])
+    @api_method(CatalogGetAppDetailsArgs, CatalogGetAppDetailsResult, roles=['CATALOG_READ'])
     def get_app_details(self, app_name, options):
         """
         Retrieve information of `app_name` `app_version_details.catalog` catalog app.

--- a/src/middlewared/middlewared/plugins/catalog/apps.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps.py
@@ -1,6 +1,6 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    AppCategoriesArgs, AppCategoriesResult, AppAvailableResponse,
+    AppCategoriesArgs, AppCategoriesResult, AppAvailableItem, AppLatestItem,
 )
 from middlewared.api.v25_04_0 import AppSimilarArgs, AppSimilarResult
 from middlewared.service import filterable_api_method, Service
@@ -14,7 +14,7 @@ class AppService(Service):
     class Config:
         cli_namespace = 'app'
 
-    @filterable_api_method(item=AppAvailableResponse, roles=['CATALOG_READ'])
+    @filterable_api_method(item=AppLatestItem, roles=['CATALOG_READ'])
     async def latest(self, filters, options):
         """
         Retrieve latest updated apps.
@@ -27,7 +27,7 @@ class AppService(Service):
             ), filters, options
         )
 
-    @filterable_api_method(item=AppAvailableResponse, roles=['CATALOG_READ'])
+    @filterable_api_method(item=AppAvailableItem, roles=['CATALOG_READ'])
     def available(self, filters, options):
         """
         Retrieve all available applications from all configured catalogs.

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -1,10 +1,10 @@
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, OneShotAlertClass
 from middlewared.api import api_method
 from middlewared.api.current import (CloudCredentialEntry,
-                                     CloudCredentialCreateArgs, CloudCredentialCreateResult,
-                                     CloudCredentialUpdateArgs, CloudCredentialUpdateResult,
-                                     CloudCredentialDeleteArgs, CloudCredentialDeleteResult,
-                                     CloudCredentialVerifyArgs, CloudCredentialVerifyResult,
+                                     CredentialsCreateArgs, CredentialsCreateResult,
+                                     CredentialsUpdateArgs, CredentialsUpdateResult,
+                                     CredentialsDeleteArgs, CredentialsDeleteResult,
+                                     CredentialsVerifyArgs, CredentialsVerifyResult,
                                      CloudSyncEntry,
                                      CloudSyncCreateArgs, CloudSyncCreateResult,
                                      CloudSyncUpdateArgs, CloudSyncUpdateResult,
@@ -13,7 +13,7 @@ from middlewared.api.current import (CloudCredentialEntry,
                                      CloudSyncListBucketsArgs, CloudSyncListBucketsResult,
                                      CloudSyncListDirectoryArgs, CloudSyncListDirectoryResult,
                                      CloudSyncSyncArgs, CloudSyncSyncResult,
-                                     CloudSyncSyncOneTimeArgs, CloudSyncSyncOneTimeResult,
+                                     CloudSyncSyncOnetimeArgs, CloudSyncSyncOnetimeResult,
                                      CloudSyncAbortArgs, CloudSyncAbortResult,
                                      CloudSyncProvidersArgs, CloudSyncProvidersResult)
 from middlewared.common.attachment import LockableFSAttachmentDelegate
@@ -537,7 +537,7 @@ class CredentialsService(CRUDService):
         data["provider"] = data["attributes"].pop("type")
         return data
 
-    @api_method(CloudCredentialVerifyArgs, CloudCredentialVerifyResult, roles=["CLOUD_SYNC_WRITE"])
+    @api_method(CredentialsVerifyArgs, CredentialsVerifyResult, roles=["CLOUD_SYNC_WRITE"])
     async def verify(self, data):
         """
         Verify if `attributes` provided for `provider` are authorized by the `provider`.
@@ -553,7 +553,7 @@ class CredentialsService(CRUDService):
             else:
                 return {"valid": False, "error": proc.stderr, "excerpt": lsjson_error_excerpt(proc.stderr)}
 
-    @api_method(CloudCredentialCreateArgs, CloudCredentialCreateResult)
+    @api_method(CredentialsCreateArgs, CredentialsCreateResult)
     async def do_create(self, data):
         """
         Create Cloud Sync Credentials.
@@ -571,7 +571,7 @@ class CredentialsService(CRUDService):
         await self.extend(data)
         return data
 
-    @api_method(CloudCredentialUpdateArgs, CloudCredentialUpdateResult)
+    @api_method(CredentialsUpdateArgs, CredentialsUpdateResult)
     async def do_update(self, id_, data):
         """
         Update Cloud Sync Credentials of `id`.
@@ -594,7 +594,7 @@ class CredentialsService(CRUDService):
 
         return new
 
-    @api_method(CloudCredentialDeleteArgs, CloudCredentialDeleteResult)
+    @api_method(CredentialsDeleteArgs, CredentialsDeleteResult)
     async def do_delete(self, id_):
         """
         Delete Cloud Sync Credentials of `id`.
@@ -938,7 +938,7 @@ class CloudSyncService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin):
 
         await self._sync(cloud_sync, options, job)
 
-    @api_method(CloudSyncSyncOneTimeArgs, CloudSyncSyncOneTimeResult, roles=["CLOUD_SYNC_WRITE"])
+    @api_method(CloudSyncSyncOnetimeArgs, CloudSyncSyncOnetimeResult, roles=["CLOUD_SYNC_WRITE"])
     @job(logs=True, abortable=True)
     async def sync_onetime(self, job, cloud_sync, options):
         """

--- a/src/middlewared/middlewared/plugins/cloud_sync_/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync_/crud.py
@@ -1,7 +1,7 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    CloudSyncCrudRestoreArgs,
-    CloudSyncCrudRestoreResult,
+    CloudSyncRestoreArgs,
+    CloudSyncRestoreResult,
 )
 from middlewared.service import Service
 
@@ -9,8 +9,8 @@ from middlewared.service import Service
 class CloudSyncService(Service):
 
     @api_method(
-        CloudSyncCrudRestoreArgs,
-        CloudSyncCrudRestoreResult,
+        CloudSyncRestoreArgs,
+        CloudSyncRestoreResult,
         roles=["CLOUD_SYNC_WRITE"],
     )
     async def restore(self, id_, data):

--- a/src/middlewared/middlewared/plugins/crypto_/cert_info.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_info.py
@@ -4,8 +4,8 @@ from middlewared.api.current import (
     CertificateCountryChoicesResult,
     CertificateAcmeServerChoicesArgs,
     CertificateAcmeServerChoicesResult,
-    CertificateECCurveChoicesArgs,
-    CertificateECCurveChoicesResult,
+    CertificateEcCurveChoicesArgs,
+    CertificateEcCurveChoicesResult,
     CertificateExtendedKeyUsageChoicesArgs,
     CertificateExtendedKeyUsageChoicesResult,
     EKU_OID, ECCurves
@@ -51,8 +51,8 @@ class CertificateService(Service):
         }
 
     @api_method(
-        CertificateECCurveChoicesArgs,
-        CertificateECCurveChoicesResult,
+        CertificateEcCurveChoicesArgs,
+        CertificateEcCurveChoicesResult,
         roles=['CERTIFICATE_READ']
     )
     async def ec_curve_choices(self):

--- a/src/middlewared/middlewared/plugins/docker/backup.py
+++ b/src/middlewared/middlewared/plugins/docker/backup.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    DockerBackupArgs, DockerBackupResult, DockerListBackupArgs, DockerListBackupResult,
+    DockerBackupArgs, DockerBackupResult, DockerListBackupsArgs, DockerListBackupsResult,
     DockerDeleteBackupArgs, DockerDeleteBackupResult,
 )
 from middlewared.plugins.apps.ix_apps.path import get_collective_config_path, get_collective_metadata_path
@@ -81,7 +81,7 @@ class DockerService(Service):
 
         return name
 
-    @api_method(DockerListBackupArgs, DockerListBackupResult, roles=['DOCKER_READ'])
+    @api_method(DockerListBackupsArgs, DockerListBackupsResult, roles=['DOCKER_READ'])
     def list_backups(self):
         """
         List existing app backups.

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_label.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_label.py
@@ -1,7 +1,7 @@
 import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
-from middlewared.api.current import EnclosureLabelSetArgs, EnclosureLabelUpdateResult
+from middlewared.api.current import EnclosureLabelSetArgs, EnclosureLabelSetResult
 from middlewared.service import private, Service
 from middlewared.service_exception import MatchNotFound, ValidationError
 
@@ -26,7 +26,7 @@ class EnclosureLabelService(Service):
             for label in await self.middleware.call("datastore.query", "enclosure.label")
         }
 
-    @api_method(EnclosureLabelSetArgs, EnclosureLabelUpdateResult, roles=["ENCLOSURE_WRITE"])
+    @api_method(EnclosureLabelSetArgs, EnclosureLabelSetResult, roles=["ENCLOSURE_WRITE"])
     async def set(self, id_, label):
         try:
             await self.middleware.call("enclosure2.query", [["id", "=", id_]], {"get": True})

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -3,7 +3,7 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 from middlewared.api import api_method
-from middlewared.api.current import FailoverDisabledReasonsArgs, FailoverDisabledReasonsResult
+from middlewared.api.current import FailoverDisabledReasonsReasonsArgs, FailoverDisabledReasonsReasonsResult
 from middlewared.service import Service, private
 from middlewared.plugins.interface.netif import netif
 from middlewared.utils.zfs import query_imported_fast_impl
@@ -19,8 +19,8 @@ class FailoverDisabledReasonsService(Service):
     SYSTEM_DATASET_SETUP_IN_PROGRESS = False
 
     @api_method(
-        FailoverDisabledReasonsArgs,
-        FailoverDisabledReasonsResult,
+        FailoverDisabledReasonsReasonsArgs,
+        FailoverDisabledReasonsReasonsResult,
         pass_app=True,
         roles=['FAILOVER_READ']
     )

--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (FCPortChoicesArgs, FCPortChoicesResult, FCPortCreateArgs, FCPortCreateResult,
+from middlewared.api.current import (FCPortPortChoicesArgs, FCPortPortChoicesResult, FCPortCreateArgs, FCPortCreateResult,
                                      FCPortDeleteArgs, FCPortDeleteResult, FCPortEntry, FCPortStatusArgs,
                                      FCPortStatusResult, FCPortUpdateArgs, FCPortUpdateResult)
 from middlewared.plugins.failover_.remote import NETWORK_ERRORS
@@ -110,7 +110,7 @@ class FCPortService(CRUDService):
 
         return response
 
-    @api_method(FCPortChoicesArgs, FCPortChoicesResult)
+    @api_method(FCPortPortChoicesArgs, FCPortPortChoicesResult)
     async def port_choices(self, include_used):
         result = {}
         if include_used:

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -22,10 +22,10 @@ from middlewared.api.current import (
     FilesystemMkdirArgs, FilesystemMkdirResult,
     FilesystemStatArgs, FilesystemStatResult,
     FilesystemStatfsArgs, FilesystemStatfsResult,
-    FilesystemSetZfsAttrsArgs, FilesystemSetZfsAttrsResult,
-    FilesystemGetZfsAttrsArgs, FilesystemGetZfsAttrsResult,
-    FilesystemGetFileArgs, FilesystemGetFileResult,
-    FilesystemPutFileArgs, FilesystemPutFileResult,
+    FilesystemSetZfsAttributesArgs, FilesystemSetZfsAttributesResult,
+    FilesystemGetZfsAttributesArgs, FilesystemGetZfsAttributesResult,
+    FilesystemGetArgs, FilesystemGetResult,
+    FilesystemPutArgs, FilesystemPutResult,
     FileFollowTailEventSourceArgs, FileFollowTailEventSourceEvent,
 )
 from middlewared.event import EventSource
@@ -154,7 +154,7 @@ class FilesystemService(Service):
         }
 
     @api_method(
-        FilesystemSetZfsAttrsArgs, FilesystemSetZfsAttrsResult,
+        FilesystemSetZfsAttributesArgs, FilesystemSetZfsAttributesResult,
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set ZFS attributes',
         audit_extended=lambda data: data['path']
@@ -191,7 +191,7 @@ class FilesystemService(Service):
         """
         return attrs.set_zfs_file_attributes_dict(data['path'], data['zfs_file_attributes'])
 
-    @api_method(FilesystemGetZfsAttrsArgs, FilesystemGetZfsAttrsResult, roles=['FILESYSTEM_ATTRS_READ'])
+    @api_method(FilesystemGetZfsAttributesArgs, FilesystemGetZfsAttributesResult, roles=['FILESYSTEM_ATTRS_READ'])
     def get_zfs_attributes(self, path):
         """
         Get the current ZFS attributes for the file at the given path
@@ -548,7 +548,7 @@ class FilesystemService(Service):
 
         return True
 
-    @api_method(FilesystemGetFileArgs, FilesystemGetFileResult, audit='Filesystem get', roles=['FULL_ADMIN'])
+    @api_method(FilesystemGetArgs, FilesystemGetResult, audit='Filesystem get', roles=['FULL_ADMIN'])
     @job(pipes=["output"])
     def get(self, job, path):
         """
@@ -561,7 +561,7 @@ class FilesystemService(Service):
         with open(path, 'rb') as f:
             shutil.copyfileobj(f, job.pipes.output.w)
 
-    @api_method(FilesystemPutFileArgs, FilesystemPutFileResult, audit='Filesystem put', roles=['FULL_ADMIN'])
+    @api_method(FilesystemPutArgs, FilesystemPutResult, audit='Filesystem put', roles=['FULL_ADMIN'])
     @job(pipes=["input"])
     def put(self, job, path, options):
         """

--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -10,10 +10,10 @@ from pydantic import Field
 from middlewared.api import api_method
 from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 from middlewared.api.current import (
-    FilesystemGetAclArgs, FilesystemGetAclResult,
-    FilesystemSetAclArgs, FilesystemSetAclResult,
+    FilesystemGetaclArgs, FilesystemGetaclResult,
+    FilesystemSetaclArgs, FilesystemSetaclResult,
     FilesystemChownArgs, FilesystemChownResult,
-    FilesystemSetPermArgs, FilesystemSetPermResult,
+    FilesystemSetpermArgs, FilesystemSetpermResult,
     NFS4ACE, POSIXACE,
 )
 from middlewared.service import private, job, ValidationErrors, Service
@@ -209,7 +209,7 @@ class FilesystemService(Service):
         job.set_progress(100, 'Finished changing owner.')
 
     @api_method(
-        FilesystemSetPermArgs, FilesystemSetPermResult,
+        FilesystemSetpermArgs, FilesystemSetpermResult,
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set permission', audit_extended=lambda data: data['path']
     )
@@ -439,8 +439,8 @@ class FilesystemService(Service):
         }
 
     @api_method(
-        FilesystemGetAclArgs,
-        FilesystemGetAclResult,
+        FilesystemGetaclArgs,
+        FilesystemGetaclResult,
         roles=['FILESYSTEM_ATTRS_READ'],
     )
     def getacl(self, path, simplified, resolve_ids):
@@ -631,8 +631,8 @@ class FilesystemService(Service):
         job.set_progress(100, 'Finished setting POSIX1e ACL.')
 
     @api_method(
-        FilesystemSetAclArgs,
-        FilesystemSetAclResult,
+        FilesystemSetaclArgs,
+        FilesystemSetaclResult,
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set ACL',
         audit_extended=lambda data: data['path']

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -1,10 +1,10 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
     AclTemplateEntry,
-    AclTemplateByPathArgs, AclTemplateByPathResult,
-    AclTemplateCreateArgs, AclTemplateCreateResult,
-    AclTemplateUpdateArgs, AclTemplateUpdateResult,
-    AclTemplateDeleteArgs, AclTemplateDeleteResult,
+    ACLTemplateByPathArgs, ACLTemplateByPathResult,
+    ACLTemplateCreateArgs, ACLTemplateCreateResult,
+    ACLTemplateUpdateArgs, ACLTemplateUpdateResult,
+    ACLTemplateDeleteArgs, ACLTemplateDeleteResult,
 )
 from middlewared.service import CallError, CRUDService, ValidationErrors
 from middlewared.service import private
@@ -102,8 +102,8 @@ class ACLTemplateService(CRUDService):
             gen_aclstring_posix1e(copy.deepcopy(data['acl']), False, verrors)
 
     @api_method(
-        AclTemplateCreateArgs,
-        AclTemplateCreateResult,
+        ACLTemplateCreateArgs,
+        ACLTemplateCreateResult,
         roles=['FILESYSTEM_ATTRS_WRITE']
     )
     async def do_create(self, data):
@@ -129,8 +129,8 @@ class ACLTemplateService(CRUDService):
         return await self.get_instance(data['id'])
 
     @api_method(
-        AclTemplateUpdateArgs,
-        AclTemplateUpdateResult,
+        ACLTemplateUpdateArgs,
+        ACLTemplateUpdateResult,
         roles=['FILESYSTEM_ATTRS_WRITE']
     )
     async def do_update(self, id_, data):
@@ -169,8 +169,8 @@ class ACLTemplateService(CRUDService):
         return await self.get_instance(id_)
 
     @api_method(
-        AclTemplateDeleteArgs,
-        AclTemplateDeleteResult,
+        ACLTemplateDeleteArgs,
+        ACLTemplateDeleteResult,
         roles=['FILESYSTEM_ATTRS_WRITE']
     )
     async def do_delete(self, id_):
@@ -303,8 +303,8 @@ class ACLTemplateService(CRUDService):
         return
 
     @api_method(
-        AclTemplateByPathArgs,
-        AclTemplateByPathResult,
+        ACLTemplateByPathArgs,
+        ACLTemplateByPathResult,
         roles=['FILESYSTEM_ATTRS_READ']
     )
     async def by_path(self, data):

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -5,7 +5,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.current import (
     FtpEntry,
-    FtpUpdateArgs, FtpUpdateResult
+    FTPUpdateArgs, FTPUpdateResult
 )
 
 
@@ -71,7 +71,7 @@ class FTPService(SystemServiceService):
             data['ssltls_certificate'] = data['ssltls_certificate']['id']
         return data
 
-    @api_method(FtpUpdateArgs, FtpUpdateResult, audit='Update FTP configuration')
+    @api_method(FTPUpdateArgs, FTPUpdateResult, audit='Update FTP configuration')
     async def do_update(self, data):
         """
         Update ftp service configuration.

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -3,7 +3,7 @@ import errno
 import wbclient
 
 from middlewared.api import api_method
-from middlewared.api.current import IdmapCacheClearArgs, IdmapCacheClearResult
+from middlewared.api.current import IdmapDomainClearIdmapCacheArgs, IdmapDomainClearIdmapCacheResult
 from middlewared.service import CallError, Service, job, private, ValidationError, filterable_api_method
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import DSType as DirectoryServiceType
@@ -190,7 +190,7 @@ class IdmapDomainService(Service):
 
         return (hash_ % max_slices) * range_size + range_size
 
-    @api_method(IdmapCacheClearArgs, IdmapCacheClearResult, roles=['DIRECTORY_SERVICE_WRITE'])
+    @api_method(IdmapDomainClearIdmapCacheArgs, IdmapDomainClearIdmapCacheResult, roles=['DIRECTORY_SERVICE_WRITE'])
     @job(lock='clear_idmap_cache', lock_queue_size=1)
     async def clear_idmap_cache(self, job):
         """

--- a/src/middlewared/middlewared/plugins/ipmi_/chassis.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/chassis.py
@@ -2,10 +2,10 @@ from subprocess import run, DEVNULL
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    IPMIChassisIdentifyArgs,
-    IPMIChassisIdentifyResult,
-    IPMIChassisInfoArgs,
-    IPMIChassisInfoResult,
+    IpmiChassisIdentifyArgs,
+    IpmiChassisIdentifyResult,
+    IpmiChassisInfoArgs,
+    IpmiChassisInfoResult,
 )
 from middlewared.service import Service
 
@@ -17,8 +17,8 @@ class IpmiChassisService(Service):
         cli_namespace = 'service.ipmi.chassis'
 
     @api_method(
-        IPMIChassisInfoArgs,
-        IPMIChassisInfoResult,
+        IpmiChassisInfoArgs,
+        IpmiChassisInfoResult,
         roles=['IPMI_READ'],
     )
     def info(self):
@@ -35,8 +35,8 @@ class IpmiChassisService(Service):
         return rv
 
     @api_method(
-        IPMIChassisIdentifyArgs,
-        IPMIChassisIdentifyResult,
+        IpmiChassisIdentifyArgs,
+        IpmiChassisIdentifyResult,
         roles=['IPMI_WRITE'],
     )
     def identify(self, verb):

--- a/src/middlewared/middlewared/plugins/ipmi_/sel.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/sel.py
@@ -2,11 +2,11 @@ from subprocess import run
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    IPMISELClearArgs,
-    IPMISELClearResult,
-    IPMISELElistEntry,
-    IPMISELInfoArgs,
-    IPMISELInfoResult,
+    IpmiSelClearArgs,
+    IpmiSelClearResult,
+    IpmiSelElistEntry,
+    IpmiSelInfoArgs,
+    IpmiSelInfoResult,
 )
 from middlewared.service import filterable_api_method, job, Service
 from middlewared.utils import filter_list
@@ -38,7 +38,7 @@ class IpmiSelService(Service):
         namespace = 'ipmi.sel'
         cli_namespace = 'service.ipmi.sel'
 
-    @filterable_api_method(item=IPMISELElistEntry, roles=['IPMI_READ'])
+    @filterable_api_method(item=IpmiSelElistEntry, roles=['IPMI_READ'])
     @job(lock=SEL_LOCK, lock_queue_size=1, transient=True)
     def elist(self, job, filters, options):
         """Query IPMI System Event Log (SEL) extended list"""
@@ -63,8 +63,8 @@ class IpmiSelService(Service):
         return filter_list(rv, filters, options)
 
     @api_method(
-        IPMISELInfoArgs,
-        IPMISELInfoResult,
+        IpmiSelInfoArgs,
+        IpmiSelInfoResult,
         roles=['IPMI_READ']
     )
     @job(lock=SEL_LOCK, lock_queue_size=1, transient=True)
@@ -84,8 +84,8 @@ class IpmiSelService(Service):
         return rv
 
     @api_method(
-        IPMISELClearArgs,
-        IPMISELClearResult,
+        IpmiSelClearArgs,
+        IpmiSelClearResult,
         roles=['IPMI_WRITE'],
     )
     @job(lock=SEL_LOCK, lock_queue_size=1)

--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -1,8 +1,8 @@
 import middlewared.sqlalchemy as sa
 from middlewared.alert.source.discovery_auth import UPGRADE_ALERTS
 from middlewared.api import api_method
-from middlewared.api.current import (IscsiAuthCreateArgs, IscsiAuthCreateResult, IscsiAuthDeleteArgs,
-                                     IscsiAuthDeleteResult, IscsiAuthEntry, IscsiAuthUpdateArgs, IscsiAuthUpdateResult)
+from middlewared.api.current import (iSCSITargetAuthCredentialCreateArgs, iSCSITargetAuthCredentialCreateResult, iSCSITargetAuthCredentialDeleteArgs,
+                                     iSCSITargetAuthCredentialDeleteResult, IscsiAuthEntry, iSCSITargetAuthCredentialUpdateArgs, iSCSITargetAuthCredentialUpdateResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 from .utils import IscsiAuthType
 
@@ -40,7 +40,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
         role_prefix = 'SHARING_ISCSI_AUTH'
         entry = IscsiAuthEntry
 
-    @api_method(IscsiAuthCreateArgs, IscsiAuthCreateResult, audit='Create iSCSI Authorized Access', audit_extended=lambda data: _auth_summary(data))
+    @api_method(iSCSITargetAuthCredentialCreateArgs, iSCSITargetAuthCredentialCreateResult, audit='Create iSCSI Authorized Access', audit_extended=lambda data: _auth_summary(data))
     async def do_create(self, data):
         """
         Create an iSCSI Authorized Access.
@@ -69,7 +69,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
 
         return await self.get_instance(data['id'])
 
-    @api_method(IscsiAuthUpdateArgs, IscsiAuthUpdateResult, audit='Update iSCSI Authorized Access', audit_callback=True)
+    @api_method(iSCSITargetAuthCredentialUpdateArgs, iSCSITargetAuthCredentialUpdateResult, audit='Update iSCSI Authorized Access', audit_callback=True)
     async def do_update(self, audit_callback, id_, data):
         """
         Update iSCSI Authorized Access of `id`.
@@ -105,7 +105,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
 
         return await self.get_instance(id_)
 
-    @api_method(IscsiAuthDeleteArgs, IscsiAuthDeleteResult, audit='Delete iSCSI Authorized Access', audit_callback=True)
+    @api_method(iSCSITargetAuthCredentialDeleteArgs, iSCSITargetAuthCredentialDeleteResult, audit='Delete iSCSI Authorized Access', audit_callback=True)
     async def do_delete(self, audit_callback, id_):
         """
         Delete iSCSI Authorized Access of `id`.

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -8,9 +8,9 @@ from collections import defaultdict
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (IscsiExtentCreateArgs, IscsiExtentCreateResult, IscsiExtentDeleteArgs,
-                                     IscsiExtentDeleteResult, IscsiExtentDiskChoicesArgs, IscsiExtentDiskChoicesResult,
-                                     IscsiExtentEntry, IscsiExtentUpdateArgs, IscsiExtentUpdateResult)
+from middlewared.api.current import (iSCSITargetExtentCreateArgs, iSCSITargetExtentCreateResult, iSCSITargetExtentDeleteArgs,
+                                     iSCSITargetExtentDeleteResult, iSCSITargetExtentDiskChoicesArgs, iSCSITargetExtentDiskChoicesResult,
+                                     IscsiExtentEntry, iSCSITargetExtentUpdateArgs, iSCSITargetExtentUpdateResult)
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.service import CallError, SharingService, ValidationErrors, private
@@ -74,8 +74,8 @@ class iSCSITargetExtentService(SharingService):
         )
 
     @api_method(
-        IscsiExtentCreateArgs,
-        IscsiExtentCreateResult,
+        iSCSITargetExtentCreateArgs,
+        iSCSITargetExtentCreateResult,
         audit='Create iSCSI extent',
         audit_extended=lambda data: data['name']
     )
@@ -124,8 +124,8 @@ class iSCSITargetExtentService(SharingService):
         return await self.get_instance(data['id'])
 
     @api_method(
-        IscsiExtentUpdateArgs,
-        IscsiExtentUpdateResult,
+        iSCSITargetExtentUpdateArgs,
+        iSCSITargetExtentUpdateResult,
         audit='Update iSCSI extent',
         audit_callback=True
     )
@@ -177,8 +177,8 @@ class iSCSITargetExtentService(SharingService):
         return await self.get_instance(id_)
 
     @api_method(
-        IscsiExtentDeleteArgs,
-        IscsiExtentDeleteResult,
+        iSCSITargetExtentDeleteArgs,
+        iSCSITargetExtentDeleteResult,
         audit='Delete iSCSI extent',
         audit_callback=True
     )
@@ -453,7 +453,7 @@ class iSCSITargetExtentService(SharingService):
         else:
             return naa
 
-    @api_method(IscsiExtentDiskChoicesArgs, IscsiExtentDiskChoicesResult)
+    @api_method(iSCSITargetExtentDiskChoicesArgs, iSCSITargetExtentDiskChoicesResult)
     async def disk_choices(self):
         """
         Return a dict of available zvols that can be used

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -3,7 +3,7 @@ import os
 from contextlib import suppress
 
 from middlewared.api import api_method
-from middlewared.api.current import IscsiGlobalSessionsArgs, IscsiGlobalSessionsResult
+from middlewared.api.current import ISCSIGlobalSessionsArgs, ISCSIGlobalSessionsResult
 from middlewared.service import private, Service
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils import filter_list, run
@@ -15,8 +15,8 @@ class ISCSIGlobalService(Service):
         namespace = 'iscsi.global'
 
     @api_method(
-        IscsiGlobalSessionsArgs,
-        IscsiGlobalSessionsResult,
+        ISCSIGlobalSessionsArgs,
+        ISCSIGlobalSessionsResult,
         roles=['SHARING_ISCSI_GLOBAL_READ']
     )
     def sessions(self, filters, options):

--- a/src/middlewared/middlewared/plugins/iscsi_/initiator.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/initiator.py
@@ -1,8 +1,8 @@
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (IscsiInitiatorCreateArgs, IscsiInitiatorCreateResult, IscsiInitiatorDeleteArgs,
-                                     IscsiInitiatorDeleteResult, IscsiInitiatorEntry, IscsiInitiatorUpdateArgs,
-                                     IscsiInitiatorUpdateResult)
+from middlewared.api.current import (iSCSITargetAuthorizedInitiatorCreateArgs, iSCSITargetAuthorizedInitiatorCreateResult, iSCSITargetAuthorizedInitiatorDeleteArgs,
+                                     iSCSITargetAuthorizedInitiatorDeleteResult, IscsiInitiatorEntry, iSCSITargetAuthorizedInitiatorUpdateArgs,
+                                     iSCSITargetAuthorizedInitiatorUpdateResult)
 from middlewared.service import CRUDService, private
 
 
@@ -40,8 +40,8 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
         entry = IscsiInitiatorEntry
 
     @api_method(
-        IscsiInitiatorCreateArgs,
-        IscsiInitiatorCreateResult,
+        iSCSITargetAuthorizedInitiatorCreateArgs,
+        iSCSITargetAuthorizedInitiatorCreateResult,
         audit='Create iSCSI initiator',
         audit_extended=lambda data: initiator_summary(data)
     )
@@ -63,8 +63,8 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
         return await self.get_instance(data['id'])
 
     @api_method(
-        IscsiInitiatorUpdateArgs,
-        IscsiInitiatorUpdateResult,
+        iSCSITargetAuthorizedInitiatorUpdateArgs,
+        iSCSITargetAuthorizedInitiatorUpdateResult,
         audit='Update iSCSI initiator',
         audit_callback=True,
     )
@@ -88,8 +88,8 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
         return await self.get_instance(id_)
 
     @api_method(
-        IscsiInitiatorDeleteArgs,
-        IscsiInitiatorDeleteResult,
+        iSCSITargetAuthorizedInitiatorDeleteArgs,
+        iSCSITargetAuthorizedInitiatorDeleteResult,
         audit='Delete iSCSI initiator',
         audit_callback=True,
     )

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -4,9 +4,9 @@ import socket
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (IscsiGlobalAluaEnabledArgs, IscsiGlobalAluaEnabledResult, IscsiGlobalEntry,
-                                     IscsiGlobalISEREnabledArgs, IscsiGlobalISEREnabledResult, IscsiGlobalUpdateArgs,
-                                     IscsiGlobalUpdateResult)
+from middlewared.api.current import (ISCSIGlobalAluaEnabledArgs, ISCSIGlobalAluaEnabledResult, IscsiGlobalEntry,
+                                     ISCSIGlobalIserEnabledArgs, ISCSIGlobalIserEnabledResult, ISCSIGlobalUpdateArgs,
+                                     ISCSIGlobalUpdateResult)
 from middlewared.async_validators import validate_port
 from middlewared.plugins.rdma.constants import RDMAprotocols
 from middlewared.service import SystemServiceService, ValidationErrors, private
@@ -105,8 +105,8 @@ class ISCSIGlobalService(SystemServiceService):
         return data
 
     @api_method(
-        IscsiGlobalUpdateArgs,
-        IscsiGlobalUpdateResult,
+        ISCSIGlobalUpdateArgs,
+        ISCSIGlobalUpdateResult,
         audit='Update iSCSI'
     )
     async def do_update(self, data):
@@ -212,8 +212,8 @@ class ISCSIGlobalService(SystemServiceService):
             self.logger.warning('Failed to stop active iSNS: %s', cp.stderr.decode())
 
     @api_method(
-        IscsiGlobalAluaEnabledArgs,
-        IscsiGlobalAluaEnabledResult,
+        ISCSIGlobalAluaEnabledArgs,
+        ISCSIGlobalAluaEnabledResult,
         roles=['SHARING_ISCSI_GLOBAL_READ']
     )
     async def alua_enabled(self):
@@ -232,8 +232,8 @@ class ISCSIGlobalService(SystemServiceService):
         return (await self.middleware.call('iscsi.global.config'))['alua']
 
     @api_method(
-        IscsiGlobalISEREnabledArgs,
-        IscsiGlobalISEREnabledResult,
+        ISCSIGlobalIserEnabledArgs,
+        ISCSIGlobalIserEnabledResult,
         roles=['SHARING_ISCSI_GLOBAL_READ']
     )
     async def iser_enabled(self):

--- a/src/middlewared/middlewared/plugins/iscsi_/portal.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/portal.py
@@ -1,8 +1,8 @@
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (IscsiPortalCreateArgs, IscsiPortalCreateResult, IscsiPortalDeleteArgs,
-                                     IscsiPortalDeleteResult, IscsiPortalEntry, IscsiPortalListenIPChoicesArgs,
-                                     IscsiPortalListenIPChoicesResult, IscsiPortalUpdateArgs, IscsiPortalUpdateResult)
+from middlewared.api.current import (ISCSIPortalCreateArgs, ISCSIPortalCreateResult, ISCSIPortalDeleteArgs,
+                                     ISCSIPortalDeleteResult, IscsiPortalEntry, ISCSIPortalListenIpChoicesArgs,
+                                     ISCSIPortalListenIpChoicesResult, ISCSIPortalUpdateArgs, ISCSIPortalUpdateResult)
 from middlewared.service import CRUDService, private, ValidationErrors
 
 
@@ -69,7 +69,7 @@ class ISCSIPortalService(CRUDService):
             })
         return data
 
-    @api_method(IscsiPortalListenIPChoicesArgs, IscsiPortalListenIPChoicesResult)
+    @api_method(ISCSIPortalListenIpChoicesArgs, ISCSIPortalListenIpChoicesResult)
     async def listen_ip_choices(self):
         """
         Returns possible choices for `listen.ip` attribute of portal create and update.
@@ -121,8 +121,8 @@ class ISCSIPortalService(CRUDService):
                     verrors.add(f'{schema}.listen', f'IP {i["ip"]} not configured on this system.')
 
     @api_method(
-        IscsiPortalCreateArgs,
-        IscsiPortalCreateResult,
+        ISCSIPortalCreateArgs,
+        ISCSIPortalCreateResult,
         audit='Create iSCSI portal',
         audit_extended=lambda data: portal_summary(data)
     )
@@ -186,8 +186,8 @@ class ISCSIPortalService(CRUDService):
                 )
 
     @api_method(
-        IscsiPortalUpdateArgs,
-        IscsiPortalUpdateResult,
+        ISCSIPortalUpdateArgs,
+        ISCSIPortalUpdateResult,
         audit='Update iSCSI portal',
         audit_callback=True,
     )
@@ -220,8 +220,8 @@ class ISCSIPortalService(CRUDService):
         return await self.get_instance(pk)
 
     @api_method(
-        IscsiPortalDeleteArgs,
-        IscsiPortalDeleteResult,
+        ISCSIPortalDeleteArgs,
+        ISCSIPortalDeleteResult,
         audit='Delete iSCSI portal',
         audit_callback=True,
     )

--- a/src/middlewared/middlewared/plugins/iscsi_/status.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/status.py
@@ -1,5 +1,5 @@
 from middlewared.api import api_method
-from middlewared.api.current import IscsiGlobalClientCountArgs, IscsiGlobalClientCountResult
+from middlewared.api.current import ISCSIGlobalClientCountArgs, ISCSIGlobalClientCountResult
 from middlewared.service import Service
 
 
@@ -10,8 +10,8 @@ class ISCSIGlobalService(Service):
         cli_namespace = 'sharing.iscsi.global'
 
     @api_method(
-        IscsiGlobalClientCountArgs,
-        IscsiGlobalClientCountResult,
+        ISCSIGlobalClientCountArgs,
+        ISCSIGlobalClientCountResult,
         roles=['SHARING_ISCSI_GLOBAL_READ']
     )
     async def client_count(self):

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -4,12 +4,12 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.current import (
     IscsiTargetToExtentEntry,
-    IscsiTargetToExtentCreateArgs,
-    IscsiTargetToExtentCreateResult,
-    IscsiTargetToExtentUpdateArgs,
-    IscsiTargetToExtentUpdateResult,
-    IscsiTargetToExtentDeleteArgs,
-    IscsiTargetToExtentDeleteResult)
+    iSCSITargetToExtentCreateArgs,
+    iSCSITargetToExtentCreateResult,
+    iSCSITargetToExtentUpdateArgs,
+    iSCSITargetToExtentUpdateResult,
+    iSCSITargetToExtentDeleteArgs,
+    iSCSITargetToExtentDeleteResult)
 
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 
@@ -41,8 +41,8 @@ class iSCSITargetToExtentService(CRUDService):
         entry = IscsiTargetToExtentEntry
 
     @api_method(
-        IscsiTargetToExtentCreateArgs,
-        IscsiTargetToExtentCreateResult,
+        iSCSITargetToExtentCreateArgs,
+        iSCSITargetToExtentCreateResult,
         audit='Create iSCSI target/LUN/extent mapping',
         audit_callback=True
     )
@@ -97,8 +97,8 @@ class iSCSITargetToExtentService(CRUDService):
         return f'{target}/{data.get("lunid")}/{extent}'
 
     @api_method(
-        IscsiTargetToExtentUpdateArgs,
-        IscsiTargetToExtentUpdateResult,
+        iSCSITargetToExtentUpdateArgs,
+        iSCSITargetToExtentUpdateResult,
         audit='Update iSCSI target/LUN/extent mapping',
         audit_callback=True
     )
@@ -126,8 +126,8 @@ class iSCSITargetToExtentService(CRUDService):
         return await self.get_instance(id_)
 
     @api_method(
-        IscsiTargetToExtentDeleteArgs,
-        IscsiTargetToExtentDeleteResult,
+        iSCSITargetToExtentDeleteArgs,
+        iSCSITargetToExtentDeleteResult,
         audit='Delete iSCSI target/LUN/extent mapping',
         audit_callback=True
     )

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -12,10 +12,10 @@ from pydantic import IPvAnyNetwork
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.base import BaseModel
-from middlewared.api.current import (IscsiTargetCreateArgs, IscsiTargetCreateResult, IscsiTargetDeleteArgs,
-                                     IscsiTargetDeleteResult, IscsiTargetEntry, IscsiTargetUpdateArgs,
-                                     IscsiTargetUpdateResult, IscsiTargetValidateNameArgs,
-                                     IscsiTargetValidateNameResult)
+from middlewared.api.current import (iSCSITargetCreateArgs, iSCSITargetCreateResult, iSCSITargetDeleteArgs,
+                                     iSCSITargetDeleteResult, IscsiTargetEntry, iSCSITargetUpdateArgs,
+                                     iSCSITargetUpdateResult, iSCSITargetValidateNameArgs,
+                                     iSCSITargetValidateNameResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 from middlewared.utils import UnexpectedFailure, run
 from .utils import AUTHMETHOD_LEGACY_MAP, sanitize_extent
@@ -101,8 +101,8 @@ class iSCSITargetService(CRUDService):
         return data
 
     @api_method(
-        IscsiTargetCreateArgs,
-        IscsiTargetCreateResult,
+        iSCSITargetCreateArgs,
+        iSCSITargetCreateResult,
         audit='Create iSCSI target',
         audit_extended=lambda data: data['name']
     )
@@ -286,8 +286,8 @@ class iSCSITargetService(CRUDService):
             await self.middleware.call('fcport.delete', fcport['id'])
 
     @api_method(
-        IscsiTargetValidateNameArgs,
-        IscsiTargetValidateNameResult,
+        iSCSITargetValidateNameArgs,
+        iSCSITargetValidateNameResult,
         roles=['SHARING_ISCSI_TARGET_WRITE']
     )
     async def validate_name(self, name, existing_id):
@@ -309,8 +309,8 @@ class iSCSITargetService(CRUDService):
                 return 'Target with this name already exists'
 
     @api_method(
-        IscsiTargetUpdateArgs,
-        IscsiTargetUpdateResult,
+        iSCSITargetUpdateArgs,
+        iSCSITargetUpdateResult,
         audit='Update iSCSI target',
         audit_callback=True
     )
@@ -384,8 +384,8 @@ class iSCSITargetService(CRUDService):
         return await self.get_instance(id_)
 
     @api_method(
-        IscsiTargetDeleteArgs,
-        IscsiTargetDeleteResult,
+        iSCSITargetDeleteArgs,
+        iSCSITargetDeleteResult,
         audit='Delete iSCSI target',
         audit_callback=True
     )

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -21,9 +21,9 @@ from middlewared.api.current import (
     KeychainCredentialUpdateArgs, KeychainCredentialUpdateResult,
     KeychainCredentialDeleteArgs, KeychainCredentialDeleteResult,
     KeychainCredentialUsedByArgs, KeychainCredentialUsedByResult,
-    KeychainCredentialGenerateSSHKeyPairArgs, KeychainCredentialGenerateSSHKeyPairResult,
-    KeychainCredentialRemoteSSHHostKeyScanArgs, KeychainCredentialRemoteSSHHostKeyScanResult,
-    KeychainCredentialRemoteSSHSemiautomaticSetupArgs, KeychainCredentialRemoteSSHSemiautomaticSetupResult,
+    KeychainCredentialGenerateSshKeyPairArgs, KeychainCredentialGenerateSshKeyPairResult,
+    KeychainCredentialRemoteSshHostKeyScanArgs, KeychainCredentialRemoteSshHostKeyScanResult,
+    KeychainCredentialRemoteSshSemiautomaticSetupArgs, KeychainCredentialRemoteSshSemiautomaticSetupResult,
 )
 from middlewared.plugins.account_.constants import NO_LOGIN_SHELL
 from middlewared.service_exception import CallError, MatchNotFound, ValidationError
@@ -458,8 +458,8 @@ class KeychainCredentialService(CRUDService):
             return credential
 
     @api_method(
-        KeychainCredentialGenerateSSHKeyPairArgs,
-        KeychainCredentialGenerateSSHKeyPairResult,
+        KeychainCredentialGenerateSshKeyPairArgs,
+        KeychainCredentialGenerateSshKeyPairResult,
         roles=["KEYCHAIN_CREDENTIAL_WRITE"]
     )
     def generate_ssh_key_pair(self):
@@ -490,8 +490,8 @@ class KeychainCredentialService(CRUDService):
         }
 
     @api_method(
-        KeychainCredentialRemoteSSHHostKeyScanArgs,
-        KeychainCredentialRemoteSSHHostKeyScanResult,
+        KeychainCredentialRemoteSshHostKeyScanArgs,
+        KeychainCredentialRemoteSshHostKeyScanResult,
         roles=["KEYCHAIN_CREDENTIAL_WRITE"]
     )
     async def remote_ssh_host_key_scan(self, data):
@@ -527,8 +527,8 @@ class KeychainCredentialService(CRUDService):
             raise CallError(f"ssh-keyscan failed: {proc.stdout + proc.stderr}")
 
     @api_method(
-        KeychainCredentialRemoteSSHSemiautomaticSetupArgs,
-        KeychainCredentialRemoteSSHSemiautomaticSetupResult,
+        KeychainCredentialRemoteSshSemiautomaticSetupArgs,
+        KeychainCredentialRemoteSshSemiautomaticSetupResult,
         roles=["KEYCHAIN_CREDENTIAL_WRITE"],
         audit="SSH Semi-automatic Setup:",
         audit_extended=lambda data: data["name"]

--- a/src/middlewared/middlewared/plugins/keychain_/ssh_connections.py
+++ b/src/middlewared/middlewared/plugins/keychain_/ssh_connections.py
@@ -1,6 +1,6 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    KeychainCredentialSetupSSHConnectionArgs, KeychainCredentialSetupSSHConnectionResult
+    KeychainCredentialSetupSshConnectionArgs, KeychainCredentialSetupSshConnectionResult
 )
 from middlewared.service import Service, ValidationErrors
 
@@ -34,8 +34,8 @@ class KeychainCredentialService(Service):
         verrors.check()
 
     @api_method(
-        KeychainCredentialSetupSSHConnectionArgs,
-        KeychainCredentialSetupSSHConnectionResult,
+        KeychainCredentialSetupSshConnectionArgs,
+        KeychainCredentialSetupSshConnectionResult,
         roles=['KEYCHAIN_CREDENTIAL_WRITE'],
         audit="Setup SSH Connection:",
         audit_extended=lambda options: options["connection_name"]

--- a/src/middlewared/middlewared/plugins/kmip/sync.py
+++ b/src/middlewared/middlewared/plugins/kmip/sync.py
@@ -4,8 +4,8 @@
 # See the file LICENSE.IX for complete terms and conditions
 from middlewared.api import api_method
 from middlewared.api.current import (
-    KmipSyncPendingArgs, KmipSyncPendingResult, KmipSyncKeysArgs, KmipSyncKeysResult,
-    KmipClearSyncPendingKeysArgs, KmipClearSyncPendingKeysResult,
+    KMIPKmipSyncPendingArgs, KMIPKmipSyncPendingResult, KMIPSyncKeysArgs, KMIPSyncKeysResult,
+    KMIPClearSyncPendingKeysArgs, KMIPClearSyncPendingKeysResult,
 )
 from middlewared.service import CallError, job, periodic, private, Service
 
@@ -44,7 +44,7 @@ class KMIPService(Service, KMIPServerMixin):
         else:
             return True
 
-    @api_method(KmipSyncPendingArgs, KmipSyncPendingResult, roles=['KMIP_READ'])
+    @api_method(KMIPKmipSyncPendingArgs, KMIPKmipSyncPendingResult, roles=['KMIP_READ'])
     async def kmip_sync_pending(self):
         """
         Returns true or false based on if there are keys which are to be synced from local database to remote KMIP
@@ -55,7 +55,7 @@ class KMIPService(Service, KMIPServerMixin):
         )
 
     @periodic(interval=86400)
-    @api_method(KmipSyncKeysArgs, KmipSyncKeysResult, roles=['KMIP_WRITE'])
+    @api_method(KMIPSyncKeysArgs, KMIPSyncKeysResult, roles=['KMIP_WRITE'])
     async def sync_keys(self):
         """
         Sync ZFS/SED keys between KMIP Server and TN database.
@@ -66,7 +66,7 @@ class KMIPService(Service, KMIPServerMixin):
         await self.middleware.call('kmip.sync_zfs_keys')
         await self.middleware.call('kmip.sync_sed_keys')
 
-    @api_method(KmipClearSyncPendingKeysArgs, KmipClearSyncPendingKeysResult, roles=['KMIP_WRITE'])
+    @api_method(KMIPClearSyncPendingKeysArgs, KMIPClearSyncPendingKeysResult, roles=['KMIP_WRITE'])
     async def clear_sync_pending_keys(self):
         """
         Clear all keys which are pending to be synced between KMIP server and TN database.

--- a/src/middlewared/middlewared/plugins/kmip/update.py
+++ b/src/middlewared/middlewared/plugins/kmip/update.py
@@ -8,7 +8,7 @@ from truenas_crypto_utils.validation import validate_cert_with_chain
 import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
-from middlewared.api.current import KmipEntry, KmipUpdateArgs, KmipUpdateResult
+from middlewared.api.current import KmipEntry, KMIPUpdateArgs, KMIPUpdateResult
 from middlewared.async_validators import validate_port
 from middlewared.service import CallError, ConfigService, job, private, ValidationErrors
 
@@ -41,7 +41,7 @@ class KMIPService(ConfigService):
             data[k] = data[k]['id']
         return data
 
-    @api_method(KmipUpdateArgs, KmipUpdateResult)
+    @api_method(KMIPUpdateArgs, KMIPUpdateResult)
     @job(lock='kmip_update')
     async def do_update(self, job, data):
         """

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/list_k8s_backups.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/list_k8s_backups.py
@@ -1,7 +1,7 @@
 import os
 
 from middlewared.api import api_method
-from middlewared.api.current import K8sToDockerListBackupsArgs, K8sToDockerListBackupsResult
+from middlewared.api.current import K8stoDockerMigrationListBackupsArgs, K8stoDockerMigrationListBackupsResult
 from middlewared.service import job, Service
 
 from .list_utils import get_backup_dir, get_default_release_details, K8s_BACKUP_NAME_PREFIX, release_details
@@ -14,7 +14,7 @@ class K8stoDockerMigrationService(Service):
         namespace = 'k8s_to_docker'
         cli_namespace = 'k8s_to_docker'
 
-    @api_method(K8sToDockerListBackupsArgs, K8sToDockerListBackupsResult, roles=['DOCKER_READ'])
+    @api_method(K8stoDockerMigrationListBackupsArgs, K8stoDockerMigrationListBackupsResult, roles=['DOCKER_READ'])
     @job(lock=lambda args: f'k8s_to_docker_list_backups_{args[0]}')
     def list_backups(self, job, kubernetes_pool):
         """

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -3,7 +3,7 @@ import os.path
 import shutil
 
 from middlewared.api import api_method
-from middlewared.api.current import K8sToDockerMigrateArgs, K8sToDockerMigrateResult
+from middlewared.api.current import K8stoDockerMigrationMigrateArgs, K8stoDockerMigrationMigrateResult
 from middlewared.plugins.apps.ix_apps.path import get_app_parent_volume_ds_name, get_installed_app_path
 from middlewared.plugins.docker.state_utils import DatasetDefaults
 from middlewared.service import CallError, job, Service
@@ -22,8 +22,8 @@ class K8stoDockerMigrationService(Service):
         cli_namespace = 'k8s_to_docker'
 
     @api_method(
-        K8sToDockerMigrateArgs,
-        K8sToDockerMigrateResult,
+        K8stoDockerMigrationMigrateArgs,
+        K8stoDockerMigrationMigrateResult,
         audit='K8s_to_docker: Migrating backup from',
         audit_extended=lambda kubernetes_pool, options=None: f'{kubernetes_pool!r} kubernetes pool to docker',
         roles=['DOCKER_WRITE']

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -13,12 +13,12 @@ from middlewared.api.current import (
     InterfaceCommitArgs, InterfaceCommitResult, InterfaceCreateArgs, InterfaceCreateResult,
     InterfaceDefaultRouteWillBeRemovedArgs, InterfaceDefaultRouteWillBeRemovedResult, InterfaceDeleteArgs,
     InterfaceDeleteResult, InterfaceHasPendingChangesArgs, InterfaceHasPendingChangesResult,
-    InterfaceIPInUseArgs, InterfaceIPInUseResult, InterfaceLacpduRateChoicesArgs, InterfaceLacpduRateChoicesResult,
+    InterfaceIpInUseArgs, InterfaceIpInUseResult, InterfaceLacpduRateChoicesArgs, InterfaceLacpduRateChoicesResult,
     InterfaceLagPortsChoicesArgs, InterfaceLagPortsChoicesResult, InterfaceRollbackArgs, InterfaceRollbackResult,
     InterfaceSaveDefaultRouteArgs, InterfaceSaveDefaultRouteResult, InterfaceUpdateArgs, InterfaceUpdateResult,
-    InterfaceVLANParentInterfaceChoicesArgs, InterfaceVLANParentInterfaceChoicesResult,
-    InterfaceWebsocketInterfaceArgs, InterfaceWebsocketInterfaceResult, InterfaceWebsocketLocalIPArgs,
-    InterfaceWebsocketLocalIPResult, InterfaceXmitHashPolicyChoicesArgs, InterfaceXmitHashPolicyChoicesResult
+    InterfaceVlanParentInterfaceChoicesArgs, InterfaceVlanParentInterfaceChoicesResult,
+    InterfaceWebsocketInterfaceArgs, InterfaceWebsocketInterfaceResult, InterfaceWebsocketLocalIpArgs,
+    InterfaceWebsocketLocalIpResult, InterfaceXmitHashPolicyChoicesArgs, InterfaceXmitHashPolicyChoicesResult
 )
 from middlewared.schema import ValidationErrors
 from middlewared.service import CallError, CRUDService, filterable_api_method, pass_app, private
@@ -1338,7 +1338,7 @@ class InterfaceService(CRUDService):
 
         return oid
 
-    @api_method(InterfaceWebsocketLocalIPArgs, InterfaceWebsocketLocalIPResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(InterfaceWebsocketLocalIpArgs, InterfaceWebsocketLocalIpResult, roles=['NETWORK_INTERFACE_READ'])
     @pass_app()
     async def websocket_local_ip(self, app):
         """Returns the local ip address for this websocket session."""
@@ -1480,8 +1480,8 @@ class InterfaceService(CRUDService):
         return {k: v for k, v in include.items() if k not in exclude}
 
     @api_method(
-        InterfaceVLANParentInterfaceChoicesArgs,
-        InterfaceVLANParentInterfaceChoicesResult,
+        InterfaceVlanParentInterfaceChoicesArgs,
+        InterfaceVlanParentInterfaceChoicesResult,
         roles=['NETWORK_INTERFACE_READ']
     )
     async def vlan_parent_interface_choices(self):
@@ -1667,7 +1667,7 @@ class InterfaceService(CRUDService):
         except Exception:
             self.logger.error('Failed to run DHCP for {}'.format(name), exc_info=True)
 
-    @api_method(InterfaceIPInUseArgs, InterfaceIPInUseResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(InterfaceIpInUseArgs, InterfaceIpInUseResult, roles=['NETWORK_INTERFACE_READ'])
     def ip_in_use(self, choices):
         """
         Get all IPv4 / Ipv6 from all valid interfaces, excluding tap and epair.

--- a/src/middlewared/middlewared/plugins/network_/global_config.py
+++ b/src/middlewared/middlewared/plugins/network_/global_config.py
@@ -2,7 +2,7 @@ import ipaddress
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    NetworkConfigurationEntry, NetWorkConfigurationUpdateArgs, NetworkConfigurationUpdateResult
+    NetworkConfigurationEntry, NetworkConfigurationUpdateArgs, NetworkConfigurationUpdateResult
 )
 import middlewared.sqlalchemy as sa
 from middlewared.service import ConfigService, private
@@ -176,7 +176,7 @@ class NetworkConfigurationService(ConfigService):
 
             await (await self.middleware.call('service.control', verb, service_name)).wait(raise_error=True)
 
-    @api_method(NetWorkConfigurationUpdateArgs, NetworkConfigurationUpdateResult)
+    @api_method(NetworkConfigurationUpdateArgs, NetworkConfigurationUpdateResult)
     async def do_update(self, data):
         """
         Update Network Configuration Service configuration.

--- a/src/middlewared/middlewared/plugins/network_/route.py
+++ b/src/middlewared/middlewared/plugins/network_/route.py
@@ -7,7 +7,7 @@ import asyncio
 from pyroute2.netlink.exceptions import NetlinkError
 
 from middlewared.api import api_method
-from middlewared.api.current import RouteSystemRoutes, RouteIPv4gwReachableArgs, RouteIPv4gwReachableResult
+from middlewared.api.current import RouteSystemRoutesItem, RouteIpv4gwReachableArgs, RouteIpv4gwReachableResult
 from middlewared.service import Service, filterable_api_method, private
 from middlewared.plugins.interface.netif import netif
 from middlewared.utils import filter_list
@@ -22,7 +22,7 @@ class RouteService(Service):
         namespace_alias = 'routes'
         cli_namespace = 'network.route'
 
-    @filterable_api_method(item=RouteSystemRoutes, roles=['NETWORK_INTERFACE_READ'])
+    @filterable_api_method(item=RouteSystemRoutesItem, roles=['NETWORK_INTERFACE_READ'])
     def system_routes(self, filters, options):
         """
         Get current/applied network routes.
@@ -143,7 +143,7 @@ class RouteService(Service):
             if remove:
                 routing_table.delete(routing_table.default_route_ipv6)
 
-    @api_method(RouteIPv4gwReachableArgs, RouteIPv4gwReachableResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(RouteIpv4gwReachableArgs, RouteIpv4gwReachableResult, roles=['NETWORK_INTERFACE_READ'])
     def ipv4gw_reachable(self, ipv4_gateway):
         """
         Get the IPv4 gateway and verify if it is reachable by any interface.

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -8,12 +8,12 @@ import shutil
 from middlewared.api import api_method
 from middlewared.api.current import (
     NfsEntry,
-    NfsUpdateArgs, NfsUpdateResult,
-    NfsBindipChoicesArgs, NfsBindipChoicesResult,
+    NFSUpdateArgs, NFSUpdateResult,
+    NFSBindipChoicesArgs, NFSBindipChoicesResult,
     NfsShareEntry,
-    NfsShareCreateArgs, NfsShareCreateResult,
-    NfsShareUpdateArgs, NfsShareUpdateResult,
-    NfsShareDeleteArgs, NfsShareDeleteResult
+    SharingNFSCreateArgs, SharingNFSCreateResult,
+    SharingNFSUpdateArgs, SharingNFSUpdateResult,
+    SharingNFSDeleteArgs, SharingNFSDeleteResult
 )
 from middlewared.common.listen import SystemServiceListenMultipleDelegate
 from middlewared.async_validators import check_path_resides_within_volume, validate_port
@@ -219,7 +219,7 @@ class NFSService(SystemServiceService):
 
         return nfs
 
-    @api_method(NfsBindipChoicesArgs, NfsBindipChoicesResult)
+    @api_method(NFSBindipChoicesArgs, NFSBindipChoicesResult)
     async def bindip_choices(self):
         """
         Returns ip choices for NFS service to use
@@ -257,7 +257,7 @@ class NFSService(SystemServiceService):
 
             return []
 
-    @api_method(NfsUpdateArgs, NfsUpdateResult, audit='Update NFS configuration')
+    @api_method(NFSUpdateArgs, NFSUpdateResult, audit='Update NFS configuration')
     async def do_update(self, data):
         """
         Update NFS Service Configuration.
@@ -440,7 +440,7 @@ class SharingNFSService(SharingService):
         entry = NfsShareEntry
 
     @api_method(
-        NfsShareCreateArgs, NfsShareCreateResult,
+        SharingNFSCreateArgs, SharingNFSCreateResult,
         audit='NFS share create', audit_extended=lambda data: data["path"]
     )
     async def do_create(self, data):
@@ -481,7 +481,7 @@ class SharingNFSService(SharingService):
         return await self.get_instance(data["id"])
 
     @api_method(
-        NfsShareUpdateArgs, NfsShareUpdateResult,
+        SharingNFSUpdateArgs, SharingNFSUpdateResult,
         audit='NFS share update', audit_callback=True
     )
     async def do_update(self, audit_callback, id_, data):
@@ -512,7 +512,7 @@ class SharingNFSService(SharingService):
         return await self.get_instance(id_)
 
     @api_method(
-        NfsShareDeleteArgs, NfsShareDeleteResult,
+        SharingNFSDeleteArgs, SharingNFSDeleteResult,
         audit='NFS share delete', audit_callback=True
     )
     async def do_delete(self, audit_callback, id_):

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -6,10 +6,10 @@ from contextlib import suppress
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    GetNFSv3ClientsEntry,
-    GetNFSv4ClientsEntry,
-    NfsClientCountArgs,
-    NfsClientCountResult,
+    NFSGetNfs3ClientsEntry,
+    NFSGetNfs4ClientsEntry,
+    NFSClientCountArgs,
+    NFSClientCountResult,
 )
 from middlewared.plugins.nfs import NFSServicePathInfo
 from middlewared.service import Service, private, filterable_api_method
@@ -73,7 +73,7 @@ class NFSService(Service):
                     os.rename(outf.name, rmtab)
 
     @filterable_api_method(
-        item=GetNFSv3ClientsEntry,
+        item=NFSGetNfs3ClientsEntry,
         # NFS_WRITE because this exposes hostnames and IP addresses
         # READONLY is considered administrative-level permission
         roles=['READONLY_ADMIN', 'SHARING_NFS_WRITE']
@@ -121,7 +121,7 @@ class NFSService(Service):
         return states or []
 
     @filterable_api_method(
-        item=GetNFSv4ClientsEntry,
+        item=NFSGetNfs4ClientsEntry,
         # NFS_WRITE because this exposes hostnames, IP addresses and other details
         # READONLY is considered administrative-level permission
         roles=['READONLY_ADMIN', 'SHARING_NFS_WRITE']
@@ -206,7 +206,7 @@ class NFSService(Service):
 
         return filter_list(clients, filters, options)
 
-    @api_method(NfsClientCountArgs, NfsClientCountResult, roles=['SHARING_NFS_READ'])
+    @api_method(NFSClientCountArgs, NFSClientCountResult, roles=['SHARING_NFS_READ'])
     def client_count(self):
         """
         Return currently connected clients count.

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -1,10 +1,12 @@
 import errno
 import subprocess
+from typing import Literal
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
+from middlewared.api.base import BaseModel
 from middlewared.api.current import (
-    NTPPeerEntry, NTPServerEntry,
+    NTPServerEntry,
     NTPServerCreateArgs, NTPServerCreateResult,
     NTPServerUpdateArgs, NTPServerUpdateResult,
     NTPServerDeleteArgs, NTPServerDeleteResult,
@@ -91,6 +93,20 @@ class NTPPeer:
     @property
     def offset_in_secs(self):
         return self._offset
+
+
+class NTPPeerEntry(BaseModel):
+    mode: Literal['SERVER', 'PEER', 'LOCAL']
+    state: Literal['BEST', 'SELECTED', 'SELECTABLE', 'FALSE_TICKER', 'TOO_VARIABLE', 'NOT_SELECTABLE']
+    remote: str
+    stratum: int
+    poll_interval: int
+    reach: int
+    lastrx: int
+    offset: float
+    offset_measured: float
+    jitter: float
+    active: bool
 
 
 class NTPServerService(CRUDService):

--- a/src/middlewared/middlewared/plugins/nvmet/global.py
+++ b/src/middlewared/middlewared/plugins/nvmet/global.py
@@ -5,11 +5,11 @@ from middlewared.api import api_method
 from middlewared.api.current import (NVMetGlobalAnaEnabledArgs,
                                      NVMetGlobalAnaEnabledResult,
                                      NVMetGlobalEntry,
-                                     NVMetGlobalRDMAEnabledArgs,
-                                     NVMetGlobalRDMAEnabledResult,
+                                     NVMetGlobalRdmaEnabledArgs,
+                                     NVMetGlobalRdmaEnabledResult,
                                      NVMetGlobalUpdateArgs,
                                      NVMetGlobalUpdateResult,
-                                     NVMetSession)
+                                     NVMetGlobalSessionsItem)
 from middlewared.plugins.rdma.constants import RDMAprotocols
 from middlewared.service import SystemServiceService, ValidationErrors, filterable_api_method, private
 from middlewared.utils import filter_list
@@ -116,8 +116,8 @@ class NVMetGlobalService(SystemServiceService, NVMetStandbyMixin):
         return False
 
     @api_method(
-        NVMetGlobalRDMAEnabledArgs,
-        NVMetGlobalRDMAEnabledResult,
+        NVMetGlobalRdmaEnabledArgs,
+        NVMetGlobalRdmaEnabledResult,
         roles=['SHARING_NVME_TARGET_READ']
     )
     async def rdma_enabled(self):
@@ -129,7 +129,7 @@ class NVMetGlobalService(SystemServiceService, NVMetStandbyMixin):
 
         return (await self.middleware.call('nvmet.global.config'))['rdma']
 
-    @filterable_api_method(item=NVMetSession, roles=['SHARING_NVME_TARGET_READ'])
+    @filterable_api_method(item=NVMetGlobalSessionsItem, roles=['SHARING_NVME_TARGET_READ'])
     async def sessions(self, filters, options):
         sessions = []
         subsys_id = None

--- a/src/middlewared/middlewared/plugins/nvmet/host.py
+++ b/src/middlewared/middlewared/plugins/nvmet/host.py
@@ -6,10 +6,10 @@ from middlewared.api.current import (NVMetHostCreateArgs,
                                      NVMetHostCreateResult,
                                      NVMetHostDeleteArgs,
                                      NVMetHostDeleteResult,
-                                     NVMetHostDHChapDHGroupChoicesArgs,
-                                     NVMetHostDHChapDHGroupChoicesResult,
-                                     NVMetHostDHChapHashChoicesArgs,
-                                     NVMetHostDHChapHashChoicesResult,
+                                     NVMetHostDhchapDhgroupChoicesArgs,
+                                     NVMetHostDhchapDhgroupChoicesResult,
+                                     NVMetHostDhchapHashChoicesArgs,
+                                     NVMetHostDhchapHashChoicesResult,
                                      NVMetHostEntry,
                                      NVMetHostGenerateKeyArgs,
                                      NVMetHostGenerateKeyResult,
@@ -190,7 +190,7 @@ class NVMetHostService(CRUDService):
             )
         return key
 
-    @api_method(NVMetHostDHChapDHGroupChoicesArgs, NVMetHostDHChapDHGroupChoicesResult)
+    @api_method(NVMetHostDhchapDhgroupChoicesArgs, NVMetHostDhchapDhgroupChoicesResult)
     async def dhchap_dhgroup_choices(self):
         """
         Returns possible choices for `dhchap_dhgroup` attribute of `host` create and update.
@@ -198,7 +198,7 @@ class NVMetHostService(CRUDService):
         """
         return ['2048-BIT', '3072-BIT', '4096-BIT', '6144-BIT', '8192-BIT']
 
-    @api_method(NVMetHostDHChapHashChoicesArgs, NVMetHostDHChapHashChoicesResult)
+    @api_method(NVMetHostDhchapHashChoicesArgs, NVMetHostDhchapHashChoicesResult)
     async def dhchap_hash_choices(self):
         """
         Returns possible choices for `dhchap_hash` attribute of `host` create and update.

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -3,7 +3,7 @@ import pathlib
 from middlewared.api import api_method
 from middlewared.api.current import (
     PoolDatasetDetailsArgs,
-    PoolDatasetDetailsResults,
+    PoolDatasetDetailsResult,
 )
 from middlewared.plugins.zfs_.utils import zvol_path_to_name, TNUserProp
 from middlewared.service import Service, private
@@ -66,7 +66,7 @@ class PoolDatasetService(Service):
         #        valid_pools.append(i['name'])
         return [], options
 
-    @api_method(PoolDatasetDetailsArgs, PoolDatasetDetailsResults, roles=['DATASET_READ'])
+    @api_method(PoolDatasetDetailsArgs, PoolDatasetDetailsResult, roles=['DATASET_READ'])
     def details(self):
         """
         Retrieve all dataset(s) details outlining any

--- a/src/middlewared/middlewared/plugins/pool_/dataset_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_info.py
@@ -2,8 +2,8 @@ from middlewared.api import api_method
 from middlewared.api.current import (
     PoolDatasetChecksumChoicesArgs, PoolDatasetChecksumChoicesResult, PoolDatasetCompressionChoicesArgs,
     PoolDatasetCompressionChoicesResult, PoolDatasetEncryptionAlgorithmChoicesArgs,
-    PoolDatasetEncryptionAlgorithmChoicesResult, PoolDatasetRecommendedZVolBlockSizeArgs,
-    PoolDatasetRecommendedZVolBlockSizeResult
+    PoolDatasetEncryptionAlgorithmChoicesResult, PoolDatasetRecommendedZvolBlocksizeArgs,
+    PoolDatasetRecommendedZvolBlocksizeResult
 )
 from middlewared.service import Service
 
@@ -41,8 +41,8 @@ class PoolDatasetService(Service):
         return {v: v for v in ZFS_ENCRYPTION_ALGORITHM_CHOICES}
 
     @api_method(
-        PoolDatasetRecommendedZVolBlockSizeArgs,
-        PoolDatasetRecommendedZVolBlockSizeResult,
+        PoolDatasetRecommendedZvolBlocksizeArgs,
+        PoolDatasetRecommendedZvolBlocksizeResult,
         roles=['DATASET_READ']
     )
     async def recommended_zvol_blocksize(self, pool):

--- a/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
@@ -1,5 +1,5 @@
 from middlewared.api import api_method
-from middlewared.api.current import PoolDatasetRecordSizeChoicesArgs, PoolDatasetRecordSizeChoicesResult
+from middlewared.api.current import PoolDatasetRecordsizeChoicesArgs, PoolDatasetRecordsizeChoicesResult
 from middlewared.service import Service
 
 
@@ -30,7 +30,7 @@ class PoolDatasetService(Service):
         (1 << 24, '16M'),
     ]
 
-    @api_method(PoolDatasetRecordSizeChoicesArgs, PoolDatasetRecordSizeChoicesResult, roles=['DATASET_READ'])
+    @api_method(PoolDatasetRecordsizeChoicesArgs, PoolDatasetRecordsizeChoicesResult, roles=['DATASET_READ'])
     def recordsize_choices(self, pool_name):
         """
         Retrieve recordsize choices for datasets.

--- a/src/middlewared/middlewared/plugins/pool_/dedup.py
+++ b/src/middlewared/middlewared/plugins/pool_/dedup.py
@@ -1,5 +1,5 @@
 from middlewared.api import api_method
-from middlewared.api.current import DDTPrefetchArgs, DDTPrefetchResult, DDTPruneArgs, DDTPruneResult
+from middlewared.api.current import PoolDdtPrefetchArgs, PoolDdtPrefetchResult, PoolDdtPruneArgs, PoolDdtPruneResult
 from middlewared.service import job, Service
 
 
@@ -8,7 +8,7 @@ class PoolService(Service):
     class Config:
         cli_namespace = 'storage.pool'
 
-    @api_method(DDTPruneArgs, DDTPruneResult, roles=['POOL_WRITE'])
+    @api_method(PoolDdtPruneArgs, PoolDdtPruneResult, roles=['POOL_WRITE'])
     @job(lock=lambda args: f'ddt_prune_{args[0].get("pool_name")}')
     async def ddt_prune(self, job, options):
         """
@@ -20,7 +20,7 @@ class PoolService(Service):
         """
         return await self.middleware.call('zfs.pool.ddt_prune', options)
 
-    @api_method(DDTPrefetchArgs, DDTPrefetchResult, roles=['POOL_WRITE'])
+    @api_method(PoolDdtPrefetchArgs, PoolDdtPrefetchResult, roles=['POOL_WRITE'])
     @job(lock=lambda args: f'ddt_prefetch_{args[0]}')
     async def ddt_prefetch(self, job, pool_name):
         """

--- a/src/middlewared/middlewared/plugins/pool_/snapshot_count.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot_count.py
@@ -1,7 +1,7 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
     PoolDatasetSnapshotCountArgs,
-    PoolDatasetSnapshotCountResults,
+    PoolDatasetSnapshotCountResult,
 )
 from middlewared.service import Service
 
@@ -12,7 +12,7 @@ class PoolDatasetService(Service):
 
     @api_method(
         PoolDatasetSnapshotCountArgs,
-        PoolDatasetSnapshotCountResults,
+        PoolDatasetSnapshotCountResult,
         roles=["DATASET_READ"],
     )
     def snapshot_count(self, dataset):

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 from middlewared.api import api_method
 from middlewared.api.base import BaseModel
-from middlewared.api.current import (RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult, RdmaCardConfigArgs,
-                                     RdmaCardConfigResult, RdmaLinkConfig)
+from middlewared.api.current import (RDMACapableProtocolsArgs, RDMACapableProtocolsResult, RDMAGetCardChoicesArgs,
+                                     RDMAGetCardChoicesResult, RdmaLinkConfig)
 from middlewared.plugins.rdma.interface import RDMAInterfaceService  # noqa (just import to start the service)
 from middlewared.service import Service, private
 from middlewared.service_exception import CallError
@@ -87,7 +87,7 @@ class RDMAService(Service):
                 result.append({'rdma': link['ifname'], 'netdev': link['netdev']})
         return result
 
-    @api_method(RdmaCardConfigArgs, RdmaCardConfigResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(RDMAGetCardChoicesArgs, RDMAGetCardChoicesResult, roles=['NETWORK_INTERFACE_READ'])
     @cache
     def get_card_choices(self):
         """Return a list containing details about each RDMA card.  Dual cards
@@ -132,7 +132,7 @@ class RDMAService(Service):
             v['name'] = ':'.join(sorted(names))
         return list(grouper.values())
 
-    @api_method(RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(RDMACapableProtocolsArgs, RDMACapableProtocolsResult, roles=['NETWORK_INTERFACE_READ'])
     async def capable_protocols(self):
         result = []
         is_ent = await self.middleware.call('system.is_enterprise')

--- a/src/middlewared/middlewared/plugins/reporting/export.py
+++ b/src/middlewared/middlewared/plugins/reporting/export.py
@@ -3,9 +3,9 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.base.jsonschema import get_json_schema
 from middlewared.api.current import (
-    ReportingExporterEntry, ReportingExporterCreateArgs, ReportingExporterCreateResult, ReportingExporterUpdateArgs,
-    ReportingExporterUpdateResult, ReportingExporterDeleteArgs, ReportingExporterDeleteResult,
-    ReportingExporterSchemasArgs, ReportingExporterSchemasResult,
+    ReportingExporterEntry, ReportingExportsCreateArgs, ReportingExportsCreateResult, ReportingExportsUpdateArgs,
+    ReportingExportsUpdateResult, ReportingExportsDeleteArgs, ReportingExportsDeleteResult,
+    ReportingExportsExporterSchemasArgs, ReportingExportsExporterSchemasResult,
 )
 from middlewared.service import CRUDService, private, ValidationErrors
 
@@ -50,7 +50,7 @@ class ReportingExportsService(CRUDService):
 
         verrors.check()
 
-    @api_method(ReportingExporterCreateArgs, ReportingExporterCreateResult)
+    @api_method(ReportingExportsCreateArgs, ReportingExportsCreateResult)
     async def do_create(self, data):
         """
         Create a specific reporting exporter configuration containing required details for exporting reporting metrics.
@@ -69,7 +69,7 @@ class ReportingExportsService(CRUDService):
 
         return await self.get_instance(oid)
 
-    @api_method(ReportingExporterUpdateArgs, ReportingExporterUpdateResult)
+    @api_method(ReportingExportsUpdateArgs, ReportingExportsUpdateResult)
     async def do_update(self, oid, data):
         """
         Update Reporting Exporter of `id`.
@@ -93,7 +93,7 @@ class ReportingExportsService(CRUDService):
 
         return await self.get_instance(oid)
 
-    @api_method(ReportingExporterDeleteArgs, ReportingExporterDeleteResult)
+    @api_method(ReportingExportsDeleteArgs, ReportingExportsDeleteResult)
     async def do_delete(self, oid):
         """
         Delete Reporting Exporter of `id`.
@@ -106,7 +106,7 @@ class ReportingExportsService(CRUDService):
         await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
         return True
 
-    @api_method(ReportingExporterSchemasArgs, ReportingExporterSchemasResult, roles=['REPORTING_READ'])
+    @api_method(ReportingExportsExporterSchemasArgs, ReportingExportsExporterSchemasResult, roles=['REPORTING_READ'])
     def exporter_schemas(self):
         """
         Get the schemas for all the reporting export types we support with their respective attributes

--- a/src/middlewared/middlewared/plugins/reporting/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/graphs.py
@@ -5,7 +5,8 @@ import typing
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    ReportingGraphArgs, ReportingGetDataResult, ReportingGraph, ReportingGetDataArgs,
+    ReportingNetdataGraphArgs, ReportingNetdataGraphResult, ReportingNetdataGraphsItem, ReportingNetdataGetDataArgs,
+    ReportingNetdataGetDataResult,
 )
 from middlewared.service import CallError, filterable_api_method, private, Service, ValidationErrors
 from middlewared.utils import filter_list
@@ -30,7 +31,7 @@ class ReportingService(Service):
     async def graph_names(self):
         return list(self.__graphs.keys())
 
-    @api_method(ReportingGraphArgs, ReportingGetDataResult, roles=['REPORTING_READ'], cli_private=True)
+    @api_method(ReportingNetdataGraphArgs, ReportingNetdataGraphResult, roles=['REPORTING_READ'], cli_private=True)
     async def netdata_graph(self, name, query):
         """
         Get reporting data for `name` graph.
@@ -45,14 +46,14 @@ class ReportingService(Service):
 
         return await graph_plugin.export_multiple_identifiers(query_params, identifiers, query['aggregate'])
 
-    @filterable_api_method(roles=['REPORTING_READ'], item=ReportingGraph, cli_private=True)
+    @filterable_api_method(roles=['REPORTING_READ'], item=ReportingNetdataGraphsItem, cli_private=True)
     async def netdata_graphs(self, filters, options):
         """
         Get reporting netdata graphs.
         """
         return filter_list([await i.as_dict() for i in self.__graphs.values()], filters, options)
 
-    @api_method(ReportingGetDataArgs, ReportingGetDataResult, roles=['REPORTING_READ'], cli_private=True)
+    @api_method(ReportingNetdataGetDataArgs, ReportingNetdataGetDataResult, roles=['REPORTING_READ'], cli_private=True)
     async def netdata_get_data(self, graphs, query):
         """
         Get reporting data for given graphs.

--- a/src/middlewared/middlewared/plugins/reporting/update.py
+++ b/src/middlewared/middlewared/plugins/reporting/update.py
@@ -2,8 +2,8 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    ReportingEntry, ReportingGraph, ReportingUpdateArgs, ReportingUpdateResult, ReportingGetDataArgs,
-    ReportingGetDataResult, ReportingGraphArgs,
+    ReportingEntry, ReportingGraphsItem, ReportingUpdateArgs, ReportingUpdateResult, ReportingGetDataArgs,
+    ReportingGetDataResult, ReportingGraphResult, ReportingGraphArgs,
 )
 from middlewared.service import filterable_api_method, ConfigService, private
 
@@ -40,7 +40,7 @@ class ReportingService(ConfigService):
         await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
         return await self.config()
 
-    @filterable_api_method(roles=['REPORTING_READ'], item=ReportingGraph, cli_private=True)
+    @filterable_api_method(roles=['REPORTING_READ'], item=ReportingGraphsItem, cli_private=True)
     async def graphs(self, filters, options):
         return await self.middleware.call('reporting.netdata_graphs', filters, options)
 
@@ -78,7 +78,7 @@ class ReportingService(ConfigService):
     async def get_all(self, query):
         return await self.middleware.call('reporting.netdata_get_all', query)
 
-    @api_method(ReportingGraphArgs, ReportingGetDataResult, roles=['REPORTING_READ'], cli_private=True)
+    @api_method(ReportingGraphArgs, ReportingGraphResult, roles=['REPORTING_READ'], cli_private=True)
     async def graph(self, name, query):
         """
         Get reporting data for `name` graph.

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -2,8 +2,8 @@ from subprocess import run
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SystemSecurityFipsAvailableArgs, SystemSecurityFipsAvailableResult,
-    SystemSecurityFipsEnabledArgs, SystemSecurityFipsEnabledResult,
+    SystemSecurityInfoFipsAvailableArgs, SystemSecurityInfoFipsAvailableResult,
+    SystemSecurityInfoFipsEnabledArgs, SystemSecurityInfoFipsEnabledResult,
 )
 from middlewared.service import CallError, Service
 
@@ -15,7 +15,7 @@ class SystemSecurityInfoService(Service):
         cli_namespace = 'system.security.info'
 
     @api_method(
-        SystemSecurityFipsAvailableArgs, SystemSecurityFipsAvailableResult,
+        SystemSecurityInfoFipsAvailableArgs, SystemSecurityInfoFipsAvailableResult,
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_available(self):
@@ -24,7 +24,7 @@ class SystemSecurityInfoService(Service):
         return bool(self.middleware.call_sync('system.license'))
 
     @api_method(
-        SystemSecurityFipsEnabledArgs, SystemSecurityFipsEnabledResult,
+        SystemSecurityInfoFipsEnabledArgs, SystemSecurityInfoFipsEnabledResult,
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_enabled(self):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -8,16 +8,16 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    GetSmbAclArgs, GetSmbAclResult,
-    SetSmbAclArgs, SetSmbAclResult,
-    SmbServiceEntry, SmbServiceUpdateArgs, SmbServiceUpdateResult,
-    SmbServiceUnixCharsetChoicesArgs, SmbServiceUnixCharsetChoicesResult,
-    SmbServiceBindIPChoicesArgs, SmbServiceBindIPChoicesResult,
-    SmbSharePresetsArgs, SmbSharePresetsResult,
-    SmbSharePrecheckArgs, SmbSharePrecheckResult,
-    SmbShareEntry, SmbShareCreateArgs, SmbShareCreateResult,
-    SmbShareUpdateArgs, SmbShareUpdateResult,
-    SmbShareDeleteArgs, SmbShareDeleteResult,
+    SharingSMBGetaclArgs, SharingSMBGetaclResult,
+    SharingSMBSetaclArgs, SharingSMBSetaclResult,
+    SmbServiceEntry, SMBUpdateArgs, SMBUpdateResult,
+    SMBUnixcharsetChoicesArgs, SMBUnixcharsetChoicesResult,
+    SMBBindipChoicesArgs, SMBBindipChoicesResult,
+    SharingSMBPresetsArgs, SharingSMBPresetsResult,
+    SharingSMBSharePrecheckArgs, SharingSMBSharePrecheckResult,
+    SmbShareEntry, SharingSMBCreateArgs, SharingSMBCreateResult,
+    SharingSMBUpdateArgs, SharingSMBUpdateResult,
+    SharingSMBDeleteArgs, SharingSMBDeleteResult,
 )
 from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.common.listen import SystemServiceListenMultipleDelegate
@@ -115,7 +115,7 @@ class SMBService(ConfigService):
         smb.pop('secrets', None)
         return smb
 
-    @api_method(SmbServiceUnixCharsetChoicesArgs, SmbServiceUnixCharsetChoicesResult)
+    @api_method(SMBUnixcharsetChoicesArgs, SMBUnixcharsetChoicesResult)
     async def unixcharset_choices(self):
         return {str(charset): charset for charset in SMBUnixCharset}
 
@@ -143,7 +143,7 @@ class SMBService(ConfigService):
             security_config,
         )
 
-    @api_method(SmbServiceBindIPChoicesArgs, SmbServiceBindIPChoicesResult)
+    @api_method(SMBBindipChoicesArgs, SMBBindipChoicesResult)
     async def bindip_choices(self):
         """
         List of valid choices for IP addresses to which to bind the SMB service.
@@ -434,7 +434,7 @@ class SMBService(ConfigService):
                     f'The following SMB shares have auditing enabled: {", ".join([x["name"] for x in audited_shares])}'
                 )
 
-    @api_method(SmbServiceUpdateArgs, SmbServiceUpdateResult, audit='Update SMB configuration')
+    @api_method(SMBUpdateArgs, SMBUpdateResult, audit='Update SMB configuration')
     @pass_app(rest=True)
     async def do_update(self, app, data):
         """
@@ -592,7 +592,7 @@ class SharingSMBService(SharingService):
         entry = SmbShareEntry
 
     @api_method(
-        SmbShareCreateArgs, SmbShareCreateResult,
+        SharingSMBCreateArgs, SharingSMBCreateResult,
         audit='SMB share create',
         audit_extended=lambda data: data['name'],
         pass_app=True,
@@ -699,7 +699,7 @@ class SharingSMBService(SharingService):
                 await self.toggle_share(newname, False)
 
     @api_method(
-        SmbShareUpdateArgs, SmbShareUpdateResult,
+        SharingSMBUpdateArgs, SharingSMBUpdateResult,
         audit='SMB share update',
         audit_callback=True,
         pass_app=True,
@@ -848,7 +848,7 @@ class SharingSMBService(SharingService):
         return await self.get_instance(id_)
 
     @api_method(
-        SmbShareDeleteArgs, SmbShareDeleteResult,
+        SharingSMBDeleteArgs, SharingSMBDeleteResult,
         audit='SMB share delete',
         audit_callback=True,
     )
@@ -1168,7 +1168,7 @@ class SharingSMBService(SharingService):
                 'This feature may be enabled in the general SMB server configuration.'
             )
 
-    @api_method(SmbSharePrecheckArgs, SmbSharePrecheckResult, roles=['READONLY_ADMIN'])
+    @api_method(SharingSMBSharePrecheckArgs, SharingSMBSharePrecheckResult, roles=['READONLY_ADMIN'])
     async def share_precheck(self, data):
         verrors = ValidationErrors()
         ds_enabled = (await self.middleware.call('directoryservices.config'))['enable']
@@ -1333,7 +1333,7 @@ class SharingSMBService(SharingService):
 
         return data
 
-    @api_method(SmbSharePresetsArgs, SmbSharePresetsResult, roles=['SHARING_SMB_READ'])
+    @api_method(SharingSMBPresetsArgs, SharingSMBPresetsResult, roles=['SHARING_SMB_READ'])
     async def presets(self):
         """
         Retrieve pre-defined configuration sets for specific use-cases. These parameter
@@ -1342,7 +1342,7 @@ class SharingSMBService(SharingService):
         return {x.name: {'verbose_name': x.value} for x in SMBSharePurpose}
 
     @api_method(
-        SetSmbAclArgs, SetSmbAclResult,
+        SharingSMBSetaclArgs, SharingSMBSetaclResult,
         roles=['SHARING_SMB_WRITE'],
         audit='Setacl SMB share',
         audit_extended=lambda data: data['share_name']
@@ -1454,7 +1454,7 @@ class SharingSMBService(SharingService):
         return await self.getacl({'share_name': data['share_name']})
 
     @api_method(
-        GetSmbAclArgs, GetSmbAclResult,
+        SharingSMBGetaclArgs, SharingSMBGetaclResult,
         roles=['SHARING_SMB_READ'],
         audit='Getacl SMB share',
         audit_extended=lambda data: data['share_name']

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -3,10 +3,10 @@ import os
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    PoolSnapshotTaskEntry, PoolSnapshotTaskCreateArgs, PoolSnapshotTaskCreateResult, PoolSnapshotTaskUpdateArgs,
-    PoolSnapshotTaskUpdateResult, PoolSnapshotTaskDeleteArgs, PoolSnapshotTaskDeleteResult,
-    PoolSnapshotTaskMaxCountArgs, PoolSnapshotTaskMaxCountResult, PoolSnapshotTaskMaxTotalCountArgs,
-    PoolSnapshotTaskMaxTotalCountResult, PoolSnapshotTaskRunArgs, PoolSnapshotTaskRunResult
+    PoolSnapshotTaskEntry, PeriodicSnapshotTaskCreateArgs, PeriodicSnapshotTaskCreateResult, PeriodicSnapshotTaskUpdateArgs,
+    PeriodicSnapshotTaskUpdateResult, PeriodicSnapshotTaskDeleteArgs, PeriodicSnapshotTaskDeleteResult,
+    PeriodicSnapshotTaskMaxCountArgs, PeriodicSnapshotTaskMaxCountResult, PeriodicSnapshotTaskMaxTotalCountArgs,
+    PeriodicSnapshotTaskMaxTotalCountResult, PeriodicSnapshotTaskRunArgs, PeriodicSnapshotTaskRunResult
 )
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.schema import Cron
@@ -78,8 +78,8 @@ class PeriodicSnapshotTaskService(CRUDService):
         return data
 
     @api_method(
-        PoolSnapshotTaskCreateArgs,
-        PoolSnapshotTaskCreateResult,
+        PeriodicSnapshotTaskCreateArgs,
+        PeriodicSnapshotTaskCreateResult,
         audit='Snapshot task create:',
         audit_extended=lambda data: data['dataset']
     )
@@ -147,8 +147,8 @@ class PeriodicSnapshotTaskService(CRUDService):
         return await self.get_instance(data['id'])
 
     @api_method(
-        PoolSnapshotTaskUpdateArgs,
-        PoolSnapshotTaskUpdateResult,
+        PeriodicSnapshotTaskUpdateArgs,
+        PeriodicSnapshotTaskUpdateResult,
         audit='Snapshot task update:',
         audit_callback=True
     )
@@ -239,8 +239,8 @@ class PeriodicSnapshotTaskService(CRUDService):
         return await self.get_instance(id_)
 
     @api_method(
-        PoolSnapshotTaskDeleteArgs,
-        PoolSnapshotTaskDeleteResult,
+        PeriodicSnapshotTaskDeleteArgs,
+        PeriodicSnapshotTaskDeleteResult,
         audit='Snapshot task delete:',
         audit_callback=True
     )
@@ -298,7 +298,7 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         return response
 
-    @api_method(PoolSnapshotTaskMaxCountArgs, PoolSnapshotTaskMaxCountResult, roles=['SNAPSHOT_TASK_READ'])
+    @api_method(PeriodicSnapshotTaskMaxCountArgs, PeriodicSnapshotTaskMaxCountResult, roles=['SNAPSHOT_TASK_READ'])
     def max_count(self):
         """
         Returns a maximum amount of snapshots (per-dataset) the system can sustain.
@@ -308,7 +308,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         # with too many, then File Explorer will show no snapshots available.
         return 512
 
-    @api_method(PoolSnapshotTaskMaxTotalCountArgs, PoolSnapshotTaskMaxTotalCountResult, roles=['SNAPSHOT_TASK_READ'])
+    @api_method(PeriodicSnapshotTaskMaxTotalCountArgs, PeriodicSnapshotTaskMaxTotalCountResult, roles=['SNAPSHOT_TASK_READ'])
     def max_total_count(self):
         """
         Returns a maximum amount of snapshots (total) the system can sustain.
@@ -319,7 +319,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         return 10000
 
     @item_method
-    @api_method(PoolSnapshotTaskRunArgs, PoolSnapshotTaskRunResult, roles=['SNAPSHOT_TASK_WRITE'])
+    @api_method(PeriodicSnapshotTaskRunArgs, PeriodicSnapshotTaskRunResult, roles=['SNAPSHOT_TASK_WRITE'])
     async def run(self, id_):
         """
         Execute a Periodic Snapshot Task of `id`.

--- a/src/middlewared/middlewared/plugins/snapshot_/task_retention.py
+++ b/src/middlewared/middlewared/plugins/snapshot_/task_retention.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    PoolSnapshotTaskUpdateWillChangeRetentionForArgs, PoolSnapshotTaskUpdateWillChangeRetentionForResult,
-    PoolSnapshotTaskDeleteWillChangeRetentionForArgs, PoolSnapshotTaskDeleteWillChangeRetentionForResult
+    PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs, PeriodicSnapshotTaskUpdateWillChangeRetentionForResult,
+    PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs, PeriodicSnapshotTaskDeleteWillChangeRetentionForResult
 )
 from middlewared.service import item_method, Service
 
@@ -14,7 +14,7 @@ class PeriodicSnapshotTaskService(Service):
         namespace = "pool.snapshottask"
 
     @item_method
-    @api_method(PoolSnapshotTaskUpdateWillChangeRetentionForArgs, PoolSnapshotTaskUpdateWillChangeRetentionForResult,
+    @api_method(PeriodicSnapshotTaskUpdateWillChangeRetentionForArgs, PeriodicSnapshotTaskUpdateWillChangeRetentionForResult,
 		roles=['SNAPSHOT_TASK_READ'])
     async def update_will_change_retention_for(self, id_, data):
         """
@@ -37,7 +37,7 @@ class PeriodicSnapshotTaskService(Service):
         return result
 
     @item_method
-    @api_method(PoolSnapshotTaskDeleteWillChangeRetentionForArgs, PoolSnapshotTaskDeleteWillChangeRetentionForResult,
+    @api_method(PeriodicSnapshotTaskDeleteWillChangeRetentionForArgs, PeriodicSnapshotTaskDeleteWillChangeRetentionForResult,
 		roles=['SNAPSHOT_TASK_READ'])
     async def delete_will_change_retention_for(self, id_):
         """

--- a/src/middlewared/middlewared/plugins/snmp.py
+++ b/src/middlewared/middlewared/plugins/snmp.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from middlewared.api import api_method
 from middlewared.api.current import (
     SnmpEntry,
-    SnmpUpdateArgs, SnmpUpdateResult
+    SNMPUpdateArgs, SNMPUpdateResult
 )
 
 from middlewared.common.ports import ServicePortDelegate
@@ -147,7 +147,7 @@ class SNMPService(SystemServiceService):
         if snmp_service['state'] == "STOPPED":
             await (await self.middleware.call("service.control", "STOP", "snmp")).wait(raise_error=True)
 
-    @api_method(SnmpUpdateArgs, SnmpUpdateResult)
+    @api_method(SNMPUpdateArgs, SNMPUpdateResult)
     async def do_update(self, data):
         """
         Update SNMP Service Configuration.

--- a/src/middlewared/middlewared/plugins/ssh.py
+++ b/src/middlewared/middlewared/plugins/ssh.py
@@ -6,7 +6,7 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SSHEntry, SSHBindIfaceChoicesArgs, SSHBindIfaceChoicesResult, SSHUpdateArgs, SSHUpdateResult
+    SSHEntry, SSHBindifaceChoicesArgs, SSHBindifaceChoicesResult, SSHUpdateArgs, SSHUpdateResult
 )
 from middlewared.async_validators import validate_port
 from middlewared.common.ports import ServicePortDelegate
@@ -56,7 +56,7 @@ class SSHService(SystemServiceService):
         role_prefix = 'SSH'
         entry = SSHEntry
 
-    @api_method(SSHBindIfaceChoicesArgs, SSHBindIfaceChoicesResult, roles=['NETWORK_INTERFACE_READ'])
+    @api_method(SSHBindifaceChoicesArgs, SSHBindifaceChoicesResult, roles=['NETWORK_INTERFACE_READ'])
     def bindiface_choices(self):
         """
         Available choices for the bindiface attribute of SSH service.

--- a/src/middlewared/middlewared/plugins/system/globalid.py
+++ b/src/middlewared/middlewared/plugins/system/globalid.py
@@ -1,7 +1,7 @@
 import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method
-from middlewared.api.current import SystemGlobalIdArgs, SystemGlobalIdResult
+from middlewared.api.current import SystemGlobalIDIdArgs, SystemGlobalIDIdResult
 from middlewared.service import Service
 
 
@@ -17,7 +17,7 @@ class SystemGlobalIDService(Service):
         namespace = "system.global"
         cli_namespace = "system.global"
 
-    @api_method(SystemGlobalIdArgs, SystemGlobalIdResult, roles=["READONLY_ADMIN"])
+    @api_method(SystemGlobalIDIdArgs, SystemGlobalIDIdResult, roles=["READONLY_ADMIN"])
     async def id(self):
         """
         Retrieve a 128 bit hexadecimal UUID value unique for each TrueNAS system.

--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 from middlewared.api import api_method
-from middlewared.api.current import SystemHostIDArgs, SystemHostIDResult, SystemInfoArgs, SystemInfoResult
+from middlewared.api.current import SystemHostIdArgs, SystemHostIdResult, SystemInfoArgs, SystemInfoResult
 from middlewared.service import no_authz_required, private, Service
 from middlewared.utils import sw_buildtime
 from middlewared.utils.cpu import cpu_info
@@ -55,7 +55,7 @@ class SystemService(Service):
     async def hostname(self) -> str:
         return socket.gethostname()
 
-    @api_method(SystemHostIDArgs, SystemHostIDResult, roles=['READONLY_ADMIN'])
+    @api_method(SystemHostIdArgs, SystemHostIdResult, roles=['READONLY_ADMIN'])
     def host_id(self):
         """
         Retrieve a hex string that is generated based

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -9,18 +9,18 @@ from datetime import date
 from licenselib.license import ContractType, Features, License
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SystemProductFeatureEnabledArgs,
-    SystemProductFeatureEnabledResult,
-    SystemProductLicenseArgs,
-    SystemProductLicenseResult,
-    SystemProductReleaseNotesUrlArgs,
-    SystemProductReleaseNotesUrlResult,
+    SystemFeatureEnabledArgs,
+    SystemFeatureEnabledResult,
+    SystemLicenseUpdateArgs,
+    SystemLicenseUpdateResult,
+    SystemReleaseNotesUrlArgs,
+    SystemReleaseNotesUrlResult,
     SystemProductTypeArgs,
     SystemProductTypeResult,
-    SystemProductVersionArgs,
-    SystemProductVersionResult,
-    SystemProductVersionShortArgs,
-    SystemProductVersionShortResult,
+    SystemVersionArgs,
+    SystemVersionResult,
+    SystemVersionShortArgs,
+    SystemVersionShortResult,
 )
 from middlewared.plugins.truenas import EULA_PENDING_PATH
 from middlewared.service import CallError, private, Service, ValidationError
@@ -73,8 +73,8 @@ class SystemService(Service):
         return await self.middleware.call('system.product_type') == ProductType.ENTERPRISE
 
     @api_method(
-        SystemProductVersionShortArgs,
-        SystemProductVersionShortResult,
+        SystemVersionShortArgs,
+        SystemVersionShortResult,
         authorization_required=False,
     )
     def version_short(self):
@@ -82,8 +82,8 @@ class SystemService(Service):
         return sw_info()['version']
 
     @api_method(
-        SystemProductReleaseNotesUrlArgs,
-        SystemProductReleaseNotesUrlResult,
+        SystemReleaseNotesUrlArgs,
+        SystemReleaseNotesUrlResult,
         roles=['SYSTEM_PRODUCT_READ']
     )
     def release_notes_url(self, version_str):
@@ -107,8 +107,8 @@ class SystemService(Service):
             return f'{base_url}/#{"".join(version_split)}'
 
     @api_method(
-        SystemProductVersionArgs,
-        SystemProductVersionResult,
+        SystemVersionArgs,
+        SystemVersionResult,
         authorization_required=False,
     )
     def version(self):
@@ -174,8 +174,8 @@ class SystemService(Service):
         return LICENSE_FILE
 
     @api_method(
-        SystemProductLicenseArgs,
-        SystemProductLicenseResult,
+        SystemLicenseUpdateArgs,
+        SystemLicenseUpdateResult,
         roles=['SYSTEM_PRODUCT_WRITE']
     )
     def license_update(self, license_):
@@ -207,8 +207,8 @@ class SystemService(Service):
         )
 
     @api_method(
-        SystemProductFeatureEnabledArgs,
-        SystemProductFeatureEnabledResult,
+        SystemFeatureEnabledArgs,
+        SystemFeatureEnabledResult,
         roles=['SYSTEM_PRODUCT_READ'],
     )
     async def feature_enabled(self, name):

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -10,8 +10,8 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.current import (
     SystemAdvancedEntry, SystemAdvancedLoginBannerArgs, SystemAdvancedLoginBannerResult,
-    SystemAdvancedSEDGlobalPasswordArgs, SystemAdvancedSEDGlobalPasswordResult,
-    SystemAdvancedSEDGlobalPasswordIsSetArgs, SystemAdvancedSEDGlobalPasswordIsSetResult, SystemAdvancedUpdateArgs,
+    SystemAdvancedSedGlobalPasswordArgs, SystemAdvancedSedGlobalPasswordResult,
+    SystemAdvancedSedGlobalPasswordIsSetArgs, SystemAdvancedSedGlobalPasswordIsSetResult, SystemAdvancedUpdateArgs,
     SystemAdvancedUpdateResult
 )
 from middlewared.service import ConfigService, private
@@ -242,8 +242,8 @@ class SystemAdvancedService(ConfigService):
         return await self.config()
 
     @api_method(
-        SystemAdvancedSEDGlobalPasswordIsSetArgs,
-        SystemAdvancedSEDGlobalPasswordIsSetResult,
+        SystemAdvancedSedGlobalPasswordIsSetArgs,
+        SystemAdvancedSedGlobalPasswordIsSetResult,
         roles=['SYSTEM_ADVANCED_READ']
     )
     async def sed_global_password_is_set(self):
@@ -252,8 +252,8 @@ class SystemAdvancedService(ConfigService):
         return bool(await self.sed_global_password())
 
     @api_method(
-        SystemAdvancedSEDGlobalPasswordArgs,
-        SystemAdvancedSEDGlobalPasswordResult,
+        SystemAdvancedSedGlobalPasswordArgs,
+        SystemAdvancedSedGlobalPasswordResult,
         roles=['SYSTEM_ADVANCED_READ']
     )
     async def sed_global_password(self):

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -1,9 +1,9 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SystemAdvancedGpuChoicesArgs,
-    SystemAdvancedGpuChoicesResult,
-    SystemAdvancedUpdateGpuPciIdArgs,
-    SystemAdvancedUpdateGpuPciIdResult,
+    SystemAdvancedGetGpuPciChoicesArgs,
+    SystemAdvancedGetGpuPciChoicesResult,
+    SystemAdvancedUpdateGpuPciIdsArgs,
+    SystemAdvancedUpdateGpuPciIdsResult,
 )
 from middlewared.service import private, Service, ValidationErrors
 from middlewared.utils.gpu import get_gpus
@@ -16,8 +16,8 @@ class SystemAdvancedService(Service):
         cli_namespace = 'system.advanced'
 
     @api_method(
-        SystemAdvancedGpuChoicesArgs,
-        SystemAdvancedGpuChoicesResult,
+        SystemAdvancedGetGpuPciChoicesArgs,
+        SystemAdvancedGetGpuPciChoicesResult,
         roles=['SYSTEM_ADVANCED_READ']
     )
     def get_gpu_pci_choices(self):
@@ -35,8 +35,8 @@ class SystemAdvancedService(Service):
         return gpus
 
     @api_method(
-        SystemAdvancedUpdateGpuPciIdArgs,
-        SystemAdvancedUpdateGpuPciIdResult,
+        SystemAdvancedUpdateGpuPciIdsArgs,
+        SystemAdvancedUpdateGpuPciIdsResult,
         roles=['SYSTEM_ADVANCED_WRITE']
     )
     async def update_gpu_pci_ids(self, isolated_gpu_pci_ids):

--- a/src/middlewared/middlewared/plugins/system_general/country.py
+++ b/src/middlewared/middlewared/plugins/system_general/country.py
@@ -1,7 +1,7 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    CertificateCountryChoicesArgs,
-    CertificateCountryChoicesResult,
+    SystemGeneralCountryChoicesArgs,
+    SystemGeneralCountryChoicesResult,
 )
 from middlewared.service import Service
 from middlewared.utils.country_codes import get_country_codes
@@ -14,8 +14,8 @@ class SystemGeneralService(Service):
         cli_namespace = 'system.general'
 
     @api_method(
-        CertificateCountryChoicesArgs,
-        CertificateCountryChoicesResult,
+        SystemGeneralCountryChoicesArgs,
+        SystemGeneralCountryChoicesResult,
         roles=['SYSTEM_GENERAL_READ']
     )
     def country_choices(self):

--- a/src/middlewared/middlewared/plugins/system_general/keymap.py
+++ b/src/middlewared/middlewared/plugins/system_general/keymap.py
@@ -1,7 +1,7 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SystemGeneralKbdMapChoicesArgs,
-    SystemGeneralKbdMapChoicesResult,
+    SystemGeneralKbdmapChoicesArgs,
+    SystemGeneralKbdmapChoicesResult,
 )
 from middlewared.service import Service
 from middlewared.utils.kbdmap_choices import kbdmap_choices
@@ -13,8 +13,8 @@ class SystemGeneralService(Service):
         cli_namespace = "system.general"
 
     @api_method(
-        SystemGeneralKbdMapChoicesArgs,
-        SystemGeneralKbdMapChoicesResult,
+        SystemGeneralKbdmapChoicesArgs,
+        SystemGeneralKbdmapChoicesResult,
     )
     async def kbdmap_choices(self):
         """Returns keyboard map choices."""

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -2,18 +2,18 @@ import asyncio
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    SystemGeneralUIAddressChoicesArgs,
-    SystemGeneralUIAddressChoicesResult,
-    SystemGeneralUICertificateChoicesArgs,
-    SystemGeneralUICertificateChoicesResult,
-    SystemGeneralUIHTTPSProtocolChoicesArgs,
-    SystemGeneralUIHTTPSProtocolChoicesResult,
-    SystemGeneralUILocalURLArgs,
-    SystemGeneralUILocalURLResult,
-    SystemGeneralUIRestartArgs,
-    SystemGeneralUIRestartResult,
-    SystemGeneralUIV6AddressChoicesArgs,
-    SystemGeneralUIV6AddressChoicesResult,
+    SystemGeneralUiAddressChoicesArgs,
+    SystemGeneralUiAddressChoicesResult,
+    SystemGeneralUiCertificateChoicesArgs,
+    SystemGeneralUiCertificateChoicesResult,
+    SystemGeneralUiHttpsprotocolsChoicesArgs,
+    SystemGeneralUiHttpsprotocolsChoicesResult,
+    SystemGeneralLocalUrlArgs,
+    SystemGeneralLocalUrlResult,
+    SystemGeneralUiRestartArgs,
+    SystemGeneralUiRestartResult,
+    SystemGeneralUiV6addressChoicesArgs,
+    SystemGeneralUiV6addressChoicesResult,
 )
 from middlewared.service import CallError, private, Service
 
@@ -28,8 +28,8 @@ class SystemGeneralService(Service):
         cli_namespace = "system.general"
 
     @api_method(
-        SystemGeneralUIAddressChoicesArgs,
-        SystemGeneralUIAddressChoicesResult,
+        SystemGeneralUiAddressChoicesArgs,
+        SystemGeneralUiAddressChoicesResult,
         roles=["SYSTEM_GENERAL_READ"],
     )
     async def ui_address_choices(self):
@@ -45,8 +45,8 @@ class SystemGeneralService(Service):
         }
 
     @api_method(
-        SystemGeneralUIV6AddressChoicesArgs,
-        SystemGeneralUIV6AddressChoicesResult,
+        SystemGeneralUiV6addressChoicesArgs,
+        SystemGeneralUiV6addressChoicesResult,
         roles=["SYSTEM_GENERAL_READ"],
     )
     async def ui_v6address_choices(self):
@@ -62,8 +62,8 @@ class SystemGeneralService(Service):
         }
 
     @api_method(
-        SystemGeneralUIHTTPSProtocolChoicesArgs,
-        SystemGeneralUIHTTPSProtocolChoicesResult,
+        SystemGeneralUiHttpsprotocolsChoicesArgs,
+        SystemGeneralUiHttpsprotocolsChoicesResult,
         roles=["SYSTEM_GENERAL_READ"],
     )
     def ui_httpsprotocols_choices(self):
@@ -71,8 +71,8 @@ class SystemGeneralService(Service):
         return dict(zip(HTTPS_PROTOCOLS, HTTPS_PROTOCOLS))
 
     @api_method(
-        SystemGeneralUICertificateChoicesArgs,
-        SystemGeneralUICertificateChoicesResult,
+        SystemGeneralUiCertificateChoicesArgs,
+        SystemGeneralUiCertificateChoicesResult,
         roles=["SYSTEM_GENERAL_READ"]
     )
     async def ui_certificate_choices(self):
@@ -86,8 +86,8 @@ class SystemGeneralService(Service):
         }
 
     @api_method(
-        SystemGeneralUIRestartArgs,
-        SystemGeneralUIRestartResult,
+        SystemGeneralUiRestartArgs,
+        SystemGeneralUiRestartResult,
         roles=["SYSTEM_GENERAL_WRITE"],
     )
     async def ui_restart(self, delay: int):
@@ -105,8 +105,8 @@ class SystemGeneralService(Service):
         )
 
     @api_method(
-        SystemGeneralUILocalURLArgs,
-        SystemGeneralUILocalURLResult,
+        SystemGeneralLocalUrlArgs,
+        SystemGeneralLocalUrlResult,
         roles=["SYSTEM_GENERAL_READ"]
     )
     async def local_url(self):

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -5,7 +5,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.current import (
     TRUECOMMAND_CONNECTING_STATUS_REASON, TruecommandStatus, TruecommandStatusReason, TruecommandEntry,
-    TruecommandUpdateArgs, TrueCommandUpdateResult,
+    TruecommandUpdateArgs, TruecommandUpdateResult,
 )
 from middlewared.service import ConfigService, private, ValidationErrors
 
@@ -72,7 +72,7 @@ class TruecommandService(ConfigService):
         })
         return config
 
-    @api_method(TruecommandUpdateArgs, TrueCommandUpdateResult)
+    @api_method(TruecommandUpdateArgs, TruecommandUpdateResult)
     async def do_update(self, data):
         """
         Update Truecommand service settings.

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -7,10 +7,10 @@ from middlewared.service import cli_private, job, private, Service
 from middlewared.api.current import (
     TrueNASSetProductionArgs, TrueNASSetProductionResult,
     TrueNASIsProductionArgs, TrueNASIsProductionResult,
-    TrueNASAcceptEULAArgs, TrueNASAcceptEULAResult,
-    TrueNASIsEULAAcceptedArgs, TrueNASIsEULAAcceptedResult,
-    TrueNASGetEULAArgs, TrueNASGetEULAResult,
-    TrueNASIsIXHardwareArgs, TrueNASIsIXHardwareResult,
+    TrueNASAcceptEulaArgs, TrueNASAcceptEulaResult,
+    TrueNASIsEulaAcceptedArgs, TrueNASIsEulaAcceptedResult,
+    TrueNASGetEulaArgs, TrueNASGetEulaResult,
+    TrueNASIsIxHardwareArgs, TrueNASIsIxHardwareResult,
     TrueNASGetChassisHardwareArgs, TrueNASGetChassisHardwareResult,
     TrueNASManagedByTruecommandArgs, TrueNASManagedByTruecommandResult, TruecommandStatus,
 )
@@ -52,14 +52,14 @@ class TrueNASService(Service):
         """
         return get_chassis_hardware()
 
-    @api_method(TrueNASIsIXHardwareArgs, TrueNASIsIXHardwareResult, roles=['READONLY_ADMIN'])
+    @api_method(TrueNASIsIxHardwareArgs, TrueNASIsIxHardwareResult, roles=['READONLY_ADMIN'])
     async def is_ix_hardware(self):
         """
         Return a boolean value on whether this is hardware that iXsystems sells.
         """
         return await self.get_chassis_hardware() != TRUENAS_UNKNOWN
 
-    @api_method(TrueNASGetEULAArgs, TrueNASGetEULAResult, roles=['READONLY_ADMIN'])
+    @api_method(TrueNASGetEulaArgs, TrueNASGetEulaResult, roles=['READONLY_ADMIN'])
     @cli_private
     def get_eula(self):
         """
@@ -71,7 +71,7 @@ class TrueNASService(Service):
         except FileNotFoundError:
             pass
 
-    @api_method(TrueNASIsEULAAcceptedArgs, TrueNASIsEULAAcceptedResult, roles=['READONLY_ADMIN'])
+    @api_method(TrueNASIsEulaAcceptedArgs, TrueNASIsEulaAcceptedResult, roles=['READONLY_ADMIN'])
     @cli_private
     def is_eula_accepted(self):
         """
@@ -79,7 +79,7 @@ class TrueNASService(Service):
         """
         return not os.path.exists(EULA_PENDING_PATH)
 
-    @api_method(TrueNASAcceptEULAArgs, TrueNASAcceptEULAResult, roles=['FULL_ADMIN'])
+    @api_method(TrueNASAcceptEulaArgs, TrueNASAcceptEulaResult, roles=['FULL_ADMIN'])
     def accept_eula(self):
         """
         Accept TrueNAS EULA.

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -8,7 +8,7 @@ from truenas_connect_utils.urls import get_registration_uri
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    TNCGetRegistrationURIArgs, TNCGetRegistrationURIResult, TNCGenerateClaimTokenArgs, TNCGenerateClaimTokenResult,
+    TrueNASConnectGetRegistrationUriArgs, TrueNASConnectGetRegistrationUriResult, TrueNASConnectGenerateClaimTokenArgs, TrueNASConnectGenerateClaimTokenResult,
 )
 from middlewared.service import CallError, Service
 
@@ -24,7 +24,7 @@ class TrueNASConnectService(Service):
         namespace = 'tn_connect'
         cli_private = True
 
-    @api_method(TNCGenerateClaimTokenArgs, TNCGenerateClaimTokenResult, roles=['TRUENAS_CONNECT_WRITE'])
+    @api_method(TrueNASConnectGenerateClaimTokenArgs, TrueNASConnectGenerateClaimTokenResult, roles=['TRUENAS_CONNECT_WRITE'])
     async def generate_claim_token(self):
         """
         Generate a claim token for TrueNAS Connect.
@@ -61,7 +61,7 @@ class TrueNASConnectService(Service):
         return claim_token
 
 
-    @api_method(TNCGetRegistrationURIArgs, TNCGetRegistrationURIResult, roles=['TRUENAS_CONNECT_READ'])
+    @api_method(TrueNASConnectGetRegistrationUriArgs, TrueNASConnectGetRegistrationUriResult, roles=['TRUENAS_CONNECT_READ'])
     async def get_registration_uri(self):
         """
         Return the registration URI for TrueNAS Connect.

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -7,7 +7,7 @@ from truenas_connect_utils.urls import get_account_service_url
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import TNCEntry, TNCUpdateArgs, TNCUpdateResult, TNCIPChoicesArgs, TNCIPChoicesResult
+from middlewared.api.current import TNCEntry, TrueNASConnectUpdateArgs, TrueNASConnectUpdateResult, TrueNASConnectIpChoicesArgs, TrueNASConnectIpChoicesResult
 from middlewared.service import CallError, ConfigService, private, ValidationErrors
 
 from .mixin import TNCAPIMixin
@@ -87,7 +87,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
 
         verrors.check()
 
-    @api_method(TNCUpdateArgs, TNCUpdateResult)
+    @api_method(TrueNASConnectUpdateArgs, TrueNASConnectUpdateResult)
     async def do_update(self, data):
         """
         Update TrueNAS Connect configuration.
@@ -165,7 +165,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             else:
                 raise CallError(f'Failed to revoke account: {response["error"]}')
 
-    @api_method(TNCIPChoicesArgs, TNCIPChoicesResult, roles=['TRUENAS_CONNECT_READ'])
+    @api_method(TrueNASConnectIpChoicesArgs, TrueNASConnectIpChoicesResult, roles=['TRUENAS_CONNECT_READ'])
     async def ip_choices(self):
         """
         Returns IP choices which can be used with TrueNAS Connect.

--- a/src/middlewared/middlewared/plugins/virt/device.py
+++ b/src/middlewared/middlewared/plugins/virt/device.py
@@ -2,11 +2,11 @@ from dataclasses import asdict
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    VirtDeviceUSBChoicesArgs, VirtDeviceUSBChoicesResult,
-    VirtDeviceGPUChoicesArgs, VirtDeviceGPUChoicesResult,
+    VirtDeviceUsbChoicesArgs, VirtDeviceUsbChoicesResult,
+    VirtDeviceGpuChoicesArgs, VirtDeviceGpuChoicesResult,
     VirtDeviceDiskChoicesArgs, VirtDeviceDiskChoicesResult,
-    VirtDeviceNICChoicesArgs, VirtDeviceNICChoicesResult,
-    VirtDevicePCIChoicesArgs, VirtDevicePCIChoicesResult,
+    VirtDeviceNicChoicesArgs, VirtDeviceNicChoicesResult,
+    VirtDevicePciChoicesArgs, VirtDevicePciChoicesResult,
 )
 from middlewared.service import CallError, private, Service
 from middlewared.utils.functools_ import cache
@@ -22,14 +22,14 @@ class VirtDeviceService(Service):
         namespace = 'virt.device'
         cli_namespace = 'virt.device'
 
-    @api_method(VirtDeviceUSBChoicesArgs, VirtDeviceUSBChoicesResult, roles=['VIRT_INSTANCE_READ'])
+    @api_method(VirtDeviceUsbChoicesArgs, VirtDeviceUsbChoicesResult, roles=['VIRT_INSTANCE_READ'])
     def usb_choices(self):
         """
         Provide choices for USB devices.
         """
         return list_usb_devices()
 
-    @api_method(VirtDeviceGPUChoicesArgs, VirtDeviceGPUChoicesResult, roles=['VIRT_INSTANCE_READ'])
+    @api_method(VirtDeviceGpuChoicesArgs, VirtDeviceGpuChoicesResult, roles=['VIRT_INSTANCE_READ'])
     async def gpu_choices(self, gpu_type):
         """
         Provide choices for GPU devices.
@@ -92,7 +92,7 @@ class VirtDeviceService(Service):
         """
         return await self.disk_choices_internal()
 
-    @api_method(VirtDeviceNICChoicesArgs, VirtDeviceNICChoicesResult, roles=['VIRT_INSTANCE_READ'])
+    @api_method(VirtDeviceNicChoicesArgs, VirtDeviceNicChoicesResult, roles=['VIRT_INSTANCE_READ'])
     async def nic_choices(self, nic_type):
         """
         Returns choices for NIC device.
@@ -109,7 +109,7 @@ class VirtDeviceService(Service):
                 )}
         return choices
 
-    @api_method(VirtDevicePCIChoicesArgs, VirtDevicePCIChoicesResult, roles=['VIRT_INSTANCE_READ'])
+    @api_method(VirtDevicePciChoicesArgs, VirtDevicePciChoicesResult, roles=['VIRT_INSTANCE_READ'])
     def pci_choices(self):
         """
         Returns choices for PCI devices valid for VM virt instances.

--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -8,11 +8,11 @@ from middlewared.service import (
 
 from middlewared.api import api_method
 from middlewared.api.current import (
-    VirtInstanceDeviceListArgs, VirtInstanceDeviceListResult,
-    VirtInstanceDeviceAddArgs, VirtInstanceDeviceAddResult,
-    VirtInstanceDeviceDeleteArgs, VirtInstanceDeviceDeleteResult,
-    VirtInstanceDeviceUpdateArgs, VirtInstanceDeviceUpdateResult,
-    VirtInstanceBootableDiskArgs, VirtInstanceBootableDiskResult,
+    VirtInstanceDeviceDeviceListArgs, VirtInstanceDeviceDeviceListResult,
+    VirtInstanceDeviceDeviceAddArgs, VirtInstanceDeviceDeviceAddResult,
+    VirtInstanceDeviceDeviceDeleteArgs, VirtInstanceDeviceDeviceDeleteResult,
+    VirtInstanceDeviceDeviceUpdateArgs, VirtInstanceDeviceDeviceUpdateResult,
+    VirtInstanceDeviceSetBootableDiskArgs, VirtInstanceDeviceSetBootableDiskResult,
 )
 from middlewared.async_validators import check_path_resides_within_volume
 from .utils import (
@@ -27,7 +27,7 @@ class VirtInstanceDeviceService(Service):
         namespace = 'virt.instance'
         cli_namespace = 'virt.instance'
 
-    @api_method(VirtInstanceDeviceListArgs, VirtInstanceDeviceListResult, roles=['VIRT_INSTANCE_READ'])
+    @api_method(VirtInstanceDeviceDeviceListArgs, VirtInstanceDeviceDeviceListResult, roles=['VIRT_INSTANCE_READ'])
     async def device_list(self, id_):
         """
         List all devices associated to an instance.
@@ -519,8 +519,8 @@ class VirtInstanceDeviceService(Service):
         }
 
     @api_method(
-        VirtInstanceDeviceAddArgs,
-        VirtInstanceDeviceAddResult,
+        VirtInstanceDeviceDeviceAddArgs,
+        VirtInstanceDeviceDeviceAddResult,
         audit='Virt: Adding device',
         audit_extended=lambda i, device: f'{device["dev_type"]!r} to {i!r} instance',
         roles=['VIRT_INSTANCE_WRITE']
@@ -551,8 +551,8 @@ class VirtInstanceDeviceService(Service):
         return True
 
     @api_method(
-        VirtInstanceDeviceUpdateArgs,
-        VirtInstanceDeviceUpdateResult,
+        VirtInstanceDeviceDeviceUpdateArgs,
+        VirtInstanceDeviceDeviceUpdateResult,
         audit='Virt: Updating device',
         audit_extended=lambda i, device: f'{device["name"]!r} of {i!r} instance',
         roles=['VIRT_INSTANCE_WRITE']
@@ -586,8 +586,8 @@ class VirtInstanceDeviceService(Service):
         return True
 
     @api_method(
-        VirtInstanceDeviceDeleteArgs,
-        VirtInstanceDeviceDeleteResult,
+        VirtInstanceDeviceDeviceDeleteArgs,
+        VirtInstanceDeviceDeviceDeleteResult,
         audit='Virt: Deleting device',
         audit_extended=lambda i, device: f'{device!r} from {i!r} instance',
         roles=['VIRT_INSTANCE_DELETE']
@@ -612,8 +612,8 @@ class VirtInstanceDeviceService(Service):
         return True
 
     @api_method(
-        VirtInstanceBootableDiskArgs,
-        VirtInstanceBootableDiskResult,
+        VirtInstanceDeviceSetBootableDiskArgs,
+        VirtInstanceDeviceSetBootableDiskResult,
         audit='Virt: Choosing',
         audit_extended=lambda id_, disk: f'{disk!r} as bootable disk for {id_!r} instance',
         roles=['VIRT_INSTANCE_WRITE']

--- a/src/middlewared/middlewared/plugins/virt/volume.py
+++ b/src/middlewared/middlewared/plugins/virt/volume.py
@@ -5,8 +5,8 @@ from time import time
 from middlewared.api import api_method
 from middlewared.api.current import (
     VirtVolumeEntry, VirtVolumeCreateArgs, VirtVolumeCreateResult, VirtVolumeUpdateArgs,
-    VirtVolumeUpdateResult, VirtVolumeDeleteArgs, VirtVolumeDeleteResult, VirtVolumeImportISOArgs,
-    VirtVolumeImportISOResult, VirtVolumeImportZvolArgs, VirtVolumeImportZvolResult
+    VirtVolumeUpdateResult, VirtVolumeDeleteArgs, VirtVolumeDeleteResult, VirtVolumeImportIsoArgs,
+    VirtVolumeImportIsoResult, VirtVolumeImportZvolArgs, VirtVolumeImportZvolResult
 )
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.service import CallError, CRUDService, job, ValidationErrors
@@ -152,8 +152,8 @@ class VirtVolumeService(CRUDService):
         return True
 
     @api_method(
-        VirtVolumeImportISOArgs,
-        VirtVolumeImportISOResult,
+        VirtVolumeImportIsoArgs,
+        VirtVolumeImportIsoResult,
         audit='Virt: Importing',
         audit_extended=lambda data: f'{data["name"]!r} ISO',
         roles=['VIRT_IMAGE_WRITE']

--- a/src/middlewared/middlewared/plugins/webui/crypto.py
+++ b/src/middlewared/middlewared/plugins/webui/crypto.py
@@ -1,8 +1,8 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
-    CSRProfilesArgs,
+    WebUICryptoCsrProfilesArgs,
     CSRProfilesModel,
-    CSRProfilesResult,
+    WebUICryptoCsrProfilesResult,
     WebUICryptoGetCertificateDomainNamesArgs,
     WebUICryptoGetCertificateDomainNamesResult,
 )
@@ -25,8 +25,8 @@ class WebUICryptoService(Service):
         return await self.middleware.call('certificate.get_domain_names', cert_id)
 
     @api_method(
-        CSRProfilesArgs,
-        CSRProfilesResult,
+        WebUICryptoCsrProfilesArgs,
+        WebUICryptoCsrProfilesResult,
         roles=['CERTIFICATE_READ']
     )
     async def csr_profiles(self):

--- a/src/middlewared/middlewared/plugins/zettarepl_/snapshot_create.py
+++ b/src/middlewared/middlewared/plugins/zettarepl_/snapshot_create.py
@@ -6,5 +6,9 @@ from zettarepl.transport.local import LocalShell
 
 
 class ZettareplService(Service):
+
+    class Config:
+        private = True
+
     def create_recursive_snapshot_with_exclude(self, dataset, snapshot, exclude):
         create_snapshot(LocalShell(), Snapshot(dataset, snapshot), True, exclude, {})

--- a/src/middlewared/middlewared/plugins/zettarepl_/snapshot_removal_date.py
+++ b/src/middlewared/middlewared/plugins/zettarepl_/snapshot_removal_date.py
@@ -15,6 +15,10 @@ from zettarepl.transport.local import LocalShell
 
 
 class ZettareplService(Service):
+
+    class Config:
+        private = True
+
     removal_dates = defaultdict(dict)
     removal_dates_loaded = False
 

--- a/src/middlewared/middlewared/pytest/unit/test_service_base.py
+++ b/src/middlewared/middlewared/pytest/unit/test_service_base.py
@@ -1,0 +1,121 @@
+import pytest
+from unittest.mock import patch
+from middlewared.api.base import BaseModel
+from middlewared.api import api_method
+from middlewared.api.current import QueryArgs
+from middlewared.service import Service
+
+
+# Mock check_model_module to allow models in test file
+@patch('middlewared.api.base.decorator.check_model_module')
+def test_valid_service_method_names(mock_check_model):
+    """Test that valid service method names pass validation during class creation"""
+    class TestGetDataArgs(BaseModel):
+        filter: str = ''
+
+    class TestGetDataResult(BaseModel):
+        result: dict
+
+    class TestUpdateDataArgs(BaseModel):
+        data: dict
+
+    class TestUpdateDataResult(BaseModel):
+        result: dict
+
+    class TestCreateArgs(BaseModel):
+        data: dict
+
+    class TestCreateResult(BaseModel):
+        result: dict
+
+    class TestService(Service):
+        class Config:
+            namespace = 'test'
+
+        @api_method(
+            TestGetDataArgs,
+            TestGetDataResult,
+            roles=['READONLY_ADMIN']
+        )
+        def get_data(self):
+            return {'data': 'test'}
+
+        @api_method(
+            TestUpdateDataArgs,
+            TestUpdateDataResult,
+            roles=['FULL_ADMIN']
+        )
+        def update_data(self):
+            return {'status': 'updated'}
+
+        @api_method(
+            TestCreateArgs,
+            TestCreateResult,
+            roles=['FULL_ADMIN']
+        )
+        def do_create(self):
+            return {'status': 'created'}
+
+
+@patch('middlewared.api.base.decorator.check_model_module')
+def test_invalid_service_method_names(mock_check_model):
+    """Test that invalid service method names raise RuntimeError during class creation"""
+    class WrongNameArgs(BaseModel):
+        filter: str = ''
+
+    class WrongNameResult(BaseModel):
+        result: dict
+
+    with pytest.raises(RuntimeError, match="has incorrect accepts class name"):
+        class InvalidService(Service):
+            class Config:
+                namespace = 'invalid'
+
+            @api_method(
+                WrongNameArgs,
+                WrongNameResult,
+                roles=['READONLY_ADMIN']
+            )
+            def get_data(self):
+                return {'data': 'test'}
+
+
+@patch('middlewared.api.base.decorator.check_model_module')
+def test_service_with_query_args(mock_check_model):
+    """Test that services using QueryArgs pass validation during class creation"""
+    class TestServiceWithQueryArgsGetDataResult(BaseModel):
+        result: dict
+
+    class TestServiceWithQueryArgs(Service):
+        class Config:
+            namespace = 'test_query'
+
+        @api_method(
+            QueryArgs,
+            TestServiceWithQueryArgsGetDataResult,
+            roles=['READONLY_ADMIN']
+        )
+        def get_data(self):
+            return {'data': 'test'}
+
+
+@patch('middlewared.api.base.decorator.check_model_module')
+def test_service_with_private_method(mock_check_model):
+    """Test that private methods are skipped during validation on class creation"""
+    class TestServiceWithPrivateMethodGetDataArgs(BaseModel):
+        filter: str = ''
+
+    class TestServiceWithPrivateMethodGetDataResult(BaseModel):
+        result: dict
+
+    class TestServiceWithPrivateMethod(Service):
+        class Config:
+            namespace = 'test_private'
+
+        @api_method(
+            TestServiceWithPrivateMethodGetDataArgs,
+            TestServiceWithPrivateMethodGetDataResult,
+            private=True
+        )
+        def _get_data(self):
+            return {'data': 'test'}

--- a/src/middlewared/middlewared/pytest/unit/test_service_part.py
+++ b/src/middlewared/middlewared/pytest/unit/test_service_part.py
@@ -1,9 +1,10 @@
 import pytest
 
-from middlewared.service import job, Service, ServicePartBase
+from middlewared.service import job, private, Service, ServicePartBase
 
 
 class SumServiceBase(ServicePartBase):
+    @private
     def sum(self, a, b):
         """
         Sum two numbers
@@ -14,6 +15,7 @@ class SumServiceBase(ServicePartBase):
 def test__method_not_defined():
     with pytest.raises(RuntimeError) as e:
         class SumServiceImpl(Service, SumServiceBase):
+            @private
             def add(self, a, b):
                 return a + b
 
@@ -23,6 +25,7 @@ def test__method_not_defined():
 def test__signatures_do_not_match():
     with pytest.raises(RuntimeError) as e:
         class SumServiceImpl(Service, SumServiceBase):
+            @private
             def sum(self, a, b, c=0):
                 return a + b
 
@@ -31,6 +34,7 @@ def test__signatures_do_not_match():
 
 def test__ok():
     class SumServiceImpl(Service, SumServiceBase):
+        @private
         def sum(self, a, b):
             return a + b
 
@@ -39,6 +43,7 @@ def test__ok():
 
 def test__schema_works():
     class SumServiceImpl(Service, SumServiceBase):
+        @private
         def sum(self, a, b):
             return a + b
 
@@ -48,10 +53,12 @@ def test__schema_works():
 def test__job():
     class JobServiceBase(ServicePartBase):
         @job()
+        @private
         def process(self, job, arg):
             pass
 
     class JobServiceImpl(Service, JobServiceBase):
+        @private
         def process(self, job, arg):
             return arg * 2
 

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -47,8 +47,8 @@ def service_config(klass, config):
 def validate_api_method_schema_class_names(klass):
     """
     Validate that API method argument class names follow the required format:
-    - accepts class should be named ServiceNameMethodNameArgs
-    - returns class should be named ServiceNameMethodNameResult
+    - accepts class should be named f"{ServiceName}{MethodName}Args"
+    - returns class should be named f"{ServiceName}{MethodName}Result"
     where MethodName is the method name converted from snake_case to CamelCase
     """
     service_name = klass.__name__

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -26,7 +26,18 @@ def filterable_api_method(
 ):
     def filterable_internal(fn):
         if item:
-            returns = query_result(item)
+            name = item.__name__
+            if name.endswith("Entry"):
+                if fn.__name__ == "query":
+                    name = name.removesuffix("Entry") + "QueryResult"
+                else:
+                    name = name.removesuffix("Entry") + "Result"
+            elif name.endswith("Item"):
+                name = name.removesuffix("Item") + "Result"
+            else:
+                raise RuntimeError(f"{item=!r} class name must end with `Entry` or `Item`")
+
+            returns = query_result(item, name)
         else:
             if not private:
                 raise ValueError('Public methods may not use GenericQueryResult.')


### PR DESCRIPTION
accepts/returns model classes are not just arbitrary string. They are used to match schema classes between different API versions and must be unique and uniformly named. This PR introduces model class names validation to ensure that.

There were already a few occasions of model classes being re-used between different API methods. This will make it impossible to change these API methods behavior separately in future releases. This PR also corrects that.