### PR TITLE
NAS-135244 / 25.04.2 / Fix configuration for SMB Veeam Fast Clone (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/smb_recordsize.py
+++ b/src/middlewared/middlewared/alert/source/smb_recordsize.py
@@ -1,0 +1,11 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class SMBVeeamFastCloneAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "SMB shares use incorrect recordsize value for Veeam Fast Clone"
+    text = "SMB shares cannot use Veeam Fast Clone due to incorrect ZFS recordsize: %(shares)s"
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -8,6 +8,7 @@ CONFIGURED_SENTINEL = '/var/run/samba/.configured'
 SMB_AUDIT_DEFAULTS = {'enable': False, 'watch_list': [], 'ignore_list': []}
 INVALID_SHARE_NAME_CHARACTERS = {'%', '<', '>', '*', '?', '|', '/', '\\', '+', '=', ';', ':', '"', ',', '[', ']'}
 RESERVED_SHARE_NAMES = ('global', 'printers', 'homes')
+VEEAM_REPO_BLOCKSIZE = 131072
 
 
 class SMBHAMODE(enum.IntEnum):
@@ -152,4 +153,22 @@ class SMBSharePreset(enum.Enum):
         'auxsmbconf': '\n'.join([
             'worm:grace_period = 300',
         ])
+    }, "cluster": False}
+    VEEAM_REPOSITORY_SHARE = {"verbose_name": "Veeam repository with Fast Clone", "params": {
+        'path_suffix': '',
+        'home': False,
+        'ro': False,
+        'browsable': True,
+        'timemachine': False,
+        'recyclebin': False,
+        'abe': False,
+        'hostsallow': [],
+        'hostsdeny': [],
+        'aapl_name_mangling': False,
+        'acl': True,
+        'durablehandle': True,
+        'shadowcopy': True,
+        'streams': True,
+        'fsrvp': False,
+        'auxsmbconf': f'block size = {VEEAM_REPO_BLOCKSIZE}',
     }, "cluster": False}

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -9,7 +9,7 @@ from middlewared.utils.filesystem.acl import FS_ACL_Type, path_get_acltype
 from middlewared.utils.io import get_io_uring_enabled
 from middlewared.utils.path import FSLocation, path_location
 from middlewared.plugins.account import DEFAULT_HOME_PATH
-from middlewared.plugins.smb_.constants import SMBEncryption, SMBPath, SMBSharePreset
+from middlewared.plugins.smb_.constants import SMBEncryption, SMBPath, SMBSharePreset, VEEAM_REPO_BLOCKSIZE
 from middlewared.plugins.smb_.utils import apply_presets, smb_strip_comments
 from middlewared.plugins.smb_.util_param import AUX_PARAM_BLACKLIST
 

--- a/tests/api2/test_smb_veeam_repo.py
+++ b/tests/api2/test_smb_veeam_repo.py
@@ -1,0 +1,69 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.utils import call
+
+SHARE_NAME = 'offset_test'
+VEEAM_BLOCKSIZE = 131072
+
+
+def check_veeam_alert(expected):
+    alert = None
+    for a in call('alert.list'):
+        if a['klass'] == 'SMBVeeamFastClone':
+            alert = a
+            break
+
+    assert bool(alert) is expected, str(alert)
+    if expected:
+        assert SHARE_NAME in alert['formatted']
+
+
+def test_record_size_smb_create_verror():
+    with dataset('smb1mib', data={'recordsize': '1M'}) as ds:
+        with pytest.raises(match='The ZFS dataset recordsize property for a dataset used by a Veeam Repository'):
+            with smb_share(os.path.join('/mnt', ds), SHARE_NAME, options={
+                'purpose': 'VEEAM_REPOSITORY_SHARE',
+                'options': {}
+            }):
+                pass
+
+
+def test_record_size_smb_update_verror():
+    with dataset('smb1mib', data={'recordsize': '1M'}) as ds:
+        # First create as regular share
+        with smb_share(os.path.join('/mnt', ds), SHARE_NAME) as share:
+            with pytest.raises(match='The ZFS dataset recordsize property for a dataset used by a Veeam Repository'):
+                call('sharing.smb.update', share['id'], {
+                    'purpose': 'VEEAM_REPOSITORY_SHARE',
+                    'options': {}
+                })
+
+
+def test_record_size_veeam_share():
+    with dataset('smb128k', data={'recordsize': '128K'}) as ds:
+        with smb_share(os.path.join('/mnt', ds), SHARE_NAME, options={
+            'purpose': 'VEEAM_REPOSITORY_SHARE',
+            'options': {}
+        }) as share:
+            smb_block_size = call('smb.getparm', 'block size', share['name'])
+
+            assert smb_block_size == VEEAM_BLOCKSIZE
+
+
+def test_veeam_alert():
+    """ Changing recordsize under SMB share should generate alert and fixing should clear it. """
+    with dataset('smb128k', data={'recordsize': '128K'}) as ds:
+        with smb_share(os.path.join('/mnt', ds), SHARE_NAME, options={
+            'purpose': 'VEEAM_REPOSITORY_SHARE',
+            'options': {}
+        }):
+            call('pool.dataset.update', ds, {'recordsize': '1M'})
+            call('etc.generate', 'smb')
+            check_veeam_alert(True)
+
+            call('pool.dataset.update', ds, {'recordsize': '128K'})
+            call('etc.generate', 'smb')
+            check_veeam_alert(False)


### PR DESCRIPTION
This commit adds a new SMB share purpose of VEEAM_REPOSITORY_SHARE, which requires the ZFS recordsize to be set to 128 KiB (per guidance from Veeam) and sets the underlying SMB block size to 128 KiB so that FileFsSizeInformation the Sectors Per Allocation Unit is reported to Veeam Backup & Restore in such a way that it will use the correct offsets and lengths when it issues
FSCTL_DUPLICTE_EXTENTS_TO_FILE requests. If this is not done, then Fast Copy requests will be rejected by ZFS due to improper alignment and ZFS will fallback to doing an internal copy of the specified range.

Original PR: https://github.com/truenas/middleware/pull/16635
