### PR TITLE
NAS-136910 / 24.10.2.4 / Properly dump REST API payload for audit insertion (by anodos325) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -12,7 +12,10 @@ from aiohttp import web
 
 from truenas_api_client import json
 
-from .auth import ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials
+from .auth import (
+    ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials,
+    dump_credentials
+)
 from .job import Job
 from .pipe import Pipes
 from .schema import Error as SchemaError
@@ -565,15 +568,17 @@ class Resource(object):
                                                                        method.upper(), resource)
                     except web.HTTPException as e:
                         credentials['credentials_data'].pop('password', None)
+                        credentials['credentials_data'].pop('api_key', None)
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': credentials,
                             'error': e.text,
                         }, False)
                         raise
+
                     app = create_application(req, authenticated_credentials)
                     credentials['credentials_data'].pop('password', None)
                     await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
-                        'credentials': credentials,
+                        'credentials': dump_credentials(authenticated_credentials),
                         'error': None,
                     }, True)
                 if auth_required:

--- a/src/middlewared/middlewared/test/integration/assets/api_key.py
+++ b/src/middlewared/middlewared/test/integration/assets/api_key.py
@@ -7,8 +7,8 @@ __all__ = ["api_key"]
 
 
 @contextlib.contextmanager
-def api_key(allowlist):
-    key = call("api_key.create", {"name": "Test API Key", "allowlist": allowlist})
+def api_key(allowlist, name="Test API Key"):
+    key = call("api_key.create", {"name": name, "allowlist": allowlist})
     try:
         yield key["key"]
     finally:


### PR DESCRIPTION
This commit uses the proper dumping function prior to sending audit messages related to REST calls.