### PR TITLE
NAS-136731 / 25.10 / Fix directory service validation error field name

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -523,7 +523,7 @@ class DirectoryServices(ConfigService):
         # First check that our credential is functional. If the credential type is
         # KERBEROS_USER or KERBEROS_PRINCIPAL then this will also perform a kinit and
         # ensure we have a basic kerberos configuration for a potential domain join
-        validate_credential(f'{SCHEMA}.credential', new, verrors, revert)
+        validate_credential(SCHEMA, new, verrors, revert)
         if verrors:
             self.__revert_changes(revert)
 


### PR DESCRIPTION
This commit fixes the field name specified in ValidationErrors raised by directoryservices.update when validating user-provided credential.