### PR TITLE
NAS-136819 / 25.10 / Limit NVMe RDMA I/O queues to 16 for ES24N shelves

### DIFF
--- a/src/freenas/usr/local/bin/nvmf-connect.sh
+++ b/src/freenas/usr/local/bin/nvmf-connect.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 RECONNECT_TIMEOUT_SEC=5
-discovery_dev=$(echo "$@" | grep -oP '(?<=--device=)\w+')
+
+# Reduce number of queues to 16 due to Viking limitation
+args=$(echo "$@" | sed -E 's/(-i\s+[0-9]+|--nr-io-queues=[0-9]+)//g') 
+args="$args -i 16"
+
+discovery_dev=$(echo "$args" | grep -oP '(?<=--device=)\w+')
 discovery_addr=$(</sys/class/nvme/${discovery_dev}/address)
 queue="/var/run/${discovery_dev}-fabric-queue"
 
@@ -9,7 +14,7 @@ while [ -s $queue ]; do
   truncate -s 0 $queue
   local_nqns=""
   disconnected=0
-  discovery_nqns=$(nvme discover $@ | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1')
+  discovery_nqns=$(nvme discover $args | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1')
 
   for nqn_f in /sys/class/nvme-fabrics/ctl/nvme*/subsysnqn; do
     dev=$(basename "$(dirname "$nqn_f")")
@@ -33,7 +38,7 @@ while [ -s $queue ]; do
     local_nqns=$(echo -e "$local_nqns" | tr -s '\n' | sort)
 
     while [ $counter -lt $RECONNECT_TIMEOUT_SEC ]; do
-      connect_nqns=$(nvme discover "$@" | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1' \
+      connect_nqns=$(nvme discover $args | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1' \
           | tr -s '\n' | sort)
 
       if [[ -n "$local_nqns" && "$local_nqns" != "$connect_nqns" ]]; then
@@ -45,6 +50,6 @@ while [ -s $queue ]; do
     done
   fi
 
-  connect_all=$(nvme connect-all $@)
+  connect_all=$(nvme connect-all $args)
 done
 echo "EXIT" > $queue


### PR DESCRIPTION
R60 has 128 cores, which causes it to request 128 I/O queues per controller. The ES24N remote accepts that full request without capping to the number it can actually support. However, ES24N only provides 896 total IO queues, which are exhausted after the seventh controller is added. Because ES24N does not dynamically reduce its queue allocation based on available resources, we have to restrict each controller to 16 queues. This change prevents “No QP” errors when populating all 24 slots

### Testing
- Validated the scenario described in [NAS-136819](https://ixsystems.atlassian.net/browse/NAS-136819) by @jervin777.
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1336/).