### PR TITLE
NAS-136437 / 25.04.2 / Fix legacy API conversion

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/inspect.py
+++ b/src/middlewared/middlewared/api/base/handler/inspect.py
@@ -1,15 +1,20 @@
+import pydantic_core
 import types
 import typing
+
+from pydantic import ValidationError
 
 from middlewared.api.base import BaseModel
 
 
-def model_field_is_model(model) -> type[BaseModel] | None:
+def model_field_is_model(model, value_hint=None, name_hint=None) -> type[BaseModel] | None:
     """
     Return` model` if it is an API model.
     Returns the first union member that is an API model if `model` is a union.
     Otherwise, returns `None`.
     :param model: potentially, API model.
+    :param value_hint: value to choose the correct union member.
+    :param name_hint: model name to choose the correct union member.
     :return: `model` or `None`
     """
     if isinstance(model, type) and issubclass(model, BaseModel):
@@ -17,7 +22,18 @@ def model_field_is_model(model) -> type[BaseModel] | None:
     if typing.get_origin(model) is types.UnionType:
         for member in model.__args__:
             if result := model_field_is_model(member):
-                return result
+                if value_hint is not None:
+                    try:
+                        result(**value_hint)
+                    except ValidationError:
+                        pass
+                    else:
+                        return result
+                elif name_hint is not None:
+                    if result.__name__ == name_hint:
+                        return result
+                else:
+                    return result
 
 
 def model_field_is_list_of_models(model) -> type[BaseModel] | None:

--- a/src/middlewared/middlewared/api/base/handler/model_provider.py
+++ b/src/middlewared/middlewared/api/base/handler/model_provider.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 class ModelProvider(ABC):
-
     @abstractmethod
     def __init__(self):
         self.models: dict[str, type[BaseModel]]
@@ -26,11 +25,12 @@ class ModuleModelProvider(ModelProvider):
     """
     Provides API models from specified module.
     """
-    def __init__(self, module: ModuleType):
+
+    def __init__(self, module_name: str):
         """
-        :param module: module that contains models
+        :param module_name: module that contains models
         """
-        self.models = models_from_module(module)
+        self.models = models_from_module(importlib.import_module(module_name))
 
 
 class LazyModuleModelProvider(ModelProvider):

--- a/src/middlewared/middlewared/api/base/handler/version.py
+++ b/src/middlewared/middlewared/api/base/handler/version.py
@@ -192,9 +192,10 @@ class APIVersionsAdapter:
                 new_model_field = new_model.model_fields[k].annotation
                 if (
                     isinstance(value[k], dict) and
-                    (current_nested_model := model_field_is_model(current_model_field)) and
-                    (new_nested_model := model_field_is_model(new_model_field)) and
-                    current_nested_model.__class__.__name__ == new_nested_model.__class__.__name__
+                    (current_nested_model := model_field_is_model(current_model_field, value_hint=value[k])) and
+                    (new_nested_model := model_field_is_model(new_model_field,
+                                                              name_hint=current_nested_model.__name__)) and
+                    current_nested_model.__name__ == new_nested_model.__name__
                 ):
                     value[k] = self._adapt_value(value[k], current_nested_model, new_nested_model, direction)
                 elif (
@@ -203,7 +204,7 @@ class APIVersionsAdapter:
                     (current_nested_model := model_field_is_model(current_nested_model)) and
                     (new_nested_model := model_field_is_list_of_models(new_model_field)) and
                     (new_nested_model := model_field_is_model(new_nested_model)) and
-                    current_nested_model.__class__.__name__ == new_nested_model.__class__.__name__
+                    current_nested_model.__name__ == new_nested_model.__name__
                 ):
                     value[k] = [
                         self._adapt_value(v, current_nested_model, new_nested_model, direction)

--- a/src/middlewared/middlewared/api/base/server/method.py
+++ b/src/middlewared/middlewared/api/base/server/method.py
@@ -22,6 +22,18 @@ class Method:
         self.name = name
         self.serviceobj, self.methodobj = self.middleware.get_method(self.name)
 
+    async def accepts_model(self):
+        """
+        :return: model that validates method input params.
+        """
+        return self.methodobj.new_style_accepts
+
+    async def returns_model(self):
+        """
+        :return: model that validates method return value.
+        """
+        return self.methodobj.new_style_returns
+
     async def call(self, app: "RpcWebSocketApp", params: list):
         """
         Calls the method in the context of a given `app`.

--- a/src/middlewared/middlewared/apps/websocket_app.py
+++ b/src/middlewared/middlewared/apps/websocket_app.py
@@ -138,7 +138,7 @@ class WebSocketApplication(RpcWebSocketApp):
                 self.middleware.api_versions_adapter,
                 passthrough_nonexistent_methods=True,
             )
-            if lam.accepts_model:
+            if lam.current_accepts_model:
                 params = await lam._adapt_params(params)
 
             async with self._softhardsemaphore:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -148,7 +148,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         api_versions = [
             (version_dir.name.replace('_', '.'), f'middlewared.api.{version_dir.name}')
             for version_dir in sorted(pathlib.Path(api_dir).iterdir())
-            if version_dir.name.startswith('v') and version_dir.is_dir()
+            if version_dir.name.startswith('v') and version_dir.is_dir() and (version_dir / '__init__.py').exists()
         ]
         for i, (version, module_name) in enumerate(api_versions):
             if i == len(api_versions) - 1:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1262,7 +1262,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
     async def api_versions_handler(self, request):
         return web.Response(
-            body=json.dumps([version.version for version in self.api_versions]),
+            body=json.dumps([version.version for version in self.api_versions if version.version != "v24.10"]),
             content_type="application/json",
         )
 

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model.py
@@ -6,15 +6,21 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class SettingsV1(BaseModel):
+class Settings(BaseModel):
     email: EmailStr | None = None
 
 
-class UpdateSettingsArgsV1(BaseModel):
+SettingsV1 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV1
 
 
-class SettingsV2(BaseModel):
+UpdateSettingsArgsV1 = UpdateSettingsArgs
+
+
+class Settings(BaseModel):
     emails: list[EmailStr]
 
     @classmethod
@@ -40,11 +46,17 @@ class SettingsV2(BaseModel):
         return value
 
 
-class UpdateSettingsArgsV2(BaseModel):
+SettingsV2 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV2
 
 
-class SettingsV3(BaseModel):
+UpdateSettingsArgsV2 = UpdateSettingsArgs
+
+
+class Settings(BaseModel):
     contacts: list[dict]
 
     @classmethod
@@ -65,8 +77,14 @@ class SettingsV3(BaseModel):
         return value
 
 
-class UpdateSettingsArgsV3(BaseModel):
+SettingsV3 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV3
+
+
+UpdateSettingsArgsV3 = UpdateSettingsArgs
 
 
 @pytest.mark.asyncio

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model_list.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model_list.py
@@ -5,16 +5,22 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class ContactV1(BaseModel):
+class Contact(BaseModel):
     name: str
     email: str
 
 
-class SettingsV1(BaseModel):
+ContactV1 = Contact
+
+
+class Settings(BaseModel):
     contacts: list[ContactV1]
 
 
-class ContactV2(BaseModel):
+SettingsV1 = Settings
+
+
+class Contact(BaseModel):
     first_name: str
     last_name: str
     email: str
@@ -36,8 +42,14 @@ class ContactV2(BaseModel):
         return value
 
 
-class SettingsV2(BaseModel):
+ContactV2 = Contact
+
+
+class Settings(BaseModel):
     contacts: list[ContactV2]
+
+
+SettingsV2 = Settings
 
 
 @pytest.mark.asyncio

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_or.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_or.py
@@ -1,0 +1,37 @@
+import copy
+
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+from middlewared.pytest.unit.helpers import TestModelProvider
+
+
+class AdvancedPerms(BaseModel):
+    READ: bool = False
+    WRITE: bool = False
+
+
+class BasicPerms(BaseModel):
+    BASIC: bool = False
+
+
+class Entry(BaseModel):
+    perms: AdvancedPerms | BasicPerms
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [
+    {"perms": {"BASIC": True}},
+    {"perms": {"READ": True, "WRITE": True}},
+])
+async def test_adapt(value):
+    adapter = APIVersionsAdapter([
+        APIVersion("v1", TestModelProvider({
+            "Entry": Entry,
+        })),
+        APIVersion("v2", TestModelProvider({
+            "Entry": Entry,
+        })),
+    ])
+    assert await adapter.adapt(copy.deepcopy(value), "Entry", "v1", "v2") == value

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_union.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_union.py
@@ -5,17 +5,23 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class EntryV1(BaseModel):
+class Entry(BaseModel):
     name: str
 
 
-class EntryV2(BaseModel):
+EntryV1 = Entry
+
+
+class Entry(BaseModel):
     first_name: str
     last_name: str
 
     @classmethod
     def to_previous(cls, value):
         return {"name": f"{value['first_name']} {value['last_name']}"}
+
+
+EntryV2 = Entry
 
 
 QueryResultV1 = query_result(EntryV1)

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -83,4 +83,7 @@ class ServiceBase(type):
             klass._config_specified = {}
 
         klass._config = service_config(klass, klass._config_specified)
+
+        klass._register_models = sum([getattr(getattr(klass, m), '_register_models', []) for m in dir(klass)], [])
+
         return klass

--- a/src/middlewared/middlewared/service/compound_service.py
+++ b/src/middlewared/middlewared/service/compound_service.py
@@ -8,6 +8,10 @@ class CompoundService(Service):
     def __init__(self, middleware, parts):
         super().__init__(middleware)
 
+        self._register_models = []
+        for part in parts:
+            self._register_models += getattr(part, '_register_models', [])
+
         config_specified = {}
         for part1, part2 in itertools.combinations(parts, 2):
             for key in set(part1._config_specified.keys()) & set(part2._config_specified.keys()):

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -166,11 +166,12 @@ truenas_server = TrueNAS_Server()
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, ssl=True):
+def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, ssl=True,
+           version="current"):
     if auth is undefined:
         auth = ("root", password())
 
-    uri = host_websocket_uri(host_ip, ssl)
+    uri = host_websocket_uri(host_ip, ssl, version)
     try:
         with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions, verify_ssl=False) as c:
             if auth is not None:
@@ -229,9 +230,9 @@ def host():
     return truenas_server
 
 
-def host_websocket_uri(host_ip=None, ssl=True):
+def host_websocket_uri(host_ip=None, ssl=True, version="current"):
     prefix = 'wss://' if ssl else 'ws://'
-    return f"{prefix}{host_ip or host().ip}/api/current"
+    return f"{prefix}{host_ip or host().ip}/api/{version}"
 
 
 def password():

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,0 +1,8 @@
+from middlewared.test.integration.utils import client
+
+OLDEST_VERSION = "v25.04.0"
+
+
+def test_account():
+    with client(version=OLDEST_VERSION) as c:
+        c.call("user.query")

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,8 +1,7 @@
-from middlewared.test.integration.utils import client
+def test_query_method(legacy_api_client, query_method):
+    version = legacy_api_client._ws.url.split("/")[-1].lstrip("v")
+    # Methods that do not exist in the previous API versions
+    if version in {"25.04.0", "25.04.1"} and query_method in {"vm.query", "vm.device.query"}:
+        return
 
-OLDEST_VERSION = "v25.04.0"
-
-
-def test_account():
-    with client(version=OLDEST_VERSION) as c:
-        c.call("user.query")
+    legacy_api_client.call(query_method)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
+from middlewared.test.integration.utils import client, session, url
 from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.pytest import failed
 
@@ -44,3 +45,38 @@ def log_test_name_to_middlewared_log(request):
 def mock_role():
     truenas_server.client.call("test.add_mock_role")
     yield
+
+
+def pytest_generate_tests(metafunc):
+    if "legacy_api_client" in metafunc.fixturenames:
+        with session() as s:
+            versions = s.get(f"{url()}/api/versions").json()
+
+        metafunc.parametrize(
+            "legacy_api_client",
+            versions,
+            indirect=True,
+            ids=[f"legacy_api_client={version}" for version in versions],
+        )
+
+    if "query_method" in metafunc.fixturenames:
+        with client() as c:
+            methods = [name for name in c.call("core.get_methods") if name.endswith(".query")]
+
+        metafunc.parametrize(
+            "query_method",
+            methods,
+            indirect=True,
+            ids=[f"query_method={method}" for method in methods],
+        )
+
+
+@pytest.fixture(scope="module")
+def legacy_api_client(request):
+    with client(version=request.param, py_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture
+def query_method(request):
+    yield request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def legacy_api_client(request):
-    with client(version=request.param, py_exceptions=False) as c:
+    with client(version=request.param) as c:
         yield c
 
 


### PR DESCRIPTION
A number of issues is being fixed here:

* ModuleModelProvider argument is module, but we pass a string. This results in the newest API version models not being loaded at all, and schema conversion not working.
* Only load API version if __init__.py exists (an empty directory of a nonexisting version might exist on the developers' machine as a result of mounting a git repo)
* Use _register_models of all the members of CompoundService (dynamically generated models were not registered)
* Test all this by just ensuring that user.query does not fail.