### PR TITLE
NAS-136525 / 25.10 / Fix service.control call in NFS and FTP test assets

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/ftp.py
+++ b/src/middlewared/middlewared/test/integration/assets/ftp.py
@@ -10,12 +10,12 @@ from middlewared.test.integration.utils import call, ssh
 def ftp_server(config=None):
     if config is not None:
         call("ftp.update", config)
-    call("service.control", "START", "ftp")
+    call("service.control", "START", "ftp", job=True)
 
     try:
         yield
     finally:
-        call("service.control", "STOP", "ftp")
+        call("service.control", "STOP", "ftp", job=True)
 
 
 @contextlib.contextmanager

--- a/src/middlewared/middlewared/test/integration/assets/nfs.py
+++ b/src/middlewared/middlewared/test/integration/assets/nfs.py
@@ -13,11 +13,11 @@ __all__ = ["nfs_share", "nfs_server"]
 @contextlib.contextmanager
 def nfs_server():
     try:
-        res = call('service.control', 'START', 'nfs', {'silent': False})
+        res = call('service.control', 'START', 'nfs', {'silent': False}, job=True)
         sleep(1)
         yield res
     finally:
-        call('service.control', 'STOP', 'nfs', {'silent': False})
+        call('service.control', 'STOP', 'nfs', {'silent': False}, job=True)
 
 
 @contextlib.contextmanager
@@ -25,10 +25,10 @@ def nfs_share(dataset):
     share = call("sharing.nfs.create", {
         "path": f"/mnt/{dataset}",
     })
-    assert call("service.control", "START", "nfs")
+    assert call("service.control", "START", "nfs", job=True)
 
     try:
         yield share
     finally:
         call("sharing.nfs.delete", share["id"])
-        call("service.control", "STOP", "nfs")
+        call("service.control", "STOP", "nfs", job=True)


### PR DESCRIPTION
The previous refactor of these assets to use `service.control` instead of `service.start` | `service.stop` omitted setting `job=True` which could theoretically lead to races / bad test results.