### PR TITLE
NAS-136974 / 26.04 / fix private zfs.resource.query_impl

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -116,7 +116,7 @@ class ZFSResourceService(Service):
     @private
     @pass_thread_local_storage
     def query_impl(self, tls, data: dict | None = None):
-        base = ZFSResourceQueryArgs().model_dump()
+        base = ZFSResourceQueryArgs().model_dump()['data']
         if data is None:
             final = base
         else:

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -123,14 +123,11 @@ class ZFSResourceService(Service):
             final = base | data
             self.validate_query_args(final)
 
-        try:
-            results = query_impl(tls.lzh, final)
-            if final["nest_results"]:
-                return self.nest_paths(results)
-            else:
-                return results
-        except ZFSPathNotFoundException as e:
-            raise ValidationError("zfs.resource.query", str(e), errno.ENOENT)
+        results = query_impl(tls.lzh, final)
+        if final["nest_results"]:
+            return self.nest_paths(results)
+        else:
+            return results
 
     @api_method(
         ZFSResourceQueryArgs,
@@ -169,4 +166,7 @@ class ZFSResourceService(Service):
             # Get hierarchical view of resources
             query({"paths": ["tank"], "nest_results": True, "get_children": True})
         """
-        return self.middleware.call_sync("zfs.resource.query_impl", data)
+        try:
+            return self.middleware.call_sync("zfs.resource.query_impl", data)
+        except ZFSPathNotFoundException as e:
+            raise ValidationError("zfs.resource.query", str(e), errno.ENOENT)


### PR DESCRIPTION
1. The pydantic model puts all the keys underneath the top-level `data` key. This doesn't show up because our tests go through the public API (`zfs.resource.query`) and pulling out the keys is handled via our `api_method` decorator
2. Move the try: catch: logic to the public API endpoint