### PR TITLE
fix virtio-blk serial number detection

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -126,7 +126,13 @@ class DiskEntry:
     @functools.cached_property
     def serial(self) -> str | None:
         """The disk's serial number as reported by sysfs"""
-        if not (serial := self.__opener(relative_path="device/serial")):
+        # nvme devices
+        serial = self.__opener(relative_path="device/serial")
+        if not serial:
+            # virtio-blk devices (vd)
+            serial = self.__opener(relative_path="serial")
+
+        if not serial:
             if raw := self.__opener(relative_path="device/vpd_pg80", mode="rb"):
                 # VPD page 0x80 (Unit Serial Number) structure:
                 #   Byte 0: Peripheral qualifier & device type


### PR DESCRIPTION
sysfs is a travesty for having any type of uniformity of how it populates files for various attributes of a disk. We're no longer properly detecting serial numbers for virtio-blk based disks. This is because the `serial` file is put at the root of the block device directory in sysfs.

Changes here just add another path check to ensure we're grabbing the serial number properly. This was confirmed to work on another developer's VM.

NOTE: we'll be sending sg/nvme IOCTL commands to the disks in half-moon to get this information instead of trying to parse sysfs antics.