### PR TITLE
NAS-132570 / 25.10 / Add product_id to iSCSI API

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-07-23_16-49_iscsi_product_id.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-07-23_16-49_iscsi_product_id.py
@@ -1,0 +1,25 @@
+"""Add iSCSI Product ID field
+
+Revision ID: 3298b9ae612b
+Revises: fe655f29b9c9
+Create Date: 2025-07-23 16:49:05.911976+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3298b9ae612b'
+down_revision = 'fe655f29b9c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_iscsitargetextent', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('iscsi_target_extent_product_id', sa.Text(), nullable=True))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
@@ -39,6 +39,7 @@ class IscsiExtentEntry(BaseModel):
     ro: bool = False
     enabled: bool = True
     vendor: str
+    product_id: Annotated[NonEmptyString, StringConstraints(max_length=16)] | None = None
     locked: bool | None
     """ Read-only value indicating whether the iscsi extent is located on a locked dataset.
 

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -378,7 +378,7 @@ HANDLER ${handler} {
         read_only ${'1' if extent['ro'] else '0'}
         usn ${extent['serial']}
         naa_id ${extent['naa']}
-        prod_id "iSCSI Disk"
+        prod_id "${extent['product_id']}"
 %       if extent['rpm'] != 'SSD':
         rotational 1
 %       else:


### PR DESCRIPTION
For SCST extents allow `product_id` to be specified on a per-extent basis.  The default (None) will result in the existing "iSCSI Disk" being returned.

Parameterize `test__inquiry` to validate that the value is seen by clients.

----
CI with passing FC and iSCSI tests [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/67/).