### PR TITLE
Fix JBOF breakage

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -292,7 +292,7 @@ class JBOFService(CRUDService):
 
     @private
     def alt_mgmt_ip(self, mgmt_ip):
-        other_mgmt_ips = filter(lambda x: x != mgmt_ip, self.get_mgmt_ips(mgmt_ip))
+        other_mgmt_ips = list(filter(lambda x: x != mgmt_ip, self.get_mgmt_ips(mgmt_ip)))
         for ip in other_mgmt_ips:
             if RedfishClient.is_redfish(ip):
                 return ip

--- a/src/middlewared/middlewared/plugins/rdma/interface/crud.py
+++ b/src/middlewared/middlewared/plugins/rdma/interface/crud.py
@@ -10,7 +10,7 @@ import middlewared.sqlalchemy as sa
 
 
 class RdmaInterfaceEntry(BaseModel):
-    id: str
+    id: int
     node: str = ''
     ifname: str
     address: IPvAnyAddress


### PR DESCRIPTION
- Wrong type was added for `id` in `RdmaInterfaceEntry` API.  Rectify.  This was preventing cleanup on JBOF removal (log message).
- Prevent breakage wrt filter in `alt_mgmt_ip`.  Code on the error path - when the 2nd mgmt IP was not accessible - had never been tested, and contained a traceback because of len(filter).