### PR TITLE
NAS-136094 / 25.10 / Avoid unnecessary cache refresh on failover events

### DIFF
--- a/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
+++ b/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
@@ -9,7 +9,7 @@
 SHELL=/bin/sh
 PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
-30 3 * * * root midclt call directoryservices.cache.refresh_impl > /dev/null 2>&1
+30 3 * * * root midclt call directoryservices.cache_refresh > /dev/null 2>&1
 45 3 * * * root midclt call config.backup >/dev/null 2>&1
 
 45 3 * * * root midclt call pool.scrub.run ${boot_pool} ${system_advanced['boot_scrub']} > /dev/null 2>&1

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -72,7 +72,7 @@ class DirectoryServices(Service):
         permissions and ACL related methods. Likewise, a cache refresh will not resolve issues
         with users being unable to authenticate to shares.
         """
-        return await job.wrap(await self.middleware.call('directoryservices.cache.refresh_impl'))
+        return await job.wrap(await self.middleware.call('directoryservices.cache.refresh_impl', True))
 
     @private
     async def get_last_password_change(self, domain=None):
@@ -148,6 +148,8 @@ class DirectoryServices(Service):
         # load on remote servers.
         if self.middleware.call_sync('failover.is_single_master_node'):
             job.set_progress(10, 'Refreshing cache'),
+            # NOTE: we're deliberately not specifying `force` here because we want to avoid
+            # unnecessary cache rebuilds during HA failover events.
             cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh_impl')
             cache_refresh.wait_sync()
 

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -147,7 +147,7 @@ class DirectoryServices(Service):
         # The UI / API user cache isn't required for standby controller. This means we can avoid unnecessary
         # load on remote servers.
         if self.middleware.call_sync('failover.is_single_master_node'):
-            job.set_progress(10, 'Refreshing cache'),
+            job.set_progress(10, 'Refreshing cache')
             # NOTE: we're deliberately not specifying `force` here because we want to avoid
             # unnecessary cache rebuilds during HA failover events.
             cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh_impl')

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -189,7 +189,7 @@ class DomainSecrets(Service):
 
     async def restore(self, netbios_name=None):
         """ Restore the contents of secrets.tdb from a stored backup of the node.
-        This is allowed if standby controller as it preps winbindd for failover. """
+        This is allowed on standby controller as it preps winbindd for failover. """
         if netbios_name is None:
             netbios_name = (await self.middleware.call('smb.config'))['netbiosname']
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -188,12 +188,8 @@ class DomainSecrets(Service):
         )
 
     async def restore(self, netbios_name=None):
-        failover_status = await self.middleware.call('failover.status')
-        if failover_status not in ('SINGLE', 'MASTER'):
-            self.logger.debug("Current failover status [%s]. Skipping secrets restore.",
-                              failover_status)
-            return False
-
+        """ Restore the contents of secrets.tdb from a stored backup of the node.
+        This is allowed if standby controller as it preps winbindd for failover. """
         if netbios_name is None:
             netbios_name = (await self.middleware.call('smb.config'))['netbiosname']
 

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -573,6 +573,9 @@ class KerberosKeytabService(CRUDService):
         if not await self.middleware.call('system.ready'):
             return
 
+        if not await self.middleware.call('failover.is_single_master_node'):
+            return
+
         ds_config = await self.middleware.call('directoryservices.config')
         if not ds_config['enable'] or ds_config['service_type'] != 'ACTIVEDIRECTORY':
             return

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -520,6 +520,9 @@ class SystemDatasetService(ConfigService):
             ):
                 os.chown(create_path_config['path'], create_path_config['uid'], create_path_config['gid'])
 
+            if (mode := create_path_config.get('mode')) and (cpath_stat.st_mode & 0o777) != mode:
+                os.chmod(create_path_config['path'], mode)
+
     def __mount(self, pool, uuid, path=SYSDATASET_PATH):
         """
         Mount group of datasets associated with our system dataset.

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -53,7 +53,8 @@ SYSTEM_DATASET_JSON_SCHEMA = {
                     'properties': {
                         'path': {'type': 'string'},
                         'uid': {'type': 'integer'},
-                        'gid': {'type': 'integer'}
+                        'gid': {'type': 'integer'},
+                        'mode': {'type': 'integer'}
                     },
                     'required': ['path', 'uid', 'gid']
                 }
@@ -94,6 +95,14 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'gid': 0,
                 'mode': 0o755,
             },
+            'create_paths': [
+                {
+                    'path': '/var/db/system/directory_services',
+                    'uid': 0,
+                    'gid': 0,
+                    'mode': 0o700
+                },
+            ],
         },
         {
             'name': os.path.join(pool_name, '.system/cores'),

--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -1,7 +1,6 @@
 import os
 import tdb
 import enum
-import json
 
 from base64 import b64encode, b64decode
 from collections import defaultdict, namedtuple
@@ -11,6 +10,7 @@ from dataclasses import dataclass
 from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 from middlewared.service_exception import MatchNotFound
 from threading import RLock
+from truenas_api_client import ejson as json
 
 FD_CLOSED = -1
 # Robust mutex support was added to libtdb after py-tdb was written and flags


### PR DESCRIPTION
This commit shifts the directory services cache files to the system dataset and adds an expiration key to the caches so that middleware can be more intelligent about whether to attempt to rebuild the cache.

This happens in one of the following circumstances:
1. User initiates cache rebuild
2. User just joined a directory service
3. Cronjob issues cache refresh per crontab

The ultimate effect is that `directoryservices.setup` during a failover event to become active will no longer trigger an expensive cache rebuild and put unnecessary load on winbindd or sssd.