### PR TITLE
NAS-136804 / 25.10 / Handle post install ip syncing correctly

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/post_install.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/post_install.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 
@@ -66,8 +67,11 @@ class TNCPostInstallService(Service):
             Status.CONFIGURED.name,
             payload,
         )
-        logger.debug('TNC Post Install: Syncing interface IPs')
-        await self.middleware.call('tn_connect.hostname.sync_interface_ips')
+        logger.debug('TNC Post Install: Triggering task for syncing interface IPs to run after 5 minutes')
+        asyncio.get_event_loop().call_later(
+            5 * 60,
+            lambda: self.middleware.create_task(self.middleware.call('tn_connect.hostname.sync_interface_ips')),
+        )
         logger.debug('TNC Post Install: Configuring nginx to consume TNC certificate')
         await self.middleware.call('tn_connect.acme.update_ui_impl')
 


### PR DESCRIPTION
This commit fixes an issue where on post install, we tried to sync hostname ips with TNC which failed because post install workflow gets executed as soon as middleware boots which means we don't have access to networking at that moment. So for first sync, let's sync ips after a 5 minute delay which should be fine. We already sync ips on networking events, but as a good measure we can do it once post install after approximately 5 minutes.