### PR TITLE
NAS-136554 / 25.10 / Fixup support for the sharing_protocol CI tests.

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -19,8 +19,7 @@ TEST_DIR_TO_RESULT = {
     'api2': 'results/api_v2_tests_result.xml',
     'directory_services': 'results/directoryservices_tests_result.xml',
     'stig': 'results/stig_tests_result.xml',
-    'sharing_protocols/nfs': 'results/sharing_protocols_nfs_tests_result.xml',
-    'sharing_protocols/smb': 'results/sharing_protocols_smb_tests_result.xml',
+    'sharing_protocols': 'results/sharing_protocols_tests_result.xml',
 }
 
 workdir = os.getcwd()

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -19,6 +19,8 @@ TEST_DIR_TO_RESULT = {
     'api2': 'results/api_v2_tests_result.xml',
     'directory_services': 'results/directoryservices_tests_result.xml',
     'stig': 'results/stig_tests_result.xml',
+    'sharing_protocols/nfs': 'results/sharing_protocols_nfs_tests_result.xml',
+    'sharing_protocols/smb': 'results/sharing_protocols_smb_tests_result.xml',
 }
 
 workdir = os.getcwd()

--- a/tests/sharing_protocols/conftest.py
+++ b/tests/sharing_protocols/conftest.py
@@ -106,16 +106,18 @@ def set_interfaces():
 
 
 def create_permanent_pool():
-    unused_disks = call('disk.get_unused')
-    assert len(unused_disks) > 0
-    call('pool.create', {
-        'name': pool,
-        'topology': {
-            'data': [{
-                'type': 'STRIPE', 'disks': [unused_disks[0]['name']]
-            }]
-        }
-    }, job=True)
+    # Create a pool if one doesn't already exist
+    if [] == call('pool.query', [["name", "=", pool]]):
+        unused_disks = call('disk.get_unused')
+        assert len(unused_disks) > 0
+        call('pool.create', {
+            'name': pool,
+            'topology': {
+                'data': [{
+                    'type': 'STRIPE', 'disks': [unused_disks[0]['name']]
+                }]
+            }
+        }, job=True)
 
     if ha:
         call('failover.update', {'disabled': False, 'master': True})


### PR DESCRIPTION
The sharing protocol CI tests are being moved to subdirectories.
This PR fixes up `runtest.py` to support running the CI tests.

To run the tests:
    `--test_dir sharing_protocols`

The results will be in `results/sharing_protocols_tests_result.xml

Also modified the pool create to use an existing pool.