### PR TITLE
Fix middlewared --dump-api errors for versioned API

### DIFF
--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -121,7 +121,7 @@ class APIDumper:
                             **accepts_json_schema["properties"][field],
                             "title": field,
                         }
-                        for field in method.methodobj.new_style_accepts.schema_model_fields()
+                        for field in accepts_model.schema_model_fields()
                     ],
                     "items": False,
                 },

--- a/src/middlewared/middlewared/api/base/server/legacy_api_method.py
+++ b/src/middlewared/middlewared/api/base/server/legacy_api_method.py
@@ -46,13 +46,13 @@ class LegacyAPIMethod(Method):
     async def accepts_model(self):
         try:
             return await self.adapter.versions[self.api_version].get_model(self.current_accepts_model.__name__)
-        except KeyError:
+        except (KeyError, APIVersionDoesNotContainModelException):
             return None
 
     async def returns_model(self):
         try:
             return await self.adapter.versions[self.api_version].get_model(self.current_returns_model.__name__)
-        except KeyError:
+        except (KeyError, APIVersionDoesNotContainModelException):
             return None
 
     async def call(self, app: "RpcWebSocketApp", id_: Any, params):


### PR DESCRIPTION
## Problem

The `middlewared --dump-api` command was failing with two errors:

1. APIVersionDoesNotContainModelException: API version 'v24.10' does not contain model 'CoreArpArgs'
   - This occurred when methods were added after an API version was released (e.g., core.arp was added after v24.10)
   - The recent legacy API conversion fix exposed this issue by properly validating model existence

2. KeyError: 'alert_class_update'
   - This occurred when field names changed between API versions (e.g., 'data' in v25.04 became 'alert_class_update' in v25.10)
   - The documentation generator was using field names from the current version while accessing schemas from version-specific models

## Solution

1. In legacy_api_method.py: Added APIVersionDoesNotContainModelException to the exception handling in accepts_model() and returns_model() methods. This allows methods that don't exist in older API versions to return None gracefully, which is the intended behavior per the existing code structure.

2. In doc.py: Changed from using `method.methodobj.new_style_accepts.schema_model_fields()` to `accepts_model.schema_model_fields()`. This ensures that the field names used for documentation match the version-specific schema being accessed, aligning with NEP-046's versioned API design where each API version maintains its own field names.

These fixes ensure that API documentation is generated correctly for each version, respecting the versioned API architecture where methods and field names can differ between versions.