### PR TITLE
NAS-136910 / 25.10 / Properly dump REST API payload for audit insertion

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -14,7 +14,10 @@ from aiohttp import web
 from truenas_api_client import json
 
 from .api.base.server.app import App
-from .auth import ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials, AuthenticationContext
+from .auth import (
+    ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials, AuthenticationContext,
+    dump_credentials
+)
 from .job import Job
 from .pipe import Pipes, InputPipes
 from .schema import Error as SchemaError
@@ -583,15 +586,15 @@ class Resource(object):
                                                                        method.upper(), resource)
                     except web.HTTPException as e:
                         credentials['credentials_data'].pop('password', None)
+                        credentials['credentials_data'].pop('api_key', None)
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': credentials,
                             'error': e.text,
                         }, False)
                         raise
                     app = await create_application(req, authenticated_credentials)
-                    credentials['credentials_data'].pop('password', None)
                     await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
-                        'credentials': credentials,
+                        'credentials': dump_credentials(authenticated_credentials),
                         'error': None,
                     }, True)
                 if auth_required:

--- a/src/middlewared/middlewared/test/integration/assets/api_key.py
+++ b/src/middlewared/middlewared/test/integration/assets/api_key.py
@@ -7,8 +7,8 @@ __all__ = ["api_key"]
 
 
 @contextlib.contextmanager
-def api_key(username="root"):
-    key = call("api_key.create", {"name": "Test API Key", "username": username})
+def api_key(username="root", name="Test API Key"):
+    key = call("api_key.create", {"name": name, "username": username})
     try:
         yield key["key"]
     finally:

--- a/tests/api2/test_audit_rest.py
+++ b/tests/api2/test_audit_rest.py
@@ -10,6 +10,7 @@ import requests
 from middlewared.test.integration.assets.account import unprivileged_user
 from middlewared.test.integration.utils import call, url
 from middlewared.test.integration.utils.audit import expect_audit_log
+from middlewared.test.integration.assets.api_key import api_key
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
@@ -80,7 +81,7 @@ def test_authenticated_call():
                 "event_data": {
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root"},
+                        "credentials_data": {"username": "root", "login_at": ANY},
                     },
                     "error": None,
                 },
@@ -202,3 +203,54 @@ def test_bogus_call():
     ]):
         response = POST("/user", {})
         assert response.status_code == 422
+
+
+def test_api_key_auth():
+    with api_key(name="RESTAUTH") as key:
+        with expect_audit_log([
+            {
+                "service_data": {
+                    "vers": {
+                        "major": 0,
+                        "minor": 1,
+                    },
+                    "origin": ANY,
+                    "protocol": "REST",
+                    "credentials": {
+                        "credentials": "API_KEY",
+                        "credentials_data": {
+                            "username": "root",
+                            "login_at": ANY,
+                            "api_key": {
+                                "id": ANY,
+                                "name": "RESTAUTH",
+                            }
+                        },
+                    },
+                },
+                "event": "AUTHENTICATION",
+                "event_data": {
+                    "credentials": {
+                        "credentials": "API_KEY",
+                        "credentials_data": {
+                            "username": "root",
+                            "login_at": ANY,
+                            "api_key": {
+                                "id": ANY,
+                                "name": "RESTAUTH",
+                            }
+                        }
+                    },
+                    "error": None,
+                },
+                "success": True,
+            },
+        ], include_logins=True):
+            r = requests.get(
+                f"{url()}/api/v2.0/smb",
+                headers={
+                    "Content-type": "application/json",
+                    "Authorization": f"Bearer {key}"
+                },
+            )
+            assert r.status_code == 200, r.text


### PR DESCRIPTION
This commit uses the proper dumping function prior to sending audit messages related to REST calls.