### PR TITLE
NAS-136766 / 25.10 / Fix crash on `update.status` call

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/update.py
+++ b/src/middlewared/middlewared/api/v25_10_0/update.py
@@ -87,6 +87,7 @@ class UpdateStatusStatus(BaseModel):
 class UpdateDownloadProgress(BaseModel):
     percent: float
     description: LongString
+    version: str
 
 
 class UpdateStatus(BaseModel):


### PR DESCRIPTION
Missing API field