### PR TITLE
NAS-136684 / 25.10 / Add directory services cert choices endpoint

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -24,6 +24,7 @@ __all__ = [
     'DirectoryServicesStatusArgs', 'DirectoryServicesStatusResult',
     'DirectoryServicesEntry', 'DirectoryServicesUpdateArgs', 'DirectoryServicesUpdateResult',
     'DirectoryServicesLeaveArgs', 'DirectoryServicesLeaveResult',
+    'DirectoryServicesCertificateChoicesArgs', 'DirectoryServicesCertificateChoicesResult',
 ]
 
 IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
@@ -627,3 +628,12 @@ class DirectoryServicesLeaveArgs(BaseModel):
 
 class DirectoryServicesLeaveResult(BaseModel):
     result: None
+
+
+class DirectoryServicesCertificateChoicesArgs(BaseModel):
+    pass
+
+
+class DirectoryServicesCertificateChoicesResult(BaseModel):
+    result: dict[int, NonEmptyString]
+    """IDs of certificates mapped to their names."""


### PR DESCRIPTION
This commit adds an endpoint to allow API consumers to see the available certificate choices for LDAP_MTLS authentication.