### PR TITLE
NAS-136921 / 26.04 / plug a slow memory leak in service.* api

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -89,8 +89,10 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
         return await self.middleware.run_in_thread(self._unit_action_sync, action, wait, self.systemd_unit_timeout, unit=unit)
 
     def _unit_action_sync(self, action, wait, timeout, unit=None):
+        unit_passed_to_us = True
         if unit is None:
             unit = self._get_systemd_unit()
+            unit_passed_to_us = False
 
         try:
             job = getattr(unit.Unit, action)(b"replace")
@@ -137,7 +139,8 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
                 del callback
                 del job_object
         finally:
-            del unit
+            if unit_passed_to_us is False:
+                del unit
 
     async def _systemd_unit(self, unit, verb):
         await systemd_unit(unit, verb)

--- a/src/middlewared/middlewared/plugins/service_/services/incus.py
+++ b/src/middlewared/middlewared/plugins/service_/services/incus.py
@@ -25,8 +25,11 @@ class IncusService(SimpleService):
         await self._unit_action("Stop")
         # incus.socket needs to be stopped in addition to the service
         unit = Unit("incus.socket")
-        unit.load()
-        await self._unit_action("Stop", unit=unit)
+        try:
+            unit.load()
+            await self._unit_action("Stop", unit=unit)
+        finally:
+            del unit
         await self.middleware.run_in_thread(self._stop_dnsmasq)
 
     def _stop_dnsmasq(self):


### PR DESCRIPTION
Investigating the peculiar scenario outlined in https://github.com/truenas/middleware/pull/16836, I saw that the parent process was consuming ~19GB of resident memory. The loop was spinning running `core.bulk` api calls, more specifically `service.restart`. I created a very simple script that runs `service.restart <service>` in a `while True` loop. Monitoring the parent process in top, the resident memory would grow sporadically in chunks. A bit more investigation using `tracemalloc` and `resource` modules, I saw that there were some left-over references to objects from `pystemd` module. I found that upstream had a memory leak related to the `Unit` class but that was fixed back in 2018. I also confirmed that our version doesn't suffer from that memory leak but I was still suspicious.

I ended up forcefully `del unit` and `del job_object` items and ran my script again. With my changes, there are still some allocations taking up memory in the parent process, however, they stabilized and did not produce the same behavior from before my changes.

I don't believe this is a leak in pystemd, I believe this is a reference counting issue with our logic because we have 452 different base classes 😄 (I'm exaggerating but hopefully making a point).