### PR TITLE
Properly disable health checks when DS disabled

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -29,11 +29,11 @@ class DomainHealth(
         private = True
 
     def _get_enabled_ds(self) -> DSType | None:
-        server_type = self.middleware.call_sync('directoryservices.config')['service_type']
-        if server_type is None:
+        ds_config = self.middleware.call_sync('directoryservices.config')
+        if not ds_config['enable']:
             return None
 
-        return DSType(server_type)
+        return DSType(ds_config['service_type'])
 
     def _perm_check(
         self,


### PR DESCRIPTION
This commit fixes a broken check to get the enabled directory service that was consumed by health checks. The health checks / alerts were being triggered with a directory service (e.g. AD) was configured but disabled.