### PR TITLE
NAS-136709 / 25.10 / Disable EA support on SMB shares

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -295,6 +295,7 @@ def generate_smb_share_conf_dict(
         'fruit:resource': 'stream',
         'comment': share_config[share_field.COMMENT],
         'browseable': share_config[share_field.BROWSEABLE],
+        'ea support': False,
     }
 
     acl_check = __transform_share_path(ds_type, share_config, config_out)

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -152,6 +152,7 @@ def test__base_parameters(nfsacl_dataset):
     assert conf['smbd max xattr size'] == 2097152
     assert conf['comment'] == DEFAULT_SHARE['comment']
     assert conf['browseable'] == DEFAULT_SHARE['browsable']
+    assert conf['ea support'] is False
 
 
 def test__base_smb_nfs4acl(nfsacl_dataset):


### PR DESCRIPTION
This commit restores behavior in Electric Eel and Core where support for EAs over the SMB protocol was not advertised. These are different from alternate data streams and when they are enabled comprise a part of the basic file information, which incurs a significant impact on directory listing performance.