### PR TITLE
NAS-136920 / 24.10.2.4 / fix busy loop on HA wrt to service.* actions (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -21,6 +21,7 @@ from middlewared.service import (
 import middlewared.sqlalchemy as sa
 from middlewared.plugins.auth import AuthService
 from middlewared.plugins.config import FREENAS_DATABASE
+from middlewared.plugins.failover_.disabled_reasons import DisabledReasonsEnum
 from middlewared.utils.contextlib import asyncnullcontext
 from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE, ZPOOL_CACHE_FILE_OVERWRITE
 from middlewared.plugins.failover_.configure import HA_LICENSE_CACHE_KEY

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1339,7 +1339,7 @@ async def service_remote(middleware, service, verb, options):
         # it'll cause a failover.call_remote loop between the
         # controllers.
         middleware.logger.warning(
-            'skipping service_remote action %s(%s) options %s because HA is unhealthy: %s',
+            'skipping %s(%s) with options %r because HA is unhealthy: %s',
             verb,
             service,
             options,

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1331,6 +1331,21 @@ async def service_remote(middleware, service, verb, options):
         return
     elif await middleware.call('failover.status') != 'MASTER':
         return
+    elif dr := await middleware.call('failover.disabled.reasons'):
+        # if we're here, it means both controllers return MASTER
+        # but we have reasons why failover isn't healthy. An
+        # edge-case with nasty fall-out. Let's forgo replicating
+        # the operation to the other controller since, minimally,
+        # it'll cause a failover.call_remote loop between the
+        # controllers.
+        middleware.logger.warning(
+            'skipping service_remote action %s(%s) options %s because HA is unhealthy: %s',
+            verb,
+            service,
+            options,
+            ', '.join([DisabledReasonsEnum[i] for i in dr])
+        )
+        return
 
     try:
         await middleware.call('failover.call_remote', 'core.bulk', [


### PR DESCRIPTION
On an internal system, an HA system was exposed to a network segmentation between the controllers. This caused both controllers to become MASTER. This caused a busy-loop of core.bulk service.restart calls to be sent back and forth to each controller endlessly. To remedy this situation I've added an extra check to ensure that `failover.disabled.reasons` needs to be empty before forwarding the remote call.

Original PR: https://github.com/truenas/middleware/pull/16836


Original PR: https://github.com/truenas/middleware/pull/16837
