### PR TITLE
NAS-136223 / 25.10 / Fix ACME registration failures due to removed contact field support (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-06-12_10-00_cleanup_orphaned_acme_registrations.py
@@ -1,0 +1,42 @@
+"""Cleanup orphaned ACME registrations
+
+Revision ID: 7a8b9c0d1e2f
+Revises: 30c9619bf9e7
+Create Date: 2025-06-12 10:00:00.000000+00:00
+"""
+from alembic import op
+
+
+revision = '7a8b9c0d1e2f'
+down_revision = '30c9619bf9e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Find orphaned entries in system_acmeregistration that don't have
+    # corresponding entries in system_acmeregistrationbody
+    orphaned_registrations = conn.execute("""
+        SELECT ar.id 
+        FROM system_acmeregistration ar
+        LEFT JOIN system_acmeregistrationbody arb ON ar.id = arb.acme_id
+        WHERE arb.id IS NULL
+    """).fetchall()
+    
+    if orphaned_registrations:
+        orphaned_ids = [row[0] for row in orphaned_registrations]
+
+        # Delete orphaned entries from system_acmeregistration
+        conn.execute(
+            "DELETE FROM system_acmeregistration WHERE id IN ({})".format(
+                ','.join('?' * len(orphaned_ids))
+            ),
+            orphaned_ids
+        )
+
+
+def downgrade():
+    # This migration is a cleanup operation, no downgrade needed
+    pass

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -165,14 +165,6 @@ class ACMERegistrationService(CRUDService):
                 'Please agree to the terms of service'
             )
 
-        # For now we assume that only root is responsible for certs issued under ACME protocol
-        email = self.middleware.call_sync('mail.local_administrator_email')
-        if not email:
-            raise CallError(
-                'Please configure an email address for any local administrator user which will be used with the ACME '
-                'server'
-            )
-
         if self.middleware.call_sync(
             'acme.registration.query', [['directory', '=', data['acme_directory_uri']]]
         ):
@@ -191,7 +183,6 @@ class ACMERegistrationService(CRUDService):
         acme_client = client.ClientV2(directory, client.ClientNetwork(key))
         register = acme_client.new_account(
             messages.NewRegistration.from_data(
-                email=email,
                 terms_of_service_agreed=True
             )
         )
@@ -218,7 +209,7 @@ class ACMERegistrationService(CRUDService):
             'system.acmeregistrationbody',
             {
                 # Let's encrypt does not send us email/contact anymore now
-                'contact': f'mailto:{email}',
+                'contact': 'mailto:',
                 'status': register.body.status,
                 'key': key.json_dumps(),
                 'acme': registration_id

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -217,7 +217,8 @@ class ACMERegistrationService(CRUDService):
             'datastore.insert',
             'system.acmeregistrationbody',
             {
-                'contact': register.body.contact[0],
+                # Let's encrypt does not send us email/contact anymore now
+                'contact': f'mailto:{email}',
                 'status': register.body.status,
                 'key': key.json_dumps(),
                 'acme': registration_id


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x bdd1eff3dac5e1074fbeb8e287d4b5bacbcda0b7
    git cherry-pick -x dfd64b43392901b9e5e5c16b8f4fd426f7ce3e4e
    git cherry-pick -x 541212501b0f1b873c515851633fbe3e1f8edfac

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~3
    git cherry-pick -x 3667d0d1bb2222654a5ba99f2c4a95d659375d9d

This PR adds changes to adapt to latest let's encrypt changes where let's encrypt is not sending us a mailto field which earlier was required on it's end. In broader scope, what has happened is that emails are no longer a requirement with the new changes on let's encrypt side and to adapt to those changes - relevant changes have been made on our end by dropping those database entries which are malformed (this would only happen for new consumers) and making sure existing + new consumers work as desired.

Note: Users who have not used let's encrypt at all with TrueNAS are affected right now, existing users who have at least once tried to generate a cert are good and for them renewals + new cert generation would work nicely.

Original PR: https://github.com/truenas/middleware/pull/16624
