### PR TITLE
add zfs.resource.query API

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_10_0/__init__.py
@@ -123,3 +123,4 @@ from .vmware import *
 from .webui_crypto import *
 from .webui_enclosure import *
 from .webui_main_dashboard import *
+from .zfs_resource_crud import *

--- a/src/middlewared/middlewared/api/v25_10_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v25_10_0/zfs_resource_crud.py
@@ -1,0 +1,314 @@
+from typing import Literal
+
+from pydantic import Field
+
+from middlewared.api.base import BaseModel, NotRequired, UniqueList
+
+__all__ = ("ZFSResourceEntry", "ZFSResourceQueryArgs", "ZFSResourceQueryResult")
+READ_ONLY = "(READ-ONLY):"
+PROP_SRC = Literal["NONE", "DEFAULT", "TEMPORARY", "LOCAL", "INHERITED", "RECEIVED"]
+
+
+class SourceValue(BaseModel):
+    type: PROP_SRC
+    """The source type."""
+    value: str | None
+    """The source value."""
+
+
+class PropertyValue(BaseModel):
+    raw: str
+    """The raw value of the property."""
+    source: SourceValue | None
+    """The source from where this property received its value."""
+    value: int | float | str | bool | None
+    """The parsed raw value of the property."""
+
+
+class ZFSPropertiesEntry(BaseModel):
+    aclinherit: PropertyValue = NotRequired
+    """Controls how ACEs are inherited for new files/directories."""
+    aclmode: PropertyValue = NotRequired
+    """Determines how ACLs are modified during chmod operations."""
+    acltype: PropertyValue = NotRequired
+    """Specifies type of ACL to use (off, nfsv4, posix)."""
+    atime: PropertyValue = NotRequired
+    """Controls whether access time is updated on file reads."""
+    canmount: PropertyValue = NotRequired
+    """Controls whether filesystem can be mounted."""
+    casesensitivity: PropertyValue = NotRequired
+    """Determines filename matching algorithm sensitivity."""
+    defaultgroupobjquota: PropertyValue = NotRequired
+    """Default object quota for new groups."""
+    defaultgroupquota: PropertyValue = NotRequired
+    """Default space quota for new groups."""
+    defaultprojectobjquota: PropertyValue = NotRequired
+    """Default object quota for new projects."""
+    defaultprojectquota: PropertyValue = NotRequired
+    """Default space quota for new projects."""
+    defaultuserobjquota: PropertyValue = NotRequired
+    """Default object quota for new users."""
+    defaultuserquota: PropertyValue = NotRequired
+    """Default space quota for new users."""
+    devices: PropertyValue = NotRequired
+    """Controls whether device files can be opened."""
+    direct: PropertyValue = NotRequired
+    """Controls direct I/O behavior (standard or always)."""
+    dnodesize: PropertyValue = NotRequired
+    """Controls dnode size for new objects."""
+    exec: PropertyValue = NotRequired
+    """Controls whether programs can be executed from filesystem."""
+    filesystem_count: PropertyValue = NotRequired
+    f"""{READ_ONLY} count of child filesystems."""
+    filesystem_limit: PropertyValue = NotRequired
+    """Maximum number of child filesystems allowed."""
+    longname: PropertyValue = NotRequired
+    """Controls support for long filenames."""
+    mounted: PropertyValue = NotRequired
+    f"""{READ_ONLY} property indicating if filesystem is mounted."""
+    mountpoint: PropertyValue = NotRequired
+    """Controls mount point used for this filesystem."""
+    nbmand: PropertyValue = NotRequired
+    """Controls non-blocking mandatory locking behavior."""
+    normalization: PropertyValue = NotRequired
+    """Unicode normalization property for filenames."""
+    overlay: PropertyValue = NotRequired
+    """Controls overlay mount behavior."""
+    quota: PropertyValue = NotRequired
+    """Limits space consumed by dataset and descendants."""
+    recordsize: PropertyValue = NotRequired
+    """Maximum block size for files in this filesystem."""
+    refquota: PropertyValue = NotRequired
+    """Limits space consumed by dataset itself (no descendants)."""
+    refreservation: PropertyValue = NotRequired
+    """Minimum space reserved for dataset itself (no descendants)."""
+    relatime: PropertyValue = NotRequired
+    """Controls relative access time updates."""
+    setuid: PropertyValue = NotRequired
+    """Controls setuid/setgid bit respect on executable files."""
+    sharenfs: PropertyValue = NotRequired
+    """Controls NFS sharing options for the filesystem."""
+    sharesmb: PropertyValue = NotRequired
+    """Controls SMB/CIFS sharing options for the filesystem."""
+    snapdir: PropertyValue = NotRequired
+    """Controls snapshot directory visibility (hidden or visible)."""
+    special_small_blocks: PropertyValue = NotRequired
+    """Size threshold for storing blocks on special vdevs."""
+    utf8only: PropertyValue = NotRequired
+    """Controls whether only UTF-8 filenames are allowed."""
+    version: PropertyValue = NotRequired
+    f"""{READ_ONLY} filesystem version number."""
+    volmode: PropertyValue = NotRequired
+    """Controls volume mode (default, geom, dev, none)."""
+    vscan: PropertyValue = NotRequired
+    """Controls virus scanning behavior."""
+    xattr: PropertyValue = NotRequired
+    """Controls extended attribute behavior (on, off, sa, dir)."""
+    zoned: PropertyValue = NotRequired
+    """Controls whether filesystem is managed from a zone."""
+    available: PropertyValue = NotRequired
+    """Amount of space available to dataset and its children."""
+    checksum: PropertyValue = NotRequired
+    """Controls checksum algorithm used to verify data integrity."""
+    compression: PropertyValue = NotRequired
+    """Controls compression algorithm used for this dataset."""
+    compressratio: PropertyValue = NotRequired
+    f"""{READ_ONLY} property showing achieved compression ratio."""
+    context: PropertyValue = NotRequired
+    """SELinux security context for the dataset."""
+    copies: PropertyValue = NotRequired
+    """Controls number of copies of data stored (1, 2, or 3)."""
+    createtxg: PropertyValue = NotRequired
+    f"""{READ_ONLY} transaction group when dataset was created."""
+    creation: PropertyValue = NotRequired
+    f"""{READ_ONLY} timestamp when dataset was created."""
+    dedup: PropertyValue = NotRequired
+    """Controls data deduplication for the dataset."""
+    defcontext: PropertyValue = NotRequired
+    """SELinux default security context for new files."""
+    encryption: PropertyValue = NotRequired
+    """Controls encryption cipher suite for the dataset."""
+    encryptionroot: PropertyValue = NotRequired
+    f"""{READ_ONLY} property showing encryption root dataset."""
+    fscontext: PropertyValue = NotRequired
+    """SELinux filesystem security context."""
+    guid: PropertyValue = NotRequired
+    f"""{READ_ONLY} globally unique identifier for the dataset."""
+    keyformat: PropertyValue = NotRequired
+    """Encryption key format (raw, hex, or passphrase)."""
+    keylocation: PropertyValue = NotRequired
+    """Location where encryption key is stored."""
+    keystatus: PropertyValue = NotRequired
+    f"""{READ_ONLY} encryption key status (available/unavailable)."""
+    logbias: PropertyValue = NotRequired
+    """Controls ZIL write behavior (latency or throughput)."""
+    logicalreferenced: PropertyValue = NotRequired
+    f"""{READ_ONLY} logical space referenced by dataset."""
+    logicalused: PropertyValue = NotRequired
+    f"""{READ_ONLY} logical space used by dataset and descendants."""
+    mlslabel: PropertyValue = NotRequired
+    """Multi-level security label for the dataset."""
+    objsetid: PropertyValue = NotRequired
+    f"""{READ_ONLY} object set identifier for the dataset."""
+    origin: PropertyValue = NotRequired
+    f"""{READ_ONLY} snapshot this dataset was cloned from."""
+    pbkdf2iters: PropertyValue = NotRequired
+    """Number of PBKDF2 iterations for key derivation."""
+    prefetch: PropertyValue = NotRequired
+    """Controls prefetch behavior (all, metadata, or none)."""
+    primarycache: PropertyValue = NotRequired
+    """Controls primary cache usage (all, metadata, or none)."""
+    readonly: PropertyValue = NotRequired
+    """Controls whether dataset can be modified."""
+    receive_resume_token: PropertyValue = NotRequired
+    f"""{READ_ONLY} token for resuming interrupted zfs receive."""
+    redact_snaps: PropertyValue = NotRequired
+    f"""{READ_ONLY} list of redaction snapshots."""
+    redundant_metadata: PropertyValue = NotRequired
+    """Controls redundant metadata storage (all or most)."""
+    refcompressratio: PropertyValue = NotRequired
+    f"""{READ_ONLY} compression ratio for referenced data."""
+    referenced: PropertyValue = NotRequired
+    f"""{READ_ONLY} space referenced by this dataset."""
+    reservation: PropertyValue = NotRequired
+    """Minimum space reserved for dataset and descendants."""
+    rootcontext: PropertyValue = NotRequired
+    """SELinux root directory security context."""
+    secondarycache: PropertyValue = NotRequired
+    """Controls secondary cache usage (all, metadata, or none)."""
+    snapdev: PropertyValue = NotRequired
+    """Controls snapshot device visibility (hidden or visible)."""
+    snapshot_count: PropertyValue = NotRequired
+    f"""{READ_ONLY} count of snapshots in this dataset."""
+    snapshot_limit: PropertyValue = NotRequired
+    """Maximum number of snapshots allowed."""
+    snapshots_changed: PropertyValue = NotRequired
+    f"""{READ_ONLY} property indicating snapshot changes."""
+    sync: PropertyValue = NotRequired
+    """Controls synchronous write behavior (standard, always, disabled)."""
+    type: PropertyValue | None = NotRequired
+    f"""{READ_ONLY} type of ZFS dataset (filesystem, volume, etc)."""
+    used: PropertyValue = NotRequired
+    f"""{READ_ONLY} space used by dataset and descendants."""
+    usedbychildren: PropertyValue = NotRequired
+    f"""{READ_ONLY} space used by child datasets."""
+    usedbydataset: PropertyValue = NotRequired
+    f"""{READ_ONLY} space used by this dataset itself."""
+    usedbyrefreservation: PropertyValue = NotRequired
+    f"""{READ_ONLY} space used by refreservation."""
+    usedbysnapshots: PropertyValue = NotRequired
+    f"""{READ_ONLY} space used by snapshots."""
+    written: PropertyValue = NotRequired
+    f"""{READ_ONLY} space referenced since previous snapshot."""
+    refreservation: PropertyValue = NotRequired
+    """Minimum space reserved for volume itself."""
+    volblocksize: PropertyValue = NotRequired
+    """Block size for volume (typically 8K or 16K)."""
+    volmode: PropertyValue = NotRequired
+    """Controls volume mode (default, geom, dev, none)."""
+    volsize: PropertyValue = NotRequired
+    """Logical size of the volume."""
+    volthreading: PropertyValue = NotRequired
+    """Controls volume threading behavior."""
+
+
+class ZFSResourceEntry(BaseModel):
+    createtxg: int
+    """Transaction group when resource was created."""
+    guid: int
+    """Globally unique identifier for the resource."""
+    name: str
+    """The name of the zfs resource."""
+    pool: str
+    """The name of the zpool that the zfs resouce is associated to."""
+    properties: ZFSPropertiesEntry
+    """The zfs properties for the resource."""
+    type: Literal["FILESYSTEM", "VOLUME"]
+    """The type of ZFS resource."""
+    user_properties: dict[str, str] | None
+    """Custom metadata properties with colon-separated names (max 256 chars)."""
+    children: list
+    """The children of this zfs resource."""
+
+
+class ZFSResourceQuery(BaseModel):
+    paths: UniqueList[str] = list()
+    """A list of zfs filesystem or volume paths to be queried. \
+    In almost all scenarios, you should provide a path of what you \
+    want to query. By providing path(s) here, it allows the API to \
+    apply optimizations so that the requested information is retrieved \
+    as efficiently and quickly as possible.
+
+    Example 1:
+        {"paths": ["tank/foo"]} will query the relevant information for \
+            this resource only.
+    Example 2:
+        {"paths": ["tank/foo", "dozer/test"]} will query the relevant \
+            information for these resources only.
+
+    NOTE:
+        paths must be non-overlapping if `get_children` is True.
+        (i.e. this won't work and will raise a validation error)
+            {
+                "paths": ["tank/foo1", "tank/foo1/foo2"],
+                "get_children": True
+            }
+    """
+    properties: list[str] | None = list()
+    """A list of zfs properties to be retrieved. Defaults to an \
+    empty list which will return a default set of zfs properties.
+    Setting this to None will retrieve no zfs properties."""
+    get_user_properties: bool = False
+    """Retrieve user properties for zfs resource(s)."""
+    get_source: bool = Field(default=True, exclude_json_schema=True)
+    """Hidden field to retrieve source information for a zfs property.
+
+    NOTE: This should only ever be toggled by internal consumers and \
+    you should know what you're doing by toggling this to False."""
+    flat: bool = True
+    """Return a "flat" object representing the zfs resource(s). For \
+    example, a flat response will look like so:
+        [
+            {
+                "name": "tank/foo",
+                "pool": "tank",
+                "children": [],
+            },
+            {
+                "name": "tank/foo/boo",
+                "pool": "tank",
+                "children": [],
+            }
+        ]
+
+    If flat is False, a response will look like so:
+        [
+            {
+                "name": "tank/foo",
+                "pool": "tank",
+                "children": [
+                    {
+                        "name": "tank/foo/boo",
+                        "pool": "tank",
+                        "children": [
+                            {
+                                "name": "tank/foo/boo/you",
+                                "pool": "tank",
+                                "children": [],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]
+    """
+    get_children: bool = False
+    """Retrieve children information for the zfs resource."""
+
+
+class ZFSResourceQueryArgs(BaseModel):
+    data: ZFSResourceQuery = ZFSResourceQuery()
+
+
+class ZFSResourceQueryResult(BaseModel):
+    result: list[ZFSResourceEntry]

--- a/src/middlewared/middlewared/plugins/zfs/normalization.py
+++ b/src/middlewared/middlewared/plugins/zfs/normalization.py
@@ -1,0 +1,122 @@
+from types import MappingProxyType
+
+from middlewared.plugins.zfs_.utils import TNUserProp
+
+__all__ = ("normalize_asdict_result",)
+
+USER_PROP_RENAME_DICT = MappingProxyType(
+    {
+        TNUserProp.DESCRIPTION.value: "comments",
+        TNUserProp.QUOTA_WARN.value: "quota_warning",
+        TNUserProp.QUOTA_CRIT.value: "quota_critical",
+        TNUserProp.REFQUOTA_WARN.value: "refquota_warning",
+        TNUserProp.REFQUOTA_CRIT.value: "refquota_critical",
+        TNUserProp.MANAGED_BY.value: "managedby",
+    }
+)
+
+
+def normalize_asdict_result(result: dict, *, normalize_source: bool) -> dict:
+    """
+    Normalize ZFS resource dictionary result from truenas_pylibzfs asdict() method.
+
+    This function transforms the raw ZFS resource dictionary returned by the
+    truenas_pylibzfs library into a normalized format suitable for API responses.
+
+    Transformations performed:
+    1. Removes the 'type_enum' key (internal enum object)
+    2. Removes the 'crypto' key (crypto properties included in properties if requested)
+    3. Converts property source enum values to string names
+    4. Renames known user properties according to USER_PROP_RENAME_DICT
+    5. Preserves unknown user properties as-is
+    6. Removes 'ZFS_TYPE_' prefix from the 'type' key
+
+    Args:
+        result (dict): Raw ZFS resource dictionary from truenas_pylibzfs asdict().
+                      Expected to contain keys: name, type, properties, user_properties.
+                      The properties dict contains property values with source information.
+                      The user_properties dict contains custom ZFS user properties.
+        normalize_source (bool): If True, will normalize the `source` key.
+
+    Returns:
+        dict: The same dictionary object modified in-place with normalized values.
+              Property sources will be converted from enum objects to string names.
+              Known user properties will be renamed according to mapping rules.
+
+    Note:
+        This function modifies the input dictionary in-place and returns the same
+        object reference. Property source enum objects are converted to their
+        string names (e.g., PropertySource.NONE becomes "NONE").
+
+    Example:
+        >>> raw_result = {
+        ...     "type_enum": <ZFSType.ZFS_TYPE_FILESYSTEM>,
+        ...     "name": "pool/dataset",
+        ...     "type": "ZFS_TYPE_FILESYSTEM",
+        ...     "crypto": None,
+        ...     "properties": {
+        ...         "used": {
+        ...             "source": {"type": <PropertySource.NONE>, "value": None}
+        ...         }
+        ...     },
+        ...     "user_properties": {
+        ...         "org.freenas:description": "My dataset"
+        ...     }
+        ... }
+        >>> normalized = normalize_asdict_result(raw_result)
+        >>> normalized = {
+        ...     "name": "pool/dataset",
+        ...     "type": "FILESYSTEM",
+        ...     "properties": {
+        ...         "used": {
+        ...             "source": {"type": "NONE", "value": None}
+        ...         }
+        ...     },
+        ...     "user_properties": {
+        ...         "comments": "My dataset"
+        ...     }
+        ... }
+    """
+    # remove the enum object
+    result.pop("type_enum", None)
+
+    # remove crypto key. if someone has requested
+    # propert(y/ies) and any of those are crypto
+    # related, then the propert(y/ies) will be
+    # be included automatically. No need to have
+    # a top-level crypto key that is a sub-set of
+    # the data that is already included
+    result.pop("crypto", None)
+
+    # type has prefix of ZFS_TYPE_
+    result["type"] = result["type"][9:]
+
+    # always add children key.
+    # NOTE: this will get dynamically
+    # populated by caller
+    result["children"] = list()
+
+    if normalize_source:
+        # update zfs properties
+        for i in result["properties"].values():
+            # looks like:
+            # {'source': {'type': <PropertySource.NONE: 1>, 'value': None}}
+            # converting it to:
+            # {'source': {'type': 'NONE', 'value': None}}
+            i["source"]["type"] = i["source"]["type"].name
+
+    # update user properties
+    if result["user_properties"]:
+        final = dict()
+        for k, v in result["user_properties"].items():
+            if k in USER_PROP_RENAME_DICT:
+                # looks like:
+                # {'org.freenas:refquota_critical': '95'}
+                # converting it to:
+                # {'refquota_critical': '95'}
+                final[USER_PROP_RENAME_DICT[k]] = v
+            else:
+                # leave it as-is
+                final[k] = v
+        result["user_properties"] = final
+    return result

--- a/src/middlewared/middlewared/plugins/zfs/property_management.py
+++ b/src/middlewared/middlewared/plugins/zfs/property_management.py
@@ -1,0 +1,167 @@
+from dataclasses import dataclass
+from typing import TypeAlias
+
+try:
+    from truenas_pylibzfs import property_sets, ZFSProperty, ZFSType
+except ImportError:
+    # NOTE: initialized this way so github CI
+    # doesn't explode since this module isn't
+    # installed in the CI VM.
+    property_sets = ZFSProperty = ZFSType = None
+
+__all__ = ("build_set_of_zfs_props",)
+
+
+ZFSPropSetType: TypeAlias = frozenset["ZFSProperty"]
+ZFSResourceType: TypeAlias = "ZFSType"
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class ZFSPropertyTemplates:
+    default: ZFSPropSetType | None = None
+    """The default set of zfs properties to be retrieved if \
+    none are provided."""
+    fs: ZFSPropSetType | None = None
+    """All available set of zfs properties for filesystems."""
+    fs_ro: ZFSPropSetType | None = None
+    """All available set of readonly zfs properties for filesystems."""
+    vol: ZFSPropSetType | None = None
+    """All available set of zfs properties for volumes."""
+    vol_ro: ZFSPropSetType | None = None
+    """All available set of readonly zfs properties for volumes."""
+    crypto: ZFSPropSetType | None = None
+    """All available zfs encryption related properties."""
+
+    @classmethod
+    def generate(cls):
+        """Generate ZFS property templates from available property sets.
+
+        Returns:
+            ZFSPropertyTemplates: A new instance with property sets populated
+                from truenas_pylibzfs if available, otherwise empty templates.
+        """
+        if property_sets is not None:
+            return cls(
+                default=property_sets.ZFS_SPACE_PROPERTIES,
+                fs=property_sets.ZFS_FILESYSTEM_PROPERTIES,
+                fs_ro=property_sets.ZFS_FILESYSTEM_READONLY_PROPERTIES,
+                vol=property_sets.ZFS_VOLUME_PROPERTIES,
+                vol_ro=property_sets.ZFS_VOLUME_READONLY_PROPERTIES,
+                crypto=frozenset(
+                    (
+                        ZFSProperty.ENCRYPTION,
+                        ZFSProperty.ENCRYPTIONROOT,
+                        ZFSProperty.KEYFORMAT,
+                        ZFSProperty.KEYLOCATION,
+                        ZFSProperty.KEYSTATUS,
+                    )
+                ),
+            )
+        return cls()
+
+
+PROPERTY_TEMPLATES = ZFSPropertyTemplates.generate()
+
+
+@dataclass(slots=True, kw_only=True)
+class DeterminedProperties:
+    """This class represents the properties that we
+    have determined to be valid based on what was given
+    to us and if the requested property is valid for the
+    underlying zfs resource type. The idea, also, is that
+    these need to only be calculated once for each zfs type
+    that we come across."""
+
+    fs: ZFSPropSetType | None = None
+    vol: ZFSPropSetType | None = None
+    snap: ZFSPropSetType | None = None
+    default: ZFSPropSetType | None = None
+
+
+def __build_cache(
+    hdl_type: ZFSResourceType, req_props: list[str], det_props: DeterminedProperties
+) -> frozenset["ZFSProperty"]:
+    """Build and cache a set of valid ZFS properties for a specific resource type.
+
+    Args:
+        hdl_type: The ZFS resource type (filesystem, or volume)
+        req_props: List of requested property names as strings
+        det_props: DeterminedProperties instance to cache results in
+
+    Returns:
+        frozenset[ZFSProperty]: Set of valid ZFS properties for the type.
+            Returns empty frozenset if no valid properties found.
+    """
+    requested_props = set()
+    is_fs = hdl_type == ZFSType.ZFS_TYPE_FILESYSTEM
+    is_vol = hdl_type == ZFSType.ZFS_TYPE_VOLUME
+    for i in req_props:
+        try:
+            prop = ZFSProperty[i.upper()]
+        except KeyError:
+            # invalid property, nothing to do
+            continue
+
+        if is_fs and prop in property_sets.ZFS_FILESYSTEM_PROPERTIES:
+            requested_props.add(prop)
+        elif is_vol and prop in property_sets.ZFS_VOLUME_PROPERTIES:
+            requested_props.add(prop)
+
+        if prop in PROPERTY_TEMPLATES.crypto:
+            # if any property requested is a crypto property,
+            # we're going to include the other crypto related
+            # properties for the convenience of the api user
+            requested_props |= PROPERTY_TEMPLATES.crypto
+
+    # Cache the result for this type
+    requested_props = requested_props or set()
+    if hdl_type == ZFSType.ZFS_TYPE_FILESYSTEM:
+        det_props.fs = requested_props
+    elif hdl_type == ZFSType.ZFS_TYPE_VOLUME:
+        det_props.vol = requested_props
+
+    return frozenset(requested_props)
+
+
+def build_set_of_zfs_props(
+    hdl_type: ZFSResourceType,
+    det_props: DeterminedProperties,
+    req_props: list[str] | None,
+) -> frozenset["ZFSProperty"]:
+    """Build a set of ZFS properties to retrieve for a given ZFS resource.
+
+    This function determines which ZFS properties should be retrieved based on
+    the resource type and requested properties. It uses caching to avoid
+    recomputing property sets for the same resource types.
+
+    Args:
+        hdl_type: The ZFS resource type (filesystem, volume, or snapshot)
+        det_props: DeterminedProperties instance used for caching results
+        req_props: List of requested property names as strings, or None
+            for no properties. An empty list (default) requests space
+            related properties.
+
+    Returns:
+        frozenset[ZFSProperty] | None: Set of valid ZFS properties to retrieve,
+            default properties if req_props is None, or None if no properties
+            should be retrieved (empty req_props list or unsupported type).
+    """
+    if req_props is None:
+        # If the req_props (requested properties) is None, then
+        # the user explicitly requested no zfs properties be retrieved
+        return frozenset()
+    elif req_props == [] or hdl_type not in (
+        ZFSType.ZFS_TYPE_FILESYSTEM,
+        ZFSType.ZFS_TYPE_VOLUME,
+    ):
+        # No properties were requested, or unsupported resource type
+        return PROPERTY_TEMPLATES.default
+
+    # Check if we already have cached properties for this type
+    if hdl_type == ZFSType.ZFS_TYPE_FILESYSTEM and det_props.fs is not None:
+        return det_props.fs
+    elif hdl_type == ZFSType.ZFS_TYPE_VOLUME and det_props.vol is not None:
+        return det_props.vol
+
+    # Now cache and return the zfs properties for this type
+    return __build_cache(hdl_type, req_props, det_props)

--- a/src/middlewared/middlewared/plugins/zfs/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/query_impl.py
@@ -1,0 +1,116 @@
+import dataclasses
+import itertools
+
+try:
+    from truenas_pylibzfs import ZFSError, ZFSException
+except ImportError:
+    ZFSError = ZFSException = None
+
+from middlewared.utils import BOOT_POOL_NAME_VALID
+from .normalization import normalize_asdict_result
+from .property_management import build_set_of_zfs_props, DeterminedProperties
+
+__all__ = ("query_impl", "ZFSPathNotFoundException")
+
+INTERNAL_FILESYSTEMS = (
+    ".system",
+    "ix-applications",
+    "ix-apps",
+    ".ix-virt",
+)
+
+
+class ZFSPathNotFoundException(Exception):
+    pass
+
+
+@dataclasses.dataclass(slots=True, kw_only=True)
+class CallbackState:
+    results: list
+    query_args: dict
+    dp: DeterminedProperties
+    eip: bool
+    """(e)xclude (i)nternal (p)aths. Unless
+    someone is querying an internal path, we
+    will exclude them."""
+
+
+def __is_internal_path(path):
+    """
+    Check if a path is an internal filesystem.
+
+    Args:
+        path: relative path representing the zfs filesystem
+
+    Returns:
+        bool: True if the path is internal, False otherwise
+    """
+    for a, b in itertools.zip_longest(BOOT_POOL_NAME_VALID, INTERNAL_FILESYSTEMS):
+        if a and (path == a or path.startswith(f"{a}/")):
+            return True
+        if b and (f"/{b}" in path):
+            return True
+    return False
+
+
+def __query_impl_callback(hdl, state):
+    if state.eip and __is_internal_path(hdl.name):
+        # returning False here will halt the iteration
+        # entirely which is not what we want to do
+        return True
+
+    state.results.append(
+        normalize_asdict_result(
+            hdl.asdict(
+                properties=build_set_of_zfs_props(
+                    hdl.type, state.dp, state.query_args["properties"]
+                ),
+                get_user_properties=state.query_args["get_user_properties"],
+                get_source=state.query_args["get_source"],
+            ),
+            normalize_source=state.query_args["get_source"],
+        )
+    )
+    if state.query_args["get_children"]:
+        hdl.iter_filesystems(callback=__query_impl_callback, state=state)
+    return True
+
+
+def __query_impl_paths(hdl, state):
+    for path in state.query_args["paths"]:
+        try:
+            rsrc = hdl.open_resource(name=path)
+            __query_impl_callback(rsrc, state)
+        except ZFSException as e:
+            if ZFSError(e.code) == ZFSError.EZFS_NOENT:
+                raise ZFSPathNotFoundException(f"{path!r}: not found")
+            raise
+
+
+def __query_impl_roots(hdl, state):
+    hdl.iter_root_filesystems(callback=__query_impl_callback, state=state)
+
+
+def __should_exclude_internal_paths(data):
+    for path in data["paths"]:
+        if __is_internal_path(path):
+            # somone is explicilty querying an
+            # internal path
+            return False
+    # no paths specified or none of the paths
+    # specified are an internal path
+    return True
+
+
+def query_impl(hdl, data):
+    state = CallbackState(
+        results=list(),
+        query_args=data,
+        dp=DeterminedProperties(),
+        eip=__should_exclude_internal_paths(data),
+    )
+    if state.query_args["paths"]:
+        __query_impl_paths(hdl, state)
+    else:
+        __query_impl_roots(hdl, state)
+    return state.results

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -138,4 +138,35 @@ class ZFSResourceService(Service):
         roles=["ZFS_RESOURCE_READ"],
     )
     def query(self, data):
+        """
+        Query ZFS resources (datasets and volumes) with flexible filtering options.
+
+        This method provides a high-performance interface for retrieving information \
+        about ZFS resources, including their properties, hierarchical relationships, \
+        and metadata. The query can be customized to retrieve specific resources, \
+        properties, and control the output format.
+
+        Raises:
+            ValidationError: If:
+                - Snapshot paths are provided (snapshots not currently supported)
+                - Overlapping paths are provided with get_children=True
+                - Requested paths don't exist (errno.ENOENT)
+
+        Examples:
+            # Query all resources with default properties
+            query()
+
+            # Query specific resources with all properties
+            query({"paths": ["tank/documents", "tank/media"]})
+
+            # Query with specific properties and children
+            query({
+                "paths": ["tank"],
+                "properties": ["mounted", "compression", "used"],
+                "get_children": True
+            })
+
+            # Get hierarchical view of resources
+            query({"paths": ["tank"], "flat": False, "get_children": True})
+        """
         return self.middleware.call_sync("zfs.resource.query_impl", data)

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -1,0 +1,141 @@
+import errno
+import pathlib
+
+from middlewared.api import api_method
+from middlewared.api.current import (
+    ZFSResourceEntry,
+    ZFSResourceQueryArgs,
+    ZFSResourceQueryResult,
+)
+from middlewared.service import Service, private
+from middlewared.service_exception import ValidationError
+from middlewared.service.decorators import pass_thread_local_storage
+
+from .query_impl import query_impl, ZFSPathNotFoundException
+
+
+class ZFSResourceService(Service):
+    class Config:
+        namespace = "zfs.resource"
+        cli_private = True
+        entry = ZFSResourceEntry
+
+    @private
+    def group_paths_by_parents(self, paths: list[str]) -> dict[str, list[str]]:
+        """
+        Group paths by their parent directories, mapping each parent to
+        all paths that are relative to it. For each path in the input list,
+        finds all other paths that are relative to that path and groups
+        them together.
+
+        Args:
+            paths: List of relative POSIX path strings
+
+        Returns:
+            Dict mapping parent paths to lists of their relative subpaths
+
+        Example:
+            >>> group_paths_by_parents(['dozer/test', 'dozer/test/foo', 'tank', 'dozer/abc'])
+            {'dozer/test': ['dozer/test/foo']}
+        """
+        root_dict = dict()
+        if not paths:
+            return root_dict
+
+        for path in paths:
+            subpaths = list()
+            for sp in paths:
+                if pathlib.Path(sp).is_relative_to(pathlib.Path(path)) and sp != path:
+                    # Find all paths that are relative to this path
+                    # (excluding the path itself)
+                    subpaths.append(sp)
+            if subpaths:
+                root_dict[path] = subpaths
+        return root_dict
+
+    @private
+    def validate_query_args(self, data):
+        for path in data["paths"]:
+            if "@" in path:
+                raise ValidationError(
+                    "zfs.resource.query",
+                    "Querying snapshot information is unsupported at this time.",
+                )
+
+        if data["get_children"] and self.group_paths_by_parents(data["paths"]):
+            raise ValidationError(
+                "zfs.resource.query",
+                (
+                    "Paths must be non-overlapping - no path can be relative to another "
+                    "when get_children is set to True."
+                ),
+            )
+
+    @private
+    def nest_paths(self, flat_list: dict) -> list[dict]:
+        """
+        Convert a flat list of dictionaries with path-like
+        names into a nested tree structure. Nodes are attached
+        to their nearest existing ancestor. If no ancestor
+        exists, they become root nodes.
+
+        Args:
+            flat_list: List of dictionaries with, minimally, the
+            following top-level keys 'name', 'pool', and 'children'.
+
+        Returns:
+            List containing the root nodes with nested children
+        """
+        node_map = {}
+        roots = []
+        # first pass is to create index
+        for item in flat_list:
+            node_map[item["name"]] = item
+            if item["name"] == item["pool"]:
+                # root filesystem (zpool)
+                roots.append(item)
+                continue
+
+        # second pass establishes parent/child relationship
+        # NOTE: the 2nd iteration is necessary
+        # because the list being passed in is not
+        # guaranteed to be in heirarchical order
+        for item in flat_list:
+            if item["name"] == item["pool"]:
+                continue
+
+            for parent in pathlib.PosixPath(item["name"]).parents:
+                if parent.name != "." and parent.name in node_map:
+                    node_map[parent.name]["children"].append(item)
+                    break
+            else:
+                # If no parent exists, this is a root
+                roots.append(item)
+        return roots
+
+    @private
+    @pass_thread_local_storage
+    def query_impl(self, tls, data: dict | None = None):
+        base = ZFSResourceQueryArgs().model_dump()
+        if data is None:
+            final = base
+        else:
+            final = base | data
+            self.validate_query_args(final)
+
+        try:
+            results = query_impl(tls.lzh, final)
+            if not final["flat"]:
+                return self.nest_paths(results)
+            else:
+                return results
+        except ZFSPathNotFoundException as e:
+            raise ValidationError("zfs.resource.query", str(e), errno.ENOENT)
+
+    @api_method(
+        ZFSResourceQueryArgs,
+        ZFSResourceQueryResult,
+        roles=["ZFS_RESOURCE_READ"],
+    )
+    def query(self, data):
+        return self.middleware.call_sync("zfs.resource.query_impl", data)

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -254,6 +254,8 @@ ROLES = {
     'VIRT_IMAGE_READ': Role(),
     'VIRT_IMAGE_WRITE': Role(includes=['VIRT_IMAGE_READ'], stig=None),
 
+    # ZFS Resources (query, create/update/delete)
+    'ZFS_RESOURCE_READ': Role(),
 }
 ROLES['READONLY_ADMIN'] = Role(includes=[role for role in ROLES if role.endswith('_READ')], builtin=False)
 

--- a/tests/api2/test_zfs_resource_query.py
+++ b/tests/api2/test_zfs_resource_query.py
@@ -1,0 +1,186 @@
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+
+import pytest
+
+
+def test_zfs_resource_query_specific_paths():
+    """Test querying specific ZFS resource paths"""
+    dataset_name = "test_query_dataset"
+    with dataset(dataset_name) as ds:
+        # Query specific dataset
+        result = call("zfs.resource.query", {"paths": [ds]})
+        assert len(result) == 1
+        assert result[0]["name"] == ds
+
+        # Create child datasets using nested dataset() calls
+        with dataset(f"{ds}/child1") as child1:
+            with dataset(f"{ds}/child2") as child2:
+                # Query multiple paths
+                result = call("zfs.resource.query", {"paths": [child1, child2]})
+                assert len(result) == 2
+                names = [r["name"] for r in result]
+                assert child1 in names
+                assert child2 in names
+
+
+def test_zfs_resource_query_with_properties():
+    """Test querying with specific properties"""
+    dataset_name = "test_query_properties"
+    with dataset(dataset_name, {"compression": "lz4", "atime": "off"}) as ds:
+        result = call(
+            "zfs.resource.query",
+            {"paths": [ds], "properties": ["compression", "atime", "mounted"]},
+        )
+
+        assert len(result) == 1
+        resource = result[0]
+        # Verify property values
+        assert resource["properties"]["compression"]["value"] == "lz4"
+        assert resource["properties"]["atime"]["value"] == "off"
+        assert resource["properties"]["mounted"]["value"] == "yes"
+
+
+def test_zfs_resource_query_flat_vs_nested():
+    """Test flat vs nested output format"""
+    parent_name = "test_query_structure"
+    with dataset(parent_name) as parent:
+        # Create nested structure using nested dataset() calls
+        with dataset(f"{parent}/child") as child:
+            with dataset(f"{child}/grandchild") as grandchild:
+                # Test flat structure (default)
+                flat_result = call(
+                    "zfs.resource.query",
+                    {"paths": [parent], "get_children": True, "flat": True},
+                )
+                assert len(flat_result) == 3  # parent, child, grandchild
+                # All should have empty children in flat mode
+                for resource in flat_result:
+                    assert resource["children"] == []
+
+                # Test nested structure
+                nested_result = call(
+                    "zfs.resource.query",
+                    {"paths": [parent], "get_children": True, "flat": False},
+                )
+                assert len(nested_result) == 1  # Only parent at root level
+                parent_resource = nested_result[0]
+                assert parent_resource["name"] == parent
+                assert len(parent_resource["children"]) == 1
+
+                child_resource = parent_resource["children"][0]
+                assert child_resource["name"] == child
+                assert len(child_resource["children"]) == 1
+
+                grandchild_resource = child_resource["children"][0]
+                assert grandchild_resource["name"] == grandchild
+                assert grandchild_resource["children"] == []
+
+
+def test_zfs_resource_query_get_children():
+    """Test get_children functionality"""
+    parent_name = "test_query_children"
+    with dataset(parent_name) as parent:
+        with dataset(f"{parent}/child0") as child0:
+            with dataset(f"{parent}/child1") as child1:
+                with dataset(f"{parent}/child2") as child2:
+                    children = [child0, child1, child2]
+
+                    # Query without get_children
+                    result = call(
+                        "zfs.resource.query", {"paths": [parent], "get_children": False}
+                    )
+                    assert len(result) == 1
+                    assert result[0]["name"] == parent
+
+                    # Query with get_children
+                    result = call(
+                        "zfs.resource.query", {"paths": [parent], "get_children": True}
+                    )
+                    assert len(result) == 4  # parent + 3 children
+
+                    names = [r["name"] for r in result]
+                    assert parent in names
+                    for child in children:
+                        assert child in names
+
+
+def test_zfs_resource_query_user_properties():
+    """Test querying user-defined properties"""
+    dataset_name = "test_query_user_props"
+    with dataset(dataset_name) as ds:
+        # Set user properties
+        ssh(f"zfs set com.example:test=value1 {ds}")
+        ssh(f"zfs set com.example:another=value2 {ds}")
+
+        # Query without user properties
+        result = call(
+            "zfs.resource.query", {"paths": [ds], "get_user_properties": False}
+        )
+        assert result[0]["user_properties"] is None
+
+        # Query with user properties
+        result = call(
+            "zfs.resource.query", {"paths": [ds], "get_user_properties": True}
+        )
+        user_props = result[0]["user_properties"]
+        assert user_props is not None
+        assert "com.example:test" in user_props
+        assert user_props["com.example:test"] == "value1"
+        assert "com.example:another" in user_props
+        assert user_props["com.example:another"] == "value2"
+
+
+def test_zfs_resource_query_validation_errors():
+    """Test validation errors for invalid queries"""
+
+    # Test snapshot path validation
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.query", {"paths": ["tank/dataset@snapshot"]})
+    assert "snapshot" in str(exc_info.value).lower()
+
+    # Test overlapping paths with get_children
+    parent_name = "test_query_overlap"
+    with dataset(parent_name) as parent:
+        with dataset(f"{parent}/child") as child:
+            with pytest.raises(Exception) as exc_info:
+                call(
+                    "zfs.resource.query",
+                    {"paths": [parent, child], "get_children": True},
+                )
+            assert "overlapping" in str(exc_info.value).lower()
+
+
+def test_zfs_resource_query_nonexistent_path():
+    """Test querying non-existent paths"""
+    with pytest.raises(Exception):
+        call("zfs.resource.query", {"paths": ["nonexistent/dataset"]})
+
+
+def test_zfs_resource_query_volume():
+    """Test querying ZFS volumes"""
+    volume_name = "test_query_volume"
+
+    # Create a volume using dataset() context manager
+    with dataset(volume_name, {"type": "VOLUME", "volsize": 100 * 1024 * 1024}) as zvol:
+        result = call("zfs.resource.query", {"paths": [zvol]})
+        assert len(result) == 1
+        assert result[0]["name"] == zvol
+        assert result[0]["type"] == "VOLUME"
+        assert "volsize" in result[0]["properties"]
+
+
+def test_zfs_resource_query_no_properties():
+    """Test querying with properties set to None"""
+    dataset_name = "test_query_no_props"
+    with dataset(dataset_name) as ds:
+        result = call("zfs.resource.query", {"paths": [ds], "properties": None})
+
+        assert len(result) == 1
+        resource = result[0]
+        # Should still have basic fields
+        assert "name" in resource
+        assert "pool" in resource
+        assert "type" in resource
+        # But properties should be empty
+        assert resource["properties"] == {}


### PR DESCRIPTION
## ZFS Resource Query API Summary

The `zfs.resource.query` API provides a high-performance interface for querying ZFS filesystem and volume information with flexible filtering options.

### Key Features:
- **Selective Querying**: Query specific ZFS resources by path or retrieve all resources
- **Property Filtering**: Retrieve only needed ZFS properties to minimize overhead  
- **Hierarchical Support**: Choose between flat list or nested tree structure output
- **Children Traversal**: Optionally include all descendants of queried resources
- **User Properties**: Support for custom user-defined properties with colon-separated names

### API Parameters:
- `paths`: List of ZFS resource paths to query (optimizes performance when specified)
- `properties`: Specific ZFS properties to retrieve (e.g., 'mounted', 'compression', 'used')
- `get_user_properties`: Include custom user properties
- `flat`: Return flat list (default) or hierarchical tree structure
- `get_children`: Include all child resources in results

### Validation:
- Prevents querying snapshots (not currently supported)
- Ensures non-overlapping paths when `get_children` is enabled
- Returns appropriate errors for non-existent paths

### Example Usage:
```python
# Query specific dataset with properties
client.call('zfs.resource.query', {
    'paths': ['tank/documents'],
    'properties': ['mounted', 'compression', 'used']
})

# Get hierarchical view with children
client.call('zfs.resource.query', {
    'paths': ['tank'],
    'get_children': True,
    'flat': False
})
```

This API is designed to replace multiple legacy endpoints with a single, efficient interface for ZFS resource querying needs.
