### PR TITLE
NAS-136461 / 25.10 / Add reload of NFS on user update.

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -984,6 +984,8 @@ class UserService(CRUDService):
         reset_tally(user['username'])
         self.middleware.call_sync('service.control', 'RELOAD', 'ssh').wait_sync(raise_error=True)
         self.middleware.call_sync('service.control', 'RELOAD', 'user').wait_sync(raise_error=True)
+        # NAS-136461: Possible group membership change. Reload nfs to avoid a 10 min delay.
+        self.middleware.call_sync('service.control', 'RELOAD', 'nfs').wait_sync(raise_error=True)
         if user['smb'] and must_change_pdb_entry:
             self.middleware.call_sync('smb.update_passdb_user', user)
 


### PR DESCRIPTION
The NFS subsystem caches group membership.   If a group membership is removed or added the NFS server will not detect it until the cache is refreshed.  This results in about 10 minutes of time where the users access was removed or added but the NFS server responds as if nothing has changed.

The fix is to reload the NFS server when a user has a change to the group membership list.  Since changes via the UI always include the group  membership the optimal solution is to reload NFS on any user change.

Tested manually with CI to be added later.