### PR TITLE
Email is no longer a requirement from Let's Encrypt

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
@@ -1,10 +1,11 @@
-"""Cleanup orphaned ACME registrations
+"""Cleanup orphaned ACME registrations and remove unused contact column
 
 Revision ID: 7a8b9c0d1e2f
 Revises: 30c9619bf9e7
 Create Date: 2025-06-12 10:00:00.000000+00:00
 """
 from alembic import op
+import sqlalchemy as sa
 
 
 revision = '7a8b9c0d1e2f'
@@ -36,7 +37,13 @@ def upgrade():
             orphaned_ids
         )
 
+    # Drop the contact column from system_acmeregistrationbody
+    # as ACME services no longer provide contact information
+    with op.batch_alter_table('system_acmeregistrationbody', schema=None) as batch_op:
+        batch_op.drop_column('contact')
+
 
 def downgrade():
-    # This migration is a cleanup operation, no downgrade needed
-    pass
+    # Add back the contact column
+    with op.batch_alter_table('system_acmeregistrationbody', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('contact', sa.String(254), nullable=True))

--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
@@ -1,0 +1,42 @@
+"""Cleanup orphaned ACME registrations
+
+Revision ID: 7a8b9c0d1e2f
+Revises: 30c9619bf9e7
+Create Date: 2025-06-12 10:00:00.000000+00:00
+"""
+from alembic import op
+
+
+revision = '7a8b9c0d1e2f'
+down_revision = '30c9619bf9e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Find orphaned entries in system_acmeregistration that don't have
+    # corresponding entries in system_acmeregistrationbody
+    orphaned_registrations = conn.execute("""
+        SELECT ar.id 
+        FROM system_acmeregistration ar
+        LEFT JOIN system_acmeregistrationbody arb ON ar.id = arb.acme_id
+        WHERE arb.id IS NULL
+    """).fetchall()
+    
+    if orphaned_registrations:
+        orphaned_ids = [row[0] for row in orphaned_registrations]
+
+        # Delete orphaned entries from system_acmeregistration
+        conn.execute(
+            "DELETE FROM system_acmeregistration WHERE id IN ({})".format(
+                ','.join('?' * len(orphaned_ids))
+            ),
+            orphaned_ids
+        )
+
+
+def downgrade():
+    # This migration is a cleanup operation, no downgrade needed
+    pass

--- a/src/middlewared/middlewared/api/v25_04_2/acme_registration.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acme_registration.py
@@ -15,7 +15,6 @@ class JWKCreate(BaseModel):
 
 class ACMERegistrationBody(BaseModel):
     id: int
-    contact: str
     status: str
     key: LongString
 

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -181,7 +181,8 @@ class ACMERegistrationService(CRUDService):
             'datastore.insert',
             'system.acmeregistrationbody',
             {
-                'contact': register.body.contact[0],
+                # Let's encrypt does not send us email/contact anymore now
+                'contact': f'mailto:{email}',
                 'status': register.body.status,
                 'key': key.json_dumps(),
                 'acme': registration_id

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -129,14 +129,6 @@ class ACMERegistrationService(CRUDService):
                 'Please agree to the terms of service'
             )
 
-        # For now we assume that only root is responsible for certs issued under ACME protocol
-        email = self.middleware.call_sync('mail.local_administrator_email')
-        if not email:
-            raise CallError(
-                'Please configure an email address for any local administrator user which will be used with the ACME '
-                'server'
-            )
-
         if self.middleware.call_sync(
             'acme.registration.query', [['directory', '=', data['acme_directory_uri']]]
         ):
@@ -155,7 +147,6 @@ class ACMERegistrationService(CRUDService):
         acme_client = client.ClientV2(directory, client.ClientNetwork(key))
         register = acme_client.new_account(
             messages.NewRegistration.from_data(
-                email=email,
                 terms_of_service_agreed=True
             )
         )
@@ -182,7 +173,7 @@ class ACMERegistrationService(CRUDService):
             'system.acmeregistrationbody',
             {
                 # Let's encrypt does not send us email/contact anymore now
-                'contact': f'mailto:{email}',
+                'contact': 'mailto:',
                 'status': register.body.status,
                 'key': key.json_dumps(),
                 'acme': registration_id

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -38,7 +38,6 @@ class ACMERegistrationBodyModel(sa.Model):
     __tablename__ = 'system_acmeregistrationbody'
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    contact = sa.Column(sa.String(254))
     status = sa.Column(sa.String(10))
     key = sa.Column(sa.Text())
     acme_id = sa.Column(sa.ForeignKey('system_acmeregistration.id'), index=True)
@@ -172,8 +171,6 @@ class ACMERegistrationService(CRUDService):
             'datastore.insert',
             'system.acmeregistrationbody',
             {
-                # Let's encrypt does not send us email/contact anymore now
-                'contact': 'mailto:',
                 'status': register.body.status,
                 'key': key.json_dumps(),
                 'acme': registration_id

--- a/src/middlewared/middlewared/plugins/acme_protocol_/client_utils.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/client_utils.py
@@ -6,7 +6,6 @@ from acme import client, messages
 
 
 class BodyDict(typing.TypedDict):
-    contact: str
     status: str
     key: str
 
@@ -31,7 +30,6 @@ def get_acme_client_and_key(data: ACMEClientAndKeyData) -> tuple[client.ClientV2
     - new_order_uri: str
     - revoke_cert_uri: str
     - body: dict
-        - contact: str
         - status: str
         - key: dict
             - e: str
@@ -46,7 +44,6 @@ def get_acme_client_and_key(data: ACMEClientAndKeyData) -> tuple[client.ClientV2
         'uri': data['uri'],
         'terms_of_service': data['tos'],
         'body': {
-            'contact': [data['body']['contact']],
             'status': data['body']['status'],
             'key': {
                 'e': key_dict['e'],

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -365,14 +365,6 @@ class CertificateService(CRUDService):
         csr_data = self.middleware.call_sync(
             'certificate.get_instance', data['csr_id']
         )
-        verrors = ValidationErrors()
-        email = self.middleware.call_sync('mail.local_administrator_email')
-        if not email:
-            verrors.add(
-                'name', ('Please configure an email address for any local administrator user which will be used with '
-                         'the ACME server'),
-            )
-        verrors.check()
 
         data['acme_directory_uri'] += '/' if data['acme_directory_uri'][-1] != '/' else ''
 

--- a/src/middlewared/middlewared/plugins/truenas_connect/acme_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/acme_utils.py
@@ -5,8 +5,6 @@ from cryptography.hazmat.primitives import serialization
 from josepy import JWKRSA
 from jsonschema import validate as jsonschema_validate, ValidationError as JSONValidationError
 
-from .cert_utils import CERT_BOT_EMAIL
-
 
 ACME_CONFIG_JSON_SCHEMA = {
     '$schema': 'http://json-schema.org/draft-07/schema#',
@@ -59,7 +57,6 @@ def normalize_acme_config(config: dict) -> dict:
         'new_order_uri': f'{parsed_url.scheme}://{parsed_url.netloc}/acme/new-order',
         'revoke_cert_uri': f'{parsed_url.scheme}://{parsed_url.netloc}/acme/revoke-cert',
         'body': {
-            'contact': CERT_BOT_EMAIL,
             'status': acme_details['account']['status'],
             'key': jwk_rsa.json_dumps(),
         }


### PR DESCRIPTION
This PR adds changes to adapt to latest let's encrypt changes where let's encrypt is not sending us a mailto field which earlier was required on it's end. In broader scope, what has happened is that emails are no longer a requirement with the new changes on let's encrypt side and to adapt to those changes - relevant changes have been made on our end by dropping those database entries which are malformed (this would only happen for new consumers) and making sure existing + new consumers work as desired.