### PR TITLE
NAS-136994 / 25.04.2.1 / Do not configure directoryservices nsswitch on standby

### DIFF
--- a/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
@@ -1,5 +1,9 @@
 <%
-    enabled_ds = middleware.call_sync('directoryservices.status')['type']
+    if middleware.call_sync('failover.is_single_master_node'):
+        enabled_ds = middleware.call_sync('directoryservices.status')['type']
+    else:
+        enabled_ds = None
+
 %>
 #
 # nsswitch.conf(5) - name service switch configuration file


### PR DESCRIPTION
This commit ensures that directoryservices do not get inserted into the nsswitch.conf on standby controller if directoryservices are enabled. 25.04 and earlier expect the standby controller to not be fully configured for directory services and so we don't want NSS calls to potentially block on waiting for winbindd / sssd to bind to non-configured service. When vrrp_master gets called the nsswitch.conf is automatically reconfigured during a middleware call to directoryservices.setup.