### PR TITLE
fixup usage of imported pytest fixtures.

### DIFF
--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -2,7 +2,7 @@ import pytest
 
 from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.test.integration.assets.account import (
-    user, group, unprivileged_user_client, test_user, temporary_update
+    user, group, unprivileged_user_client, temporary_update
 )
 from middlewared.test.integration.utils import call, client
 from middlewared.test.integration.utils.audit import expect_audit_method_calls

--- a/tests/api2/test_user_ssh_password.py
+++ b/tests/api2/test_user_ssh_password.py
@@ -2,7 +2,7 @@ import pytest
 
 from auto_config import pool_name
 from middlewared.service_exception import ValidationErrors
-from middlewared.test.integration.assets.account import user, group, test_user, temporary_update
+from middlewared.test.integration.assets.account import user, group, temporary_update
 from middlewared.test.integration.utils import call, ssh
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,16 @@
 import os
 import pytest
 
-from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
 from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.pytest import failed
+
+# pytest fixtures
+# Importing pytest fixtures in test modules is not supported.
+# The work-around is to import them in conftest.py (this module),
+# making them available (in scope) for all test modules.
+# See: https://stackoverflow.com/questions/75647682/how-can-i-resolve-flake8-unused-import-error-for-pytest-fixture-imported-from
+from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
+from middlewared.test.integration.assets.account import test_user  # noqa
 
 pytest.register_assert_rewrite("middlewared.test")
 


### PR DESCRIPTION
pytest fixtures should not be imported in test modules. 

From the Flake8 maintainer and pytest core developer:
> the supported way to make reusable fixtures is to place them in a conftest.py which is in a directory above all the tests that need it. tests will have these fixtures "in scope" automatically

See:  [stackoverflow post](https://stackoverflow.com/questions/75647682/how-can-i-resolve-flake8-unused-import-error-for-pytest-fixture-imported-from)

This PR fixes up our usage of imported pytest fixtures.

Successful CI [test run](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4775/) with effected modules