### PR TITLE
NAS-136596 / 25.10 / Add automatic interface discovery for TrueNAS Connect

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-07-08_23-27_tnc_use_all_interfaces.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-07-08_23-27_tnc_use_all_interfaces.py
@@ -1,0 +1,26 @@
+""" Add use_all_interfaces to truenas_connect
+
+Revision ID: 4f3a2b5c6d7e
+Revises: 3693df62fd6f
+Create Date: 2025-07-08 23:27:00.000000+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4f3a2b5c6d7e'
+down_revision = '3693df62fd6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('truenas_connect', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('use_all_interfaces', sa.Boolean(), nullable=False, server_default='1'))
+
+
+def downgrade():
+    with op.batch_alter_table('truenas_connect', schema=None) as batch_op:
+        batch_op.drop_column('use_all_interfaces')

--- a/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
@@ -21,6 +21,7 @@ class TNCEntry(BaseModel):
     ips: list[NonEmptyString]
     interfaces: list[str]
     interfaces_ips: list[str]
+    use_all_interfaces: bool
     status: NonEmptyString
     status_reason: NonEmptyString
     certificate: int | None
@@ -35,6 +36,7 @@ class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
     ips: list[IPvAnyAddress]
     interfaces: list[str]
+    use_all_interfaces: bool
     account_service_base_url: HttpsOnlyURL
     leca_service_base_url: HttpsOnlyURL
     tnc_base_url: HttpsOnlyURL

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -100,13 +100,14 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
 
         ips_changed = set(old_config['ips']) != set(data['ips'])
         interfaces_changed = set(old_config.get('interfaces', [])) != set(data.get('interfaces', []))
+        interfaces_changed |= old_config['use_all_interfaces'] != data['use_all_interfaces']
 
         if (ips_changed or interfaces_changed) and (
             data['enabled'] is True and old_config['status'] not in (Status.DISABLED.name, Status.CONFIGURED.name)
         ):
             verrors.add(
                 'tn_connect_update',
-                'IPs and interfaces cannot be changed when TrueNAS Connect is in a state '
+                'IPs and interfaces settings cannot be changed when TrueNAS Connect is in a state '
                 'other than disabled or completely configured'
             )
 

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -134,7 +134,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             'enabled': data['enabled'],
             'ips': data['ips'],
             'interfaces': data.get('interfaces', []),
-            'use_all_interfaces': data.get('use_all_interfaces', True),
+            'use_all_interfaces': data['use_all_interfaces'],
         } | {k: data[k] for k in ('account_service_base_url', 'leca_service_base_url', 'tnc_base_url', 'heartbeat_url')}
 
         # Extract IPs from interfaces using ip_in_use method

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -30,6 +30,7 @@ class TrueNASConnectModel(sa.Model):
     ips = sa.Column(sa.JSON(list), nullable=False)
     interfaces = sa.Column(sa.JSON(list), nullable=False, default=list)
     interfaces_ips = sa.Column(sa.JSON(list), nullable=False, default=list)
+    use_all_interfaces = sa.Column(sa.Boolean(), default=True, nullable=False)
     status = sa.Column(sa.String(255), default=Status.DISABLED.name, nullable=False)
     certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
     account_service_base_url = sa.Column(
@@ -70,16 +71,16 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
     async def validate_data(self, old_config, data):
         verrors = ValidationErrors()
 
-        # Ensure at least one interface or at least one IP is provided
-        if data['enabled'] and not data['ips'] and not data['interfaces']:
+        # Ensure at least one interface or at least one IP is provided (unless use_all_interfaces is True)
+        if data['enabled'] and not data['ips'] and not data['interfaces'] and not data['use_all_interfaces']:
             verrors.add(
                 'tn_connect_update',
-                'At least one IP or interface must be provided when TrueNAS Connect is enabled'
+                'At least one IP or interface must be provided when TrueNAS Connect is enabled '
+                '(or use_all_interfaces must be set to true)'
             )
 
         data['ips'] = [str(ip) for ip in data['ips']]
 
-        # Validate interfaces exist
         if data['interfaces']:
             all_interfaces = await self.middleware.call('interface.query', [], {'extra': {'retrieve_names_only': True}})
             interface_names = {iface['name'] for iface in all_interfaces}
@@ -89,7 +90,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
                     verrors.add('tn_connect_update.interfaces', f'Interface "{interface}" does not exist')
 
             # If no direct IPs are provided, ensure selected interfaces have at least one IP
-            if data['enabled'] and not data['ips']:
+            if data['enabled'] and not data['ips'] and data['use_all_interfaces'] is False:
                 interface_ips = await self.get_interface_ips(data['interfaces'])
                 if not interface_ips:
                     verrors.add(
@@ -132,10 +133,15 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             'enabled': data['enabled'],
             'ips': data['ips'],
             'interfaces': data.get('interfaces', []),
+            'use_all_interfaces': data.get('use_all_interfaces', True),
         } | {k: data[k] for k in ('account_service_base_url', 'leca_service_base_url', 'tnc_base_url', 'heartbeat_url')}
 
-        # Extract IPs from selected interfaces using ip_in_use method
-        db_payload['interfaces_ips'] = await self.get_interface_ips(db_payload['interfaces'])
+        # Extract IPs from interfaces using ip_in_use method
+        # If use_all_interfaces is True, get IPs from all interfaces
+        if db_payload['use_all_interfaces']:
+            db_payload['interfaces_ips'] = await self.get_all_interface_ips()
+        else:
+            db_payload['interfaces_ips'] = await self.get_interface_ips(db_payload['interfaces'])
         if config['enabled'] is False and data['enabled'] is True:
             # Finalization registration is triggered when claim token is generated
             # We make sure there is no pending claim token
@@ -188,6 +194,18 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             'any': False,
         })
         return [ip['address'] for ip in ip_data]
+
+    @private
+    async def get_all_interface_ips(self):
+        """
+        Returns a list of IPs from all interfaces.
+        """
+        # Get all interface names
+        all_interfaces = await self.middleware.call('interface.query', [], {'extra': {'retrieve_names_only': True}})
+        interface_names = [iface['name'] for iface in all_interfaces]
+
+        # Get IPs from all interfaces
+        return await self.get_interface_ips(interface_names)
 
     @private
     async def unset_registration_details(self):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -52,8 +52,11 @@ class TestTNCInterfacesValidation:
     @pytest.mark.asyncio
     async def test_validate_data_requires_ip_or_interface(self, tnc_service):
         """Test that at least one IP or interface is required when enabled."""
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
-        data = {'enabled': True, 'ips': [], 'interfaces': []}
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
+        data = {'enabled': True, 'ips': [], 'interfaces': [], 'use_all_interfaces': False}
 
         with pytest.raises(ValidationErrors) as exc_info:
             await tnc_service.validate_data(old_config, data)
@@ -78,8 +81,11 @@ class TestTNCInterfacesValidation:
 
         tnc_service.middleware.call = AsyncMock(side_effect=mock_middleware_call)
 
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
-        data = {'enabled': True, 'ips': [], 'interfaces': ['ens3', 'invalid_interface']}
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
+        data = {'enabled': True, 'ips': [], 'interfaces': ['ens3', 'invalid_interface'], 'use_all_interfaces': False}
 
         with pytest.raises(ValidationErrors) as exc_info:
             await tnc_service.validate_data(old_config, data)
@@ -99,8 +105,11 @@ class TestTNCInterfacesValidation:
             [],
         ]
 
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
-        data = {'enabled': True, 'ips': [], 'interfaces': ['ens5']}  # ens5 has no IPs
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
+        data = {'enabled': True, 'ips': [], 'interfaces': ['ens5'], 'use_all_interfaces': False}  # ens5 has no IPs
 
         with pytest.raises(ValidationErrors) as exc_info:
             await tnc_service.validate_data(old_config, data)
@@ -114,8 +123,14 @@ class TestTNCInterfacesValidation:
         mock_interface_names = [{'name': 'ens3'}, {'name': 'ens4'}, {'name': 'ens5'}]
         tnc_service.middleware.call = AsyncMock(return_value=mock_interface_names)
 
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
-        data = {'enabled': True, 'ips': ['192.168.1.100'], 'interfaces': ['ens5']}  # ens5 has no IPs
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
+        data = {
+            'enabled': True, 'ips': ['192.168.1.100'], 'interfaces': ['ens5'],
+            'use_all_interfaces': False
+        }  # ens5 has no IPs
 
         # Should not raise any errors
         await tnc_service.validate_data(old_config, data)
@@ -132,6 +147,7 @@ class TestTNCInterfacesValidation:
             'ips': ['192.168.1.10'],
             'interfaces': [],
             'status': Status.CERT_GENERATION_IN_PROGRESS.name,
+            'use_all_interfaces': True,
             'account_service_base_url': 'https://example.com/',
             'leca_service_base_url': 'https://example.com/',
             'tnc_base_url': 'https://example.com/',
@@ -141,6 +157,7 @@ class TestTNCInterfacesValidation:
             'enabled': True,
             'ips': ['192.168.1.10'],
             'interfaces': ['ens3'],
+            'use_all_interfaces': True,
             'account_service_base_url': 'https://example.com/',
             'leca_service_base_url': 'https://example.com/',
             'tnc_base_url': 'https://example.com/',
@@ -161,7 +178,10 @@ class TestTNCUseAllInterfaces:
         """Test that use_all_interfaces=True allows enabling without specific IPs or interfaces."""
         tnc_service.middleware.call = AsyncMock()
 
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
         data = {'enabled': True, 'ips': [], 'interfaces': [], 'use_all_interfaces': True}
 
         # Should not raise any errors
@@ -172,7 +192,10 @@ class TestTNCUseAllInterfaces:
         """Test that use_all_interfaces=False requires at least one IP or interface."""
         tnc_service.middleware.call = AsyncMock()
 
-        old_config = {'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name}
+        old_config = {
+            'enabled': False, 'ips': [], 'interfaces': [], 'status': Status.DISABLED.name,
+            'use_all_interfaces': True
+        }
         data = {'enabled': True, 'ips': [], 'interfaces': [], 'use_all_interfaces': False}
 
         with pytest.raises(ValidationErrors) as exc_info:
@@ -297,6 +320,7 @@ class TestTNCInterfacesUpdate:
             'interfaces': [],
             'status': Status.DISABLED.name,
             'interfaces_ips': [],
+            'use_all_interfaces': True,
             'account_service_base_url': 'https://example.com/',
             'leca_service_base_url': 'https://example.com/',
             'tnc_base_url': 'https://example.com/',
@@ -339,6 +363,7 @@ class TestTNCInterfacesUpdate:
                 'interfaces': [],
                 'status': Status.DISABLED.name,
                 'interfaces_ips': [],
+                'use_all_interfaces': True,
                 'account_service_base_url': 'https://example.com/',
                 'leca_service_base_url': 'https://example.com/',
                 'tnc_base_url': 'https://example.com/',
@@ -354,6 +379,7 @@ class TestTNCInterfacesUpdate:
                 'status': 'CLAIM_TOKEN_MISSING',
                 'status_reason': 'Claim token is missing',
                 'certificate': None,
+                'use_all_interfaces': False,
                 'account_service_base_url': 'https://example.com/',
                 'leca_service_base_url': 'https://example.com/',
                 'tnc_base_url': 'https://example.com/',
@@ -366,7 +392,8 @@ class TestTNCInterfacesUpdate:
         data = {
             'enabled': True,
             'ips': [],
-            'interfaces': ['ens3', 'ens4']
+            'interfaces': ['ens3', 'ens4'],
+            'use_all_interfaces': False
         }
 
         # Track the datastore.update call
@@ -402,6 +429,7 @@ class TestTNCInterfacesUpdate:
             'interfaces': [],
             'status': Status.DISABLED.name,
             'interfaces_ips': [],
+            'use_all_interfaces': True,
             'account_service_base_url': 'https://example.com/',
             'leca_service_base_url': 'https://example.com/',
             'tnc_base_url': 'https://example.com/',
@@ -443,6 +471,7 @@ class TestTNCInterfacesUpdate:
                 'interfaces': [],
                 'status': Status.DISABLED.name,
                 'interfaces_ips': [],
+                'use_all_interfaces': True,
                 'account_service_base_url': 'https://example.com/',
                 'leca_service_base_url': 'https://example.com/',
                 'tnc_base_url': 'https://example.com/',
@@ -458,6 +487,7 @@ class TestTNCInterfacesUpdate:
                 'status': 'CLAIM_TOKEN_MISSING',
                 'status_reason': 'Claim token is missing',
                 'certificate': None,
+                'use_all_interfaces': False,
                 'account_service_base_url': 'https://example.com/',
                 'leca_service_base_url': 'https://example.com/',
                 'tnc_base_url': 'https://example.com/',
@@ -470,7 +500,8 @@ class TestTNCInterfacesUpdate:
         data = {
             'enabled': True,
             'ips': [],
-            'interfaces': ['ens6']
+            'interfaces': ['ens6'],
+            'use_all_interfaces': False
         }
 
         # Track the datastore.update call


### PR DESCRIPTION
This PR adds changes so by default TNC is configured with all the available interfaces on the system. What this means in practice is that whatever IPs we have configured on any interface, we will send them to TNC so their A records can be created appropriately unless user explicitly disables this with his/her own personal preference. 