### PR TITLE
NAS-137006 / 26.04 / Properly grab update status error

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/status.py
+++ b/src/middlewared/middlewared/plugins/update_/status.py
@@ -82,6 +82,7 @@ class UpdateService(Service):
                 'update_download_progress': self.update_download_progress,
             })
         except Exception as e:
+            self.logger.exception('Failed to get update status')
             return self._result('ERROR', {
                 'error': repr(e),
             })


### PR DESCRIPTION
## Problem

We saw on a system that `update.status` returned the following output
```
{"code": "ERROR", "status": null, "error": "TypeError(\"'NoneType' object is not subscriptable\")", "update_download_progress": null}
```

## Solution

Improve error reporting so we grab complete stack trace so we can at leave have more insight into what might have happened. Looking at the implementation itself, there is no obvious issue in the code semantics which could highlight this issue