### PR TITLE
NAS-136579 / 25.10 / Fix STIG tests for HA

### DIFF
--- a/tests/stig/test_02_openssl.py
+++ b/tests/stig/test_02_openssl.py
@@ -8,19 +8,19 @@ retry = 5
 fips_version = "3.0.9"
 
 
-# Sometimes this test fails because the testing environment has broken failover (randomly. Fun transient error. Reports a failed heartbeat).
-@pytest.mark.flaky(reruns=retry, reruns_delay=5)
+@pytest.mark.timeout(1200)
 @pytest.mark.skipif(not ha, reason='Test only valid for HA')
 def test_fips_version():
     # The reason we have a set of commands in a payload is because of some annoying FIPS technicalities.
     # Basically, when FIPS is enabled, we can't use SSH because the SSH key used by root isn't using a FIPS provided algorithm. (this might need to be investigated further)
     # To allow testing, we write our FIPS information to a file during this phase, and then go disable FIPS to get SSH back all in one joint command.
-    payload = """midclt call --job system.security.update '{"enable_fips": true}' && openssl list -providers > /root/osslproviders && midclt call system.reboot.info >> /root/osslproviders && midclt call --job system.security.update '{"enable_fips": false}'"""
+    payload = """midclt call --job system.security.update '{"enable_fips": true}' && openssl list -providers > /root/osslproviders && midclt call system.reboot.info >> /root/osslproviders && sleep 30 && midclt call --job system.security.update '{"enable_fips": false}'"""
 
-    ssh(payload, complete_response=True, timeout=300)
+    ssh(payload, complete_response=True, timeout=400)
 
     # Check that things are what we expect when FIPS was enabled
     enabled_info = ssh("cat /root/osslproviders")
+
     assert fips_version in enabled_info
     assert "FIPS configuration was changed." in enabled_info
 


### PR DESCRIPTION
STIG tests were failing consistently with HA in CI.  Rectify.
- Suppress calling private APIs when STIG is enabled (including in autouse fixtures)
- Be more intentional about waiting for long-running operations to complete (including 2 node reboots).
- Because of multiple reboots can no longer leverage websocket connection with unrestricted privileges 

----
Passing CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/stig_tests/256/).