### PR TITLE
NAS-136219 / 25.10 / Send license string to TNC on registration

### DIFF
--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -120,14 +120,15 @@ class SystemService(Service):
         return 'LINUX'
 
     @private
-    def license(self):
-        return self._get_license()
+    def license(self, include_raw_license: bool = False):
+        return self._get_license(include_raw_license=include_raw_license)
 
     @staticmethod
-    def _get_license():
+    def _get_license(include_raw_license: bool = False):
         try:
             with open(LICENSE_FILE) as f:
-                licenseobj = License.load(f.read().strip('\n'))
+                raw_license = f.read().strip('\n')
+                licenseobj = License.load(raw_license)
         except Exception:
             return
 
@@ -166,6 +167,9 @@ class SystemService(Service):
             # means they were issued having dedup+jails instead.
             if Features.dedup in licenseobj.features and Features.jails in licenseobj.features:
                 license_['features'].append(Features.fibrechannel.name.upper())
+
+        if include_raw_license:
+            license_['raw_license'] = raw_license
 
         return license_
 

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -209,7 +209,7 @@ class SystemService(Service):
     @private
     def license_string(self):
         with contextlib.suppress(Exception):
-            with open(LICENSE_FILE) as f:
+            with open(LICENSE_FILE, 'r') as f:
                 return f.read().strip('\n')
 
     @api_method(

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
-import contextlib
+
 import os
 from datetime import date
 
@@ -209,12 +209,6 @@ class SystemService(Service):
         self.middleware.run_coroutine(
             self.middleware.call_hook('system.post_license_update', prev_product_type=prev_product_type), wait=False,
         )
-
-    @private
-    def license_string(self):
-        with contextlib.suppress(Exception):
-            with open(LICENSE_FILE, 'r') as f:
-                return f.read().strip('\n')
 
     @api_method(
         SystemFeatureEnabledArgs,

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
-
+import contextlib
 import os
 from datetime import date
 
@@ -205,6 +205,12 @@ class SystemService(Service):
         self.middleware.run_coroutine(
             self.middleware.call_hook('system.post_license_update', prev_product_type=prev_product_type), wait=False,
         )
+
+    @private
+    def license_string(self):
+        with contextlib.suppress(Exception):
+            with open(LICENSE_FILE) as f:
+                return f.read().strip('\n')
 
     @api_method(
         SystemFeatureEnabledArgs,

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -88,11 +88,8 @@ class TrueNASConnectService(Service):
         }
 
         # Add license information if valid license exists
-        license_info = await self.middleware.call('system.license')
+        license_info = await self.middleware.call('system.license', True)
         if license_info is not None and not license_info.get('expired', True):
-            if license_str := await self.middleware.call('system.license_string'):
-                # We should have license string available, just having another sanity
-                # conditional here to ensure we do not end up with None
-                query_params['license'] = license_str
+            query_params['license'] = license_info['raw_license']
 
         return f'{get_registration_uri(config)}?{urlencode(query_params)}'

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -90,9 +90,9 @@ class TrueNASConnectService(Service):
         # Add license information if valid license exists
         license_info = await self.middleware.call('system.license')
         if license_info is not None and not license_info.get('expired', True):
-            if license := await self.middleware.call('system.license_string'):
+            if license_str := await self.middleware.call('system.license_string'):
                 # We should have license string available, just having another sanity
                 # conditional here to ensure we do not end up with None
-                query_params['license'] = license
+                query_params['license'] = license_str
 
         return f'{get_registration_uri(config)}?{urlencode(query_params)}'

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -87,4 +87,9 @@ class TrueNASConnectService(Service):
             'token': claim_token,
         }
 
+        # Add license information if valid license exists
+        license_info = await self.middleware.call('system.license')
+        if license_info is not None and not license_info.get('expired', True):
+            query_params['license'] = license_info
+
         return f'{get_registration_uri(config)}?{urlencode(query_params)}'

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -90,6 +90,9 @@ class TrueNASConnectService(Service):
         # Add license information if valid license exists
         license_info = await self.middleware.call('system.license')
         if license_info is not None and not license_info.get('expired', True):
-            query_params['license'] = license_info
+            if license := await self.middleware.call('system.license_string'):
+                # We should have license string available, just having another sanity
+                # conditional here to ensure we do not end up with None
+                query_params['license'] = license
 
         return f'{get_registration_uri(config)}?{urlencode(query_params)}'


### PR DESCRIPTION
This PR adds changes to send available license string when drafting up registration URL of TNC. It is only done if the license is available and has not expired.