### PR TITLE
NAS-136630 / 25.10 / Remove idmap_autorid as a choice for idmap backends

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-07-14_12-22_autorid-migration.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-07-14_12-22_autorid-migration.py
@@ -20,7 +20,7 @@ depends_on = None
 
 def migrate_autorid_to_rid(conn, config: dict) -> None:
     """ This function converts an idmap_autorid configuration into a roughly equivalent idmap_rid configuration.
-    Trusted domains are also disabled (if enabled) to allow admin to make set up any relevant configuration before
+    Trusted domains are also disabled (if enabled) to allow admin to set up any relevant configuration before
     re-enabling. """
     idmap = loads(decrypt(config['ad_idmap']))
     if idmap['idmap_domain']['idmap_backend'] != 'AUTORID':

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-07-14_12-22_autorid-migration.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-07-14_12-22_autorid-migration.py
@@ -1,0 +1,64 @@
+"""Get rid of autorid
+
+Revision ID: 3d738dbd75ef
+Revises: 4465da1dbb37
+Create Date: 2025-07-14 12:22:17.431832+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from json import loads, dumps
+from middlewared.plugins.pwenc import encrypt, decrypt
+
+
+# revision identifiers, used by Alembic.
+revision = '3d738dbd75ef'
+down_revision = '4465da1dbb37'
+branch_labels = None
+depends_on = None
+
+
+def migrate_autorid_to_rid(conn, config: dict) -> None:
+    """ This function converts an idmap_autorid configuration into a roughly equivalent idmap_rid configuration.
+    Trusted domains are also disabled (if enabled) to allow admin to make set up any relevant configuration before
+    re-enabling. """
+    idmap = loads(decrypt(config['ad_idmap']))
+    if idmap['idmap_domain']['idmap_backend'] != 'AUTORID':
+        return
+
+    rangesize = idmap['idmap_domain']['rangesize']
+    # Autorid sets offset for currently-joined domain at second rangesize increment
+    range_low = idmap['idmap_domain']['range_low'] + rangesize
+    range_high = idmap['idmap_domain']['range_high']
+
+    new_domain = {
+        'idmap_backend': 'RID',
+        'sssd_compat': False,
+        'range_low': range_low,
+        'range_high': range_high
+    }
+
+    builtin = {
+        'name': None,
+        'range_low': idmap['idmap_domain']['range_low'],
+        'range_high': idmap['idmap_domain']['range_low'] + 10000
+    }
+
+    new_idmap = encrypt(dumps({'builtin': builtin, 'idmap_domain': new_domain}))
+
+    stmt = (
+        'UPDATE directoryservices SET '
+        'ad_idmap = :idmap, '
+        'ad_enable_trusted_domains = 0'
+    )
+    conn.execute(stmt, idmap=new_idmap)
+
+
+def upgrade():
+    conn = op.get_bind()
+    ds = dict(conn.execute('SELECT * FROM directoryservices').fetchone())
+
+    if ds['service_type'] != 'ACTIVEDIRECTORY':
+        return
+
+    migrate_autorid_to_rid(conn, ds)

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -102,25 +102,12 @@ class AD_Idmap(IdmapDomainBase):
     Windows Server 2003 R2. """
     unix_primary_group: bool = False
     """ Defines if the user's primary group is fetched from SFU attributes or the Active Directory primary group. \
-    If True, the TrueNAS server uses the gidNumber LDAP attribute. If False, it uses the primaryGroupID LDAP attribute.
+    If True, the TrueNAS server uses the `gidNumber` LDAP attribute. If False, it uses the `primaryGroupID` LDAP \
+    attribute.
     """
     unix_nss_info: bool = False
     """ If True, the login shell and home directory are retrieved from LDAP attributes. If False, or if the Active \
     Directory LDAP entry lacks SFU attributes, the home directory defaults to `/var/empty`. """
-
-
-class Autorid_Idmap(IdmapDomainBase):
-    """ The AUTORID backend uses an algorithmic mapping scheme to map UIDs and GIDs to SIDs. It works like the RID \
-    backend, but automatically configures the range for each domain in the forest. """
-    idmap_backend: Literal['AUTORID']
-    rangesize: int = Field(default=100000, ge=10000, le=1000000000)
-    """ Defines the number of uids / gids available per domain range. SIDs with RIDs larger than this value will be \
-    mapped into extension ranges depending on the number of available ranges."""
-    readonly: bool = False
-    """ Sets the module to read-only mode. The TrueNAS server will not create new ranges or mappings in the idmap \
-    pool. """
-    ignore_builtin: bool = False
-    """ Do not process mapping requests for the BUILTIN domain. """
 
 
 class LDAP_Idmap(IdmapDomainBase):
@@ -203,10 +190,6 @@ class PrimaryDomainIdmap(BaseModel):
     LDAP schema attributes that assign explicit UID and GID numbers to accounts. """
 
 
-class PrimaryDomainIdmapAutoRid(BaseModel):
-    idmap_domain: Autorid_Idmap
-
-
 class CredKRBPrincipal(BaseModel):
     credential_type: Literal[DSCredType.KERBEROS_PRINCIPAL]
     principal: NonEmptyString
@@ -251,7 +234,7 @@ class ActiveDirectoryConfig(BaseModel):
     domain: NonEmptyString
     """ The full DNS domain name of the Active Directory domain. This must not be a domain controller. \
     Example: "mydomain.internal".  """
-    idmap: PrimaryDomainIdmap | PrimaryDomainIdmapAutoRid = Field(default=PrimaryDomainIdmap(), examples=[
+    idmap: PrimaryDomainIdmap = Field(default=PrimaryDomainIdmap(), examples=[
         {
             'builtin': {'range_low': 90000001, 'range_high': 100000000},
             'idmap_domain': {
@@ -261,14 +244,6 @@ class ActiveDirectoryConfig(BaseModel):
                 'range_high': 200000000,
             },
         },
-        {
-            'idmap_domain': {
-                'name': 'MYDOMAIN',
-                'idmap_backend': 'AUTORID',
-                'range_low': 90000001,
-                'range_high': 2000000000
-            }
-        }
     ])
     """ Configuration for mapping Active Directory accounts to accounts on the TrueNAS server. The exact settings may \
     vary based on other servers and Linux clients in the domain. Defaults are suitable for new deployments without \

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -514,6 +514,11 @@ class DirectoryServices(ConfigService):
 
             return self.middleware.call_sync('directoryservices.config')
 
+        if not old['enable'] and new['service_type'] == DSType.AD.value:
+            # There may be a stale server affinity in the samba gencache and stale idmappings
+            # We should clear these before trying to enable AD
+            self.middleware.call_sync('idmap.clear_idmap_cache').wait_sync()
+
         # First check that our credential is functional. If the credential type is
         # KERBEROS_USER or KERBEROS_PRINCIPAL then this will also perform a kinit and
         # ensure we have a basic kerberos configuration for a potential domain join

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -193,7 +193,7 @@ class IdmapDomainService(Service):
     @private
     async def backend_options(self):
         """ legacy wrapper currently maintained to avoid breaking the UI """
-        return {'AD': 'AD', 'AUTORID': 'AUTORID', 'RID': 'RID', 'LDAP': 'LDAP', 'RFC2307': 'RFC2307'}
+        return {'AD': 'AD', 'RID': 'RID', 'LDAP': 'LDAP', 'RFC2307': 'RFC2307'}
 
     @private
     def convert_sids(self, sidlist):

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -395,15 +395,7 @@ class SMBService(Service):
 
         # Because the beginning range is determined by the range of IDs allocated for BUILTIN
         # users we have to request from the samba running configuration
-        idmap_backend = self.middleware.call_sync("smb.getparm", "idmap config * : backend", "GLOBAL")
         idmap_range = self.middleware.call_sync("smb.getparm", "idmap config * : range", "GLOBAL")
-
-        if idmap_backend != "tdb":
-            """
-            idmap_autorid and potentially other allocating idmap backends may be used for
-            the default domain. We do not want to touch how these are allocated.
-            """
-            return False
 
         low_range = int(idmap_range.split("-")[0].strip())
         for b in (SMBBuiltin.ADMINISTRATORS, SMBBuiltin.USERS, SMBBuiltin.GUESTS):

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -457,6 +457,9 @@ def generate_smb_conf_dict(
         # AD configuration can override this
         'idmap config * : backend': 'tdb',
         'idmap config * : range': '90000001 - 90010001',
+        # We are setting this to read-only to prevent misconfiguration of trusted
+        # domains from accidentally setting mappings in the tdb file.
+        'idmap config * : read only': True,
     }
 
     """
@@ -559,18 +562,12 @@ def generate_smb_conf_dict(
         })
 
         idmap = ds_config['configuration']['idmap']['idmap_domain']
-        if ds_config['configuration']['idmap']['idmap_domain']['idmap_backend'] == 'AUTORID':
-            idmap_prefix = 'idmap config * :'
-        else:
-            builtin = ds_config['configuration']['idmap']['builtin']
-            idmap_prefix = f'idmap config {idmap["name"]}'
-
-            smbconf.update({
-                'idmap config * : backend': 'tdb',
-                'idmap config * : range': f'{builtin["range_low"]} - {builtin["range_high"]}'
-            })
+        builtin = ds_config['configuration']['idmap']['builtin']
+        idmap_prefix = f'idmap config {idmap["name"]}'
 
         smbconf.update({
+            'idmap config * : backend': 'tdb',
+            'idmap config * : range': f'{builtin["range_low"]} - {builtin["range_high"]}',
             f'{idmap_prefix} : backend': idmap['idmap_backend'].lower(),
             f'{idmap_prefix} : range': f'{idmap["range_low"]} - {idmap["range_high"]}',
         })


### PR DESCRIPTION
Historically our support team has pushed users to either use idmap_rid or idmap_ad (depending on domain configuration) in case with trusted domains we encourage users to separately configure idmap_rid or idmap_ad for each trusted domain. idmap_autorid is problematic when there are multiple truenas servers and multiple trusted domains because there is no guarantee that any particular server has the same idmap ranges configured as a different server.

Since we've been actively discouraging its use for many years now, it's probably better with other directory services redesign efforts in 25.10 to simply remove it as a choice.