### PR TITLE
NAS-136762 / 25.04.2 / Avoid blocking main loop on session logout (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -168,7 +168,7 @@ class SessionManager:
 
             del self.sessions[app.session_id]
 
-            session.credentials.logout()
+            await self.middleware.run_in_thread(session.credentials.logout)
 
             if not internal_session:
                 self.middleware.send_event("auth.sessions", "REMOVED", fields=dict(id=app.session_id))


### PR DESCRIPTION
Depending on the middleware credential type, the PAM authenticator may need to take a global utmp lock while removing the record.

Original PR: https://github.com/truenas/middleware/pull/16772
