### PR TITLE
NAS-134926 / 25.10 / Fix GPU critical device detection logic and improve human-readable device descriptions

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -78,13 +78,22 @@ class VMDeviceService(Service):
         data['controller_type'] = controller_type
         # Use critical information from iommu_info if available
         # If we cannot find the iommu entry, we mark the device as critical by default
-        data['critical'] = igi['critical'] if igi else True
+        data['critical'] = True
         # Only include number and addresses in iommu_group for API compatibility
-        data['iommu_group'] = {k: v for k, v in igi.items() if k in ('number', 'addresses')} if igi else None
+        data['iommu_group'] = None
         data['available'] = all(i == 'vfio-pci' for i in drivers) and not data['critical']
         data['drivers'] = drivers
         data['device_path'] = os.path.join('/sys/bus/pci/devices', obj.sys_name)
         data['reset_mechanism_defined'] = os.path.exists(os.path.join(data['device_path'], 'reset'))
+
+        if igi:
+            data.update({
+                'critical': igi['critical'],
+                'iommu_group': {
+                    'number': igi['number'],
+                    'addresses': igi['addresses'],
+                },
+            })
 
         prefix = obj.sys_name + (f' {controller_type!r}' if controller_type else '')
         vendor = data['capability']['vendor'].strip()

--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -79,7 +79,8 @@ class VMDeviceService(Service):
         # Use critical information from iommu_info if available
         # If we cannot find the iommu entry, we mark the device as critical by default
         data['critical'] = igi['critical'] if igi else True
-        data['iommu_group'] = igi
+        # Only include number and addresses in iommu_group for API compatibility
+        data['iommu_group'] = {k: v for k, v in igi.items() if k in ('number', 'addresses')} if igi else None
         data['available'] = all(i == 'vfio-pci' for i in drivers) and not data['critical']
         data['drivers'] = drivers
         data['device_path'] = os.path.join('/sys/bus/pci/devices', obj.sys_name)

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
@@ -1,3 +1,4 @@
+import collections
 import textwrap
 
 import pytest
@@ -200,33 +201,67 @@ def test_critical_gpu(
 
         from_name_mock.side_effect = mock_from_name
 
-        with patch('middlewared.utils.gpu.subprocess.Popen', MagicMock()) as popen_mock:
-            comm_mock = MagicMock()
-            comm_mock.returncode = 0
-            comm_mock.communicate.return_value = ls_pci.strip().encode(), b''
-            popen_mock.return_value = comm_mock
+        # Build device_to_class and bus_to_devices from the test data
+        device_to_class = {}
+        bus_to_devices = collections.defaultdict(list)
+        # Parse ls_pci to get device addresses
+        gpu_devices = []
+        for line in ls_pci.strip().split('\n'):
+            if line.strip():
+                addr = line.split()[0]
+                gpu_devices.append(addr)
+                # Add to device_to_class based on device type
+                if 'VGA compatible controller' in line:
+                    device_to_class[addr] = 0x030000  # VGA
+                elif 'Audio device' in line:
+                    device_to_class[addr] = 0x040300  # Audio
+                elif 'SMBus' in line:
+                    device_to_class[addr] = 0x0c0500  # SMBus
+                elif 'PCI bridge' in line:
+                    device_to_class[addr] = 0x060400  # PCI bridge
+                # Add to bus_to_devices
+                try:
+                    parts = addr.split(':')
+                    domain = int(parts[0], 16)
+                    bus = int(parts[1], 16)
+                    bus_to_devices[(domain, bus)].append(addr)
+                except (IndexError, ValueError):
+                    pass
+        # Mock build_pci_device_cache
+        with patch('middlewared.utils.gpu.build_pci_device_cache') as mock_build_cache:
+            mock_build_cache.return_value = (device_to_class, bus_to_devices)
 
             # Mock the bridge analysis functions
             with patch('middlewared.utils.iommu.get_devices_behind_bridge') as mock_get_devices:
                 # For bridge 0000:00:01.0, return GPU devices behind it
-                mock_get_devices.return_value = ['0000:01:00.0', '0000:01:00.1']
+                def get_devices_side_effect(bridge_addr, bus_to_devices=None, device_to_class=None):
+                    if bridge_addr == '0000:00:01.0':
+                        return ['0000:01:00.0', '0000:01:00.1']
+                    return []
+                mock_get_devices.side_effect = get_devices_side_effect
 
-                with patch('middlewared.utils.iommu.get_pci_device_class') as mock_get_class:
-                    def get_class_side_effect(path):
-                        # Return appropriate class based on device
-                        if '01:00.0' in path or '17:00.0' in path:
-                            return '0x030000'  # VGA controller
-                        elif '01:00.1' in path or '17:00.1' in path:
-                            return '0x040300'  # Audio
-                        elif '00:01.0' in path:
-                            return '0x060400'  # PCI bridge
-                        elif '00:1f.4' in path:
-                            return '0x0c0500'  # SMBus
-                        return '0x000000'
+                # Mock build_pci_device_cache for iommu.py
+                with patch('middlewared.utils.iommu.build_pci_device_cache') as mock_iommu_build:
+                    mock_iommu_build.return_value = (device_to_class, bus_to_devices)
 
-                    mock_get_class.side_effect = get_class_side_effect
+                    with patch('middlewared.utils.iommu.get_pci_device_class') as mock_get_class:
+                        def get_class_side_effect(path):
+                            # Return appropriate class based on device
+                            for addr, class_code in device_to_class.items():
+                                if addr in path:
+                                    return f'0x{class_code:06x}'
+                            return '0x000000'
 
-                    with patch('middlewared.utils.gpu.get_iommu_groups_info', lambda *args, **kwargs: iommu_group):
-                        gpus = get_gpus()[0]
-                        assert gpus['uses_system_critical_devices'] == uses_system_critical_devices
-                        assert gpus['critical_reason'] == critical_reason
+                        mock_get_class.side_effect = get_class_side_effect
+
+                        # Mock get_iommu_groups_info with pci_build_cache parameter
+                        def mock_get_iommu_groups_info(get_critical_info=False, pci_build_cache=None):
+                            return iommu_group
+
+                        with patch('middlewared.utils.gpu.get_iommu_groups_info',
+                                   side_effect=mock_get_iommu_groups_info):
+                            gpus = get_gpus()
+                            assert len(gpus) > 0, "No GPUs found"
+                            gpu = gpus[0]
+                            assert gpu['uses_system_critical_devices'] == uses_system_critical_devices
+                            assert gpu['critical_reason'] == critical_reason

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
@@ -79,7 +79,8 @@ DEVICE_DATA = {
                 },
             },
             True,
-            'Critical devices found: 0000:00:1f.4\nCritical devices found in same IOMMU group: 0000:00:1f.4'
+            ('Devices sharing memory management: SMBus (0000:00:1f.4)\n'
+             'Devices sharing memory management in same IOMMU group: SMBus (0000:00:1f.4)')
         ),
         (
             textwrap.dedent('''
@@ -107,7 +108,7 @@ DEVICE_DATA = {
                 },
             },
             True,
-            'Critical devices found in same IOMMU group: 0000:17:00.0'
+            'Devices sharing memory management in same IOMMU group: VGA compatible controller (0000:17:00.0)'
         ),
         (
             textwrap.dedent('''
@@ -135,7 +136,7 @@ DEVICE_DATA = {
                 },
             },
             True,
-            'Critical devices found in same IOMMU group: 0000:17:00.1'
+            'Devices sharing memory management in same IOMMU group: Audio device (0000:17:00.1)'
         )
     ]
 )

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
@@ -25,6 +25,24 @@ DEVICE_DATA = {
         'ID_PCI_SUBCLASS_FROM_DATABASE': 'SMBus',
         'PCI_SLOT_NAME': '0000:00:1f.4',
     },
+    '0000:00:01.0': {
+        'PCI_ID': '8086:1901',
+        'ID_VENDOR_FROM_DATABASE': 'Intel Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'PCI bridge',
+        'PCI_SLOT_NAME': '0000:00:01.0',
+    },
+    '0000:01:00.0': {
+        'PCI_ID': '10DE:2489',
+        'ID_VENDOR_FROM_DATABASE': 'NVIDIA Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'VGA compatible controller',
+        'PCI_SLOT_NAME': '0000:01:00.0',
+    },
+    '0000:01:00.1': {
+        'PCI_ID': '10DE:228B',
+        'ID_VENDOR_FROM_DATABASE': 'NVIDIA Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'Audio device',
+        'PCI_SLOT_NAME': '0000:01:00.1',
+    },
 }
 
 
@@ -78,9 +96,8 @@ DEVICE_DATA = {
                     'critical': True
                 },
             },
-            True,
-            ('Devices sharing memory management: SMBus (0000:00:1f.4)\n'
-             'Devices sharing memory management in same IOMMU group: SMBus (0000:00:1f.4)')
+            False,  # GPU is in different IOMMU group than SMBus
+            None
         ),
         (
             textwrap.dedent('''
@@ -108,7 +125,7 @@ DEVICE_DATA = {
                 },
             },
             True,
-            'Devices sharing memory management in same IOMMU group: VGA compatible controller (0000:17:00.0)'
+            'Devices sharing memory management: SMBus (0000:00:1f.4)'
         ),
         (
             textwrap.dedent('''
@@ -135,8 +152,36 @@ DEVICE_DATA = {
                     'critical': True
                 },
             },
-            True,
-            'Devices sharing memory management in same IOMMU group: Audio device (0000:17:00.1)'
+            False,  # GPU is in group 10, SMBus is in group 9 - different groups
+            None
+        ),
+        (
+            textwrap.dedent('''
+                0000:00:01.0 PCI bridge: Intel Corporation 6th-10th Gen Core Processor PCIe Controller (x16) (rev 07)
+                0000:01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)
+                0000:01:00.1 Audio device: NVIDIA Corporation GA104 High Definition Audio Controller (rev a1)
+            '''),
+            '0000:01:00.0',
+            ['0000:01:00.1'],  # child_ids not used in new logic
+            {
+                '0000:00:01.0': {
+                    'number': 2,
+                    'addresses': [],
+                    'critical': False  # Bridge should not be critical
+                },
+                '0000:01:00.0': {
+                    'number': 2,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:01:00.1': {
+                    'number': 2,
+                    'addresses': [],
+                    'critical': False
+                },
+            },
+            False,
+            None
         )
     ]
 )
@@ -144,17 +189,44 @@ def test_critical_gpu(
     ls_pci, gpu_pci_id, child_ids, iommu_group, uses_system_critical_devices, critical_reason
 ):
     with patch('middlewared.utils.gpu.pyudev.Devices.from_name', MagicMock()) as from_name_mock:
-        udev_mock = MagicMock()
-        udev_mock.get = lambda key, default: DEVICE_DATA[gpu_pci_id].get(key, default)
-        udev_mock.parent.children = [DEVICE_DATA[child_id] for child_id in child_ids]
-        from_name_mock.return_value = udev_mock
+        def mock_from_name(context, subsystem, device_name):
+            udev_mock = MagicMock()
+            if device_name in DEVICE_DATA:
+                udev_mock.get = lambda key, default: DEVICE_DATA[device_name].get(key, default)
+            else:
+                # For devices not in DEVICE_DATA, return empty values
+                udev_mock.get = lambda key, default: default
+            return udev_mock
+
+        from_name_mock.side_effect = mock_from_name
+
         with patch('middlewared.utils.gpu.subprocess.Popen', MagicMock()) as popen_mock:
             comm_mock = MagicMock()
             comm_mock.returncode = 0
             comm_mock.communicate.return_value = ls_pci.strip().encode(), b''
             popen_mock.return_value = comm_mock
 
-            with patch('middlewared.utils.gpu.get_iommu_groups_info', lambda *args, **kwargs: iommu_group):
-                gpus = get_gpus()[0]
-                assert gpus['uses_system_critical_devices'] == uses_system_critical_devices
-                assert gpus['critical_reason'] == critical_reason
+            # Mock the bridge analysis functions
+            with patch('middlewared.utils.iommu.get_devices_behind_bridge') as mock_get_devices:
+                # For bridge 0000:00:01.0, return GPU devices behind it
+                mock_get_devices.return_value = ['0000:01:00.0', '0000:01:00.1']
+
+                with patch('middlewared.utils.iommu.get_pci_device_class') as mock_get_class:
+                    def get_class_side_effect(path):
+                        # Return appropriate class based on device
+                        if '01:00.0' in path or '17:00.0' in path:
+                            return '0x030000'  # VGA controller
+                        elif '01:00.1' in path or '17:00.1' in path:
+                            return '0x040300'  # Audio
+                        elif '00:01.0' in path:
+                            return '0x060400'  # PCI bridge
+                        elif '00:1f.4' in path:
+                            return '0x0c0500'  # SMBus
+                        return '0x000000'
+
+                    mock_get_class.side_effect = get_class_side_effect
+
+                    with patch('middlewared.utils.gpu.get_iommu_groups_info', lambda *args, **kwargs: iommu_group):
+                        gpus = get_gpus()[0]
+                        assert gpus['uses_system_critical_devices'] == uses_system_critical_devices
+                        assert gpus['critical_reason'] == critical_reason

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_pci_structures.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_pci_structures.py
@@ -1,0 +1,402 @@
+"""
+Comprehensive tests for various GPU PCI topologies and critical device detection.
+Tests include simple cases, bridge scenarios, complex topologies, and edge cases.
+"""
+import collections
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from middlewared.utils.gpu import get_gpus
+from middlewared.utils.iommu import get_iommu_groups_info
+
+
+# Mock PCI topologies for testing
+MOCK_TOPOLOGIES = {
+    'simple_gpu_not_critical': {
+        'description': 'Simple GPU with audio device, no critical devices',
+        'lspci': """
+0000:01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)
+0000:01:00.1 Audio device: NVIDIA Corporation GA104 High Definition Audio Controller (rev a1)
+        """,
+        'devices': {
+            '0000:01:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 1,
+            },
+            '0000:01:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 1,
+            },
+        },
+        'expected_critical': False,
+        'expected_reason': None,
+    },
+
+    'gpu_with_smbus': {
+        'description': 'GPU sharing IOMMU group with SMBus (critical)',
+        'lspci': """
+0000:01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)
+0000:01:00.1 Audio device: NVIDIA Corporation GA104 High Definition Audio Controller (rev a1)
+0000:00:1f.4 SMBus: Intel Corporation Sunrise Point-H SMBus (rev 31)
+        """,
+        'devices': {
+            '0000:01:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 2,
+            },
+            '0000:01:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 2,
+            },
+            '0000:00:1f.4': {
+                'class': '0x0c0500',  # SMBus
+                'vendor': 'Intel Corporation',
+                'subclass': 'SMBus',
+                'iommu_group': 2,
+            },
+        },
+        'expected_critical': True,
+        'expected_reason': 'Devices sharing memory management: SMBus (0000:00:1f.4)',
+    },
+
+    'gpu_with_simple_bridge': {
+        'description': 'GPU behind PCI bridge with no critical devices',
+        'lspci': """
+0000:00:01.0 PCI bridge: Intel Corporation 6th-10th Gen Core Processor PCIe Controller (x16) (rev 07)
+0000:01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)
+0000:01:00.1 Audio device: NVIDIA Corporation GA104 High Definition Audio Controller (rev a1)
+        """,
+        'devices': {
+            '0000:00:01.0': {
+                'class': '0x060400',  # PCI Bridge
+                'vendor': 'Intel Corporation',
+                'subclass': 'PCI bridge',
+                'iommu_group': 2,
+            },
+            '0000:01:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 2,
+            },
+            '0000:01:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 2,
+            },
+        },
+        'bridge_devices': {
+            '0000:00:01.0': ['0000:01:00.0', '0000:01:00.1'],
+        },
+        'expected_critical': False,
+        'expected_reason': None,
+    },
+
+    'gpu_with_bridge_and_critical': {
+        'description': 'GPU behind bridge that also has critical device',
+        'lspci': """
+0000:00:1c.0 PCI bridge: Intel Corporation Sunrise Point-H PCI Express Root Port (rev f1)
+0000:02:00.0 VGA compatible controller: NVIDIA Corporation GM107 [GeForce GTX 750 Ti] (rev a2)
+0000:02:00.1 Audio device: NVIDIA Corporation GM107 High Definition Audio Controller (rev a1)
+0000:02:01.0 SMBus: Intel Corporation C620 Series Chipset Family SMBus (rev 09)
+        """,
+        'devices': {
+            '0000:00:1c.0': {
+                'class': '0x060400',  # PCI Bridge
+                'vendor': 'Intel Corporation',
+                'subclass': 'PCI bridge',
+                'iommu_group': 5,
+            },
+            '0000:02:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 5,
+            },
+            '0000:02:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 5,
+            },
+            '0000:02:01.0': {
+                'class': '0x0c0500',  # SMBus
+                'vendor': 'Intel Corporation',
+                'subclass': 'SMBus',
+                'iommu_group': 5,
+            },
+        },
+        'bridge_devices': {
+            '0000:00:1c.0': ['0000:02:00.0', '0000:02:00.1', '0000:02:01.0'],
+        },
+        'expected_critical': True,
+        'expected_reason': 'Devices sharing memory management: PCI bridge (0000:00:1c.0), SMBus (0000:02:01.0)',
+    },
+
+    'chained_bridges_no_critical': {
+        'description': 'GPU behind chained bridges with no critical devices',
+        'lspci': """
+0000:00:01.0 PCI bridge: Intel Corporation PCIe Root Port (rev 07)
+0000:01:00.0 PCI bridge: PLX Technology PEX 8747 48-Lane PCIe Switch (rev ca)
+0000:02:00.0 VGA compatible controller: AMD Radeon Pro W6800 (rev c3)
+0000:02:00.1 Audio device: AMD Navi 21 HDMI Audio (rev 01)
+        """,
+        'devices': {
+            '0000:00:01.0': {
+                'class': '0x060400',  # PCI Bridge
+                'vendor': 'Intel Corporation',
+                'subclass': 'PCI bridge',
+                'iommu_group': 3,
+            },
+            '0000:01:00.0': {
+                'class': '0x060400',  # PCI Bridge (PLX switch)
+                'vendor': 'PLX Technology',
+                'subclass': 'PCI bridge',
+                'iommu_group': 3,
+            },
+            '0000:02:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'AMD',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 3,
+            },
+            '0000:02:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'AMD',
+                'subclass': 'Audio device',
+                'iommu_group': 3,
+            },
+        },
+        'bridge_devices': {
+            '0000:00:01.0': ['0000:01:00.0'],
+            '0000:01:00.0': ['0000:02:00.0', '0000:02:00.1'],
+        },
+        'expected_critical': False,
+        'expected_reason': None,
+    },
+
+    'multi_gpu_different_groups': {
+        'description': 'Multiple GPUs in different IOMMU groups',
+        'lspci': """
+0000:01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)
+0000:01:00.1 Audio device: NVIDIA Corporation GA104 High Definition Audio Controller (rev a1)
+0000:02:00.0 VGA compatible controller: NVIDIA Corporation TU117 [GeForce GTX 1650] (rev a1)
+0000:02:00.1 Audio device: NVIDIA Corporation TU117 High Definition Audio Controller (rev a1)
+        """,
+        'devices': {
+            '0000:01:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 10,
+            },
+            '0000:01:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 10,
+            },
+            '0000:02:00.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 11,
+            },
+            '0000:02:00.1': {
+                'class': '0x040300',  # Audio
+                'vendor': 'NVIDIA Corporation',
+                'subclass': 'Audio device',
+                'iommu_group': 11,
+            },
+        },
+        'expected_critical': False,
+        'expected_reason': None,
+        'gpu_count': 2,
+    },
+
+    'integrated_gpu_critical': {
+        'description': 'Intel integrated GPU sharing group with host bridge',
+        'lspci': """
+0000:00:00.0 Host bridge: Intel Corporation 8th Gen Core Processor Host Bridge/DRAM Registers (rev 07)
+0000:00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 630 (rev 02)
+        """,
+        'devices': {
+            '0000:00:00.0': {
+                'class': '0x060000',  # Host bridge
+                'vendor': 'Intel Corporation',
+                'subclass': 'Host bridge',
+                'iommu_group': 0,
+            },
+            '0000:00:02.0': {
+                'class': '0x030000',  # VGA
+                'vendor': 'Intel Corporation',
+                'subclass': 'VGA compatible controller',
+                'iommu_group': 0,
+            },
+        },
+        'expected_critical': True,
+        'expected_reason': 'Devices sharing memory management: Host bridge (0000:00:00.0)',
+    },
+}
+
+
+def create_mock_pyudev_device(device_info):
+    """Create a mock pyudev device with the specified attributes."""
+    mock = MagicMock()
+    mock.get = MagicMock(side_effect=lambda key, default='': {
+        'PCI_ID': device_info.get('pci_id', ''),
+        'ID_VENDOR_FROM_DATABASE': device_info.get('vendor', ''),
+        'ID_PCI_SUBCLASS_FROM_DATABASE': device_info.get('subclass', ''),
+        'PCI_SLOT_NAME': device_info.get('address', ''),
+    }.get(key, default))
+    return mock
+
+
+@pytest.mark.parametrize('topology_name', list(MOCK_TOPOLOGIES.keys()))
+def test_gpu_pci_topology(topology_name):
+    """Test various GPU PCI topologies for correct critical device detection."""
+    topology = MOCK_TOPOLOGIES[topology_name]
+
+    # Build IOMMU groups info
+    iommu_groups = {}
+    for addr, device_info in topology['devices'].items():
+        iommu_groups[addr] = {
+            'number': device_info['iommu_group'],
+            'addresses': [],
+            'critical': False,  # Will be determined by get_iommu_groups_info logic
+        }
+
+    # Mock subprocess for lspci
+    with patch('middlewared.utils.gpu.subprocess.Popen') as mock_popen:
+        mock_popen.return_value.communicate.return_value = (
+            topology['lspci'].strip().encode(), b''
+        )
+        mock_popen.return_value.returncode = 0
+
+        # Mock pyudev
+        def mock_from_name(context, subsystem, device_addr):
+            if device_addr in topology['devices']:
+                device_info = topology['devices'][device_addr].copy()
+                device_info['address'] = device_addr
+                return create_mock_pyudev_device(device_info)
+            return create_mock_pyudev_device({})
+
+        with patch('middlewared.utils.gpu.pyudev.Devices.from_name', side_effect=mock_from_name):
+
+            # Mock both get_pci_device_class and build_pci_device_cache
+            with patch('middlewared.utils.iommu.get_pci_device_class') as mock_get_class:
+                def mock_get_class_code(path):
+                    for addr, info in topology['devices'].items():
+                        if addr in path:
+                            return info['class']  # Return string as expected
+                    return '0x000000'
+                mock_get_class.side_effect = mock_get_class_code
+
+                with patch('middlewared.utils.iommu.build_pci_device_cache') as mock_build_cache:
+                    # Build the cache data from topology
+                    device_to_class = {}
+                    bus_to_devices = collections.defaultdict(list)
+                    for addr, info in topology['devices'].items():
+                        device_to_class[addr] = int(info['class'], 16)
+                        try:
+                            parts = addr.split(':')
+                            domain = int(parts[0], 16)
+                            bus = int(parts[1], 16)
+                            bus_to_devices[(domain, bus)].append(addr)
+                        except (IndexError, ValueError):
+                            pass
+                    mock_build_cache.return_value = (device_to_class, bus_to_devices)
+
+                    # Mock bridge device detection with new signature
+                    def mock_get_devices_behind_bridge(bridge_addr, bus_to_devices=None, device_to_class=None):
+                        return topology.get('bridge_devices', {}).get(bridge_addr, [])
+
+                    with patch('middlewared.utils.iommu.get_devices_behind_bridge',
+                               side_effect=mock_get_devices_behind_bridge):
+                        # Mock pathlib for IOMMU group scanning
+                        with patch('middlewared.utils.iommu.pathlib.Path') as mock_path:
+                            # Mock the IOMMU groups directory structure
+                            mock_iommu_paths = []
+                            for addr, info in topology['devices'].items():
+                                mock_device = MagicMock()
+                                mock_device.is_dir.return_value = True
+                                mock_device.name = addr
+                                mock_device.parent.parent.name = str(info['iommu_group'])
+                                mock_iommu_paths.append(mock_device)
+                            mock_path.return_value.glob.return_value = mock_iommu_paths
+
+                            # Get IOMMU groups with critical info
+                            iommu_groups = get_iommu_groups_info(get_critical_info=True)
+
+                            # Mock the IOMMU groups for get_gpus
+                            with patch('middlewared.utils.gpu.get_iommu_groups_info',
+                                       return_value=iommu_groups):
+
+                                # Get GPUs
+                                gpus = get_gpus()
+
+                                # Check expectations
+                                expected_gpu_count = topology.get('gpu_count', 1)
+                                assert len(gpus) == expected_gpu_count, \
+                                    f"Expected {expected_gpu_count} GPU(s), got {len(gpus)}"
+
+                                if expected_gpu_count == 1:
+                                    gpu = gpus[0]
+                                    assert gpu['uses_system_critical_devices'] == topology['expected_critical'], \
+                                        f"Expected critical={topology['expected_critical']}, " \
+                                        f"got {gpu['uses_system_critical_devices']}"
+
+                                    if topology['expected_critical']:
+                                        assert gpu['critical_reason'] == topology['expected_reason'], \
+                                            f"Expected reason: {topology['expected_reason']}, " \
+                                            f"got: {gpu['critical_reason']}"
+                                    else:
+                                        assert gpu['critical_reason'] is None
+
+
+def test_error_handling():
+    """Test error handling for invalid configurations."""
+    # Test with no GPUs
+    with patch('middlewared.utils.gpu.subprocess.Popen') as mock_popen:
+        mock_popen.return_value.communicate.return_value = (b'', b'')
+        mock_popen.return_value.returncode = 0
+
+        with patch('middlewared.utils.gpu.get_iommu_groups_info', return_value={}):
+            gpus = get_gpus()
+            assert len(gpus) == 0
+
+
+def test_circular_bridge_reference():
+    """Test handling of circular bridge references (error case)."""
+    # This should not cause infinite recursion
+    with patch('middlewared.utils.iommu.get_devices_behind_bridge') as mock_get_devices:
+        # Create circular reference: bridge A -> bridge B -> bridge A
+        def circular_devices(bridge_addr):
+            if bridge_addr == '0000:00:01.0':
+                return ['0000:01:00.0']
+            elif bridge_addr == '0000:01:00.0':
+                return ['0000:00:01.0']  # Circular!
+            return []
+
+        def circular_devices_wrapper(bridge_addr, bus_to_devices=None, device_to_class=None):
+            return circular_devices(bridge_addr)
+
+        mock_get_devices.side_effect = circular_devices_wrapper
+
+        with patch('middlewared.utils.iommu.get_pci_device_class') as mock_get_class:
+            mock_get_class.return_value = '0x060400'  # All are bridges
+
+            # This should not hang or crash
+            from middlewared.utils.iommu import is_pci_bridge_critical
+            result = is_pci_bridge_critical('0000:00:01.0')
+            assert result is False  # Should handle gracefully

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_passthrough_choices.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_passthrough_choices.py
@@ -104,6 +104,7 @@ def test__get_pci_device_details(pcidevs, results):
                     'function': '0x0'
                 }
             ],
+            'critical': True,  # Host bridge is critical
         },
         '0000:00:04.0': {
             'number': 28,
@@ -115,6 +116,7 @@ def test__get_pci_device_details(pcidevs, results):
                     'function': '0x0'
                 }
             ],
+            'critical': False,  # System peripheral is not critical
         }
     }
     assert VMDeviceService(Middleware()).get_pci_device_details(pcidevs, iommu_info) == results

--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -7,7 +7,8 @@ from typing import TextIO
 import pyudev
 
 from middlewared.service_exception import CallError
-from .iommu import get_iommu_groups_info, SENSITIVE_PCI_DEVICE_TYPES
+
+from .iommu import get_iommu_groups_info
 
 
 RE_PCI_ADDR = re.compile(r'(?P<domain>.*):(?P<bus>.*):(?P<slot>.*)\.')
@@ -17,12 +18,10 @@ def get_pci_device_description(pci_slot: str, subclass: str = None, model: str =
     """
     Get human-readable device description with PCI slot.
     Uses caching to avoid repeated lookups for the same device.
-
     Args:
         pci_slot: PCI slot address (e.g., "0000:00:1f.4")
         subclass: ID_PCI_SUBCLASS_FROM_DATABASE value
         model: ID_MODEL_FROM_DATABASE value
-
     Returns:
         Human-readable description like "SMBus (0000:00:1f.4)"
     """
@@ -64,8 +63,31 @@ def get_nvidia_gpus() -> dict[str, dict]:
                         gpus[i.name] = gpu
     except (FileNotFoundError, ValueError):
         pass
-
     return gpus
+
+
+def _parse_gpu_description(gpu_line: str, device_type: str) -> str:
+    """
+    Safely parse GPU description from lspci output.
+    Args:
+        gpu_line: Line from lspci output
+        device_type: Device type string (e.g., 'VGA compatible controller')
+    Returns:
+        Parsed description or fallback string
+    """
+    try:
+        # Split by device type
+        if device_type in gpu_line:
+            desc_part = gpu_line.split(f'{device_type}:')[-1]
+            # Remove revision info if present
+            if '(rev' in desc_part:
+                desc_part = desc_part.split('(rev')[0]
+            return desc_part.strip()
+    except (IndexError, ValueError):
+        pass
+    # Fallback: return everything after the PCI address
+    parts = gpu_line.split(None, 1)
+    return parts[1] if len(parts) > 1 else 'Unknown GPU'
 
 
 def get_critical_devices_in_iommu_group_mapping(iommu_groups: dict) -> dict[str, set[str]]:
@@ -73,7 +95,6 @@ def get_critical_devices_in_iommu_group_mapping(iommu_groups: dict) -> dict[str,
     for pci_slot, pci_details in iommu_groups.items():
         if pci_details['critical']:
             iommu_groups_mapping_with_critical_devices[pci_details['number']].add(pci_slot)
-
     return iommu_groups_mapping_with_critical_devices
 
 
@@ -82,7 +103,6 @@ def get_gpus() -> list:
     stdout, stderr = cp.communicate()
     if cp.returncode:
         raise CallError(f'Unable to list available gpus: {stderr.decode()}')
-
     gpus = []
     gpu_slots = []
     for line in stdout.decode().splitlines():
@@ -94,15 +114,17 @@ def get_gpus() -> list:
             if k in line:
                 gpu_slots.append((line.strip(), k))
                 break
-
     iommu_groups = get_iommu_groups_info(get_critical_info=True)
-    critical_iommu_mapping = get_critical_devices_in_iommu_group_mapping(iommu_groups)
+    # Precompute group_id -> [devices] mapping for efficiency
+    group_to_devices = collections.defaultdict(list)
+    for device_addr, device_info in iommu_groups.items():
+        group_to_devices[device_info['number']].append(device_addr)
 
+    udev_context = pyudev.Context()
     for gpu_line, key in gpu_slots:
         addr = gpu_line.split()[0]
         addr_re = RE_PCI_ADDR.match(addr)
-
-        gpu_dev = pyudev.Devices.from_name(pyudev.Context(), 'pci', addr)
+        gpu_dev = pyudev.Devices.from_name(udev_context, 'pci', addr)
         # Let's normalise vendor for consistency
         vendor = None
         vendor_id_from_db = gpu_dev.get('ID_VENDOR_FROM_DATABASE', '').lower()
@@ -112,69 +134,53 @@ def get_gpus() -> list:
             vendor = 'INTEL'
         elif 'amd' in vendor_id_from_db:
             vendor = 'AMD'
-
         devices = []
         critical_reason = None
-        critical_devices = {}
-        critical_devices_based_on_iommu = {}
+        critical_devices = []
+        # Get the GPU's IOMMU group number
+        gpu_iommu_group = iommu_groups.get(addr, {}).get('number')
+        # Get all devices in the same IOMMU group as the GPU (using precomputed mapping)
+        devices_in_group = group_to_devices.get(gpu_iommu_group, []) if gpu_iommu_group is not None else []
+        # Process each device in the same IOMMU group
+        for device_addr in devices_in_group:
+            try:
+                # Get device information
+                device = pyudev.Devices.from_name(udev_context, 'pci', device_addr)
+                pci_id = device.get('PCI_ID', '')
+                subclass = device.get('ID_PCI_SUBCLASS_FROM_DATABASE', '')
+                model = device.get('ID_MODEL_FROM_DATABASE', '')
+                # Add to devices list
+                devices.append({
+                    'pci_id': pci_id,
+                    'pci_slot': device_addr,
+                    'vm_pci_slot': f'pci_{device_addr.replace(".", "_").replace(":", "_")}',
+                })
+                # Check if this device is critical
+                if iommu_groups.get(device_addr, {}).get('critical', False):
+                    device_desc = get_pci_device_description(device_addr, subclass, model)
+                    critical_devices.append(device_desc)
+            except (OSError, IOError, ValueError):
+                # If we can't get device info due to permission or I/O issues,
+                # still add it to the list with minimal information
+                devices.append({
+                    'pci_id': '',
+                    'pci_slot': device_addr,
+                    'vm_pci_slot': f'pci_{device_addr.replace(".", "_").replace(":", "_")}',
+                })
 
-        # So we will try to mark those gpu's as critical which meet following criteria:
-        # 1) Have a device which belongs to sensitive pci devices group
-        # 2) Have a device which is in same iommu group as a device which belongs to sensitive pci devices group
-
-        # Check if the GPU itself is in a critical IOMMU group
-        if critical_iommu_mapping[iommu_groups.get(addr, {}).get('number')]:
-            # Get GPU device info for description
-            gpu_subclass = gpu_dev.get('ID_PCI_SUBCLASS_FROM_DATABASE', '')
-            gpu_model = gpu_dev.get('ID_MODEL_FROM_DATABASE', '')
-            device_desc = get_pci_device_description(addr, gpu_subclass, gpu_model)
-            critical_devices_based_on_iommu[addr] = device_desc
-
-        for child in filter(lambda c: all(k in c for k in ('PCI_SLOT_NAME', 'PCI_ID')), gpu_dev.parent.children):
-            pci_slot = child['PCI_SLOT_NAME']
-            subclass = child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '')
-            model = child.get('ID_MODEL_FROM_DATABASE', '')
-
-            devices.append({
-                'pci_id': child['PCI_ID'],
-                'pci_slot': pci_slot,
-                'vm_pci_slot': f'pci_{pci_slot.replace(".", "_").replace(":", "_")}',
-            })
-
-            # Check if it's a critical device type
-            for k in SENSITIVE_PCI_DEVICE_TYPES.values():
-                if k.lower() in subclass.lower():
-                    device_desc = get_pci_device_description(pci_slot, subclass, model)
-                    critical_devices[pci_slot] = device_desc
-                    break
-
-            # Check IOMMU group
-            if critical_iommu_mapping[iommu_groups.get(pci_slot, {}).get('number')]:
-                device_desc = get_pci_device_description(pci_slot, subclass, model)
-                critical_devices_based_on_iommu[pci_slot] = device_desc
-
+        # Build critical reason if there are critical devices in the group
         if critical_devices:
-            device_list = ', '.join(critical_devices.values())
+            device_list = ', '.join(critical_devices)
             critical_reason = f'Devices sharing memory management: {device_list}'
-
-        if critical_devices_based_on_iommu:
-            device_list = ', '.join(critical_devices_based_on_iommu.values())
-            if critical_reason:
-                critical_reason += '\n'
-            else:
-                critical_reason = ''
-            critical_reason += f'Devices sharing memory management in same IOMMU group: {device_list}'
-
         gpus.append({
             'addr': {
                 'pci_slot': addr,
                 **{k: addr_re.group(k) for k in ('domain', 'bus', 'slot')},
             },
-            'description': gpu_line.split(f'{key}:')[-1].split('(rev')[0].strip(),
+            'description': _parse_gpu_description(gpu_line, key),
             'devices': devices,
             'vendor': vendor,
             'uses_system_critical_devices': bool(critical_reason),
             'critical_reason': critical_reason,
         })
-
     return gpus

--- a/src/middlewared/middlewared/utils/iommu.py
+++ b/src/middlewared/middlewared/utils/iommu.py
@@ -21,6 +21,13 @@ _SENSITIVE_PCI_CLASS_CODES_NUMERIC = {
     int(k, 16): v for k, v in SENSITIVE_PCI_DEVICE_TYPES.items()
 }
 
+# GPU device class codes (upper 16 bits)
+GPU_CLASS_CODES = {
+    0x0300: 'VGA compatible controller',    # Standard VGA
+    0x0302: '3D controller',                # 3D graphics controller
+    0x0380: 'Display controller',           # Other display controller
+}
+
 
 def read_sysfs_hex(path: str, default: int = 0) -> int:
     """Read a hex value from sysfs file."""
@@ -175,7 +182,7 @@ def _is_bridge_critical_recursive(
     return False
 
 
-def get_iommu_groups_info(get_critical_info: bool = False) -> dict[str, dict]:
+def get_iommu_groups_info(get_critical_info: bool = False, pci_build_cache: tuple = None) -> dict[str, dict]:
     addresses = collections.defaultdict(list)
     final = dict()
     with contextlib.suppress(FileNotFoundError):
@@ -198,7 +205,7 @@ def get_iommu_groups_info(get_critical_info: bool = False) -> dict[str, dict]:
             }
             if get_critical_info:
                 # Build efficient caches upfront if we need critical info
-                device_to_class, bus_to_devices = build_pci_device_cache()
+                device_to_class, bus_to_devices = pci_build_cache if pci_build_cache else build_pci_device_cache()
                 # Get device class from cache
                 class_code = device_to_class.get(i.name, 0)
                 class_id = (class_code >> 8) & 0xFFFF  # Extract 16-bit class ID

--- a/src/middlewared/middlewared/utils/iommu.py
+++ b/src/middlewared/middlewared/utils/iommu.py
@@ -16,23 +16,163 @@ SENSITIVE_PCI_DEVICE_TYPES = {
     '0x0600': 'Host bridge',
 }
 
+# Internal numeric mapping for efficient comparisons
+_SENSITIVE_PCI_CLASS_CODES_NUMERIC = {
+    int(k, 16): v for k, v in SENSITIVE_PCI_DEVICE_TYPES.items()
+}
+
+
+def read_sysfs_hex(path: str, default: int = 0) -> int:
+    """Read a hex value from sysfs file."""
+    try:
+        with open(path, 'r') as f:
+            return int(f.read().strip(), 16)
+    except (FileNotFoundError, ValueError):
+        return default
+
 
 def get_pci_device_class(pci_path: str) -> str:
+    """Get PCI device class as a hex string."""
     with contextlib.suppress(FileNotFoundError):
         with open(os.path.join(pci_path, 'class'), 'r') as r:
             return r.read().strip()
-
     return ''
+
+
+def build_pci_device_cache() -> tuple[dict[str, int], dict[tuple[int, int], list[str]]]:
+    """
+    Build efficient caches for PCI device information.
+    Returns:
+        Tuple of:
+        - device_to_class: Mapping of device address to class code
+        - bus_to_devices: Mapping of (domain, bus) tuple to list of device addresses
+    """
+    device_to_class = {}
+    bus_to_devices = collections.defaultdict(list)
+    pci_devices_path = pathlib.Path('/sys/bus/pci/devices')
+    if pci_devices_path.exists():
+        for device_path in pci_devices_path.iterdir():
+            if device_path.is_dir() and RE_DEVICE_NAME.fullmatch(device_path.name):
+                device_addr = device_path.name
+                # Cache class code
+                device_to_class[device_addr] = read_sysfs_hex(os.path.join(str(device_path), 'class'))
+                # Extract domain and bus number for mapping
+                with contextlib.suppress(IndexError, ValueError):
+                    parts = device_addr.split(':')
+                    domain = int(parts[0], 16)
+                    bus = int(parts[1], 16)
+                    bus_to_devices[(domain, bus)].append(device_addr)
+
+    return device_to_class, bus_to_devices
+
+
+def get_bridge_bus_range(bridge_path: str) -> tuple[int, int]:
+    """
+    Get the secondary and subordinate bus numbers for a PCI bridge.
+    Returns:
+        Tuple of (secondary_bus, subordinate_bus) or (-1, -1) if not found
+    """
+    secondary = read_sysfs_hex(os.path.join(bridge_path, 'secondary_bus_number'), -1)
+    subordinate = read_sysfs_hex(os.path.join(bridge_path, 'subordinate_bus_number'), -1)
+    return secondary, subordinate
+
+
+def get_devices_behind_bridge(
+    bridge_addr: str,
+    bus_to_devices: dict[tuple[int, int], list[str]] = None,
+) -> list[str]:
+    """
+    Get all PCI devices behind a specific PCI bridge using proper bus ranges.
+    Args:
+        bridge_addr: PCI address of the bridge
+        bus_to_devices: Optional pre-built bus mapping
+        device_to_class: Optional pre-built device class mapping (unused)
+    Returns:
+        List of PCI addresses behind the bridge (excluding the bridge itself)
+    """
+    if bus_to_devices is None:
+        _, bus_to_devices = build_pci_device_cache()
+
+    bridge_path = f'/sys/bus/pci/devices/{bridge_addr}'
+    secondary_bus, subordinate_bus = get_bridge_bus_range(bridge_path)
+    if secondary_bus == -1 or subordinate_bus == -1:
+        return []
+
+    # Extract bridge domain for proper lookup
+    try:
+        bridge_domain = int(bridge_addr.split(':')[0], 16)
+    except (IndexError, ValueError):
+        return []
+
+    # Collect all devices on buses within the bridge's range
+    devices_behind = []
+    for bus in range(secondary_bus, subordinate_bus + 1):
+        devices_behind.extend(bus_to_devices.get((bridge_domain, bus), []))
+
+    # Filter out the bridge itself
+    devices_behind = [dev for dev in devices_behind if dev != bridge_addr]
+    return devices_behind
+
+
+def is_pci_bridge_critical(
+    bridge_addr: str,
+    device_to_class: dict[str, int] = None,
+    bus_to_devices: dict[tuple[int, int], list[str]] = None
+) -> bool:
+    """
+    Check if a PCI bridge has critical devices behind it.
+    Args:
+        bridge_addr: PCI address of the bridge
+        device_to_class: Optional pre-built device class mapping
+        bus_to_devices: Optional pre-built bus mapping
+    Returns:
+        True if bridge has critical devices behind it
+    """
+    if device_to_class is None or bus_to_devices is None:
+        device_to_class, bus_to_devices = build_pci_device_cache()
+
+    # Use internal recursive function with visited set for cycle detection
+    visited = set()
+    return _is_bridge_critical_recursive(
+        bridge_addr, device_to_class, bus_to_devices, visited
+    )
+
+
+def _is_bridge_critical_recursive(
+    bridge_addr: str,
+    device_to_class: dict[str, int],
+    bus_to_devices: dict[tuple[int, int], list[str]],
+    visited: set[str]
+) -> bool:
+    """Recursively check if a bridge has critical devices behind it."""
+    if bridge_addr in visited:
+        return False
+
+    visited.add(bridge_addr)
+    devices_behind = get_devices_behind_bridge(bridge_addr, bus_to_devices)
+    for device_addr in devices_behind:
+        class_code = device_to_class.get(device_addr, 0)
+        class_id = (class_code >> 8) & 0xFFFF  # Extract 16-bit class ID
+        # Check if it's a critical device type (excluding PCI bridges)
+        if class_id in _SENSITIVE_PCI_CLASS_CODES_NUMERIC and class_id != 0x0604:
+            return True
+        # If it's another bridge, recursively check
+        if class_id == 0x0604:
+            if _is_bridge_critical_recursive(
+                device_addr, device_to_class, bus_to_devices, visited
+            ):
+                return True
+    return False
 
 
 def get_iommu_groups_info(get_critical_info: bool = False) -> dict[str, dict]:
     addresses = collections.defaultdict(list)
     final = dict()
     with contextlib.suppress(FileNotFoundError):
+        # First pass: collect all devices and their classes
         for i in pathlib.Path('/sys/kernel/iommu_groups').glob('*/devices/*'):
             if not i.is_dir() or not i.parent.parent.name.isdigit() or not RE_DEVICE_NAME.fullmatch(i.name):
                 continue
-
             iommu_group = int(i.parent.parent.name)
             dbs, func = i.name.split('.')
             dom, bus, slot = dbs.split(':')
@@ -47,9 +187,20 @@ def get_iommu_groups_info(get_critical_info: bool = False) -> dict[str, dict]:
                 'addresses': addresses[iommu_group],
             }
             if get_critical_info:
-                final[i.name]['critical'] = any(
-                    k.lower() in get_pci_device_class(os.path.join('/sys/bus/pci/devices', i.name))
-                    for k in SENSITIVE_PCI_DEVICE_TYPES.keys()
-                )
-
+                # Build efficient caches upfront if we need critical info
+                device_to_class, bus_to_devices = build_pci_device_cache()
+                # Get device class from cache
+                class_code = device_to_class.get(i.name, 0)
+                class_id = (class_code >> 8) & 0xFFFF  # Extract 16-bit class ID
+                # Initially mark as critical based on device type
+                is_critical = False
+                # Check if it's a sensitive device type
+                if class_id in _SENSITIVE_PCI_CLASS_CODES_NUMERIC:
+                    if class_id == 0x0604:  # PCI Bridge - needs special handling
+                        # Only mark bridge as critical if it has critical devices behind it
+                        is_critical = is_pci_bridge_critical(i.name, device_to_class, bus_to_devices)
+                    else:
+                        # All other sensitive types are always critical
+                        is_critical = True
+                final[i.name]['critical'] = is_critical
     return final

--- a/src/middlewared/middlewared/utils/iommu.py
+++ b/src/middlewared/middlewared/utils/iommu.py
@@ -72,8 +72,19 @@ def get_bridge_bus_range(bridge_path: str) -> tuple[int, int]:
     Returns:
         Tuple of (secondary_bus, subordinate_bus) or (-1, -1) if not found
     """
-    secondary = read_sysfs_hex(os.path.join(bridge_path, 'secondary_bus_number'), -1)
-    subordinate = read_sysfs_hex(os.path.join(bridge_path, 'subordinate_bus_number'), -1)
+    # Note: These sysfs files contain decimal numbers as ASCII strings, not hex
+    try:
+        with open(os.path.join(bridge_path, 'secondary_bus_number'), 'r') as f:
+            secondary = int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        secondary = -1
+
+    try:
+        with open(os.path.join(bridge_path, 'subordinate_bus_number'), 'r') as f:
+            subordinate = int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        subordinate = -1
+
     return secondary, subordinate
 
 
@@ -86,7 +97,6 @@ def get_devices_behind_bridge(
     Args:
         bridge_addr: PCI address of the bridge
         bus_to_devices: Optional pre-built bus mapping
-        device_to_class: Optional pre-built device class mapping (unused)
     Returns:
         List of PCI addresses behind the bridge (excluding the bridge itself)
     """


### PR DESCRIPTION
## Problem

  1. **GPUs incorrectly marked as critical**: PCI bridges were always considered critical devices. This caused GPUs to be marked as unavailable for passthrough when they shared an IOMMU group with a bridge, even if that bridge only connected to the GPU itself.

  2. **Incomplete device lists**: The `devices` field only showed the GPU device, missing audio controllers and other devices that must be passed through together.

  3. **Unclear error messages**: Critical reasons showed raw PCI addresses like "0000:00:1f.4" instead of human-readable descriptions like "SMBus (0000:00:1f.4)".

  ## Solution

  1. **Smart PCI bridge detection**: Bridges are now only marked critical if they have critical devices (Host bridge, SMBus, etc.) behind them. Bridges connecting only to GPUs are no longer considered critical.

  2. **Complete device enumeration**: All devices in the GPU's IOMMU group are now listed, ensuring associated audio devices and other components are included.

  3. **Human-readable messages**: Critical reasons now show device types with their PCI addresses for clarity.

  Additionally fixed a bug where bus numbers were incorrectly parsed as hex instead of decimal, and added comprehensive test coverage for various PCI topologies.