### PR TITLE
NAS-136920 / 25.04.2.1 / fix busy loop on HA wrt to service.* actions (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1266,7 +1266,7 @@ async def service_remote(middleware, service, verb, options):
         # it'll cause a failover.call_remote loop between the
         # controllers.
         middleware.logger.warning(
-            'skipping service_remote action %s(%s) options %s because HA is unhealthy: %s',
+            'skipping %s(%s) with options %r because HA is unhealthy: %s',
             verb,
             service,
             options,


### PR DESCRIPTION
On an internal system, an HA system was exposed to a network segmentation between the controllers. This caused both controllers to become MASTER. This caused a busy-loop of core.bulk service.restart calls to be sent back and forth to each controller endlessly. To remedy this situation I've added an extra check to ensure that `failover.disabled.reasons` needs to be empty before forwarding the remote call.

Original PR: https://github.com/truenas/middleware/pull/16836
