### PR TITLE
NAS-136805 / 25.10 / Fix JBOFEntry model

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/jbof.py
+++ b/src/middlewared/middlewared/api/v25_10_0/jbof.py
@@ -23,10 +23,16 @@ class JBOFEntry(BaseModel):
     """Redfish administrative username."""
     mgmt_password: Secret[str]
     """Redfish administrative password."""
+    index: int
+    """Index of the JBOF.  Used to determine data plane IP addresses."""
+    uuid: str
+    """UUID of the JBOF as reported by the enclosure firmware."""
 
 
 class JBOFCreate(JBOFEntry):
     id: Excluded = excluded_field()
+    index: Excluded = excluded_field()
+    uuid: Excluded = excluded_field()
 
 
 class JBOFUpdate(JBOFCreate, metaclass=ForUpdateMetaclass):


### PR DESCRIPTION
Some items were accidentally omitted from the API model for `JBOFEntry`.  Add them.


----
(Changes tested with hardware.)