### PR TITLE
NAS-136834 / 25.10 / Avoid possible module load race condition

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import os
 import subprocess
 import time
 from typing import Literal
@@ -870,7 +871,8 @@ class JBOFService(CRUDService):
 
     @private
     def load_modules(self):
-        subprocess.run(['modprobe', 'nvme_rdma'])
+        if not os.path.exists('/dev/nvme-fabrics'):
+            subprocess.run(['modprobe', 'nvme_rdma'])
 
     @private
     @job(lock='configure_job')

--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -869,6 +869,10 @@ class JBOFService(CRUDService):
                 return
 
     @private
+    def load_modules(self):
+        subprocess.run(['modprobe', 'nvme_rdma'])
+
+    @private
     @job(lock='configure_job')
     async def configure_job(self, job, reload_fenced=False):
         """Bring up any previously configured JBOF NVMe/RoCE configuration.
@@ -890,6 +894,9 @@ class JBOFService(CRUDService):
             err = 'No JBOFs need to be configured'
             job.set_progress(100, err)
             return {'failed': failed, 'message': err}
+
+        # Just in case this hasn't already been loaded.
+        await self.middleware.call('jbof.load_modules')
 
         # Bring up the JBOFs in parallel.
         exceptions = await asyncio.gather(


### PR DESCRIPTION
Found that on certain non-HA systems there could be a race condition that caused JBOF to not attach on boot.