### PR TITLE
NAS-136989 / 26.04 / Fix cdrom device path validation (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -27,7 +27,7 @@ __all__ = [
 class VMCDROMDevice(BaseModel):
     dtype: Literal['CDROM']
     """Device type identifier for CD-ROM/DVD devices."""
-    path: NonEmptyString = Field(pattern='^/mnt/[^{}]*$')
+    path: NonEmptyString = Field(pattern=r'^[^{}]*$')
     """Path must not contain "{", "}" characters, and it should start with "/mnt/"."""
 
 

--- a/src/middlewared/middlewared/api/v26_04_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v26_04_0/vm_device.py
@@ -27,7 +27,7 @@ __all__ = [
 class VMCDROMDevice(BaseModel):
     dtype: Literal['CDROM']
     """Device type identifier for CD-ROM/DVD devices."""
-    path: NonEmptyString = Field(pattern='^/mnt/[^{}]*$')
+    path: NonEmptyString = Field(pattern=r'^[^{}]*$')
     """Path must not contain "{", "}" characters, and it should start with "/mnt/"."""
 
 

--- a/src/middlewared/setup.cfg
+++ b/src/middlewared/setup.cfg
@@ -18,7 +18,7 @@ output_dir = middlewared/locale
 previous = true
 
 [flake8]
-extend-ignore = A003,LIT001,LIT003
+extend-ignore = A003,LIT001,LIT003,LIT101
 per-file-ignores =
     src/middlewared/middlewared/api/**/__init__.py:F401,F403,F405
 max-line-length = 120


### PR DESCRIPTION
## Problem
In older releases we allowed CDROM devices to live outside `/mnt` which is not ideal. However the problem we see right now is that if we validate this in the pydantic model itself, `vm.query` can fail which is not ideal.

## Solution
We are already checking that the cdrom device is in a pool, so we don't have to do the same validation in pydantic.

Original PR: https://github.com/truenas/middleware/pull/16859
