### PR TITLE
NAS-136782 / 25.10 / Fix filter for checking time machine share

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/services/ADISK.service.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/services/ADISK.service.py
@@ -31,7 +31,7 @@ def render(service, middleware, render_ctx):
         raise FileShouldNotExist()
 
     shares = middleware.call_sync('sharing.smb.query', [
-        ['OR', [['purpose', '=', ['TIMEMACHINE_SHARE']], ['options.timemachine', '=', True]]],
+        ['OR', [['purpose', '=', 'TIMEMACHINE_SHARE'], ['options.timemachine', '=', True]]],
         ['enabled', '=', True], ['locked', '=', False]
     ])
 
@@ -49,7 +49,7 @@ def render(service, middleware, render_ctx):
 
     for dkno, share in enumerate(shares):
         txt_records.append(
-            f'dk{dkno}=adVN={share["name"]},adVF=0x82,adVU={share["vuid"]}'
+            f'dk{dkno}=adVN={share["name"]},adVF=0x82,adVU={share["options"]["vuid"]}'
         )
 
     try:

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -415,7 +415,7 @@ def test_003_mdns_smb_share(request):
                     props = _get_tm_props(tm, b'dk0')
                     assert props['adVN'] == SMB_NAME1, props
                     assert props['adVF'] == '0x82', props
-                    assert props['adVU'] == share1['vuid'], props
+                    assert props['adVU'] == share1['options']['vuid'], props
                     # Now make another time machine share
                     with dataset(dataset_name2):
                         with smb_share(SMB_PATH2, {'name': SMB_NAME2,
@@ -433,17 +433,17 @@ def test_003_mdns_smb_share(request):
                             # Let's not make any assumption about which share is which
                             if props0['adVN'] == SMB_NAME1:
                                 # SHARE 1 in props0
-                                assert props0['adVU'] == share1['vuid'], props0
+                                assert props0['adVU'] == share1['options']['vuid'], props0
                                 # SHARE 2 in props1
                                 assert props1['adVN'] == SMB_NAME2, props1
-                                assert props1['adVU'] == share2['vuid'], props1
+                                assert props1['adVU'] == share2['options']['vuid'], props1
                             else:
                                 # SHARE 1 in props1
                                 assert props1['adVN'] == SMB_NAME1, props1
-                                assert props1['adVU'] == share1['vuid'], props1
+                                assert props1['adVU'] == share1['options']['vuid'], props1
                                 # SHARE 2 in props0
                                 assert props0['adVN'] == SMB_NAME2, props0
-                                assert props0['adVU'] == share2['vuid'], props0
+                                assert props0['adVU'] == share2['options']['vuid'], props0
                     # Still have one TM share
                     allow_settle()
                     ac.find_items()


### PR DESCRIPTION
This commit fixes the filter that determines whether an SMB share needs an ADISK mDNS record.