### PR TITLE
NAS-136426 / 25.10 / Allow specifying interfaces for TrueNAS connect

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-06-26_20-30_tnc_interfaces.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-06-26_20-30_tnc_interfaces.py
@@ -1,0 +1,28 @@
+""" Add interfaces and interfaces_ips to truenas_connect
+
+Revision ID: tnc_interfaces_001
+Revises:
+Create Date: 2025-06-26 20:30:00.000000+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'tnc_interfaces_001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('truenas_connect', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('interfaces', sa.JSON(), nullable=False, server_default='[]'))
+        batch_op.add_column(sa.Column('interfaces_ips', sa.JSON(), nullable=False, server_default='[]'))
+
+
+def downgrade():
+    with op.batch_alter_table('truenas_connect', schema=None) as batch_op:
+        batch_op.drop_column('interfaces_ips')
+        batch_op.drop_column('interfaces')

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-06-29_20-30_tnc_interfaces.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-06-29_20-30_tnc_interfaces.py
@@ -1,8 +1,8 @@
 """ Add interfaces and interfaces_ips to truenas_connect
 
-Revision ID: tnc_interfaces_001
-Revises:
-Create Date: 2025-06-26 20:30:00.000000+00:00
+Revision ID: 2368b4b28a87
+Revises: d4e0268ca57d
+Create Date: 2025-06-29 20:30:00.000000+00:00
 
 """
 from alembic import op
@@ -10,16 +10,16 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'tnc_interfaces_001'
-down_revision = None
+revision = '2368b4b28a87'
+down_revision = 'd4e0268ca57d'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     with op.batch_alter_table('truenas_connect', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('interfaces', sa.JSON(), nullable=False, server_default='[]'))
-        batch_op.add_column(sa.Column('interfaces_ips', sa.JSON(), nullable=False, server_default='[]'))
+        batch_op.add_column(sa.Column('interfaces', sa.TEXT(), nullable=False, server_default='[]'))
+        batch_op.add_column(sa.Column('interfaces_ips', sa.TEXT(), nullable=False, server_default='[]'))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/api/v25_10_0/interface.py
+++ b/src/middlewared/middlewared/api/v25_10_0/interface.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 from middlewared.api.base import (
     BaseModel, IPv4Address, UniqueList, IPvAnyAddress, Excluded, excluded_field, ForUpdateMetaclass,
-    single_argument_result, NotRequired
+    single_argument_result, NotRequired, NonEmptyString,
 )
 
 
@@ -166,6 +166,8 @@ class InterfaceIPInUseOptions(BaseModel):
     """Return wildcard addresses (0.0.0.0 and ::)."""
     static: bool = False
     """Only return configured static IPs."""
+    interfaces: list[NonEmptyString] = Field(default_factory=list)
+    """Only return IPs from specified interfaces. If empty, returns IPs from all interfaces."""
 
 
 class InterfaceIPInUseItem(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
@@ -5,8 +5,10 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult', 'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
-    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult', 'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult',
+    'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
+    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult',
+    'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 
 
@@ -15,6 +17,8 @@ class TNCEntry(BaseModel):
     enabled: bool
     registration_details: dict
     ips: list[NonEmptyString]
+    interfaces: list[str]
+    interfaces_ips: list[str]
     status: NonEmptyString
     status_reason: NonEmptyString
     certificate: int | None
@@ -28,6 +32,7 @@ class TNCEntry(BaseModel):
 class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
+    interfaces: list[str]
     account_service_base_url: HttpsOnlyURL
     leca_service_base_url: HttpsOnlyURL
     tnc_base_url: HttpsOnlyURL

--- a/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
@@ -5,9 +5,11 @@ from middlewared.api.base.types import HttpsOnlyURL
 
 
 __all__ = [
-    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs', 'TrueNASConnectGetRegistrationUriResult',
+    'TNCEntry', 'TrueNASConnectGetRegistrationUriArgs',
+    'TrueNASConnectGetRegistrationUriResult',
     'TrueNASConnectUpdateArgs', 'TrueNASConnectUpdateResult',
-    'TrueNASConnectGenerateClaimTokenArgs', 'TrueNASConnectGenerateClaimTokenResult',
+    'TrueNASConnectGenerateClaimTokenArgs',
+    'TrueNASConnectGenerateClaimTokenResult',
     'TrueNASConnectIpChoicesArgs', 'TrueNASConnectIpChoicesResult',
 ]
 

--- a/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
@@ -20,7 +20,10 @@ class TNCHostnameService(Service):
 
     async def register_update_ips(self, ips=None):
         tnc_config = await self.middleware.call('tn_connect.config_internal')
+        # If no IPs provided, use combined IPs from config (direct IPs + interface IPs)
+        if ips is None:
+            ips = tnc_config['ips'] + tnc_config.get('interfaces_ips', [])
         try:
-            return await register_update_ips(tnc_config, ips or tnc_config['ips'])
+            return await register_update_ips(tnc_config, ips)
         except TNCCallError as e:
             raise CallError(str(e))

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -64,9 +64,6 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         config.pop('last_heartbeat_failure_datetime', None)
         if config['certificate']:
             config['certificate'] = config['certificate']['id']
-        # Ensure interfaces and interfaces_ips are included
-        config['interfaces'] = config.get('interfaces', [])
-        config['interfaces_ips'] = config.get('interfaces_ips', [])
         return config
 
     @private

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -7,7 +7,10 @@ from truenas_connect_utils.urls import get_account_service_url
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import TNCEntry, TrueNASConnectUpdateArgs, TrueNASConnectUpdateResult, TrueNASConnectIpChoicesArgs, TrueNASConnectIpChoicesResult
+from middlewared.api.current import (
+    TNCEntry, TrueNASConnectUpdateArgs, TrueNASConnectUpdateResult,
+    TrueNASConnectIpChoicesArgs, TrueNASConnectIpChoicesResult,
+)
 from middlewared.service import CallError, ConfigService, private, ValidationErrors
 
 from .mixin import TNCAPIMixin
@@ -25,6 +28,8 @@ class TrueNASConnectModel(sa.Model):
     jwt_token = sa.Column(sa.EncryptedText(), default=None, nullable=True)
     registration_details = sa.Column(sa.JSON(dict), nullable=False)
     ips = sa.Column(sa.JSON(list), nullable=False)
+    interfaces = sa.Column(sa.JSON(list), nullable=False, default=list)
+    interfaces_ips = sa.Column(sa.JSON(list), nullable=False, default=list)
     status = sa.Column(sa.String(255), default=Status.DISABLED.name, nullable=False)
     certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
     account_service_base_url = sa.Column(
@@ -59,6 +64,9 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         config.pop('last_heartbeat_failure_datetime', None)
         if config['certificate']:
             config['certificate'] = config['certificate']['id']
+        # Ensure interfaces and interfaces_ips are included
+        config['interfaces'] = config.get('interfaces', [])
+        config['interfaces_ips'] = config.get('interfaces_ips', [])
         return config
 
     @private

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -72,18 +72,52 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
     @private
     async def validate_data(self, old_config, data):
         verrors = ValidationErrors()
-        if data['enabled'] and not data['ips']:
-            verrors.add('tn_connect_update.ips', 'This field is required when TrueNAS Connect is enabled')
+
+        # Ensure at least one interface or at least one IP is provided
+        if data['enabled'] and not data['ips'] and not data['interfaces']:
+            verrors.add(
+                'tn_connect_update',
+                'At least one IP or interface must be provided when TrueNAS Connect is enabled'
+            )
 
         data['ips'] = [str(ip) for ip in data['ips']]
 
+        # Validate interfaces exist
+        if data['interfaces']:
+            all_interfaces = await self.middleware.call('interface.query')
+            interface_names = {iface['id'] for iface in all_interfaces}
+
+            for interface in data['interfaces']:
+                if interface not in interface_names:
+                    verrors.add('tn_connect_update.interfaces', f'Interface "{interface}" does not exist')
+
+            # If no direct IPs are provided, ensure selected interfaces have at least one IP
+            if data['enabled'] and not data['ips']:
+                has_any_ip = False
+                for iface in all_interfaces:
+                    if iface['id'] in data['interfaces']:
+                        # Check if interface has any IPv4 or IPv6 address
+                        aliases = iface.get('state', {}).get('aliases', [])
+                        if any(alias['type'] in ('INET', 'INET6') for alias in aliases):
+                            has_any_ip = True
+                            break
+
+                if not has_any_ip:
+                    verrors.add(
+                        'tn_connect_update.interfaces',
+                        'Selected interfaces must have at least one IP address configured'
+                    )
+
         ips_changed = set(old_config['ips']) != set(data['ips'])
-        if ips_changed and (
+        interfaces_changed = set(old_config.get('interfaces', [])) != set(data.get('interfaces', []))
+
+        if (ips_changed or interfaces_changed) and (
             data['enabled'] is True and old_config['status'] not in (Status.DISABLED.name, Status.CONFIGURED.name)
         ):
             verrors.add(
-                'tn_connect_update.ips',
-                'IPs cannot be changed when TrueNAS Connect is in a state other than disabled or completely configured'
+                'tn_connect_update',
+                'IPs and interfaces cannot be changed when TrueNAS Connect is in a state '
+                'other than disabled or completely configured'
             )
 
         if data['enabled'] and old_config['enabled']:
@@ -122,12 +156,17 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             await self.unset_registration_details()
             db_payload.update(get_unset_payload())
 
+        # Check if IPs or interfaces have changed
+        combined_ips_old = config['ips'] + config.get('interfaces_ips', [])
+        combined_ips_new = db_payload['ips'] + db_payload['interfaces_ips']
+
         if (
             config['status'] == Status.CONFIGURED.name and db_payload.get(
                 'status', Status.CONFIGURED.name
             ) == Status.CONFIGURED.name
-        ) and config['ips'] != db_payload['ips']:
-            response = await self.middleware.call('tn_connect.hostname.register_update_ips', db_payload['ips'])
+        ) and set(combined_ips_old) != set(combined_ips_new):
+            # Send combined IPs to TNC service
+            response = await self.middleware.call('tn_connect.hostname.register_update_ips', combined_ips_new)
             if response['error']:
                 raise CallError(f'Failed to update IPs with TrueNAS Connect: {response["error"]}')
 

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -81,8 +81,8 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
 
         # Validate interfaces exist
         if data['interfaces']:
-            all_interfaces = await self.middleware.call('interface.query')
-            interface_names = {iface['id'] for iface in all_interfaces}
+            all_interfaces = await self.middleware.call('interface.query', [], {'extra': {'retrieve_names_only': True}})
+            interface_names = {iface['name'] for iface in all_interfaces}
 
             for interface in data['interfaces']:
                 if interface not in interface_names:

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_interface_ip_in_use.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_interface_ip_in_use.py
@@ -1,0 +1,304 @@
+from unittest.mock import Mock, patch
+import pytest
+
+from middlewared.plugins.network import InterfaceService
+from middlewared.pytest.unit.helpers import create_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+class MockInterface:
+    """Mock interface object that mimics netif.Interface behavior."""
+    def __init__(self, name, aliases):
+        self.orig_name = name
+        self._aliases = aliases
+
+    def asdict(self):
+        return {'aliases': self._aliases}
+
+
+@pytest.fixture
+def mock_interfaces():
+    """Create a set of mock interfaces with various IPs."""
+    return {
+        'en0': MockInterface('en0', [
+            {'type': 'INET', 'address': '192.168.1.10', 'netmask': 24, 'broadcast': '192.168.1.255'},
+            {'type': 'INET6', 'address': '2001:db8::1', 'netmask': 64},
+            {'type': 'INET6', 'address': 'fe80::1', 'netmask': 64},  # link-local
+        ]),
+        'en1': MockInterface('en1', [
+            {'type': 'INET', 'address': '10.0.0.10', 'netmask': 24, 'broadcast': '10.0.0.255'},
+            {'type': 'INET6', 'address': '2001:db8::2', 'netmask': 64},
+        ]),
+        'lo0': MockInterface('lo0', [
+            {'type': 'INET', 'address': '127.0.0.1', 'netmask': 8, 'broadcast': '127.255.255.255'},
+            {'type': 'INET6', 'address': '::1', 'netmask': 128},
+        ]),
+        'tap0': MockInterface('tap0', [  # Should be ignored by default
+            {'type': 'INET', 'address': '172.16.0.1', 'netmask': 24, 'broadcast': '172.16.0.255'},
+        ]),
+    }
+
+
+@pytest.fixture
+def middleware_with_interfaces(mock_interfaces):
+    """Create middleware with mocked interface methods."""
+    m = Middleware()
+
+    # Mock interface.query for static IP lookup
+    m['interface.query'] = Mock(return_value=[
+        {
+            'aliases': [
+                {'address': '192.168.1.10'},
+                {'address': '2001:db8::1'},
+            ],
+            'failover_virtual_aliases': [],
+            'name': 'en0',
+        },
+        {
+            'aliases': [
+                {'address': '10.0.0.10'},
+            ],
+            'failover_virtual_aliases': [],
+            'name': 'en1',
+        }
+    ])
+
+    # Mock failover.licensed
+    m['failover.licensed'] = Mock(return_value=False)
+
+    # Mock interface.internal_interfaces
+    m['interface.internal_interfaces'] = Mock(return_value=['tap', 'epair'])
+
+    return m
+
+
+def test_ip_in_use_default_behavior(middleware_with_interfaces, mock_interfaces):
+    """Test default behavior returns all IPs from all non-internal interfaces."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+        })
+
+        # Should get IPs from en0 and en1, but not tap0 (internal) or lo0 (not requested)
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '10.0.0.10' in addresses     # en1 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+        assert '2001:db8::2' in addresses   # en1 IPv6
+        assert 'fe80::1' not in addresses   # link-local filtered
+        assert '172.16.0.1' not in addresses  # tap interface ignored
+
+
+def test_ip_in_use_with_single_interface(middleware_with_interfaces, mock_interfaces):
+    """Test filtering by a single interface."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': ['en0'],
+        })
+
+        # Should only get IPs from en0
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+        assert '10.0.0.10' not in addresses  # en1 IPv4 should not be included
+        assert '2001:db8::2' not in addresses  # en1 IPv6 should not be included
+
+
+def test_ip_in_use_with_multiple_interfaces(middleware_with_interfaces, mock_interfaces):
+    """Test filtering by multiple interfaces."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': ['en0', 'en1'],
+        })
+
+        # Should get IPs from both en0 and en1
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '10.0.0.10' in addresses     # en1 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+        assert '2001:db8::2' in addresses   # en1 IPv6
+
+
+def test_ip_in_use_with_empty_interfaces_list(middleware_with_interfaces, mock_interfaces):
+    """Test that empty interfaces list behaves like default (all interfaces)."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': [],
+        })
+
+        # Should behave like default - get IPs from all non-internal interfaces
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '10.0.0.10' in addresses     # en1 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+        assert '2001:db8::2' in addresses   # en1 IPv6
+
+
+def test_ip_in_use_with_nonexistent_interface(middleware_with_interfaces, mock_interfaces):
+    """Test that non-existent interface names are ignored."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': ['nonexistent', 'en0'],
+        })
+
+        # Should only get IPs from en0 (nonexistent is ignored)
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+        assert len(result) == 2  # Only IPs from en0
+
+
+def test_ip_in_use_with_loopback_and_interface_filter(middleware_with_interfaces, mock_interfaces):
+    """Test combining loopback option with interface filtering."""
+    # Mock interface.internal_interfaces to include 'lo' so it can be removed
+    middleware_with_interfaces['interface.internal_interfaces'] = Mock(return_value=['tap', 'epair', 'lo'])
+
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': True,
+            'any': False,
+            'static': False,
+            'interfaces': ['lo0', 'en0'],
+        })
+
+        # Should get IPs from lo0 and en0
+        addresses = [ip['address'] for ip in result]
+        assert '127.0.0.1' in addresses     # lo0 IPv4
+        assert '::1' in addresses           # lo0 IPv6
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6
+
+
+def test_ip_in_use_with_static_filter_and_interfaces(middleware_with_interfaces, mock_interfaces):
+    """Test combining static IP filter with interface filtering."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': True,
+            'interfaces': ['en0', 'en1'],
+        })
+
+        # Should only get static IPs from specified interfaces
+        addresses = [ip['address'] for ip in result]
+        assert '192.168.1.10' in addresses  # en0 static IPv4
+        assert '10.0.0.10' in addresses     # en1 static IPv4
+        assert '2001:db8::1' in addresses   # en0 static IPv6
+        # en1 IPv6 is not in the static config, so should not appear
+
+
+def test_ip_in_use_ipv6_link_local_with_interfaces(middleware_with_interfaces, mock_interfaces):
+    """Test IPv6 link-local filtering with interface specification."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+
+        # First without link-local
+        result = service.ip_in_use({
+            'ipv4': False,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': ['en0'],
+        })
+
+        addresses = [ip['address'] for ip in result]
+        assert '2001:db8::1' in addresses
+        assert 'fe80::1' not in addresses
+
+        # Now with link-local
+        result = service.ip_in_use({
+            'ipv4': False,
+            'ipv6': True,
+            'ipv6_link_local': True,
+            'loopback': False,
+            'any': False,
+            'static': False,
+            'interfaces': ['en0'],
+        })
+
+        addresses = [ip['address'] for ip in result]
+        assert '2001:db8::1' in addresses
+        assert 'fe80::1' in addresses
+
+
+def test_ip_in_use_any_option_not_affected_by_interfaces(middleware_with_interfaces, mock_interfaces):
+    """Test that 'any' addresses (0.0.0.0, ::) are not affected by interface filter."""
+    with patch('middlewared.plugins.network.netif') as mock_netif:
+        mock_netif.list_interfaces = Mock(return_value=mock_interfaces)
+
+        service = create_service(middleware_with_interfaces, InterfaceService)
+        result = service.ip_in_use({
+            'ipv4': True,
+            'ipv6': True,
+            'ipv6_link_local': False,
+            'loopback': False,
+            'any': True,
+            'static': False,
+            'interfaces': ['en0'],  # Should not affect 'any' addresses
+        })
+
+        addresses = [ip['address'] for ip in result]
+        assert '0.0.0.0' in addresses       # Any IPv4
+        assert '::' in addresses            # Any IPv6
+        assert '192.168.1.10' in addresses  # en0 IPv4
+        assert '2001:db8::1' in addresses   # en0 IPv6

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -1,0 +1,313 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from middlewared.service import ValidationErrors
+from middlewared.plugins.truenas_connect.update import TrueNASConnectService
+from truenas_connect_utils.status import Status
+
+
+@pytest.fixture
+def tnc_service():
+    """Create a mock TrueNASConnectService instance."""
+    service = TrueNASConnectService(None)
+    service.middleware = MagicMock()
+    return service
+
+
+@pytest.fixture
+def mock_interfaces():
+    """Mock interface.query response."""
+    return [
+        {
+            'id': 'ens3',
+            'state': {
+                'aliases': [
+                    {'type': 'INET', 'address': '192.168.1.10'},
+                    {'type': 'INET6', 'address': 'fe80::1'},
+                    {'type': 'INET6', 'address': '2001:db8::1'},
+                ]
+            }
+        },
+        {
+            'id': 'ens4',
+            'state': {
+                'aliases': [
+                    {'type': 'INET', 'address': '10.0.0.10'},
+                ]
+            }
+        },
+        {
+            'id': 'ens5',
+            'state': {
+                'aliases': []
+            }
+        }
+    ]
+
+
+class TestTNCInterfacesValidation:
+    """Test validation logic for interfaces."""
+
+    @pytest.mark.asyncio
+    async def test_validate_data_requires_ip_or_interface(self, tnc_service):
+        """Test that at least one IP or interface is required when enabled."""
+        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        data = {'enabled': True, 'ips': [], 'interfaces': []}
+
+        with pytest.raises(ValidationErrors) as exc_info:
+            await tnc_service.validate_data(old_config, data)
+
+        assert 'At least one IP or interface must be provided' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_data_interface_exists(self, tnc_service, mock_interfaces):
+        """Test validation of interface existence."""
+        tnc_service.middleware.call = AsyncMock(return_value=mock_interfaces)
+
+        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        data = {'enabled': True, 'ips': [], 'interfaces': ['ens3', 'invalid_interface']}
+
+        with pytest.raises(ValidationErrors) as exc_info:
+            await tnc_service.validate_data(old_config, data)
+
+        assert 'Interface "invalid_interface" does not exist' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_data_interface_has_ip(self, tnc_service, mock_interfaces):
+        """Test that selected interfaces must have at least one IP when no direct IPs provided."""
+        tnc_service.middleware.call = AsyncMock(return_value=mock_interfaces)
+
+        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        data = {'enabled': True, 'ips': [], 'interfaces': ['ens5']}  # ens5 has no IPs
+
+        with pytest.raises(ValidationErrors) as exc_info:
+            await tnc_service.validate_data(old_config, data)
+
+        assert 'Selected interfaces must have at least one IP address configured' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_data_interface_with_direct_ips(self, tnc_service, mock_interfaces):
+        """Test that interface without IPs is allowed if direct IPs are provided."""
+        tnc_service.middleware.call = AsyncMock(return_value=mock_interfaces)
+
+        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        data = {'enabled': True, 'ips': ['192.168.1.100'], 'interfaces': ['ens5']}  # ens5 has no IPs
+
+        # Should not raise any errors
+        await tnc_service.validate_data(old_config, data)
+
+    @pytest.mark.asyncio
+    async def test_validate_data_status_restriction(self, tnc_service, mock_interfaces):
+        """Test that IPs/interfaces cannot be changed in certain states."""
+        tnc_service.middleware.call = AsyncMock(return_value=mock_interfaces)
+
+        old_config = {
+            'enabled': True,
+            'ips': ['192.168.1.10'],
+            'interfaces': [],
+            'status': Status.CERT_GENERATION_IN_PROGRESS.name
+        }
+        data = {
+            'enabled': True,
+            'ips': ['192.168.1.10'],
+            'interfaces': ['ens3'],
+            'account_service_base_url': 'https://example.com/',
+            'leca_service_base_url': 'https://example.com/',
+            'tnc_base_url': 'https://example.com/',
+            'heartbeat_url': 'https://example.com/'
+        }
+
+        with pytest.raises(ValidationErrors) as exc_info:
+            await tnc_service.validate_data(old_config, data)
+
+        assert 'cannot be changed when TrueNAS Connect is in a state' in str(exc_info.value)
+
+
+class TestTNCInterfacesUpdate:
+    """Test update logic for interfaces."""
+
+    @pytest.mark.asyncio
+    async def test_do_update_extracts_interface_ips(self, tnc_service, mock_interfaces):
+        """Test that do_update properly extracts IPs from selected interfaces."""
+        tnc_service.middleware.call = AsyncMock()
+        tnc_service.middleware.call.side_effect = [
+            # config() call
+            {
+                'id': 1,
+                'enabled': False,
+                'ips': [],
+                'interfaces': [],
+                'status': Status.DISABLED.name,
+                'interfaces_ips': [],
+                'account_service_base_url': 'https://example.com/',
+                'leca_service_base_url': 'https://example.com/',
+                'tnc_base_url': 'https://example.com/',
+                'heartbeat_url': 'https://example.com/'
+            },
+            # interface.query() call in validate_data
+            mock_interfaces,
+            # interface.query() call in do_update
+            mock_interfaces,
+            # datastore.update() call
+            None,
+            # config() call for return
+            {
+                'id': 1,
+                'enabled': True,
+                'ips': [],
+                'interfaces': ['ens3', 'ens4'],
+                'interfaces_ips': ['192.168.1.10', '2001:db8::1', '10.0.0.10'],
+                'status': Status.CLAIM_TOKEN_MISSING.name
+            }
+        ]
+
+        tnc_service.config = AsyncMock(return_value={
+            'id': 1,
+            'enabled': False,
+            'ips': [],
+            'interfaces': [],
+            'status': Status.DISABLED.name,
+            'interfaces_ips': [],
+            'account_service_base_url': 'https://example.com/',
+            'leca_service_base_url': 'https://example.com/',
+            'tnc_base_url': 'https://example.com/',
+            'heartbeat_url': 'https://example.com/'
+        })
+
+        tnc_service.middleware.send_event = MagicMock()
+
+        data = {
+            'enabled': True,
+            'ips': [],
+            'interfaces': ['ens3', 'ens4']
+        }
+
+        await tnc_service.do_update(data)
+
+        # Verify datastore.update was called with correct payload
+        update_call = tnc_service.middleware.call.call_args_list[3]
+        assert update_call[0][0] == 'datastore.update'
+        db_payload = update_call[0][3]
+
+        # Check extracted IPs (should not include link-local IPv6)
+        assert set(db_payload['interfaces_ips']) == {'192.168.1.10', '2001:db8::1', '10.0.0.10'}
+        assert db_payload['interfaces'] == ['ens3', 'ens4']
+
+    @pytest.mark.asyncio
+    async def test_do_update_combined_ips_registration(self, tnc_service, mock_interfaces):
+        """Test that hostname registration uses combined IPs."""
+        tnc_service.middleware.call = AsyncMock()
+        tnc_service.middleware.call.side_effect = [
+            # config() call
+            {
+                'id': 1,
+                'enabled': True,
+                'ips': ['192.168.1.100'],
+                'interfaces': ['ens3'],
+                'interfaces_ips': ['192.168.1.10'],
+                'status': Status.CONFIGURED.name,
+                'account_service_base_url': 'https://example.com/',
+                'leca_service_base_url': 'https://example.com/',
+                'tnc_base_url': 'https://example.com/',
+                'heartbeat_url': 'https://example.com/'
+            },
+            # interface.query() call in validate_data
+            mock_interfaces,
+            # interface.query() call in do_update
+            mock_interfaces,
+            # hostname.register_update_ips() call
+            {'error': None},
+            # datastore.update() call
+            None,
+            # config() call for return
+            {
+                'id': 1,
+                'enabled': True,
+                'ips': ['192.168.1.100'],
+                'interfaces': ['ens4'],
+                'interfaces_ips': ['10.0.0.10'],
+                'status': Status.CONFIGURED.name
+            }
+        ]
+
+        tnc_service.config = AsyncMock(return_value={
+            'id': 1,
+            'enabled': True,
+            'ips': ['192.168.1.100'],
+            'interfaces': ['ens3'],
+            'interfaces_ips': ['192.168.1.10'],
+            'status': Status.CONFIGURED.name,
+            'account_service_base_url': 'https://example.com/',
+            'leca_service_base_url': 'https://example.com/',
+            'tnc_base_url': 'https://example.com/',
+            'heartbeat_url': 'https://example.com/'
+        })
+
+        tnc_service.middleware.send_event = MagicMock()
+
+        data = {
+            'enabled': True,
+            'ips': ['192.168.1.100'],
+            'interfaces': ['ens4']
+        }
+
+        await tnc_service.do_update(data)
+
+        # Verify hostname.register_update_ips was called with combined IPs
+        register_call = tnc_service.middleware.call.call_args_list[3]
+        assert register_call[0][0] == 'tn_connect.hostname.register_update_ips'
+        combined_ips = register_call[0][1]
+        assert set(combined_ips) == {'192.168.1.100', '10.0.0.10'}
+
+
+class TestTNCHostnameService:
+    """Test hostname service updates."""
+
+    @pytest.mark.asyncio
+    async def test_register_update_ips_uses_combined_ips(self):
+        """Test that register_update_ips uses combined IPs when no IPs provided."""
+        from middlewared.plugins.truenas_connect.hostname import TNCHostnameService
+
+        service = TNCHostnameService(None)
+        service.middleware = MagicMock()
+        service.middleware.call = AsyncMock(return_value={
+            'ips': ['192.168.1.10'],
+            'interfaces_ips': ['10.0.0.10', '172.16.0.10'],
+            'jwt_token': 'test_token'
+        })
+
+        with patch('middlewared.plugins.truenas_connect.hostname.register_update_ips',
+                   new_callable=AsyncMock) as mock_register:
+            mock_register.return_value = {}
+
+            await service.register_update_ips()
+
+            # Verify the function was called with combined IPs
+            mock_register.assert_called_once()
+            called_ips = mock_register.call_args[0][1]
+            assert set(called_ips) == {'192.168.1.10', '10.0.0.10', '172.16.0.10'}
+
+    @pytest.mark.asyncio
+    async def test_register_update_ips_with_explicit_ips(self):
+        """Test that register_update_ips uses provided IPs when specified."""
+        from middlewared.plugins.truenas_connect.hostname import TNCHostnameService
+
+        service = TNCHostnameService(None)
+        service.middleware = MagicMock()
+        service.middleware.call = AsyncMock(return_value={
+            'ips': ['192.168.1.10'],
+            'interfaces_ips': ['10.0.0.10'],
+            'jwt_token': 'test_token'
+        })
+
+        with patch('middlewared.plugins.truenas_connect.hostname.register_update_ips',
+                   new_callable=AsyncMock) as mock_register:
+            mock_register.return_value = {}
+
+            explicit_ips = ['1.2.3.4', '5.6.7.8']
+            await service.register_update_ips(explicit_ips)
+
+            # Verify the function was called with explicit IPs only
+            mock_register.assert_called_once()
+            called_ips = mock_register.call_args[0][1]
+            assert called_ips == explicit_ips


### PR DESCRIPTION
This PR adds changes to allow binding interfaces with truenas connect. Basically this will mean that users don't have to rely on specifying IPs which can change later on and rather we will use interfaces which are persistent and remain. 

To catch up to any ip changes on interfaces, we will be doing that in a subsequent PR.