### PR TITLE
NAS-136437 / 25.04.3 / Fix legacy API conversion

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/model_provider.py
+++ b/src/middlewared/middlewared/api/base/handler/model_provider.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 class ModelProvider(ABC):
-
     @abstractmethod
     def __init__(self):
         self.models: dict[str, type[BaseModel]]
@@ -26,11 +25,12 @@ class ModuleModelProvider(ModelProvider):
     """
     Provides API models from specified module.
     """
-    def __init__(self, module: ModuleType):
+
+    def __init__(self, module_name: str):
         """
-        :param module: module that contains models
+        :param module_name: module that contains models
         """
-        self.models = models_from_module(module)
+        self.models = models_from_module(importlib.import_module(module_name))
 
 
 class LazyModuleModelProvider(ModelProvider):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -148,7 +148,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         api_versions = [
             (version_dir.name.replace('_', '.'), f'middlewared.api.{version_dir.name}')
             for version_dir in sorted(pathlib.Path(api_dir).iterdir())
-            if version_dir.name.startswith('v') and version_dir.is_dir()
+            if version_dir.name.startswith('v') and version_dir.is_dir() and (version_dir / '__init__.py').exists()
         ]
         for i, (version, module_name) in enumerate(api_versions):
             if i == len(api_versions) - 1:

--- a/src/middlewared/middlewared/service/compound_service.py
+++ b/src/middlewared/middlewared/service/compound_service.py
@@ -8,6 +8,10 @@ class CompoundService(Service):
     def __init__(self, middleware, parts):
         super().__init__(middleware)
 
+        self._register_models = []
+        for part in parts:
+            self._register_models += getattr(part, '_register_models', [])
+
         config_specified = {}
         for part1, part2 in itertools.combinations(parts, 2):
             for key in set(part1._config_specified.keys()) & set(part2._config_specified.keys()):

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -166,11 +166,12 @@ truenas_server = TrueNAS_Server()
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, ssl=True):
+def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, ssl=True,
+           version="current"):
     if auth is undefined:
         auth = ("root", password())
 
-    uri = host_websocket_uri(host_ip, ssl)
+    uri = host_websocket_uri(host_ip, ssl, version)
     try:
         with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions, verify_ssl=False) as c:
             if auth is not None:
@@ -229,9 +230,9 @@ def host():
     return truenas_server
 
 
-def host_websocket_uri(host_ip=None, ssl=True):
+def host_websocket_uri(host_ip=None, ssl=True, version="current"):
     prefix = 'wss://' if ssl else 'ws://'
-    return f"{prefix}{host_ip or host().ip}/api/current"
+    return f"{prefix}{host_ip or host().ip}/api/{version}"
 
 
 def password():

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,0 +1,8 @@
+from middlewared.test.integration.utils import client
+
+OLDEST_VERSION = "v25.04.0"
+
+
+def test_account():
+    with client(version=OLDEST_VERSION) as c:
+        c.call("user.query")


### PR DESCRIPTION
A number of issues is being fixed here:
* `ModuleModelProvider` argument is `module`, but we pass a string. This results in the newest API version models not being loaded at all, and schema conversion not working.
* Only load API version if `__init__.py` exists (an empty directory of a nonexisting version might exist on the developers' machine as a result of mounting a git repo)
* Use `_register_models` of all the members of `CompoundService` (dynamically generated models were not registered)
* Test all this by just ensuring that `user.query` does not fail.