### PR TITLE
Robustize test_fips_version with delay

### DIFF
--- a/tests/stig/test_02_openssl.py
+++ b/tests/stig/test_02_openssl.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 from middlewared.test.integration.utils import call, ssh
 from auto_config import ha
@@ -11,12 +12,18 @@ fips_version = "3.0.9"
 @pytest.mark.timeout(1200)
 @pytest.mark.skipif(not ha, reason='Test only valid for HA')
 def test_fips_version():
+    # First check that HA is in good state
+    for i in range(10):
+        if call('failover.disabled.reasons') == []:
+            break
+        time.sleep(5)
+
     # The reason we have a set of commands in a payload is because of some annoying FIPS technicalities.
     # Basically, when FIPS is enabled, we can't use SSH because the SSH key used by root isn't using a FIPS provided algorithm. (this might need to be investigated further)
     # To allow testing, we write our FIPS information to a file during this phase, and then go disable FIPS to get SSH back all in one joint command.
-    payload = """midclt call --job system.security.update '{"enable_fips": true}' && openssl list -providers > /root/osslproviders && midclt call system.reboot.info >> /root/osslproviders && sleep 30 && midclt call --job system.security.update '{"enable_fips": false}'"""
+    payload = """midclt call --job system.security.update '{"enable_fips": true}' && openssl list -providers > /root/osslproviders && midclt call system.reboot.info >> /root/osslproviders && sleep 60 && midclt call --job system.security.update '{"enable_fips": false}'"""
 
-    ssh(payload, complete_response=True, timeout=400)
+    ssh(payload, complete_response=True, timeout=500)
 
     # Check that things are what we expect when FIPS was enabled
     enabled_info = ssh("cat /root/osslproviders")


### PR DESCRIPTION
The recent PR #16820 greatly improved the STIG test CI.

However, (when run in the regular jenkins CI) the `test_fips_version` was only passing approx one time in three (1/3).

This PR is to improve that situation, by adding some further delays in the test.

With these changes the test passed three times in a row (3/3): [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/stig_tests/262/), [here ](http://jenkins.eng.ixsystems.net:8080/job/tests/job/stig_tests/263/ )and [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/stig_tests/264/)