### PR TITLE
NAS-134598 / 25.10 / syslog single and mutual TLS

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -1,6 +1,5 @@
 <%
 from middlewared.logger import DEFAULT_SYSLOG_PATH, ALL_LOG_FILES
-## from time import sleep   # MCG DEBUG
 
 logger = middleware.logger
 

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -1,5 +1,6 @@
 <%
 from middlewared.logger import DEFAULT_SYSLOG_PATH, ALL_LOG_FILES
+## from time import sleep   # MCG DEBUG
 
 logger = middleware.logger
 
@@ -17,25 +18,32 @@ def generate_syslog_remote_destination(advanced_config):
 
     host = host.replace("[", "").replace("]", "")
     transport = advanced_config["syslog_transport"].lower()
+    cert_id = advanced_config["syslog_tls_certificate"]
 
-    remotelog_stanza = 'destination loghost { '
-    remotelog_stanza += f'syslog("{host}" port({port}) ip-protocol(6) transport("{transport}")'
+    remotelog_stanza = 'destination loghost {\n'
+    remotelog_stanza += '  syslog(\n'
+    remotelog_stanza += f'    "{host}"\n'
+    remotelog_stanza += f'    port({port})\n'
+    remotelog_stanza += '    ip-protocol(6)\n'
+    remotelog_stanza += f'    transport("{transport}")\n'
 
     if advanced_config["syslog_transport"] == "TLS":
         # Both mutual and one-way TLS require this
-        remotelog_stanza += ' tls(ca-file("/etc/ssl/certs/ca-certificates.crt")'
+        remotelog_stanza += '    tls(\n'
+        remotelog_stanza += '      ca-file("/etc/ssl/certs/ca-certificates.crt")\n'
 
-        certificate = middleware.call_sync(
-            "certificate.query", [("id", "=", advanced_config["syslog_tls_certificate"])]
-        )
-        if certificate and not certificate[0]["revoked"]:
+        if cert_id is not None:
             # Mutual TLS
-            remotelog_stanza += f' key-file(\"{certificate[0]["privatekey_path"]}\")'
-            remotelog_stanza += f' cert-file(\"{certificate[0]["certificate_path"]}\")'
+            certificate = []
+            certificate = middleware.call_sync(
+                "certificate.query", [["id", "=", cert_id]]
+            )
+            if certificate is not []:
+                remotelog_stanza += f'      key-file(\"{certificate[0]["privatekey_path"]}\")\n'
+                remotelog_stanza += f'      cert-file(\"{certificate[0]["certificate_path"]}\")\n'
+        remotelog_stanza += '    )\n'
 
-        remotelog_stanza += ')'
-
-    remotelog_stanza += '); };\n'
+    remotelog_stanza += '  );\n};\n'    
     remotelog_stanza += 'log { source(tn_middleware_src); filter(f_tnremote); destination(loghost); };\n'
     remotelog_stanza += 'log { source(tn_auditd_src); filter(f_tnremote); destination(loghost); };\n'
     remotelog_stanza += 'log { source(s_src); filter(f_tnremote); destination(loghost); };'


### PR DESCRIPTION
Remote syslog supports single and mutual TLS authentication.
For single (one way) TLS: the client (TrueNAS server) needs only the ca directory configuration.
For mutual TLS: The TrueNAS server needs the CA directory that includes the syslog CA cert _and_ the syslog CA signed syslog client cert and key.

This PR:

- Remove 'revoked' check which was breaking the call.
- Refactored the remote syslog stanza to be more readable.
- Add TLS CI tests.  

Note: The CI tests are not end-to-end and validate the syslog-ng config file only.   The configuration _was_ tested manually.
Note: See [NAS-136443](https://ixsystems.atlassian.net/browse/NAS-136443).  Adding the CA cert must be done manually via the API (`midclt call certificate.create`)

CI [test run](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4920/)