### PR TITLE
Fix VM arch_type default when secure boot is enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -285,6 +285,11 @@ class VMService(CRUDService, VMSupervisorMixin):
             # https://docs.openstack.org/nova/latest/admin/secure-boot.html
             if not data['machine_type']:
                 data['machine_type'] = 'pc-q35-6.2'
+                if not data['arch_type']:
+                    # If arch type is not specified, we assume x86_64 architecture
+                    # we set this because otherwise vm.update will fail if this is not set
+                    # explicitly
+                    data['arch_type'] = 'x86_64'
             elif data['machine_type'] and 'pc-q35' not in data['machine_type']:
                 verrors.add(
                     f'{schema_name}.machine_type',


### PR DESCRIPTION
## Problem
When secure boot is enabled and machine_type is not specified, the system sets a default machine_type but doesn't set a corresponding arch_type. This causes vm.update to fail because arch_type is required - it will work if it is explicitly set right now.

## Solution
Set default arch_type to 'x86_64' when machine_type is defaulted to 'pc-q35-6.2' for secure boot configurations. This ensures vm.update operations succeed by providing the required arch_type field.