### PR TITLE
NAS-136680 / 25.10 / Force AD machine account name to upper-case

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -542,7 +542,7 @@ class KerberosKeytabService(CRUDService):
                 {'prefix': self._config.datastore_prefix}
             )
 
-        netbiosname = self.middleware.call_sync('smb.config')['netbiosname']
+        netbiosname = self.middleware.call_sync('smb.config')['netbiosname'].upper()
         machine_acct = f'{netbiosname}$@{ds_config["configuration"]["domain"]}'
 
         ds_cred = ds_config['credential']


### PR DESCRIPTION
This commit fixes the case of the kerberos principal name that gets inserted when we update the active directory machine account password.