### PR TITLE
NAS-136438 / 25.04.2 / incus port 53 should be shown as used (by stavros-k)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -280,9 +280,9 @@ class VirtGlobalService(ConfigService):
             'type': data['type'].upper(),
             'managed': data['managed'],
             'ipv4_address': data['config']['ipv4.address'],
-            'ipv4_nat': data['config']['ipv4.nat'],
+            'ipv4_nat': data['config']['ipv4.nat'] == 'true',
             'ipv6_address': data['config']['ipv6.address'],
-            'ipv6_nat': data['config']['ipv6.nat'],
+            'ipv6_nat': data['config']['ipv6.nat'] == 'true',
         }
 
     @private


### PR DESCRIPTION
- fixed an issue in `get_network`, where the result was expected to have booleans for `ipv#_nat` fields. but incus was returning strings.

```sh
root@truenas[...ist-packages/middlewared/plugins/virt]#   curl --unix-socket /var/lib/incus/unix.socket http://unix.socket/1.0/networks/incusbr0 | jq
```

```json
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "config": {
      "ipv4.address": "10.77.15.1/24",
      "ipv4.nat": "true",
      "ipv6.address": "fd42:24af:a7f5:5435::1/64",
      "ipv6.nat": "true"
    },
    "description": "",
    "name": "incusbr0",
    "type": "bridge",
    "used_by": [
      "/1.0/profiles/default"
    ],
    "managed": true,
    "status": "Created",
    "locations": [
      "none"
    ],
    "project": "default"
  }
}
```

Original PR: https://github.com/truenas/middleware/pull/16658
