### PR TITLE
NAS-136770 / 25.10 / Fix multiple failover issues with directory services

### DIFF
--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -7,8 +7,8 @@
     from middlewared.utils.directoryservices.common import ds_config_to_fqdn
     from middlewared.utils.directoryservices.constants import DSCredType, DSType
 
-    ds_type = middleware.call_sync('directoryservices.status')['type']
     ds_config = middleware.call_sync('directoryservices.config')
+    ds_type = ds_config['service_type']
     if ds_type == DSType.LDAP.value:
         kerberos_realm = ds_config['kerberos_realm'] 
         aux = []

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
@@ -62,7 +62,8 @@ class ADJoinMixin:
         for etc_file in DSType.AD.etc_files:
             self.middleware.call_sync('etc.generate', etc_file)
 
-        self.middleware.call_sync('service.control', 'RESTART', 'idmap', DEF_SVC_OPTS).wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'STOP', 'idmap', DEF_SVC_OPTS).wait_sync()
+        self.middleware.call_sync('service.control', 'START', 'idmap', DEF_SVC_OPTS).wait_sync(raise_error=True)
 
         # Wait for winbind to come online to provide some time for sysvol replication
         self._ad_wait_wbclient()
@@ -342,7 +343,7 @@ class ADJoinMixin:
                     if not retries or 'Server not found in Kerberos database' not in exc.errmsg:
                         raise
 
-                    self.logger.debug('%s: Failed to perform nsupdate due to potentially slow sysvol replication.',
+                    self.logger.debug('%s: Failed to perform nsupdate due to potentially slow sysvol replication. Retrying.',
                                       conf['dns_name'])
                     sleep(5)
                     retries -= 1

--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -162,8 +162,13 @@ class DSCache(Service):
                 try:
                     self._insert(data['idtype'], entry)
                 except Exception:
-                    self.logger.warning('Failed to insert %s into directory services cache', entry)
+                    # Insertion into the cache file failed. This is unexpected and may indicate system dataset issues
+                    # (for example, a race on moving around system dataset). It's better to just skip the insertion and
+                    # let someone else handle system dataset issues.
+                    self.logger.warning('Failed to insert %s into directory services cache', entry, exc_info=True)
             except KeyError:
+                # KeyError here means that the `user.get_user_obj` or `group.get_group_obj` call failed. In this case
+                # we return None (lookup failure)
                 entry = None
 
         if entry and not options['smb']:

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -686,7 +686,6 @@ class DirectoryServices(ConfigService):
             self.middleware.call_sync('datastore.update', 'directoryservices', old['id'], compressed)
 
         if self.middleware.call_sync('failover.status') == 'MASTER':
-            remote_config = self.middleware.call_sync('failover.call_remote', 'directoryservices.config')
             self.middleware.call_sync(
                 'failover.call_remote', 'directoryservices.connection.activate_standby', [kdc_saf_cache_get()]
             )
@@ -695,8 +694,6 @@ class DirectoryServices(ConfigService):
                 self.middleware.call_sync('failover.call_remote', 'directoryservices.health.recover')
             except Exception:
                 self.logger.warning('Failed to activate directory servics on standby controller', exc_info=True)
-        else:
-            self.logger.debug("XXX: not HA")
 
         return self.middleware.call_sync('directoryservices.config')
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -691,7 +691,7 @@ class DirectoryServices(ConfigService):
                     'failover.call_remote', 'directoryservices.connection.activate_standby', [kdc_saf_cache_get()]
                 )
             except Exception:
-                self.logger.warning('Failed to active directory services on standby controller', exc_info=True)
+                self.logger.warning('Failed to activate directory services on standby controller', exc_info=True)
             else:
                 try:
                     # Perform a recover op to forcibly reset the state
@@ -768,7 +768,7 @@ class DirectoryServices(ConfigService):
             )
 
         if failover_status not in ('SINGLE', 'MASTER'):
-            raise CallError('Directory services must be left from the active storage controller')
+            raise CallError('Cannot leave directory services from the standby controller.')
 
         # overwrite cred with admin-provided one. We need elevated permissions to do this
         ds_config['credential'] = cred['credential']

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -12,7 +12,9 @@ from middlewared.plugins.directoryservices_.util_cache import expire_cache
 from middlewared.service import ConfigService, private, job
 from middlewared.service_exception import CallError, MatchNotFound, ValidationErrors
 from middlewared.utils.directoryservices.ad import get_domain_info, lookup_dc
-from middlewared.utils.directoryservices.krb5 import ktutil_list_impl
+from middlewared.utils.directoryservices.krb5 import (
+    ktutil_list_impl, kdc_saf_cache_get, kdc_saf_cache_remove
+)
 from middlewared.utils.directoryservices.constants import (
     DSCredType, DomainJoinResponse, DSStatus, DSType, DEF_SVC_OPTS
 )
@@ -333,6 +335,8 @@ class DirectoryServices(ConfigService):
 
     @private
     def common_validation(self, old, new, verrors):
+        if not self.middleware.call_sync('failover.is_single_master_node'):
+            raise CallError('Directory services configuration changes must be made on active storage controller')
 
         # Most changes should not be done while we're enabled as they can result
         # in a production outage that is unacceptable in enterprise environments
@@ -681,6 +685,19 @@ class DirectoryServices(ConfigService):
             compressed = self.compress(new)
             self.middleware.call_sync('datastore.update', 'directoryservices', old['id'], compressed)
 
+        if self.middleware.call_sync('failover.status') == 'MASTER':
+            remote_config = self.middleware.call_sync('failover.call_remote', 'directoryservices.config')
+            self.middleware.call_sync(
+                'failover.call_remote', 'directoryservices.connection.activate_standby', [kdc_saf_cache_get()]
+            )
+            try:
+                # Perform a recover op to forcibly reset the state
+                self.middleware.call_sync('failover.call_remote', 'directoryservices.health.recover')
+            except Exception:
+                self.logger.warning('Failed to activate directory servics on standby controller', exc_info=True)
+        else:
+            self.logger.debug("XXX: not HA")
+
         return self.middleware.call_sync('directoryservices.config')
 
     @private
@@ -725,6 +742,7 @@ class DirectoryServices(ConfigService):
 
         await self.middleware.call('datastore.update', 'directoryservices', pk, config)
         await self.middleware.run_in_thread(expire_cache)
+        await self.middleware.run_in_thread(kdc_saf_cache_remove)
 
     @api_method(
         DirectoryServicesLeaveArgs, DirectoryServicesLeaveResult,
@@ -739,11 +757,16 @@ class DirectoryServices(ConfigService):
         revert = []
         verrors = ValidationErrors()
 
+        failover_status = self.middleware.call_sync('failover.status')
+
         ds_config = self.middleware.call_sync('directoryservices.config')
         if not ds_config['enable']:
             raise CallError(
                 'The directory service must be enabled before the TrueNAS server can leave the domain.'
             )
+
+        if failover_status not in ('SINGLE', 'MASTER'):
+            raise CallError('Directory services must be left from the active storage controller')
 
         # overwrite cred with admin-provided one. We need elevated permissions to do this
         ds_config['credential'] = cred['credential']
@@ -779,7 +802,16 @@ class DirectoryServices(ConfigService):
         for etc_file in ds_type.etc_files:
             self.middleware.call_sync('etc.generate', etc_file)
 
-        # These service changes need to be propagated to the remote node since join will cease working
+        if failover_status == 'MASTER':
+            try:
+                self.middleware.call_sync(
+                    'failover.call_remote',
+                    'directoryservices.connection.deactivate_standby',
+                    [ds_type.value]
+                )
+            except Exception:
+                self.logger.warning('Failed to deactivate directory services on standby controller', exc_info=True)
+
         if ds_type is DSType.IPA:
             self.middleware.call_sync('service.control', 'STOP', 'sssd').wait_sync(raise_error=True)
         else:

--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -9,7 +9,6 @@ from .ldap_health_mixin import LDAPHealthMixin
 from middlewared.service import Service
 from middlewared.service_exception import CallError
 from middlewared.utils.directoryservices.constants import DSStatus, DSType
-from middlewared.utils.directoryservices.krb5_constants import KRB_Keytab
 from middlewared.utils.directoryservices.health import (
     ADHealthError, DSHealthObj, HEALTH_EVENT_NAME, IPAHealthError, KRB5HealthError,
     LDAPHealthError, MAX_RECOVER_ATTEMPTS,

--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -9,6 +9,7 @@ from .ldap_health_mixin import LDAPHealthMixin
 from middlewared.service import Service
 from middlewared.service_exception import CallError
 from middlewared.utils.directoryservices.constants import DSStatus, DSType
+from middlewared.utils.directoryservices.krb5_constants import KRB_Keytab
 from middlewared.utils.directoryservices.health import (
     ADHealthError, DSHealthObj, HEALTH_EVENT_NAME, IPAHealthError, KRB5HealthError,
     LDAPHealthError, MAX_RECOVER_ATTEMPTS,

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -1014,6 +1014,13 @@ class FailoverEventsService(Service):
         self.run_call('disk.retaste')
         logger.info('Done retasting disks (if required)')
 
+        logger.info('Activating directory services')
+        try:
+            self.run_call('directoryservices.connection.activate_standby', None)
+        except Exception:
+            logger.warning('Failed to activate directory services', exc_info=True)
+        logger.info('Done activating directory services')
+
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -424,9 +424,6 @@ class SMBService(Service):
         4) flush various caches if required.
         """
         entries = []
-        if (status := self.middleware.call_sync('failover.status')) not in ('SINGLE', 'MASTER'):
-            self.middleware.logger.debug('%s: skipping groupmap sync due to failover status', status)
-            return
 
         if not bypass_sentinel_check and not self.middleware.call_sync('smb.is_configured'):
             raise CallError(

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -148,6 +148,12 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'gid': 0,
                 'mode': 0o755,
             },
+            'post_mount_actions': [
+                {
+                    'method': 'smb.setup_directories',
+                    'args': [],
+                }
+            ]
         },
         {
             'name': os.path.join(pool_name, '.system/vm'),

--- a/src/middlewared/middlewared/test/integration/assets/directory_service.py
+++ b/src/middlewared/middlewared/test/integration/assets/directory_service.py
@@ -280,4 +280,4 @@ def directoryservice(
                 if service_type in ('ACTIVEDIRECTORY', 'IPA'):
                     call('directoryservices.leave', {'credential': credential}, job=True)
                 else:
-                    call('directoryservices.reset')
+                    call('directoryservices.update', {'service_type': None, 'enable': False})

--- a/src/middlewared/middlewared/test/integration/utils/failover.py
+++ b/src/middlewared/middlewared/test/integration/utils/failover.py
@@ -6,19 +6,20 @@ from time import sleep
 try:
     apifolder = os.getcwd()
     sys.path.append(apifolder)
-    from auto_config import ha, hostname
+    from auto_config import ha as ha_enabled
 except ImportError:
-    ha = False
-    hostname = None
+    ha_enabled = False
 
 from .call import call
+from .ha import settle_ha
+from .ssh import ssh
 
-__all__ = ["disable_failover"]
+__all__ = ["disable_failover", "do_failover"]
 
 
 @contextlib.contextmanager
 def disable_failover():
-    if ha:
+    if ha_enabled:
         call("failover.update", {"disabled": True, "master": True})
 
     try:
@@ -28,44 +29,26 @@ def disable_failover():
             call("failover.update", {"disabled": False, "master": True})
 
 
-def wait_for_standby():
-    '''
-    NOTE:
-       1) This routine is for dual-controller (ha) only
-       2) This is nearly identical to 'wait_for_standby' in test_006_pool_and_sysds
+def wait_for_standby(delay=5, retries=60):
+    """ TODO: this is a wrapper around settle_ha, consumers should be fixed """
+    if not ha_enabled:
+        return
 
-    This routine will wait for the standby controller to return from a reboot.
-    '''
-    if ha:
-        sleep(5)
+    settle_ha(delay, retries)
 
-        sleep_time = 1
-        max_wait_time = 300
-        rebooted = False
-        waited_time = 0
 
-        while waited_time < max_wait_time and not rebooted:
-            if call('failover.remote_connected'):
-                rebooted = True
-            else:
-                waited_time += sleep_time
-                sleep(sleep_time)
+def do_failover(delay=5, settle_retries=180, description='', abusive=False):
+    orig_master_node = call('failover.node')
 
-        assert rebooted, f'Standby did not connect after {max_wait_time} seconds'
+    # This node is MASTER and failover isn't disabled for some reason
+    assert call('failover.status') == 'MASTER'
+    assert not call('failover.disabled.reasons')
 
-        waited_time = 0  # need to reset this
-        is_backup = False
-        while waited_time < max_wait_time and not is_backup:
-            try:
-                is_backup = call('failover.call_remote', 'failover.status') == 'BACKUP'
-            except Exception:
-                pass
-
-            if not is_backup:
-                waited_time += sleep_time
-                sleep(sleep_time)
-
-        assert is_backup, f'Standby node did not become BACKUP after {max_wait_time} seconds'
-        pass
+    if abusive:
+        ssh('echo 1 > /proc/sys/kernel/sysrq && echo b > /proc/sysrq-trigger', check=False)
     else:
-        pass
+        call('system.reboot', f'do_failover(): {description}')
+
+    sleep(delay)
+    settle_ha(delay, settle_retries)
+    assert call('failover.node') != orig_master_node

--- a/src/middlewared/middlewared/test/integration/utils/failover.py
+++ b/src/middlewared/middlewared/test/integration/utils/failover.py
@@ -25,7 +25,7 @@ def disable_failover():
     try:
         yield
     finally:
-        if ha:
+        if ha_enabled:
             call("failover.update", {"disabled": False, "master": True})
 
 

--- a/src/middlewared/middlewared/test/integration/utils/ha.py
+++ b/src/middlewared/middlewared/test/integration/utils/ha.py
@@ -16,6 +16,7 @@ def settle_ha(delay=5, retries=24):
         try:
             reasons = call('failover.disabled.reasons')
             if not reasons:
+                assert not call('failover.call_remote', 'failover.in_progress')
                 return
         except Exception:
             pass

--- a/src/middlewared/middlewared/utils/directoryservices/common.py
+++ b/src/middlewared/middlewared/utils/directoryservices/common.py
@@ -1,5 +1,6 @@
 from middlewared.utils.directoryservices.constants import DSType
 
+
 def ds_config_to_fqdn(ds_config: dict) -> str:
     if ds_config['service_type'] not in (DSType.AD.value, DSType.IPA.value):
         raise ValueError(f'{ds_config["service_type"]}: service type unsupported.')

--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 from .krb5_constants import krb_tkt_flag, krb5ccache, KRB_ETYPE, KRB_Keytab
 from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 from middlewared.service_exception import CallError
-from middlewared.utils import filter_list
+from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.utils.io import write_if_changed
 from middlewared.utils.time_utils import utc_now
 from tempfile import NamedTemporaryFile
@@ -31,7 +31,7 @@ KRB5_KT_VNO = b'\x05\x02'  # KRB v5 keytab version 2, (last changed in 2009)
 # we need to lock in the KDC we used to join for a period of time
 
 SAF_CACHE_TIMEOUT = timedelta(hours=1)
-SAF_CACHE_FILE = os.path.join(SYSDATASET_PATH, 'directory_services', '.KDC_SERVER_AFFINITY')
+SAF_CACHE_FILE = os.path.join('/root', '.KDC_SERVER_AFFINITY')
 
 
 # The following schemas are used for validation of klist / ktutil_list output
@@ -548,3 +548,9 @@ def kdc_saf_cache_set(kdc: str) -> None:
 
     expiration = int((utc_now(naive=False) + SAF_CACHE_TIMEOUT).timestamp())
     write_if_changed(SAF_CACHE_FILE, f'{kdc} {expiration}')
+
+def kdc_saf_cache_remove() -> None:
+    try:
+        os.unlink(SAF_CACHE_FILE)
+    except FileNotFoundError:
+        pass

--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from .krb5_constants import krb_tkt_flag, krb5ccache, KRB_ETYPE, KRB_Keytab
 from middlewared.service_exception import CallError
+from middlewared.utils import filter_list
 from middlewared.utils.io import write_if_changed
 from middlewared.utils.time_utils import utc_now
 from tempfile import NamedTemporaryFile

--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -16,9 +16,7 @@ import time
 from contextlib import contextmanager
 from datetime import timedelta
 from .krb5_constants import krb_tkt_flag, krb5ccache, KRB_ETYPE, KRB_Keytab
-from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 from middlewared.service_exception import CallError
-from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.utils.io import write_if_changed
 from middlewared.utils.time_utils import utc_now
 from tempfile import NamedTemporaryFile
@@ -548,6 +546,7 @@ def kdc_saf_cache_set(kdc: str) -> None:
 
     expiration = int((utc_now(naive=False) + SAF_CACHE_TIMEOUT).timestamp())
     write_if_changed(SAF_CACHE_FILE, f'{kdc} {expiration}')
+
 
 def kdc_saf_cache_remove() -> None:
     try:

--- a/src/middlewared/middlewared/utils/gencache.py
+++ b/src/middlewared/middlewared/utils/gencache.py
@@ -10,6 +10,9 @@ from middlewared.utils.tdb import (
 
 GENCACHE_FILE = '/var/run/samba-lock/gencache.tdb'
 GENCACHE_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
+SAFKEY_PREFIX = 'SAF/DOMAIN'
+SAFJOIN_PREFIX = 'SAFJOIN/DOMAIN'
+
 
 
 class IDMAPCacheType(enum.Enum):
@@ -41,7 +44,7 @@ def wipe_gencache_entries() -> None:
         return hdl.clear()
 
 
-def flush_gencache_entries() -> None:
+def flush_gencache_entries(keep_saf=False) -> None:
     """
     delete all keys in gencache
 
@@ -51,6 +54,9 @@ def flush_gencache_entries() -> None:
     """
     with get_tdb_handle(GENCACHE_FILE, GENCACHE_TDB_OPTIONS) as hdl:
         for entry in hdl.entries():
+            if keep_saf and entry['key'].startswith((SAFKEY_PREFIX, SAFJOIN_PREFIX)):
+                continue
+
             hdl.delete(entry['key'])
 
 

--- a/src/middlewared/middlewared/utils/gencache.py
+++ b/src/middlewared/middlewared/utils/gencache.py
@@ -14,7 +14,6 @@ SAFKEY_PREFIX = 'SAF/DOMAIN'
 SAFJOIN_PREFIX = 'SAFJOIN/DOMAIN'
 
 
-
 class IDMAPCacheType(enum.Enum):
     UID2SID = 'IDMAP/UID2SID'
     GID2SID = 'IDMAP/GID2SID'
@@ -51,6 +50,12 @@ def flush_gencache_entries(keep_saf=False) -> None:
     This matches behavior of "net cache flush" which iterates and
     deletes entries. If we fail due to corrupt TDB file then it will
     be wiped.
+
+    keep_saf: the winbindd connection manager uses gencache keys to
+    keep track of the last DC it successfully talked to. Keeping the
+    winbindd saf cache across flushing other entries will help to
+    avoid service disruptions if we need to only wipe user / group
+    entries.
     """
     with get_tdb_handle(GENCACHE_FILE, GENCACHE_TDB_OPTIONS) as hdl:
         for entry in hdl.entries():

--- a/tests/directory_services/test_zzz_truenas_ha.py
+++ b/tests/directory_services/test_zzz_truenas_ha.py
@@ -1,0 +1,70 @@
+import pytest
+
+from middlewared.test.integration.assets.directory_service import directoryservice
+from middlewared.test.integration.utils import call, ssh, truenas_server
+from middlewared.test.integration.utils.failover import do_failover, ha_enabled
+from time import sleep
+
+
+SAF_PATH = '/root/.KDC_SERVER_AFFINITY'
+
+
+def check_ds_status(status_dict, expected):
+    msg = status_dict['status_msg']
+    status = status_dict['status']
+    assert status == expected, f'{expected}: unexpected status [{status}]: {msg}'
+
+
+def get_server_affinity(server_ip):
+    saf_data = ssh(f'cat {SAF_PATH}', ip=server_ip)
+    return saf_data.split()[0]
+
+
+def check_server_affinity():
+    # Verfiy that both nodes have same KDC affinity set
+    nodea_affinity = get_server_affinity(truenas_server.nodea_ip)
+    nodeb_affinity = get_server_affinity(truenas_server.nodeb_ip)
+    assert nodea_affinity == nodeb_affinity
+
+
+def check_status_ad_impl():
+    # Compare machine account passwords.
+    workgroup = call('smb.config')['workgroup']
+    active_secrets = call('directoryservices.secrets.get_machine_secret', workgroup)
+    standby_secrets = call('failover.call_remote', 'directoryservices.secrets.get_machine_secret', [workgroup])
+    assert active_secrets == standby_secrets
+
+
+@pytest.mark.skipif(not ha_enabled, reason='HA only test')
+@pytest.mark.parametrize('service_type', ['ACTIVEDIRECTORY', 'IPA', 'LDAP'])
+def test_failover(service_type):
+    with directoryservice(service_type) as ds:
+        # This node is healthy, but let's check on remote node
+        check_ds_status(call('failover.call_remote', 'directoryservices.status'), 'HEALTHY')
+
+        do_failover()
+
+        # Check this node is HEALTHY
+        check_ds_status(call('directoryservices.status'), 'HEALTHY')
+
+        # Check that state is correct on standby
+        match service_type:
+            case 'ACTIVEDIRECTORY':
+                check_server_affinity()
+                check_status_ad_impl()
+            case 'IPA':
+                check_server_affinity()
+            case 'LDAP':
+                pass
+            case _:
+                raise RuntimeError(f'{service_type}: unhandled directory service type')
+
+        # Check remote node is HEALTHY
+        check_ds_status(call('failover.call_remote', 'directoryservices.status'), 'HEALTHY')
+
+        # Force test recover
+        call('directoryservices.health.recover')
+        call('failover.call_remote', 'directoryservices.health.recover')
+
+    check_ds_status(call('directoryservices.status'), None)
+    check_ds_status(call('failover.call_remote', 'directoryservices.status'), None)

--- a/tests/directory_services/test_zzz_truenas_ha.py
+++ b/tests/directory_services/test_zzz_truenas_ha.py
@@ -3,7 +3,6 @@ import pytest
 from middlewared.test.integration.assets.directory_service import directoryservice
 from middlewared.test.integration.utils import call, ssh, truenas_server
 from middlewared.test.integration.utils.failover import do_failover, ha_enabled
-from time import sleep
 
 
 SAF_PATH = '/root/.KDC_SERVER_AFFINITY'
@@ -38,7 +37,7 @@ def check_status_ad_impl():
 @pytest.mark.skipif(not ha_enabled, reason='HA only test')
 @pytest.mark.parametrize('service_type', ['ACTIVEDIRECTORY', 'IPA', 'LDAP'])
 def test_failover(service_type):
-    with directoryservice(service_type) as ds:
+    with directoryservice(service_type):
         # This node is healthy, but let's check on remote node
         check_ds_status(call('failover.call_remote', 'directoryservices.status'), 'HEALTHY')
 


### PR DESCRIPTION
In 25.10 the design for how directory services integrate with HA
was changed in such a way that it is now expected that the 
connection should be healthy on both the active and standby controller.
This is to provide consistent access on both storage controllers regardless
of HA state. During abusive testing multiple issues were discovered.

* Add explicit failover tests for directory services
  - Add a new test asset to initiate a failover event and wait for
    standby to settle.
  - Fix multiple issues with existing failvoer test asset
    "wait_for_standby"

* Shift the location of the directory services KDC affinity cache
  In a multi-DC environment the standby controller would not
  properly become healthy because it failed to communicate with
  the correct KDC immediately after domain join.

* Add method directoryservices.connection.activate_standby to
  perform required tasks for having healthy directory services
  on the standby controller after a failover event and after enabling
  a directory service on HA.

* Add method directoryservices.connection.deactivate_standby to
  cleanly disable the directory services on the standby controller.