### PR TITLE
NAS-136446 / 25.10 / Handle KRBError when trying to restore secrets

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
@@ -219,7 +219,7 @@ class ADHealthMixin:
                     domain_info['kdc_server'],
                     machine_pass
                 )
-            except CallError:
+            except (CallError, KRB5Error):
                 faulted_reason = (
                     'Stored machine account secret is invalid. This may indicate that '
                     'the machine account password was reset in Active Directory without '


### PR DESCRIPTION
This commit fixes some verbose log spam that was being generated when middleware tried to recover from someone deleting our computer account from under us. We failed to kinit via keytab and our stored machine account password in the local secrets.tdb file, and so we tried to restore a saved copy of it. During the restoration we attempt to kinit with the old credential, and this was failing due with a KRBError that wasn't being caught and turned into an ADHealthError. This commit adds some minimal decoding of the kerberos error in the context of our stored machine account and eliminates the log spam.