### PR TITLE
NAS-136979 / 26.04 / add raise_on_nonent to zfs.resource.query_impl

### DIFF
--- a/src/middlewared/middlewared/api/v26_04_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v26_04_0/zfs_resource_crud.py
@@ -1,7 +1,5 @@
 from typing import Literal
 
-from pydantic import Field
-
 from middlewared.api.base import BaseModel, NotRequired, UniqueList
 
 __all__ = ("ZFSResourceEntry", "ZFSResourceQueryArgs", "ZFSResourceQueryResult")
@@ -260,11 +258,8 @@ class ZFSResourceQuery(BaseModel):
     Setting this to None will retrieve no zfs properties."""
     get_user_properties: bool = False
     """Retrieve user properties for zfs resource(s)."""
-    get_source: bool = Field(default=True, exclude_json_schema=True)
-    """Hidden field to retrieve source information for a zfs property.
-
-    NOTE: This should only ever be toggled by internal consumers and \
-    you should know what you're doing by toggling this to False."""
+    get_source: bool = False
+    """Retrieve source information for a zfs property."""
     nest_results: bool = False
     """Return a nested object that associates all children to their \
     respective parents in the filesystem. By default, each zfs resource \

--- a/src/middlewared/middlewared/plugins/zfs/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/query_impl.py
@@ -83,7 +83,10 @@ def __query_impl_paths(hdl, state):
             __query_impl_callback(rsrc, state)
         except ZFSException as e:
             if ZFSError(e.code) == ZFSError.EZFS_NOENT:
-                raise ZFSPathNotFoundException(f"{path!r}: not found")
+                if state.query_args.get("raise_on_noent", False):
+                    raise ZFSPathNotFoundException(f"{path!r}: not found")
+                else:
+                    continue
             raise
 
 


### PR DESCRIPTION
1. the `exclude_json_schema` keyword argument does not hide this from API documentation so remove it since it has no harm in exposing it
2. add a private `raise_on_noent` keyword argument that can be passed to zfs.resource.query_impl. This will prevent an exception from being raised when some queries for a path that doesn't exist. This will be very important as we transition internal callers to this