### PR TITLE
NAS-136593 / 25.10 / Adjust job progress when applying update file

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class UpdateService(Service):
     @private
-    def install(self, job, path, options):
+    def install(self, job, path, options, max_progress=100):
         if os.path.exists(UPLOADED_DB_PATH):
             raise CallError(
                 "An unapplied uploaded configuration exists. Please, reboot the system to apply this configuration "
@@ -33,7 +33,7 @@ class UpdateService(Service):
             )
 
         def progress_callback(progress, description):
-            job.set_progress((0.5 + 0.5 * progress) * 100, description)
+            job.set_progress((0.5 + 0.5 * progress) * max_progress, description)
 
         progress_callback(0, "Reading update file")
         with mount_update(path) as mounted:


### PR DESCRIPTION
This commit fixes an issue where if scale build gives 100 or 96 percentage, we walk back from that figure when in middleware we send a subsequent event with 95 percentage. So in such cases, we max out the progress reported by scale build to 90 and then take it to completion in middleware.

Related to https://github.com/truenas/scale-build/pull/886