### PR TITLE
NAS-136741 / 25.04.2 / Avoid ctypes.util.find_library() from main loop (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/account/authenticator.py
+++ b/src/middlewared/middlewared/utils/account/authenticator.py
@@ -32,6 +32,7 @@ from .utmp import login, logout, PyUtmpEntry, PyUtmpExit, PyUtmpType, UTMP_LOCK,
 MIDDLEWARE_HOST_PREFIX = 'tn-mw'
 UTMP_MAX_SESSIONS = 10000
 libc = ctypes.CDLL('libc.so.6', use_errno=True)
+PAM_REF = pam.pam()  # dlopen PAM libraries and define ctypes
 
 
 # utmp is basically treated as a key-value store based on the tn_line field. We
@@ -177,10 +178,26 @@ class UserPamAuthenticator(pam.PamAuthenticator):
     separate global threading lock.
     """
     def __init__(self):
-        super().__init__()
+        # We intentionally don't super().init() here because we python-pam will
+        # search for libraries every time the object is created. We just use references
+        # to ctype functions that we looked up once
         self.truenas_state = TrueNASAuthenticatorState()
         self.TRUENAS_LOCK = threading.Lock()
         self.truenas_pam_conv = None  # reference to initialized pam_conv object
+        self.libc = libc
+        self.handle = None
+        self.pam_start = PAM_REF.pam_start
+        self.pam_acct_mgmt = PAM_REF.pam_acct_mgmt
+        self.pam_set_item = PAM_REF.pam_set_item
+        self.pam_setcred = PAM_REF.pam_setcred
+        self.pam_strerror = PAM_REF.pam_strerror
+        self.pam_authenticate = PAM_REF.pam_authenticate
+        self.pam_open_session = PAM_REF.pam_open_session
+        self.pam_close_session = PAM_REF.pam_close_session
+        self.pam_putenv = PAM_REF.pam_putenv
+        self.pam_misc_setenv = PAM_REF.pam_misc_setenv
+        self.pam_getenv = PAM_REF.pam_getenv
+        self.pam_getenvlist = PAM_REF.getenvlist
 
     def _get_user_obj(self, username):
         # populate our internal passwd reference. This should only be called once during authentication


### PR DESCRIPTION
This commit shifts around when pam functions get defined in middleware so that we're not having to search for libraries repeatedely.

Original PR: https://github.com/truenas/middleware/pull/16758
