### PR TITLE
port 53 should be shown as used

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -23,7 +23,7 @@ from middlewared.service_exception import CallError
 from middlewared.utils import run, BOOT_POOL_NAME_VALID
 
 from .utils import (
-    VirtGlobalStatus, incus_call, VNC_PASSWORD_DIR, TRUENAS_STORAGE_PROP_STR, INCUS_STORAGE
+    VirtGlobalStatus, incus_call, VNC_PASSWORD_DIR, TRUENAS_STORAGE_PROP_STR, INCUS_BRIDGE, INCUS_STORAGE
 )
 
 if TYPE_CHECKING:
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 
 
 BRIDGE_AUTO = '[AUTO]'
-INCUS_BRIDGE = 'incusbr0'
 POOL_DISABLED = '[DISABLED]'
 RE_FAILED_INSTANCE = re.compile(r'Failed creating instance "(.*)" record')
 
@@ -280,9 +279,9 @@ class VirtGlobalService(ConfigService):
             'type': data['type'].upper(),
             'managed': data['managed'],
             'ipv4_address': data['config']['ipv4.address'],
-            'ipv4_nat': data['config']['ipv4.nat'],
+            'ipv4_nat': data['config']['ipv4.nat'] == 'true',
             'ipv6_address': data['config']['ipv6.address'],
-            'ipv6_nat': data['config']['ipv6.nat'],
+            'ipv6_nat': data['config']['ipv6.nat'] == 'true',
         }
 
     @private

--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -14,7 +14,7 @@ from middlewared.utils import MIDDLEWARE_RUN_DIR
 
 from .websocket import IncusWS
 
-
+INCUS_BRIDGE = 'incusbr0'
 CDROM_PREFIX = 'ix_cdrom'
 HTTP_URI = 'http://unix.socket'
 INCUS_METADATA_CDROM_KEY = 'user.ix_cdrom_devices'


### PR DESCRIPTION
- `port.validate_port` now correctly reports port 53 as used.
- fixed an issue in `get_network`, where the result was expected to have booleans for ipv#_nat fields. but incus was returning strings.

```sh
root@truenas[...ist-packages/middlewared/plugins/virt]#   curl --unix-socket /var/lib/incus/unix.socket http://unix.socket/1.0/networks/incusbr0 | jq
```

```json
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "config": {
      "ipv4.address": "10.77.15.1/24",
      "ipv4.nat": "true",
      "ipv6.address": "fd42:24af:a7f5:5435::1/64",
      "ipv6.nat": "true"
    },
    "description": "",
    "name": "incusbr0",
    "type": "bridge",
    "used_by": [
      "/1.0/profiles/default"
    ],
    "managed": true,
    "status": "Created",
    "locations": [
      "none"
    ],
    "project": "default"
  }
}
```