### PR TITLE
Fix issue with locally-stored AD creds getting out of sync

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -545,6 +545,11 @@ def generate_smb_conf_dict(
             'template homedir': home_path,
             'winbind enum users': ds_config['enable_account_cache'],
             'winbind enum groups': ds_config['enable_account_cache'],
+            # The machine password timeout is currently set to zero to match
+            # behavior with earlier TrueNAS versions. This can be removed once we've
+            # properly tested edge-cases with HA and have CI coverage for winbindd-initiated
+            # password changes.
+            'machine password timeout': 0,
         })
 
         idmap = ds_config['configuration']['idmap']['idmap_domain']


### PR DESCRIPTION
This commit restores previous TrueNAS behavior regarding stored machine account passwords. Since TrueNAS 11.3, TrueNAS has exclusively used the AD machine account kerberos principal for authentication with active directory. The Samba version in 25.04 changed some aspects of interaction with AD through winbindd in such a way that winbindd now is able to apply the default settings for periodic machine account password changes. This had the unfortunate side-effect of the having the stored middleware AD machine account credentials getting out-of-sync with what's in AD and health checks flagging credentials as becoming invalid. This is due to potentially slow sysvol replication and lack of coordination between samba's libads and MIT kerberos regarding which KDC to communicate with.

In 25.10 we will delegate password changes to middlewared (manually call the relevant `net` command) so that we can better supervise the process in HA and lock kerberos into a single KDC for a period of time.