### PR TITLE
NAS-136706 / 25.10 / fix API test failure

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
@@ -40,6 +40,13 @@ class IscsiExtentEntry(BaseModel):
     enabled: bool = True
     vendor: str
     locked: bool | None
+    """ Read-only value indicating whether the iscsi extent is located on a locked dataset.
+
+    Returns:
+        - True: The extent is in a locked dataset.
+        - False: The extent is not in a locked dataset.
+        - None: Lock status is not available because path locking information was not requested.
+    """
 
 
 class IscsiExtentCreate(IscsiExtentEntry):

--- a/src/middlewared/middlewared/api/v25_10_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nfs.py
@@ -153,7 +153,13 @@ class NfsShareEntry(BaseModel):
     enabled: bool = True
     """ Enable or disable the share. """
     locked: bool | None
-    """ Lock state of the dataset (if encrypted). """
+    """ Read-only value indicating whether the share is located on a locked dataset.
+
+    Returns:
+        - True: The share is in a locked dataset.
+        - False: The share is not in a locked dataset.
+        - None: Lock status is not available because path locking information was not requested.
+    """
     expose_snapshots: bool = False
     """
     Enterprise feature to enable access to the ZFS snapshot directory for the export.

--- a/src/middlewared/middlewared/api/v25_10_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_0/smb.py
@@ -566,8 +566,14 @@ class SmbShareEntry(BaseModel):
     access_based_share_enumeration: bool = False
     """ If set, the share is only included when an SMB client requests a list of shares on the SMB server if \
     the share (not filesystem) access control list (see `sharing.smb.getacl`) grants access to the user. """
-    locked: bool
-    """ Read-only value showing if the share is in a locked dataset. """
+    locked: bool | None
+    """ Read-only value indicating whether the share is located on a locked dataset.
+
+    Returns:
+        - True: The share is in a locked dataset.
+        - False: The share is not in a locked dataset.
+        - None: Lock status is not available because path locking information was not requested.
+    """
     audit: SmbAuditConfig = Field(default_factory=SmbAuditConfig, examples=[
         {'enable': True, 'watch_list': ['interns'], 'ignore_list': []},
         {'enable': True, 'watch_list': [], 'ignore_list': ['automation']}


### PR DESCRIPTION
This fixes the SMBEntry API annotation for the `locked` field. I also took the liberty to improve and extend the documentation for this key since this field is hidden behind overly complex, undocumented "extra" parameters that have to be passed to the relevant sharing services.