### PR TITLE
NAS-136439 / 25.10 / Remove ID type both and version directory services cache

### DIFF
--- a/docs/source/accounts/implementation.rst
+++ b/docs/source/accounts/implementation.rst
@@ -159,7 +159,6 @@ all with the NSS `uid` or `gid`. For example in the following group entry::
     "sudo_commands_nopasswd": [],
     "smb": false,
     "group": "test",
-    "id_type_both": false,
     "local": true,
     "sid": null,
     "roles": [],

--- a/src/middlewared/middlewared/api/v25_10_0/group.py
+++ b/src/middlewared/middlewared/api/v25_10_0/group.py
@@ -52,7 +52,6 @@ class GroupEntry(BaseModel):
     "Specifies whether the group should be mapped into an NT group."
     group: NonEmptyString
     """ A string used to identify a group. Identical to the `name` key. """
-    id_type_both: bool
     local: bool
     """ If `True`, the group is local to the TrueNAS server. If `False`, the group is provided by a directory service. """
     sid: str | None
@@ -72,7 +71,6 @@ class GroupCreate(GroupEntry):
     id: Excluded = excluded_field()
     builtin: Excluded = excluded_field()
     group: Excluded = excluded_field()
-    id_type_both: Excluded = excluded_field()
     local: Excluded = excluded_field()
     sid: Excluded = excluded_field()
     roles: Excluded = excluded_field()

--- a/src/middlewared/middlewared/api/v25_10_0/user.py
+++ b/src/middlewared/middlewared/api/v25_10_0/user.py
@@ -109,7 +109,6 @@ class UserEntry(BaseModel):
     email: EmailStr | None = None
     """ Email address of the user. If the user has the `FULL_ADMIN` role, they will receive email alerts and
     notifications. """
-    id_type_both: bool
     local: bool
     """ If `True`, the account is local to the TrueNAS server. If `False`, the account is provided by a directory
     service. """
@@ -150,7 +149,6 @@ class UserCreate(UserEntry):
     unixhash: Excluded = excluded_field()
     smbhash: Excluded = excluded_field()
     builtin: Excluded = excluded_field()
-    id_type_both: Excluded = excluded_field()
     local: Excluded = excluded_field()
     immutable: Excluded = excluded_field()
     twofactor_auth_configured: Excluded = excluded_field()

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -342,7 +342,6 @@ class UserService(CRUDService):
 
         user.update({
             'local': True,
-            'id_type_both': False,
             'sid': sid,
             'roles': list(user_roles),
             'api_keys': ctx['user_api_keys'][user['username']]
@@ -364,7 +363,6 @@ class UserService(CRUDService):
         to_remove = [
             'api_keys',
             'local',
-            'id_type_both',
             'sid',
             'immutable',
             'home_create',
@@ -1949,7 +1947,6 @@ class GroupService(CRUDService):
 
         group.update({
             'local': True,
-            'id_type_both': False,
             'sid': sid,
             'roles': privilege_mappings['roles']
         })
@@ -1960,7 +1957,6 @@ class GroupService(CRUDService):
         to_remove = [
             'name',
             'local',
-            'id_type_both',
             'sid',
             'roles'
         ]

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -6,6 +6,7 @@ from middlewared.api.current import (
     DirectoryServicesStatusArgs, DirectoryServicesStatusResult,
     DirectoryServicesCacheRefreshArgs, DirectoryServicesCacheRefreshResult,
 )
+from middlewared.plugins.directoryservices_.util_cache import check_cache_version
 from middlewared.service import Service, private, job
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.health import DSHealthObj
@@ -166,3 +167,9 @@ async def setup(middleware):
         'Sent on directory service state changes.',
         roles=['DIRECTORY_SERVICE_READ']
     )
+    truenas_version = await middleware.call('system.version_short')
+
+    try:
+        await middleware.run_in_thread(check_cache_version, truenas_version)
+    except Exception:
+        middleware.logger.warning('Failed to check directory services cache', exc_info=True)

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -241,7 +241,8 @@ class ACLTemplateService(CRUDService):
         if ds['type'] != DSType.AD.value or ds['status'] != DSStatus.HEALTHY.name:
             return
 
-        domain_info = await self.middleware.call('idmap.domain_info', 'DS_TYPE_ACTIVEDIRECTORY')
+        workgroup = (await self.middleware.call('smb.config'))['workgroup']
+        domain_info = await self.middleware.call('idmap.domain_info', workgroup)
         if 'ACTIVE_DIRECTORY' not in domain_info['domain_flags']['parsed']:
             self.logger.warning(
                 '%s: domain is not identified properly as an Active Directory domain.',

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -135,8 +135,8 @@ class SMBService(Service):
 
         if ad_state == DSStatus.HEALTHY.name:
             try:
-                domain_info = self.middleware.call_sync('idmap.domain_info',
-                                                        'DS_TYPE_ACTIVEDIRECTORY')
+                workgroup = self.middleware.call_sync('smb.config')['workgroup']
+                domain_info = self.middleware.call_sync('idmap.domain_info', workgroup)
                 domain_sid = domain_info['sid']
                 # add domain account SIDS
                 entries.append((SMBGroupMembership(

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
@@ -105,7 +105,6 @@ async def test_use_ssh_enabled_validation(
             smb=False,
             group={},
             password_disabled=True,
-            id_type_both=False,
             local=True,
             immutable=False,
             twofactor_auth_configured=twofactor_enabled,

--- a/tests/unit/test_passdb.py
+++ b/tests/unit/test_passdb.py
@@ -76,7 +76,6 @@ SAMPLE_USER = {
     'immutable': False,
     'twofactor_auth_configured': False,
     'local': True,
-    'id_type_both': False,
     'sid': 'S-1-5-21-710078819-430336432-4106732522-20075',
     'roles': [],
     'last_password_change': 1711547527,  # Deliberately old password


### PR DESCRIPTION
This commit removes the `id_type_both` key from user entries since we are not abstracting away this implementation detail from from the public API in SMB share ACL and other areas. A side-effect of this change is that idmap domain information no longer needs to be queried when generating AD cache (or passed to related functions). This commit also adds a version identifier to directory services caches so that we automatically invalidate them on middleware startup of the underlying TrueNAS version changed (this is because the fields for users can change between versions).