### PR TITLE
NAS-136683 / 25.10 / Make sure we don't present a CA cert as a valid option for different services

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/certificate.py
+++ b/src/middlewared/middlewared/api/v25_10_0/certificate.py
@@ -56,6 +56,7 @@ class CertificateEntry(BaseModel):
     cert_type: NonEmptyString
     cert_type_existing: bool
     cert_type_CSR: bool
+    cert_type_CA: bool
     chain_list: list[LongString]
     key_length: int | None
     key_type: NonEmptyString | None

--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -51,7 +51,7 @@ class AppService(Service):
         Returns certificates which can be used by applications.
         """
         return await self.middleware.call(
-            'certificate.query', [['cert_type_CSR', '=', False], ['parsed', '=', True]],
+            'certificate.query', [['cert_type_CSR', '=', False], ['cert_type_CA', '=', False], ['parsed', '=', True]],
             {'select': ['name', 'id']}
         )
 

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -68,7 +68,7 @@ class CertificateService(CRUDService):
         verrors = ValidationErrors()
         if cert:
             cert = cert[0]
-            if cert['cert_type'] != 'CERTIFICATE' or cert['cert_type_CSR']:
+            if cert['cert_type'] != 'CERTIFICATE' or cert['cert_type_CSR'] or cert['cert_type_CA']:
                 verrors.add(
                     schema_name,
                     'Selected certificate id is not a valid certificate'

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -71,7 +71,7 @@ class CertificateService(CRUDService):
             if cert['cert_type'] != 'CERTIFICATE' or cert['cert_type_CSR'] or cert['cert_type_CA']:
                 verrors.add(
                     schema_name,
-                    'Selected certificate id is not a valid certificate'
+                    'Selected certificate must be a valid certificate and not a CSR or CA'
                 )
             else:
                 await self.cert_checks(cert, verrors, schema_name)

--- a/src/middlewared/middlewared/plugins/crypto_/query_utils.py
+++ b/src/middlewared/middlewared/plugins/crypto_/query_utils.py
@@ -29,6 +29,7 @@ def normalize_cert_attrs(cert: dict) -> None:
         'cert_type': 'CERTIFICATE',
         'cert_type_existing': bool(cert['type'] & CERT_TYPE_EXISTING),
         'cert_type_CSR': bool(cert['type'] & CERT_TYPE_CSR),
+        'cert_type_CA': False,
         'chain_list': [],
         'key_length': None,
         'key_type': None,
@@ -60,6 +61,11 @@ def normalize_cert_attrs(cert: dict) -> None:
         if not cert_data:
             failed_parsing = True
             cert_extend_report_error('certificate', cert)
+        else:
+            # Check if this is a CA certificate by examining BasicConstraints
+            basic_constraints = cert.get('extensions', {}).get('BasicConstraints')
+            if basic_constraints and 'CA:TRUE' in basic_constraints:
+                cert['cert_type_CA'] = True
 
     if cert['privatekey']:
         key_obj = load_private_key(cert['privatekey'])

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -786,6 +786,10 @@ class DirectoryServices(ConfigService):
         return {
             i['id']: i['name']
             for i in await self.middleware.call(
-                'certificate.query', [['cert_type', '=', 'CERTIFICATE'], ['cert_type_CSR', '=', False]]
+                'certificate.query', [
+                    ['cert_type', '=', 'CERTIFICATE'],
+                    ['cert_type_CSR', '=', False],
+                    ['cert_type_CA', '=', False]
+                ]
             )
         }

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -24,7 +24,11 @@ class SystemAdvancedService(Service):
         return {
             i['id']: i['name']
             for i in await self.middleware.call(
-                'certificate.query', [['revoked', '=', False], ['cert_type_CSR', '=', False]]
+                'certificate.query', [
+                    ['revoked', '=', False],
+                    ['cert_type_CSR', '=', False],
+                    ['cert_type_CA', '=', False]
+                ]
             )
         }
 

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -25,7 +25,6 @@ class SystemAdvancedService(Service):
             i['id']: i['name']
             for i in await self.middleware.call(
                 'certificate.query', [
-                    ['revoked', '=', False],
                     ['cert_type_CSR', '=', False],
                     ['cert_type_CA', '=', False]
                 ]

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -81,7 +81,7 @@ class SystemGeneralService(Service):
         return {
             i["id"]: i["name"]
             for i in await self.middleware.call(
-                "certificate.query", [("cert_type_CSR", "=", False)]
+                "certificate.query", [("cert_type_CSR", "=", False), ("cert_type_CA", "=", False)]
             )
         }
 


### PR DESCRIPTION
This PR adds changes to make sure that we flag certs which are CAs and secondly make sure that when we present choices for different services we have, we don't show CA certs as valid in them. Lastly when we validate certs to be used with a service, we are also making sure that the cert in question is not a CA