### PR TITLE
fix 2fa on HA

### DIFF
--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -98,8 +98,9 @@ class TwoFactorAuthService(ConfigService):
         if not config['enabled']:
             await self.middleware.call('auth.set_authenticator_assurance_level', 'LEVEL_1')
 
-        await (await self.middleware.call('service.control', 'RELOAD', 'ssh')).wait(raise_error=True)
-        await self.middleware.call('etc.generate', 'user')
+        for svc in ('ssh', 'user'):
+            # Going through service.control ensures HA is handled.
+            await (await self.middleware.call('service.control', 'RELOAD', svc)).wait(raise_error=True)
 
         return await self.config()
 


### PR DESCRIPTION
After 2fa is enabled on HA, a failover would lead to a situation where the login page would not present the 2fa form. This is because we're only generating the oath file on the currently running active. Fix the issue by going through the `service.control` API which ensures the operations will automatically propagate to the standby on HA systems.