### PR TITLE
NAS-136696 / 25.10 / Ensure ix-apps is mounted at it's proper place

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -2,7 +2,7 @@ import errno
 
 from middlewared.service import CallError, Service
 
-from .state_utils import IX_APPS_MOUNT_PATH, Status
+from .state_utils import docker_dataset_custom_props, IX_APPS_MOUNT_PATH, Status
 
 
 class DockerFilesystemManageService(Service):
@@ -15,6 +15,8 @@ class DockerFilesystemManageService(Service):
         if docker_ds := (await self.middleware.call('docker.config'))['dataset']:
             try:
                 if mount:
+                    # Check if ix-apps dataset mount point needs updating
+                    await self.ensure_ix_apps_mount_point(docker_ds)
                     await self.middleware.call('zfs.dataset.mount', docker_ds, {'recursive': True, 'force_mount': True})
                 else:
                     await self.middleware.call('zfs.dataset.umount', docker_ds, {'force': True})
@@ -31,6 +33,40 @@ class DockerFilesystemManageService(Service):
 
     async def umount(self):
         return await self.common_func(False)
+
+    async def ensure_ix_apps_mount_point(self, docker_ds):
+        """
+        Ensure ix-apps dataset is mounted at /mnt/.ix-apps and update it accordingly.
+
+        This is helpful in the event when user rolled back to a previous version of TN
+        where docker apps were not supported, what happens here is that the mountpoint of
+        ix-apps dataset is reset and it gets mounted under root dataset. Now when he comes back
+        to newer TN version, we need to update the mount point of ix-apps dataset so it gets reflected
+        properly.
+        """
+        dataset_info = await self.middleware.call(
+            'zfs.dataset.query',
+            [['name', '=', docker_ds]], {
+                'extra': {'properties': ['mountpoint'], 'retrieve_children': False}
+            }
+        )
+        if not dataset_info:
+            return
+
+        current_mount = dataset_info[0]['properties'].get('mountpoint', {}).get('value')
+        # If the mount point is not at the expected location, fix it
+        if current_mount != IX_APPS_MOUNT_PATH:
+            # Update the main ix-apps dataset mount point
+            await self.middleware.call(
+                'zfs.dataset.update',
+                docker_ds, {
+                    'properties': {
+                        'mountpoint': {
+                            'value': docker_dataset_custom_props(docker_ds.split('/')[-1])['mountpoint']
+                        },
+                    },
+                }
+            )
 
     async def ix_apps_is_mounted(self, dataset_to_check=None):
         """


### PR DESCRIPTION
This commit fixes a bug where if a user rollsback to a TN version which does not has docker apps, ix-apps dataset mountpoint would be reset and it would get mounted under it's root dataset. In this case we would like to make sure that the mountpoint correctly reflects where we want ix-apps to be mounted.