### PR TITLE
NAS-136310 / 25.04.3 / Add auditing for service start, stop, reload and restart.

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -155,7 +155,9 @@ class ServiceService(CRUDService):
             Bool('silent', default=True),
             register=True,
         ),
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE']
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        audit='Service: start',
+        audit_extended=lambda service: service,
     )
     @returns(Bool('started_service', description='Will return `true` if service successfully started'))
     @pass_app(rest=True)
@@ -241,7 +243,9 @@ class ServiceService(CRUDService):
     @accepts(
         Str('service'),
         Ref('service-control'),
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE']
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        audit='Service: stop',
+        audit_extended=lambda service: service,
     )
     @returns(Bool('service_stopped', description='Will return `true` if service successfully stopped'))
     @pass_app(rest=True)
@@ -279,7 +283,9 @@ class ServiceService(CRUDService):
     @accepts(
         Str('service'),
         Ref('service-control'),
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE']
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        audit='Service: restart',
+        audit_extended=lambda service: service,
     )
     @returns(Bool('service_restarted'))
     @pass_app(rest=True)
@@ -341,7 +347,9 @@ class ServiceService(CRUDService):
     @accepts(
         Str('service'),
         Ref('service-control'),
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE']
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        audit='Service: reload',
+        audit_extended=lambda service: service,
     )
     @returns(Bool('service_reloaded'))
     @pass_app(rest=True)


### PR DESCRIPTION
Added auditing of service start, stop, reload and restart.

Manual spot testing to confirm function.

```
root@fangtooth-hv-nfs[~]# midclt call service.start nfs
True
root@fangtooth-hv-nfs[~]# midclt call service.reload nfs
True
root@fangtooth-hv-nfs[~]# midclt call service.restart nfs
True
root@fangtooth-hv-nfs[~]# midclt call service.stop nfs
True
root@fangtooth-hv-nfs[~]# midclt call audit.query '{"query-filters": [["event_data.method", "in", ["service.start","service.stop","service.reload","service.restart"]]], "query-options":{"select": ["event_data","success"]}}' | jq
[
  {
    "event_data": {
      "method": "service.stop",
      "params": [
        "nfs"
      ],
      "description": "Service: stop nfs",
      "authenticated": true,
      "authorized": true
    },
    "success": true
  },
  {
    "event_data": {
      "method": "service.start",
      "params": [
        "nfs"
      ],
      "description": "Service: start nfs",
      "authenticated": true,
      "authorized": true
    },
    "success": true
  },
  {
    "event_data": {
      "method": "service.reload",
      "params": [
        "nfs"
      ],
      "description": "Service: reload nfs",
      "authenticated": true,
      "authorized": true
    },
    "success": true
  },
  {
    "event_data": {
      "method": "service.restart",
      "params": [
        "nfs"
      ],
      "description": "Service: restart nfs",
      "authenticated": true,
      "authorized": true
    },
    "success": true
  },
  {
    "event_data": {
      "method": "service.stop",
      "params": [
        "nfs"
      ],
      "description": "Service: stop nfs",
      "authenticated": true,
      "authorized": true
    },
    "success": true
  }
]
root@fangtooth-hv-nfs[~]# 
```