### PR TITLE
NAS-136932 / 25.10 / Add log entry to middleware log on HA reboot

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/scheduled_reboot_alert.py
+++ b/src/middlewared/middlewared/plugins/failover_/scheduled_reboot_alert.py
@@ -52,8 +52,10 @@ def setup_impl(middleware):
     watchdog_time, fenced_time = get_sentinel_files_time_and_clean_them_up(middleware)
     if watchdog_time and (not fenced_time or watchdog_time > fenced_time):
         middleware.call_sync("alert.oneshot_create", "FailoverReboot", {'fqdn': fqdn, 'now': now})
+        middleware.logger.warning('Failover reboot occurred at %d', watchdog_time)
     elif fenced_time:
         middleware.call_sync("alert.oneshot_create", "FencedReboot", {'fqdn': fqdn, 'now': now})
+        middleware.logger.warning('Fenced reboot occurred at %d', fenced_time)
     else:
         middleware.call_sync("alert.oneshot_delete", "FencedReboot")
         middleware.call_sync("alert.oneshot_delete", "FailoverReboot")


### PR DESCRIPTION
When middlware restarts after HA-related state transition from active to standby controller we generate an alert. This commit also adds a log message to the middleware log so that we have a clearer audit trail for when one of these special circumstances has occured.