### PR TITLE
NAS-136437 / 25.10 / Fix legacy API conversion (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/inspect.py
+++ b/src/middlewared/middlewared/api/base/handler/inspect.py
@@ -1,15 +1,20 @@
+import pydantic_core
 import types
 import typing
+
+from pydantic import ValidationError
 
 from middlewared.api.base import BaseModel
 
 
-def model_field_is_model(model) -> type[BaseModel] | None:
+def model_field_is_model(model, value_hint=None, name_hint=None) -> type[BaseModel] | None:
     """
     Return` model` if it is an API model.
     Returns the first union member that is an API model if `model` is a union.
     Otherwise, returns `None`.
     :param model: potentially, API model.
+    :param value_hint: value to choose the correct union member.
+    :param name_hint: model name to choose the correct union member.
     :return: `model` or `None`
     """
     if isinstance(model, type) and issubclass(model, BaseModel):
@@ -17,7 +22,18 @@ def model_field_is_model(model) -> type[BaseModel] | None:
     if typing.get_origin(model) is types.UnionType:
         for member in model.__args__:
             if result := model_field_is_model(member):
-                return result
+                if value_hint is not None:
+                    try:
+                        result(**value_hint)
+                    except ValidationError:
+                        pass
+                    else:
+                        return result
+                elif name_hint is not None:
+                    if result.__name__ == name_hint:
+                        return result
+                else:
+                    return result
 
 
 def model_field_is_list_of_models(model) -> type[BaseModel] | None:

--- a/src/middlewared/middlewared/api/base/handler/inspect.py
+++ b/src/middlewared/middlewared/api/base/handler/inspect.py
@@ -1,4 +1,3 @@
-import pydantic_core
 import types
 import typing
 

--- a/src/middlewared/middlewared/api/base/handler/model_provider.py
+++ b/src/middlewared/middlewared/api/base/handler/model_provider.py
@@ -16,7 +16,6 @@ ModelFactory: TypeAlias = Callable[[type[BaseModel]], type[BaseModel]]
 
 
 class ModelProvider(ABC):
-
     @abstractmethod
     def __init__(self):
         self.models: dict[str, type[BaseModel]]
@@ -43,11 +42,12 @@ class ModuleModelProvider(ModelProvider):
     """
     Provides API models from specified module.
     """
-    def __init__(self, module: ModuleType):
+
+    def __init__(self, module_name: str):
         """
-        :param module: Module that contains models.
+        :param module_name: module that contains models
         """
-        self.models = models_from_module(module)
+        self.models = models_from_module(importlib.import_module(module_name))
 
 
 class LazyModuleModelProvider(ModelProvider):

--- a/src/middlewared/middlewared/api/base/handler/version.py
+++ b/src/middlewared/middlewared/api/base/handler/version.py
@@ -168,9 +168,10 @@ class APIVersionsAdapter:
                 new_model_field = new_model.model_fields[k].annotation
                 if (
                     isinstance(value[k], dict) and
-                    (current_nested_model := model_field_is_model(current_model_field)) and
-                    (new_nested_model := model_field_is_model(new_model_field)) and
-                    current_nested_model.__class__.__name__ == new_nested_model.__class__.__name__
+                    (current_nested_model := model_field_is_model(current_model_field, value_hint=value[k])) and
+                    (new_nested_model := model_field_is_model(new_model_field,
+                                                              name_hint=current_nested_model.__name__)) and
+                    current_nested_model.__name__ == new_nested_model.__name__
                 ):
                     value[k] = self._adapt_value(value[k], current_nested_model, new_nested_model, direction)
                 elif (
@@ -179,7 +180,7 @@ class APIVersionsAdapter:
                     (current_nested_model := model_field_is_model(current_nested_model)) and
                     (new_nested_model := model_field_is_list_of_models(new_model_field)) and
                     (new_nested_model := model_field_is_model(new_nested_model)) and
-                    current_nested_model.__class__.__name__ == new_nested_model.__class__.__name__
+                    current_nested_model.__name__ == new_nested_model.__name__
                 ):
                     value[k] = [
                         self._adapt_value(v, current_nested_model, new_nested_model, direction)

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -40,15 +40,15 @@ class APIDumper:
         self.api = api
         self.role_manager = role_manager
 
-    def dump(self):
+    async def dump(self):
         return APIDump(
             version=self.version,
             version_title=self.version_title,
-            methods=self._dump_methods(),
+            methods=await self._dump_methods(),
             events=self._dump_events(),
         )
 
-    def _dump_methods(self):
+    async def _dump_methods(self):
         result = []
         for method in self.api.methods:
             if method.serviceobj._config.private:
@@ -60,11 +60,19 @@ class APIDumper:
             if not hasattr(method.methodobj, "new_style_accepts"):
                 continue
 
-            result.append(self._dump_method(method))
+            method_dump = await self._dump_method(method)
+            if method_dump is None:
+                continue
+
+            result.append(method_dump)
 
         return sorted(result, key=lambda method: method.name)
 
-    def _dump_method(self, method: Method):
+    async def _dump_method(self, method: Method):
+        schemas = await self._dump_method_schemas(method)
+        if schemas is None:
+            return None
+
         name = method.name
         plugin, method_name = name.rsplit(".", 1)
         if method_name in ("do_create", "do_update", "do_delete"):
@@ -87,15 +95,20 @@ class APIDumper:
             name=name,
             roles=sorted(self.role_manager.atomic_roles_for_method(name)),
             doc=doc,
-            schemas=self._dump_method_schemas(method),
+            schemas=schemas,
             removed_in=getattr(method.methodobj, "_removed_in", None),
         )
 
-    def _dump_method_schemas(self, method: Method):
-        accepts_json_schema = method.methodobj.new_style_accepts.model_json_schema()
+    async def _dump_method_schemas(self, method: Method):
+        accepts_model = await method.accepts_model()
+        returns_model = await method.returns_model()
+        if accepts_model is None or returns_model is None:
+            return None
+
+        accepts_json_schema = accepts_model.model_json_schema()
         accepts_json_schema = replace_refs(accepts_json_schema)
 
-        returns_json_schema = method.methodobj.new_style_returns.model_json_schema(mode="serialization")
+        returns_json_schema = returns_model.model_json_schema(mode="serialization")
         returns_json_schema = replace_refs(returns_json_schema)
 
         return {

--- a/src/middlewared/middlewared/api/base/server/legacy_api_method.py
+++ b/src/middlewared/middlewared/api/base/server/legacy_api_method.py
@@ -37,21 +37,35 @@ class LegacyAPIMethod(Method):
             methodobj = crud_methodobj
 
         if hasattr(methodobj, "new_style_accepts"):
-            self.accepts_model = methodobj.new_style_accepts
-            self.returns_model = methodobj.new_style_returns
+            self.current_accepts_model = methodobj.new_style_accepts
+            self.current_returns_model = methodobj.new_style_returns
         else:
-            self.accepts_model = None
-            self.returns_model = None
+            self.current_accepts_model = None
+            self.current_returns_model = None
+
+    async def accepts_model(self):
+        try:
+            return await self.adapter.versions[self.api_version].get_model(self.current_accepts_model.__name__)
+        except KeyError:
+            return None
+
+    async def returns_model(self):
+        try:
+            return await self.adapter.versions[self.api_version].get_model(self.current_returns_model.__name__)
+        except KeyError:
+            return None
 
     async def call(self, app: "RpcWebSocketApp", id_: Any, params):
-        if self.accepts_model:
+        if self.current_accepts_model:
             params = await self._adapt_params(params)
 
         return await super().call(app, id_, params)
 
     async def _adapt_params(self, params):
         try:
-            legacy_accepts_model = await self.adapter.versions[self.api_version].get_model(self.accepts_model.__name__)
+            legacy_accepts_model = await self.adapter.versions[self.api_version].get_model(
+                self.current_accepts_model.__name__
+            )
         except APIVersionDoesNotContainModelException:
             if self.passthrough_nonexistent_methods:
                 return params
@@ -69,14 +83,14 @@ class LegacyAPIMethod(Method):
             self.adapter.current_version,
         )
 
-        return [adapted_params_dict[field] for field in self.accepts_model.model_fields]
+        return [adapted_params_dict[field] for field in self.current_accepts_model.model_fields]
 
     async def _dump_result(self, app: "RpcWebSocketApp", methodobj, result):
-        if self.accepts_model:  # FIXME: Remove this check when all models become new style
+        if self.current_accepts_model:  # FIXME: Remove this check when all models become new style
             try:
                 model, result = await self.adapter.adapt_model(
                     {"result": result},
-                    self.returns_model.__name__,
+                    self.current_returns_model.__name__,
                     self.adapter.current_version,
                     self.api_version,
                 )
@@ -92,7 +106,7 @@ class LegacyAPIMethod(Method):
         return await super()._dump_result(app, methodobj, result)
 
     def dump_args(self, params):
-        if self.accepts_model:
-            return dump_params(self.accepts_model, params, False)
+        if self.current_accepts_model:  # FIXME: Remove this check when all models become new style
+            return dump_params(self.current_accepts_model, params, False)
 
         return super().dump_args(params)

--- a/src/middlewared/middlewared/api/base/server/method.py
+++ b/src/middlewared/middlewared/api/base/server/method.py
@@ -22,6 +22,18 @@ class Method:
         self.name = name
         self.serviceobj, self.methodobj = self.middleware.get_method(self.name)
 
+    async def accepts_model(self):
+        """
+        :return: model that validates method input params.
+        """
+        return self.methodobj.new_style_accepts
+
+    async def returns_model(self):
+        """
+        :return: model that validates method return value.
+        """
+        return self.methodobj.new_style_returns
+
     @property
     def private(self):
         return getattr(self.methodobj, "_private", False)

--- a/src/middlewared/middlewared/apps/websocket_app.py
+++ b/src/middlewared/middlewared/apps/websocket_app.py
@@ -138,7 +138,7 @@ class WebSocketApplication(RpcWebSocketApp):
                 self.middleware.api_versions_adapter,
                 passthrough_nonexistent_methods=True,
             )
-            if lam.accepts_model:
+            if lam.current_accepts_model:
                 params = await lam._adapt_params(params)
 
             async with self._softhardsemaphore:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -166,7 +166,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         api_versions = [
             (version_dir.name.replace('_', '.'), f'middlewared.api.{version_dir.name}')
             for version_dir in sorted(pathlib.Path(api_dir).iterdir())
-            if version_dir.name.startswith('v') and version_dir.is_dir()
+            if version_dir.name.startswith('v') and version_dir.is_dir() and (version_dir / '__init__.py').exists()
         ]
         for i, (version, module_name) in enumerate(api_versions):
             if i == len(api_versions) - 1:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1286,7 +1286,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
     async def api_versions_handler(self, request):
         return web.Response(
-            body=json.dumps([version.version for version in self.api_versions]),
+            body=json.dumps([version.version for version in self.api_versions if version.version != "v24.10"]),
             content_type="application/json",
         )
 

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -54,7 +54,6 @@ import contextlib
 from dataclasses import dataclass
 import errno
 import functools
-import importlib
 import inspect
 import multiprocessing
 import os
@@ -175,7 +174,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         ]
         for i, (version, module_name) in enumerate(api_versions):
             if i == len(api_versions) - 1:
-                module_provider = ModuleModelProvider(importlib.import_module(module_name))
+                module_provider = ModuleModelProvider(module_name)
             else:
                 module_provider = LazyModuleModelProvider(io_thread_pool_executor, module_name)
 

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model.py
@@ -6,15 +6,21 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class SettingsV1(BaseModel):
+class Settings(BaseModel):
     email: EmailStr | None = None
 
 
-class UpdateSettingsArgsV1(BaseModel):
+SettingsV1 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV1
 
 
-class SettingsV2(BaseModel):
+UpdateSettingsArgsV1 = UpdateSettingsArgs
+
+
+class Settings(BaseModel):
     emails: list[EmailStr]
 
     @classmethod
@@ -40,11 +46,17 @@ class SettingsV2(BaseModel):
         return value
 
 
-class UpdateSettingsArgsV2(BaseModel):
+SettingsV2 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV2
 
 
-class SettingsV3(BaseModel):
+UpdateSettingsArgsV2 = UpdateSettingsArgs
+
+
+class Settings(BaseModel):
     contacts: list[dict]
 
     @classmethod
@@ -65,8 +77,14 @@ class SettingsV3(BaseModel):
         return value
 
 
-class UpdateSettingsArgsV3(BaseModel):
+SettingsV3 = Settings
+
+
+class UpdateSettingsArgs(BaseModel):
     settings: SettingsV3
+
+
+UpdateSettingsArgsV3 = UpdateSettingsArgs
 
 
 @pytest.mark.asyncio

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model_list.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_nested_model_list.py
@@ -5,16 +5,22 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class ContactV1(BaseModel):
+class Contact(BaseModel):
     name: str
     email: str
 
 
-class SettingsV1(BaseModel):
+ContactV1 = Contact
+
+
+class Settings(BaseModel):
     contacts: list[ContactV1]
 
 
-class ContactV2(BaseModel):
+SettingsV1 = Settings
+
+
+class Contact(BaseModel):
     first_name: str
     last_name: str
     email: str
@@ -36,8 +42,14 @@ class ContactV2(BaseModel):
         return value
 
 
-class SettingsV2(BaseModel):
+ContactV2 = Contact
+
+
+class Settings(BaseModel):
     contacts: list[ContactV2]
+
+
+SettingsV2 = Settings
 
 
 @pytest.mark.asyncio

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_or.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_or.py
@@ -1,0 +1,37 @@
+import copy
+
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+from middlewared.pytest.unit.helpers import TestModelProvider
+
+
+class AdvancedPerms(BaseModel):
+    READ: bool = False
+    WRITE: bool = False
+
+
+class BasicPerms(BaseModel):
+    BASIC: bool = False
+
+
+class Entry(BaseModel):
+    perms: AdvancedPerms | BasicPerms
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [
+    {"perms": {"BASIC": True}},
+    {"perms": {"READ": True, "WRITE": True}},
+])
+async def test_adapt(value):
+    adapter = APIVersionsAdapter([
+        APIVersion("v1", TestModelProvider({
+            "Entry": Entry,
+        })),
+        APIVersion("v2", TestModelProvider({
+            "Entry": Entry,
+        })),
+    ])
+    assert await adapter.adapt(copy.deepcopy(value), "Entry", "v1", "v2") == value

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_union.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_union.py
@@ -5,17 +5,23 @@ from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
 from middlewared.pytest.unit.helpers import TestModelProvider
 
 
-class EntryV1(BaseModel):
+class Entry(BaseModel):
     name: str
 
 
-class EntryV2(BaseModel):
+EntryV1 = Entry
+
+
+class Entry(BaseModel):
     first_name: str
     last_name: str
 
     @classmethod
     def to_previous(cls, value):
         return {"name": f"{value['first_name']} {value['last_name']}"}
+
+
+EntryV2 = Entry
 
 
 QueryResultV1 = query_result(EntryV1)

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -147,6 +147,7 @@ class ServiceBase(type):
             klass._config_specified = {}
 
         klass._config = service_config(klass, klass._config_specified)
+        klass._register_models = sum([getattr(getattr(klass, m), '_register_models', []) for m in dir(klass)], [])
 
         # Validate API method argument class names
         validate_api_method_schema_class_names(klass)

--- a/src/middlewared/middlewared/service/compound_service.py
+++ b/src/middlewared/middlewared/service/compound_service.py
@@ -8,6 +8,10 @@ class CompoundService(Service):
     def __init__(self, middleware, parts):
         super().__init__(middleware)
 
+        self._register_models = []
+        for part in parts:
+            self._register_models += getattr(part, '_register_models', [])
+
         config_specified = {
             'events': [],
             'event_sources': {},

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,0 +1,8 @@
+from middlewared.test.integration.utils import client
+
+OLDEST_VERSION = "v25.04.0"
+
+
+def test_account():
+    with client(version=OLDEST_VERSION) as c:
+        c.call("user.query")

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -4,4 +4,34 @@ def test_query_method(legacy_api_client, query_method):
     if version in {"25.04.0", "25.04.1"} and query_method in {"vm.query", "vm.device.query"}:
         return
 
+    if version in {"25.04.0", "25.04.1", "25.04.2"} and query_method in {
+        "audit.query",
+        "certificate.query",
+        "cloudsync.query",
+        "disk.query",
+        "dns.query",
+        "interface.query",
+        "ipmi.lan.query",
+        "jbof.query",
+        "kerberos.keytab.query",
+        "kerberos.realm.query",
+        "nvmet.host.query",
+        "nvmet.host_subsys.query",
+        "nvmet.namespace.query",
+        "nvmet.port.query",
+        "nvmet.port_subsys.query",
+        "nvmet.subsys.query",
+        "pool.query",
+        "pool.dataset.query",
+        "pool.snapshot.query",
+        "privilege.query",
+        "replication.query",
+        "rsynctask.query",
+        "service.query",
+        "sharing.smb.query",
+        "tunable.query",
+        "vmware.query",
+    }:
+        return
+
     legacy_api_client.call(query_method)

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,8 +1,7 @@
-from middlewared.test.integration.utils import client
+def test_query_method(legacy_api_client, query_method):
+    version = legacy_api_client._ws.url.split("/")[-1].lstrip("v")
+    # Methods that do not exist in the previous API versions
+    if version in {"25.04.0", "25.04.1"} and query_method in {"vm.query", "vm.device.query"}:
+        return
 
-OLDEST_VERSION = "v25.04.0"
-
-
-def test_account():
-    with client(version=OLDEST_VERSION) as c:
-        c.call("user.query")
+    legacy_api_client.call(query_method)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def legacy_api_client(request):
-    with client(version=request.param, py_exceptions=False) as c:
+    with client(version=request.param) as c:
         yield c
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f7660aa21774721289a52a708135f5cf2d207682
    git cherry-pick -x 32fe0bb58ac5b32a79f29ca7fd0420a175b69424
    git cherry-pick -x da1810ef6e03181c7f3281206e2906468638714a
    git cherry-pick -x 2c361259dbfb1bfe88bee4f49ddc01d9d35de635
    git cherry-pick -x b4f6ac92c3f3eae2be2c6330845e05a4b2112b71
    git cherry-pick -x 24ce28f85b9250e2bd6ac1ca05945c3cc4f60f74
    git cherry-pick -x 5a586c0cb79563a39cf6acd972bd099f8f745f2e

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7b77af7e65b103afd3d107534f4608a1343c1f40

A number of issues is being fixed here:

* ModuleModelProvider argument is module, but we pass a string. This results in the newest API version models not being loaded at all, and schema conversion not working.
* Only load API version if __init__.py exists (an empty directory of a nonexisting version might exist on the developers' machine as a result of mounting a git repo)
* Use _register_models of all the members of CompoundService (dynamically generated models were not registered)
* Test all this by just ensuring that user.query does not fail.

Original PR: https://github.com/truenas/middleware/pull/16668
