### PR TITLE
NAS-136328 / 25.04.2 / Remove TOKEN_PLAIN from auth mech choices for OTPW (by anodos325)

### DIFF
--- a/tests/api2/test_auth_onetime.py
+++ b/tests/api2/test_auth_onetime.py
@@ -57,6 +57,9 @@ def test_onetime_password_generate_token_fail(onetime_password):
         })
         assert resp['response_type'] == 'SUCCESS'
 
+        auth_mech_choices = c.call('auth.mechanism_choices')
+        assert 'TOKEN_PLAIN' not in auth_mech_choices
+
         with pytest.raises(CallError) as ce:
             c.call('auth.generate_token')
 


### PR DESCRIPTION
This is an enhancement requested by the UI team. If the current session is authenticated via a onetime password, adjust our available authentication mechanism choices for the *session* to exclude authentication tokens. This provides a hint to UI to not issue request to generate the token and allows code simplification.

Original PR: https://github.com/truenas/middleware/pull/16636
