### PR TITLE
NAS-136775 / 25.04.2 / fallthrough auth.login_ex on unhealthy HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -762,10 +762,25 @@ class AuthService(Service):
         """
         if await self.middleware.call('failover.licensed'):
             if await self.middleware.call('failover.status') == 'BACKUP':
-                return {
-                    'response_type': AuthResp.REDIRECT,
-                    'urls': await self.middleware.call('failover.call_remote', 'failover.get_ips'),
-                }
+                try:
+                    rem_status = await self.middleware.call(
+                        'failover.call_remote', 'failover.status', [], {'connect_timeout': 2}
+                    )
+                    if rem_status == 'MASTER':
+                        return {
+                            'response_type': AuthResp.REDIRECT,
+                            'urls': await self.middleware.call(
+                                'failover.call_remote', 'failover.get_ips'),
+                        }
+                except Exception:
+                    self.logger.exception('Unhandled exception checking remote system')
+
+            # NOTE: It's okay to fall through here on HA systems. If the creds are
+            # correct then the caller can check the various failover endpoints to check
+            # the overall HA status. Without falling through here, a user won't be able
+            # to login via our API on an HA system. This puts the responsibiility of
+            # the end-user (in this example, it's the local UI) on whether to show the
+            # web page contents.
 
         mechanism = AuthMech[data['mechanism']]
         if app.authentication_context is None:


### PR DESCRIPTION
Seems to be a reoccurring theme whereby HA is disabled and then both controllers are power cycled, rebooted, etc. When HA is disabled...failover will not work by design. It has been this way since the beginning. However, some changes to the UI login page have introduced a situation where the user is unable to login at all without any indication as to why (even if the credentials that are provided are valid).

This changes the logic to return REDIRECT _ONLY_ when HA is healthy and the user is trying to login to the standby controller. Otherwise, the login attempt will fall through like normal.

This shifts the responsibility of whether to continue the login process and show the web page contents back to the caller (local UI in this scenario).

Original PR: https://github.com/truenas/middleware/pull/16781
