### PR TITLE
NAS-136737 / 25.10 / Send directoryservices.status events more often

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -4,6 +4,7 @@ from .constants import DSStatus, DSType
 from threading import Lock
 
 MAX_RECOVER_ATTEMPTS = 5
+HEALTH_EVENT_NAME = 'directoryservices.status'
 
 
 class KRB5HealthCheckFailReason(enum.IntEnum):


### PR DESCRIPTION
This commit expands the situations in which middleware sends `directoryservices.status` so that one is sent every time the health state is updated. This includes disabling directory services and transitions from DISABLED -> JOINING -> HEALTHY or HEALTHY -> LEAVING -> DISABLED.