### PR TITLE
NAS-136491 / 25.10 / Do not allow TNC environment to be user configurable

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v25_10_0/tn_connect.py
@@ -55,14 +55,6 @@ class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     """Array of network interface names that TrueNAS Connect should use."""
     use_all_interfaces: bool
     """Whether to automatically use all available network interfaces."""
-    account_service_base_url: HttpsOnlyURL
-    """Base URL for the TrueNAS Connect account service API."""
-    leca_service_base_url: HttpsOnlyURL
-    """Base URL for the Let's Encrypt Certificate Authority service."""
-    tnc_base_url: HttpsOnlyURL
-    """Base URL for the TrueNAS Connect service."""
-    heartbeat_url: HttpsOnlyURL
-    """URL endpoint for sending heartbeat signals to maintain connection status."""
 
 
 class TrueNASConnectUpdateResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
@@ -1,8 +1,8 @@
-from middlewared.api.base import BaseModel, HttpsOnlyURL, single_argument_args
+from middlewared.api.base import BaseModel, ForUpdateMetaclass, HttpsOnlyURL, single_argument_args
 
 
 @single_argument_args('tn_connect_update_environment')
-class TrueNASConnectUpdateEnvironmentArgs(BaseModel):
+class TrueNASConnectUpdateEnvironmentArgs(BaseModel, metaclass=ForUpdateMetaclass):
     account_service_base_url: HttpsOnlyURL
     leca_service_base_url: HttpsOnlyURL
     tnc_base_url: HttpsOnlyURL

--- a/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
@@ -1,0 +1,9 @@
+from middlewared.api.base import BaseModel, HttpsOnlyURL, single_argument_args
+
+
+@single_argument_args('tn_connect_update_environment')
+class TrueNASConnectUpdateEnvironmentArgs(BaseModel):
+    account_service_base_url: HttpsOnlyURL
+    leca_service_base_url: HttpsOnlyURL
+    tnc_base_url: HttpsOnlyURL
+    heartbeat_url: HttpsOnlyURL

--- a/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/private_models.py
@@ -1,4 +1,5 @@
 from middlewared.api.base import BaseModel, ForUpdateMetaclass, HttpsOnlyURL, single_argument_args
+from middlewared.api.current import TNCEntry
 
 
 @single_argument_args('tn_connect_update_environment')
@@ -7,3 +8,7 @@ class TrueNASConnectUpdateEnvironmentArgs(BaseModel, metaclass=ForUpdateMetaclas
     leca_service_base_url: HttpsOnlyURL
     tnc_base_url: HttpsOnlyURL
     heartbeat_url: HttpsOnlyURL
+
+
+class TrueNASConnectUpdateEnvironmentResult(BaseModel):
+    result: TNCEntry

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -112,13 +112,6 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
                 'other than disabled or completely configured'
             )
 
-        if data['enabled'] and old_config['enabled']:
-            for k in ('account_service_base_url', 'leca_service_base_url', 'tnc_base_url', 'heartbeat_url'):
-                if data[k] != old_config[k]:
-                    verrors.add(
-                        f'tn_connect_update.{k}', 'This field cannot be changed when TrueNAS Connect is enabled'
-                    )
-
         verrors.check()
 
     @api_method(TrueNASConnectUpdateArgs, TrueNASConnectUpdateResult)
@@ -136,7 +129,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
             'ips': data['ips'],
             'interfaces': data.get('interfaces', []),
             'use_all_interfaces': data['use_all_interfaces'],
-        } | {k: data[k] for k in ('account_service_base_url', 'leca_service_base_url', 'tnc_base_url', 'heartbeat_url')}
+        }
 
         # Extract IPs from interfaces using ip_in_use method
         # If use_all_interfaces is True, get IPs from all interfaces

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -14,7 +14,7 @@ from middlewared.api.current import (
 from middlewared.service import CallError, ConfigService, private, ValidationErrors
 
 from .mixin import TNCAPIMixin
-from .private_models import TrueNASConnectUpdateEnvironmentArgs
+from .private_models import TrueNASConnectUpdateEnvironmentArgs, TrueNASConnectUpdateEnvironmentResult
 from .utils import CLAIM_TOKEN_CACHE_KEY, get_unset_payload, TNC_IPS_CACHE_KEY
 
 
@@ -175,7 +175,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
 
         return new_config
 
-    @api_method(TrueNASConnectUpdateEnvironmentArgs, TNCEntry, private=True)
+    @api_method(TrueNASConnectUpdateEnvironmentArgs, TrueNASConnectUpdateEnvironmentResult, private=True)
     async def update_environment(self, data):
         config = await self.middleware.call('tn_connect.config')
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -127,7 +127,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         db_payload = {
             'enabled': data['enabled'],
             'ips': data['ips'],
-            'interfaces': data.get('interfaces', []),
+            'interfaces': data['interfaces'],
             'use_all_interfaces': data['use_all_interfaces'],
         }
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -290,11 +290,7 @@ class TestTNCUseAllInterfaces:
             'enabled': True,
             'ips': [],
             'interfaces': ['ens3'],
-            'use_all_interfaces': True,
-            'account_service_base_url': 'https://example.com/',
-            'leca_service_base_url': 'https://example.com/',
-            'tnc_base_url': 'https://example.com/',
-            'heartbeat_url': 'https://example.com/'
+            'use_all_interfaces': True
         })
 
         # Verify that get_all_interface_ips was called (which calls interface.query)


### PR DESCRIPTION
This PR adds changes to not allow TNC environment to be user configurable and instead we expose a private endpoint which support can use to change environment as requested by @ZackaryWelch.