### PR TITLE
NAS-136576 / 25.04.3 / Add missing assert_validation_errors

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -128,6 +128,14 @@ def get_ip_addr(ip):
 
 
 @contextlib.contextmanager
+def assert_validation_errors(attribute: str, errmsg: str):
+    with pytest.raises(ValidationErrors) as ve:
+        yield
+    assert ve.value.errors[0].attribute == attribute
+    assert ve.value.errors[0].errmsg.startswith(errmsg)
+
+
+@contextlib.contextmanager
 def iscsi_auth(tag, user, secret, peeruser=None, peersecret=None, discovery_auth=None):
     payload = {
         'tag': tag,


### PR DESCRIPTION
The test function `assert_validation_errors` was added to master in PR #16347, which was **not** backported to FT.

However, that function was then used in the tests for PR #16585 which **was** backported to FT.

Simplest & least intrusive fix is to just backport the test function, which is what this PR does.
