### PR TITLE
NAS-136583

### DIFF
--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -63,6 +63,9 @@ class AdminSessionAlertSource(AlertSource):
                     'username',
                     'address',
                     'success'
+                ],
+                'order_by': [
+                    'message_timestamp'
                 ]
             }
         })

--- a/tests/api2/test_root_session_alert.py
+++ b/tests/api2/test_root_session_alert.py
@@ -29,9 +29,14 @@ def check_session_alert(call_fn):
 
 
 def test_root_session(set_product_type):
-    # first check with our regular persistent session
-    check_session_alert(call)
+    # In full CI runs cannot first check with our regular
+    # persistent session, as it may be more than 100 sessions
+    # ago.  However, we can check that the alert has already
+    # been raised.
+    alert = call('alert.run_source', 'AdminSession')
+    assert alert
 
+    # However, *can* ensure that a new session gets recorded
+    # as part of the Alert
     with client(host_ip=truenas_server.ip) as c:
-        # check that we also pick up second alert
         check_session_alert(c.call)

--- a/tests/api2/test_root_session_alert.py
+++ b/tests/api2/test_root_session_alert.py
@@ -15,7 +15,7 @@ def set_product_type(request):
 
 def get_session_alert(call_fn, session_id):
     # sleep a little while to let auth event get logged
-    sleep(5)
+    sleep(10)
 
     alert = call_fn('alert.run_source', 'AdminSession')
     assert alert


### PR DESCRIPTION
Eliminate some test fragility now that we no longer record **every** session in the alert (just the most recent 100).

See CI test run [5088](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5088/).