### PR TITLE
NAS-136660 / 25.04.2 / Properly validate ports in virt plugin (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -106,7 +106,7 @@ class VirtGlobalService(ConfigService):
         if new['pool'] and (mapping := (await self.middleware.call('port.ports_mapping')).get(53)):
             port_usages = set()
             for usages in map(lambda i: mapping.get(i, {}).get('port_details', []), ('0.0.0.0', '::')):
-                for u in usages:
+                for u in filter(lambda j: 53 in [i[1] for i in j['ports']], usages):
                     port_usages.add(u['description'])
 
             if port_usages:


### PR DESCRIPTION
## Problem
The `port_details` field in `port.ports_mapping` includes descriptions for all ports used by a service. Currently, the code retrieves and displays the descriptions of all ports without filtering for the specific port being used by the application.

## Solution

Update the logic to filter and include only the description relevant to the specific port used by the application.

Original PR: https://github.com/truenas/middleware/pull/16721
