### PR TITLE
NAS-136703 / 25.10 / Fix error code if claim token already exists for TNC

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import logging
 import uuid
 from urllib.parse import urlencode
@@ -39,6 +40,7 @@ class TrueNASConnectService(Service):
         if config['status'] not in (Status.CLAIM_TOKEN_MISSING.name, Status.REGISTRATION_FINALIZATION_TIMEOUT.name):
             raise CallError(
                 'Claim token has already been generated, please finalize registration before generating a new one',
+                errno=errno.EEXIST,
             )
 
         claim_token = str(uuid.uuid4())


### PR DESCRIPTION
This commit fixes error code to raise EEXIST if claim token already exists and consumer tries to generate a new claim token.