### PR TITLE
NAS-136814 / 25.10 / Fix `pool.dataset.get_quota` failing when the quota's user no longer exists

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
@@ -45,7 +45,7 @@ def quota_cb(quota, state):
         # to be safe
         return True
 
-    entry = {'quota_type': state['qt'], 'id': quota.xid, 'name': quota.xid, value_key: quota.value}
+    entry = {'quota_type': state['qt'], 'id': quota.xid, 'name': None, value_key: quota.value}
     if quota.xid not in state['quotas']:
         # only resolve the xid once
         try:


### PR DESCRIPTION
Fixes https://github.com/truenas/middleware/pull/16745 which incorrectly set the name to the id in the case that name resolution fails. The return schema for `pool.dataset.get_quota` specifies string or null, and null is reserved specifically for this purpose according to the API docs.