### PR TITLE
NAS-136753 / 25.10 / Fix model_validator for directoryservices entry

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -522,8 +522,8 @@ class DirectoryServicesEntry(BaseModel):
 
         # insert the currently-configured service_type into the configuration
         # dict so that the discriminator works as expected.
-        if 'configuration' in data_in:
-            if 'service_type' in data_in:
+        if 'configuration' in data_in and isinstance(data_in['configuration'], dict):
+            if 'service_type' in data_in and data_in['service_type'] is not None:
                 data_in['configuration']['service_type'] = data_in['service_type']
             else:
                 raise ValueError('"service_type" field is required if "configuration" field is specified')

--- a/tests/directory_services/test_activedirectory_basic.py
+++ b/tests/directory_services/test_activedirectory_basic.py
@@ -372,3 +372,10 @@ def test_keytab_restore():
 
         # verify that it was recreated during health check
         call('kerberos.keytab.query', [['name', '=', 'AD_MACHINE_ACCOUNT']], {'get': True})
+
+
+def test_reset_directory_services():
+    """ Verify that resetting the directory services config to NULL values doesn't break
+    the schema parser. """
+    call('directoryservices.reset')
+    call('directoryservices.config')


### PR DESCRIPTION
This commit fixes handling for case where the directoryservices config has been reset. In this situation configuration will be None and service_type will be None.