### PR TITLE
NAS-136301 / 25.10 / Prevent admin user lockout

### DIFF
--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -240,7 +240,6 @@ def test_account_update_invalid_username(test_user: dict):
 
 @pytest.mark.parametrize("name", [
     pp("root", id="root is last"),
-    pp("truenas_admin", id="truenas_admin is last"),
     pp("adminuser", id="admin_user is last"),
 ])
 def test_account_last_admin(admin_users, name):
@@ -248,10 +247,10 @@ def test_account_last_admin(admin_users, name):
         that we cannot lock the last remaining FULL_ADMIN user'''
 
     admin_users_count = len(admin_users)
-    assert admin_users_count > 0
+    assert admin_users_count >= 2, admin_users
 
     admin_to_lock = [usr for usr in admin_users if usr['username'] != name]
-    assert len(admin_to_lock) == admin_users_count - 1
+    assert len(admin_to_lock) == admin_users_count - 1, admin_to_lock
 
     last_admin = [usr for usr in admin_users if usr['username'] == name][0]
     assert last_admin['username'] == name


### PR DESCRIPTION
Add validation to user update to prevent locking all admin user accounts.
The update to lock an admin user will be blocked if that user is the last remaining FULL_ADMIN user.

Passing CI test is [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4814/).