### PR TITLE
NAS-136854 / 25.10 / Fix ValidationError on NULL IPA smb_domain

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -185,6 +185,11 @@ class DirectoryServices(ConfigService):
             # strip off `ipa_` prefix
             config_out['configuration'][key.removeprefix('ipa_')] = data[key]
 
+        if not config_out['configuration']['smb_domain']:
+            # sa.JSON will convert null to empty dict, but our pydantic model expects None in this
+            # situation (rather than empty dict)
+            config_out['configuration']['smb_domain'] = None
+
     @private
     async def extend_ldap(self, data, config_out):
         """ Extend with LDAP columns if service_type is LDAP """


### PR DESCRIPTION
This commit fixes the ipa_extend method to convert an empty smb_domain dict returned by datastore plugin into None type. The unexpected return was causing spurious pydantic validation errors in the UI.