### PR TITLE
NAS-133741 / 25.10 / Make VMs run gracefully on enterprise systems

### DIFF
--- a/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
+++ b/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
@@ -1,17 +1,16 @@
 import os
 import shutil
 
-from middlewared.plugins.vm.utils import (
-    get_vm_nvram_file_name, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID, SYSTEM_NVRAM_FOLDER_PATH,
-)
+from middlewared.plugins.vm.utils import get_vm_nvram_file_name, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID
 
 
 DEFAULT_NVRAM_FOLDER_PATH = '/var/lib/libvirt/qemu/nvram'
+SYSTEM_NVRAM_FOLDER_PATH_OLD_DATA = '/data/subsystems/vm/nvram'
 
 
 def migrate(middleware):
-    os.makedirs(SYSTEM_NVRAM_FOLDER_PATH, exist_ok=True)
-    os.chown(SYSTEM_NVRAM_FOLDER_PATH, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+    os.makedirs(SYSTEM_NVRAM_FOLDER_PATH_OLD_DATA, exist_ok=True)
+    os.chown(SYSTEM_NVRAM_FOLDER_PATH_OLD_DATA, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
 
     if middleware.call_sync('system.is_ha_capable'):
         middleware.logger.debug('Skipping nvram migration as system is HA capable')
@@ -26,7 +25,7 @@ def migrate(middleware):
 
 def migrate_vm_nvram_file(middleware, vm):
     file_name = get_vm_nvram_file_name(vm)
-    new_path = os.path.join(SYSTEM_NVRAM_FOLDER_PATH, file_name)
+    new_path = os.path.join(SYSTEM_NVRAM_FOLDER_PATH_OLD_DATA, file_name)
     to_copy_path = os.path.join(DEFAULT_NVRAM_FOLDER_PATH, file_name)
     if os.path.exists(to_copy_path):
         shutil.copy2(to_copy_path, new_path)

--- a/src/middlewared/middlewared/migration/0014_nvram_attr_to_sysdataset.py
+++ b/src/middlewared/middlewared/migration/0014_nvram_attr_to_sysdataset.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+
+from middlewared.plugins.vm.utils import LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID
+
+
+OLD_NVRAM_FOLDER_PATH = '/data/subsystems/vm/nvram'
+NEW_NVRAM_FOLDER_PATH = '/var/db/system/vm/nvram'
+
+
+def migrate(middleware):
+    """
+    Migrate VM NVRAM files from old location (/data/subsystems/vm/nvram) to
+    new system dataset location (/var/db/system/vm/nvram).
+
+    This migration keeps the old files intact for backup purposes.
+    """
+    # Check if old path exists and has files
+    if not os.path.exists(OLD_NVRAM_FOLDER_PATH):
+        middleware.logger.debug(
+            'Old NVRAM folder path %r does not exist, nothing to migrate',
+            OLD_NVRAM_FOLDER_PATH
+        )
+        return
+
+    # Ensure system dataset is properly mounted
+    sysdataset_path = middleware.call_sync('systemdataset.sysdataset_path')
+    if not sysdataset_path:
+        middleware.logger.warning('System dataset is not mounted, skipping NVRAM migration')
+        return
+
+    # Create new nvram directory if it doesn't exist
+    # The parent /var/db/system/vm should already exist from
+    # system dataset mount
+    if not os.path.exists(NEW_NVRAM_FOLDER_PATH):
+        try:
+            os.makedirs(NEW_NVRAM_FOLDER_PATH, exist_ok=True)
+            os.chown(NEW_NVRAM_FOLDER_PATH, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+        except Exception as e:
+            middleware.logger.error(
+                'Failed to create new NVRAM folder path: %s', e
+            )
+            return
+
+    # Get list of NVRAM files to migrate
+    try:
+        nvram_files = [f for f in os.listdir(OLD_NVRAM_FOLDER_PATH) if f.endswith('_VARS.fd')]
+    except Exception as e:
+        middleware.logger.error(
+            'Failed to list files in old NVRAM folder: %s', e
+        )
+        return
+
+    if not nvram_files:
+        middleware.logger.debug('No NVRAM files found to migrate')
+        return
+
+    # Copy each NVRAM file to new location
+    migrated_count = 0
+    for nvram_file in nvram_files:
+        old_path = os.path.join(OLD_NVRAM_FOLDER_PATH, nvram_file)
+        new_path = os.path.join(NEW_NVRAM_FOLDER_PATH, nvram_file)
+
+        try:
+            # Skip if file already exists in new location
+            if os.path.exists(new_path):
+                middleware.logger.debug('NVRAM file %r already exists in new location, skipping', nvram_file)
+                continue
+
+            # Copy file to new location
+            shutil.copy2(old_path, new_path)
+            # Set proper ownership
+            os.chown(new_path, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+            migrated_count += 1
+            middleware.logger.debug('Successfully migrated NVRAM file %r', nvram_file)
+        except Exception as e:
+            middleware.logger.error('Failed to migrate NVRAM file %r: %s', nvram_file, e)
+
+    middleware.logger.info('Migrated %d NVRAM files to system dataset', migrated_count)

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -774,6 +774,7 @@ class FailoverEventsService(Service):
             self.run_call('kmip.initialize_keys')
             logger.info('Done syncing encryption keys with KMIP server')
 
+        self.start_vms()
         self.start_apps()
         self.start_virt()
 
@@ -843,6 +844,8 @@ class FailoverEventsService(Service):
             name='failover_stop_docker',
         )
         stop_docker_thread.start()
+        stop_vm_thread = threading.Thread(target=self.stop_vms, name='failover_stop_vms')
+        stop_vm_thread.start()
 
         # We will try to give some time to containers to gracefully stop before zpools will be forcefully
         # exported. This is to avoid any potential data corruption.
@@ -1015,6 +1018,17 @@ class FailoverEventsService(Service):
         self.FAILOVER_RESULT = 'SUCCESS'
 
         return self.FAILOVER_RESULT
+
+    def start_vms(self):
+        logger.info('Starting VMs which are set to start on boot')
+        self.middleware.create_task(self.middleware.call('vm.start_on_boot'))
+
+    def stop_vms(self):
+        logger.info('Trying to gracefully stop VMs')
+        try:
+            self.run_call('vm.handle_shutdown')
+        except Exception:
+            logger.error('Failed to gracefully stop VMs', exc_info=True)
 
     def start_apps(self):
         self.start_apps_impl()

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -1,5 +1,7 @@
 import os
 
+from middlewared.plugins.vm.utils import LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID
+
 from .utils import SYSDATASET_PATH
 
 
@@ -137,6 +139,26 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'gid': 0,
                 'mode': 0o755,
             },
+        },
+        {
+            'name': os.path.join(pool_name, '.system/vm'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+            'chown_config': {
+                'uid': LIBVIRT_QEMU_UID,
+                'gid': LIBVIRT_QEMU_GID,
+                'mode': 0o755,
+            },
+            'create_paths': [
+                {
+                    'path': '/var/db/system/vm/nvram',
+                    'uid': LIBVIRT_QEMU_UID,
+                    'gid': LIBVIRT_QEMU_GID
+                },
+            ],
         },
         {
             'name': os.path.join(pool_name, f'.system/configs-{uuid}'),

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -101,6 +101,30 @@ class VMService(Service, VMSupervisorMixin):
     async def terminate_timeout(self):
         return max(map(lambda v: v['shutdown_timeout'], await self.middleware.call('vm.query')), default=10)
 
+    @private
+    async def handle_shutdown(self):
+        async def poweroff_stop_vm(vm):
+            if vm['status']['state'] == 'RUNNING':
+                stop_job = await self.middleware.call('vm.stop', vm['id'], {'force_after_timeout': True})
+                await stop_job.wait()
+                if stop_job.error:
+                    self.middleware.logger.error('Stopping %r VM failed: %r', vm['name'], stop_job.error)
+            else:
+                try:
+                    await self.middleware.call('vm.poweroff', vm['id'])
+                except Exception:
+                    self.middleware.logger.error('Powering off %r VM failed', vm['name'], exc_info=True)
+
+        vms = await self.middleware.call('vm.query', [('status.state', 'in', ACTIVE_STATES)])
+        if vms:
+            async with SHUTDOWN_LOCK:  # FIXME: Why a global lock?? Not needed....
+                await asyncio_map(poweroff_stop_vm, vms, 16)
+                self.middleware.logger.debug('VM(s) stopped successfully')
+                # We do this in vm.terminate as well, reasoning for repeating this here is that we don't want to
+                # stop libvirt on middlewared restarts, we only want that to happen if a shutdown has been initiated
+                # and we have cleanly exited
+                await self.middleware.call('vm.deinitialize_vms', {'reload_ui': False})
+
 
 async def __event_system_ready(middleware, event_type, args):
     """
@@ -119,27 +143,7 @@ async def __event_system_ready(middleware, event_type, args):
 
 
 async def __event_system_shutdown(middleware, event_type, args):
-    async def poweroff_stop_vm(vm):
-        if vm['status']['state'] == 'RUNNING':
-            stop_job = await middleware.call('vm.stop', vm['id'], {'force_after_timeout': True})
-            await stop_job.wait()
-            if stop_job.error:
-                middleware.logger.error('Stopping %r VM failed: %r', vm['name'], stop_job.error)
-        else:
-            try:
-                await middleware.call('vm.poweroff', vm['id'])
-            except Exception:
-                middleware.logger.error('Powering off %r VM failed', vm['name'], exc_info=True)
-
-    vms = await middleware.call('vm.query', [('status.state', 'in', ACTIVE_STATES)])
-    if vms:
-        async with SHUTDOWN_LOCK:  # FIXME: Why a global lock?? Not needed....
-            await asyncio_map(poweroff_stop_vm, vms, 16)
-            middleware.logger.debug('VM(s) stopped successfully')
-            # We do this in vm.terminate as well, reasoning for repeating this here is that we don't want to
-            # stop libvirt on middlewared restarts, we only want that to happen if a shutdown has been initiated
-            # and we have cleanly exited
-            await middleware.call('vm.deinitialize_vms', {'reload_ui': False})
+    await middleware.call('vm.handle_shutdown')
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -2,7 +2,7 @@ from xml.etree import ElementTree as etree
 
 
 ACTIVE_STATES = ['RUNNING', 'SUSPENDED']
-SYSTEM_NVRAM_FOLDER_PATH = '/data/subsystems/vm/nvram'
+SYSTEM_NVRAM_FOLDER_PATH = '/var/db/system/vm/nvram'
 LIBVIRT_QEMU_UID = 986
 LIBVIRT_QEMU_GID = 986
 LIBVIRT_URI = 'qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock'


### PR DESCRIPTION
## Context

VMs make use of NVRAM files which lived in `/data` directory earlier which resulted in VMs not working properly in a HA context. Changes have been made to migrate these files to system dataset and make sure we persist them there and fix some other issues we had with HA.