### PR TITLE
NAS-136229 / 25.10 / Fix cloud backup snapshot pruning when snapshots are used

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -151,7 +151,8 @@ class CloudBackupService(Service):
             restic_config = get_restic_config(cloud_backup)
             await run_restic(
                 job,
-                restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--prune"],
+                restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--group-by", "",
+                                     "--prune"],
                 restic_config.env,
             )
 


### PR DESCRIPTION
`--group-by` must be used, because otherwise snapshots are grouped by source dif, which is different every time