### PR TITLE
NAS-136392 / 25.04.2 / Do not crash in pool.dataset.processes on procfd EACCES (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -160,7 +160,10 @@ class PoolDatasetService(Service):
                         fd = f'/proc/{pid}/fd/{f}'
                         is_link = False
                         realpath = None
-                        with contextlib.suppress(FileNotFoundError):
+                        # stat(2) from host may fail with EACCES if file is inside private mount
+                        # namespace in a container. An example of why this can happen is if file is
+                        # in snap installed in an Ubuntu container.
+                        with contextlib.suppress(FileNotFoundError, PermissionError):
                             # Have second suppression here so that we don't lose list of files
                             # if we have TOCTOU issue on one of files.
                             #


### PR DESCRIPTION
This addresses an issue reported by community member in the forums. os.stat("/proc/pid/fd") failed with PermissionError in case where pid was for nextcloud snap installed in Ubuntu container and readlink on fd was `/snap/nextcloud/48223/bin/run-httpd`. Suppressing the error in this situation is okay since the snap will always be installed in the root dataset of the container and so check for running containers is sufficient for our purposes of identifying in-use datasets.

Original PR: https://github.com/truenas/middleware/pull/16641
