### PR TITLE
Avoid unnecessary IP syncs with TNC if not required

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
@@ -6,7 +6,7 @@ from truenas_connect_utils.hostname import hostname_config, register_update_ips
 
 from middlewared.service import CallError, Service
 
-from .utils import CONFIGURED_TNC_STATES
+from .utils import CONFIGURED_TNC_STATES, TNC_IPS_CACHE_KEY
 
 
 logger = logging.getLogger('truenas_connect')
@@ -50,6 +50,8 @@ class TNCHostnameService(Service):
         response = await self.middleware.call('tn_connect.hostname.register_update_ips')
         if response['error']:
             logger.error('Failed to update IPs with TrueNAS Connect: %s', response['error'])
+        else:
+            await self.middleware.call('cache.put', TNC_IPS_CACHE_KEY, interfaces_ips, 30 * 60)
 
     async def handle_update_ips(self, event_type, args):
         """

--- a/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
@@ -40,7 +40,7 @@ class TNCHostnameService(Service):
         else:
             interfaces_ips = await self.middleware.call('tn_connect.get_interface_ips', tnc_config['interfaces'])
 
-        logger.debug('Updating TrueNAS Connect with interface IPs: %r', ', '.join(interfaces_ips))
+        logger.debug('Updating TrueNAS Connect database with interface IPs: %r', ', '.join(interfaces_ips))
         await self.middleware.call(
             'datastore.update', 'truenas_connect', tnc_config['id'], {
                 'interfaces_ips': interfaces_ips,
@@ -64,7 +64,7 @@ class TNCHostnameService(Service):
         if response['error']:
             logger.error('Failed to update IPs with TrueNAS Connect: %s', response['error'])
         else:
-            await self.middleware.call('cache.put', TNC_IPS_CACHE_KEY, interfaces_ips, 30 * 60)
+            await self.middleware.call('cache.put', TNC_IPS_CACHE_KEY, interfaces_ips, 60 * 60)
 
     async def handle_update_ips(self, event_type, args):
         """

--- a/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/hostname.py
@@ -32,7 +32,6 @@ class TNCHostnameService(Service):
             raise CallError(str(e))
 
     async def sync_interface_ips(self):
-        logger.debug('Syncing interface IPs for TrueNAS Connect')
         tnc_config = await self.middleware.call('tn_connect.config')
 
         # Get interface IPs based on use_all_interfaces flag
@@ -47,6 +46,8 @@ class TNCHostnameService(Service):
                 'interfaces_ips': interfaces_ips,
             }
         )
+
+        logger.debug('Syncing interface IPs for TrueNAS Connect')
         response = await self.middleware.call('tn_connect.hostname.register_update_ips')
         if response['error']:
             logger.error('Failed to update IPs with TrueNAS Connect: %s', response['error'])

--- a/src/middlewared/middlewared/plugins/truenas_connect/utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/utils.py
@@ -12,6 +12,7 @@ CONFIGURED_TNC_STATES = (
     Status.CERT_RENEWAL_SUCCESS.name,
 )
 HEARTBEAT_INTERVAL = 120
+TNC_IPS_CACHE_KEY = 'truenas_connect_sync_ips'
 
 
 def get_unset_payload() -> dict:


### PR DESCRIPTION
This PR adds changes to make some changes to avoid unnecessary IP syncs with TNC. What we do is, that on first interface change event - we cache the ips we synced with TNC and then on a subsequent event, we make sure that we only sync with TNC if there is an actual change in the ips.