### PR TITLE
NAS-136961 / 26.04 / remove zfs.dataset.query from apps/ix_volumes.py

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_volumes.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_volumes.py
@@ -26,13 +26,17 @@ class AppsIxVolumeService(Service):
 
         docker_ds = (await self.middleware.call('docker.config'))['dataset']
         datasets = await self.middleware.call(
-            'zfs.dataset.query', [['id', '^', f'{get_app_mounts_ds(docker_ds)}/']], {
-                'extra': {'retrieve_properties': False, 'flat': True}
+            'zfs.resource.query_impl',
+            {
+                'paths': [get_app_mounts_ds(docker_ds)],
+                'get_children': True,
+                'get_source': False,
+                'properties': None
             }
         )
         apps = collections.defaultdict(list)
-        for ds_name in filter(lambda d: d.count('/') > 3, map(lambda d: d['id'], datasets)):
-            name_split = ds_name.split('/', 4)
+        for ds in filter(lambda x: x['name'].count('/') > 3, datasets):
+            name_split = ds['name'].split('/', 4)
             apps[name_split[3]].append(name_split[-1])
 
         volumes = []


### PR DESCRIPTION
Now that we've branched we're able to start making changes like this. This marks the beginning of removing the calls to `zfs.dataset.query` which is still using our process pool. Using `zfs.resource.query_impl` uses our thread pool and our relatively newly minted libzfs C python library that we've been working on for a bit. The difference in speed is dramatic.