### PR TITLE
NAS-136779 / 26.04 / Fix some query endpoints' options schemas

### DIFF
--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel as PydanticBaseModel, ConfigDict, create_model, F
 from pydantic._internal._decorators import Decorator, PydanticDescriptorProxy
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.json_schema import SkipJsonSchema
-from pydantic.main import IncEx
+from pydantic.main import IncEx, Model
 
 from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
 from middlewared.utils.lang import undefined
@@ -310,17 +310,17 @@ def single_argument_result(klass, klass_name=None):
     return model
 
 
-def query_result(item, name=None):
-    result_item = query_result_item(item)
+def query_result(item: type[PydanticBaseModel], name: str | None = None) -> type[BaseModel]:
+    ResultItem = query_result_item(item)
     return create_model(
         name or item.__name__.removesuffix("Entry") + "QueryResult",
         __base__=(BaseModel,),
         __module__=item.__module__,
-        result=Annotated[list[result_item] | result_item | int, Field()],
+        result=Annotated[list[ResultItem] | ResultItem | int, Field()],
     )
 
 
-def query_result_item(item):
+def query_result_item(item: type[Model]) -> type[Model]:
     # All fields must be non-required since we can query subsets of fields
     return create_model(
         item.__name__.removesuffix("Entry") + "QueryResultItem",

--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel as PydanticBaseModel, ConfigDict, create_model, F
 from pydantic._internal._decorators import Decorator, PydanticDescriptorProxy
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.json_schema import SkipJsonSchema
-from pydantic.main import IncEx, Model
+from pydantic.main import IncEx, ModelT
 
 from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
 from middlewared.utils.lang import undefined
@@ -320,7 +320,7 @@ def query_result(item: type[PydanticBaseModel], name: str | None = None) -> type
     )
 
 
-def query_result_item(item: type[Model]) -> type[Model]:
+def query_result_item(item: type[ModelT]) -> type[ModelT]:
     # All fields must be non-required since we can query subsets of fields
     return create_model(
         item.__name__.removesuffix("Entry") + "QueryResultItem",

--- a/src/middlewared/middlewared/api/v26_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v26_04_0/acl.py
@@ -436,13 +436,20 @@ class AclTemplateFormatOptions(BaseModel):
     """Whether to resolve numeric user/group IDs to names in ACL entries."""
 
 
+class ACLTemplateByPathQueryOptions(QueryOptions):
+    extra: Excluded = excluded_field()
+    select: Excluded = excluded_field()
+    count: Excluded = excluded_field()
+    get: Excluded = excluded_field()
+
+
 @single_argument_args('filesystem_acl')
 class ACLTemplateByPathArgs(BaseModel):
     path: str = ""
     """Filesystem path to filter templates by compatibility or empty string for all."""
     query_filters: QueryFilters = Field(alias='query-filters', default=[])
     """Query filters to apply when selecting templates."""
-    query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
+    query_options: ACLTemplateByPathQueryOptions = Field(alias='query-options', default=ACLTemplateByPathQueryOptions())
     """Query options for pagination and ordering of results."""
     format_options: AclTemplateFormatOptions = Field(alias='format-options', default=AclTemplateFormatOptions())
     """Formatting options for how template data is returned."""

--- a/src/middlewared/middlewared/api/v26_04_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v26_04_0/iscsi_global.py
@@ -1,7 +1,7 @@
 from pydantic import Field
 
 from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, single_argument_args
-from .common import QueryFilters, QueryOptions
+
 
 __all__ = [
     "IscsiGlobalEntry",
@@ -13,8 +13,7 @@ __all__ = [
     "ISCSIGlobalIserEnabledResult",
     "ISCSIGlobalClientCountArgs",
     "ISCSIGlobalClientCountResult",
-    "ISCSIGlobalSessionsArgs",
-    "ISCSIGlobalSessionsResult"
+    "ISCSIGlobalSessionsItem",
 ]
 
 
@@ -74,7 +73,7 @@ class ISCSIGlobalClientCountResult(BaseModel):
     """Number of currently connected iSCSI clients."""
 
 
-class IscsiSession(BaseModel):
+class ISCSIGlobalSessionsItem(BaseModel):
     initiator: str
     """iSCSI Qualified Name (IQN) of the initiator."""
     initiator_addr: str
@@ -105,15 +104,3 @@ class IscsiSession(BaseModel):
     """Whether this session is using iSER (iSCSI Extensions for RDMA)."""
     offload: bool
     """Whether hardware offload is enabled for this session."""
-
-
-class ISCSIGlobalSessionsArgs(BaseModel):
-    query_filters: QueryFilters = []
-    """Query filters to apply to the session listing."""
-    query_options: QueryOptions = QueryOptions()
-    """Query options for sorting and pagination."""
-
-
-class ISCSIGlobalSessionsResult(BaseModel):
-    result: list[IscsiSession]
-    """Array of active iSCSI sessions."""

--- a/src/middlewared/middlewared/api/v26_04_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_04_0/pool_dataset.py
@@ -628,12 +628,12 @@ class PoolDatasetGetQuotaArgs(BaseModel):
     """The type of quotas to retrieve."""
     filters: QueryFilters = []
     """Query filters to limit the results returned."""
-    options: QueryOptions = Field(default_factory=QueryOptions)
+    options: QueryOptions = QueryOptions()
     """Query options such as sorting and pagination."""
 
 
 class PoolDatasetGetQuotaResult(BaseModel):
-    result: list[PoolDatasetQuota]
+    result: list[PoolDatasetQuota] | PoolDatasetQuota | int
     """Array of quota information for the specified quota type."""
 
 

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -225,15 +225,6 @@ class AuditService(ConfigService):
         Supported export_formats are CSV, JSON, and YAML. The endpoint returns a
         local filesystem path where the resulting audit report is located.
         """
-        if data['query-options'].get('count') is True:
-            raise CallError('Raw row count may not be exported', errno.EINVAL)
-
-        if data['query-options'].get('get') is True:
-            raise CallError(
-                'Use of "get" query-option is not supported for export',
-                errno.EINVAL
-            )
-
         export_format = data.pop('export_format')
         job.set_progress(0, f'Quering data for {export_format} audit report')
         if not (res := self.middleware.call_sync('audit.query', data)):

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -344,27 +344,7 @@ class FilesystemService(Service):
         For example {"select": ["path", "type"]} will avoid querying an xattr list and
         ZFS attributes for files in a directory.
 
-        NOTE: an empty list for select (default) is treated as requesting all information.
-
-        Each entry of the list consists of:
-          name(str): name of the file
-          path(str): absolute path of the entry
-          realpath(str): absolute real path of the entry (if SYMLINK)
-          type(str): DIRECTORY | FILE | SYMLINK | OTHER
-          size(int): size of the entry
-          allocation_size(int): on-disk size of entry
-          mode(int): file mode/permission
-          uid(int): user id of entry owner
-          gid(int): group id of entry owner
-          acl(bool): extended ACL is present on file
-          is_mountpoint(bool): path is a mountpoint
-          is_ctldir(bool): path is within special .zfs directory
-          attributes(list): list of statx file attributes that apply to the
-          file. See statx(2) manpage for more details.
-          xattrs(list): list of extended attribute names.
-          zfs_attrs(list): list of ZFS file attributes on file
         """
-
         path = pathlib.Path(path)
         if not path.exists():
             raise CallError(f'Directory {path} does not exist', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -2,9 +2,8 @@ import glob
 import os
 from contextlib import suppress
 
-from middlewared.api import api_method
-from middlewared.api.current import ISCSIGlobalSessionsArgs, ISCSIGlobalSessionsResult
-from middlewared.service import private, Service
+from middlewared.api.current import ISCSIGlobalSessionsItem
+from middlewared.service import private, Service, filterable_api_method
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils import filter_list, run
 
@@ -14,11 +13,7 @@ class ISCSIGlobalService(Service):
     class Config:
         namespace = 'iscsi.global'
 
-    @api_method(
-        ISCSIGlobalSessionsArgs,
-        ISCSIGlobalSessionsResult,
-        roles=['SHARING_ISCSI_GLOBAL_READ']
-    )
+    @filterable_api_method(item=ISCSIGlobalSessionsItem, roles=['SHARING_ISCSI_GLOBAL_READ'])
     def sessions(self, filters, options):
         """
         Get a list of currently running iSCSI sessions. This includes initiator and target names


### PR DESCRIPTION
Some of our public endpoints fail if passed certain query options like "get" or "count" because the options are in the schema but the method doesn't support them. Some other endpoints do support the options, but the return schema doesn't reflect it. 

Apply case-by-case schema fixes to:
* `iscsi.global.sessions`
* `pool.dataset.get_quota`
* `audit.query`
* `audit.export`
* `filesystem.acltemplate.by_path`

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5426/