### PR TITLE
NAS-136328 / 25.10 / Remove TOKEN_PLAIN from auth mech choices for OTPW

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -625,10 +625,23 @@ class AuthService(Service):
             )
 
     @api_method(AuthMechanismChoicesArgs, AuthMechanismChoicesResult, authentication_required=False)
-    async def mechanism_choices(self) -> list:
+    @pass_app()
+    async def mechanism_choices(self, app) -> list:
         """ Get list of available authentication mechanisms available for auth.login_ex """
         aal = CURRENT_AAL.level
-        return [mech.name for mech in aal.mechanisms]
+        cred_allows_token = True
+
+        # The currently authenticated credential may actually restrict whether it can
+        # generate authentication tokens. This is used by UI as a hint that it shouldn't
+        # try to generate tokens for this user.
+        if app and not app.authenticated_credentials.may_create_auth_token:
+            cred_allows_token = False
+
+        choices = [mech.name for mech in aal.mechanisms]
+        if not cred_allows_token and AuthMech.TOKEN_PLAIN in choices:
+            choices.remove(AuthMech.TOKEN_PLAIN.value)
+
+        return choices
 
     @cli_private
     @api_method(AuthLoginExContinueArgs, AuthLoginExContinueResult, authentication_required=False)

--- a/tests/api2/test_auth_onetime.py
+++ b/tests/api2/test_auth_onetime.py
@@ -57,6 +57,9 @@ def test_onetime_password_generate_token_fail(onetime_password):
         })
         assert resp['response_type'] == 'SUCCESS'
 
+        auth_mech_choices = c.call('auth.mechanism_choices')
+        assert 'TOKEN_PLAIN' not in auth_mech_choices
+
         with pytest.raises(CallError) as ce:
             c.call('auth.generate_token')
 


### PR DESCRIPTION
This is an enhancement requested by the UI team. If the current session is authenticated via a onetime password, adjust our available authentication mechanism choices for the *session* to exclude authentication tokens. This provides a hint to UI to not issue request to generate the token and allows code simplification.