### PR TITLE
NAS-136898 / 25.10 / Regenerate the users.oath file when DS becomes healthy

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -172,9 +172,9 @@ class DomainHealth(
             return self.recover(attempts + 1, reason)
 
         self.check()
-        # If we're here we've recovered. Since the users.oath file for
-        # directory services users requires that we have functional SID resolution
-        # we have to regenerate the users file here.
+        # If we're here we've recovered. Since the users.oath file for directory services users requires that we have
+        # functional SID resolution we have to regenerate the users file here. We are not calling service.control
+        # for the USER service because the other node in HA is responsible for its own health checks.
         self.middleware.call_sync('etc.generate', 'user')
 
     def set_state(self, ds_type, ds_status, status_msg=None):

--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -172,6 +172,10 @@ class DomainHealth(
             return self.recover(attempts + 1, reason)
 
         self.check()
+        # If we're here we've recovered. Since the users.oath file for
+        # directory services users requires that we have functional SID resolution
+        # we have to regenerate the users file here.
+        self.middleware.call_sync('etc.generate', 'user')
 
     def set_state(self, ds_type, ds_status, status_msg=None):
         ds = DSType(ds_type)


### PR DESCRIPTION
Active directory user oath configuration is keyed to the user SID value rather than being based on name, uid, or synthetic datastore IDs because all of the former are mutable. This means that if AD is broken when the users.oath file is generated then AD users will be omitted. When we transition from FAULTED to HEALTHY through directoryservices.health.recover we need to regenerate the users.oath file to properly resolve any directoryservices entries.