### PR TITLE
Fix return type of directoryservices.cache_refresh

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -72,7 +72,8 @@ class DirectoryServices(Service):
         permissions and ACL related methods. Likewise, a cache refresh will not resolve issues
         with users being unable to authenticate to shares.
         """
-        return await job.wrap(await self.middleware.call('directoryservices.cache.refresh_impl', True))
+        await job.wrap(await self.middleware.call('directoryservices.cache.refresh_impl', True))
+        return
 
     @private
     async def get_last_password_change(self, domain=None):


### PR DESCRIPTION
The return type of this method was inadvertently changed while implementing a change to avoid cache refresh on HA failover.