### PR TITLE
NAS-136734 / 25.10 / Fix handle license update

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -1,4 +1,4 @@
-from middlewared.service import CallError, periodic, Service, private
+from middlewared.service import CallError, periodic, Service
 
 from .state_utils import APPS_STATUS, IX_APPS_MOUNT_PATH, Status, STATUS_DESCRIPTIONS
 

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -131,7 +131,7 @@ async def _event_system_shutdown(middleware, event_type, args):
         await middleware.call('service.control', 'STOP', 'docker')  # No need to wait for this to complete
 
 
-async def handle_license_update(middleware, prev_product_type, *args, **kwargs):
+async def handle_license_update(middleware, *args, **kwargs):
     if not await middleware.call('docker.license_active'):
         # We will like to stop docker in this case
         middleware.create_task(middleware.call('service.stop', 'docker'))


### PR DESCRIPTION
`handle_license_update` had an invalid (and unnecessary) parameter: `prev_product_type`.  Introduced in PR #16687

```
[2025/07/16 09:13:01] (ERROR) middlewared._call_hook_base():622 - Failed to run hook system.post_license_update:<function handle_license_update at 0x7fef993f9800>(*(), **{'prev_license': None}) @cee:{"TNLOG": {"exception": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.11/dist-packages/middlewared/main.py\", line 613, in _call_hook_base\n    fut = hook['method'](self, *args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nTypeError: handle_license_update() missing 1 required positional argument: 'prev_product_type'", "type": "PYTHON_EXCEPTION", "time": "2025-07-16 16:13:01.626732"}}
```
