### PR TITLE
NAS-136949 / 25.10 / Ignore libvirt service actions in service_remote on HA systems

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1182,7 +1182,7 @@ async def service_remote(middleware, service, verb, options):
         # to not replicate to the remote controller
         return
 
-    ignore = ('system', 'nfs', 'netdata', 'truecommand', 'docker')
+    ignore = ('system', 'nfs', 'netdata', 'truecommand', 'docker', 'libvirtd', 'libvirtd-guests')
     if service in ignore:
         # doesn't matter what's going on, no reason to do
         # any type of service action on the remote controller


### PR DESCRIPTION
This is the "belt and suspenders" approach that compliments the changes introduced here https://github.com/truenas/middleware/pull/16830. With those changes this shouldn't be possible, however, it's better to be safe than sorry. While I'm here, I went ahead and added some comments to explain what each if-condition does and it's context.