### PR TITLE
NAS-136698 / 25.10 / Generate a new claim token automatically for TNC

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -36,10 +36,9 @@ class TrueNASConnectService(Service):
         if config['enabled'] is False:
             raise CallError('TrueNAS Connect is not enabled')
 
-        if config['status'] != Status.CLAIM_TOKEN_MISSING.name:
+        if config['status'] not in (Status.CLAIM_TOKEN_MISSING.name, Status.REGISTRATION_FINALIZATION_TIMEOUT.name):
             raise CallError(
-                'Claim token has already been generated, either finalize registration '
-                'or re-enable TNC to reset claim token'
+                'Claim token has already been generated, please finalize registration before generating a new one',
             )
 
         claim_token = str(uuid.uuid4())


### PR DESCRIPTION
This commit adds changes to generate a new claim token automatically for TNC if old one expired due to registration not being finalized.