### PR TITLE
Account for partition start in `disk.get_data_partition_size`

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -7,11 +7,13 @@ from middlewared.service import CallError, private, Service
 class DiskService(Service):
 
     @private
-    def get_data_partition_size(self, disk):
+    def get_data_partition_size(self, disk, partition_start=0):
         size = self.middleware.call_sync('disk.get_dev_size', disk)
         # Reserve 2 GiB or disk space (but no more than 1%) to allow this disk to be replaced with a slightly
         # smaller one in the future.
         size = size - int(min(2 * 1024 ** 3, size * 0.01))
+        # Subtract any preceding partition sizes
+        size -= partition_start
         # Align the partition size to the even number of MiB
         align = 1024 ** 2
         size = size // align * align

--- a/src/middlewared/middlewared/plugins/pool_/expand.py
+++ b/src/middlewared/middlewared/plugins/pool_/expand.py
@@ -73,7 +73,7 @@ class PoolService(Service):
 
     @private
     async def expand_partition(self, part_data):
-        size = await self.middleware.call('disk.get_data_partition_size', part_data['disk'])
+        size = await self.middleware.call('disk.get_data_partition_size', part_data['disk'], part_data['start'])
         if size <= part_data['size']:
             return
 

--- a/src/middlewared/middlewared/test/integration/utils/disk.py
+++ b/src/middlewared/middlewared/test/integration/utils/disk.py
@@ -5,9 +5,9 @@ from middlewared.test.integration.utils import call
 __all__ = ['retry_get_parts_on_disk']
 
 
-def retry_get_parts_on_disk(disk, max_tries=10):
+def retry_get_parts_on_disk(disk, max_tries=10, min_parts=1):
     for i in range(max_tries):
-        if parts := call('disk.list_partitions', disk):
+        if len(parts := call('disk.list_partitions', disk)) >= min_parts:
             return parts
         time.sleep(1)
     else:


### PR DESCRIPTION
There are some systems with pools created on legacy systems. That systems have data partitions starting after swap partition. Account for that.

`test_expand_partition_does_not_destroy_data` was testing a situation that is no longer possible (we won't be trying to expand beyond the disk size if the expanded partition does not start at the beginning of the disk).