### PR TITLE
add has_internal_path helper function

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/query_impl.py
@@ -5,18 +5,11 @@ try:
 except ImportError:
     ZFSError = ZFSException = None
 
-from middlewared.utils import BOOT_POOL_NAME_VALID
 from .normalization import normalize_asdict_result
 from .property_management import build_set_of_zfs_props, DeterminedProperties
+from .utils import has_internal_path
 
 __all__ = ("query_impl", "ZFSPathNotFoundException")
-
-INTERNAL_FILESYSTEMS = (
-    ".system",
-    "ix-applications",
-    "ix-apps",
-    ".ix-virt",
-)
 
 
 class ZFSPathNotFoundException(Exception):
@@ -34,27 +27,8 @@ class CallbackState:
     will exclude them."""
 
 
-def __is_internal_path(path):
-    """
-    Check if a path is an internal filesystem.
-
-    Args:
-        path: relative path representing the zfs filesystem
-
-    Returns:
-        bool: True if the path is internal, False otherwise
-    """
-    for i in BOOT_POOL_NAME_VALID:
-        if path == i or path.startswith(f"{i}/"):
-            return True
-    for i in INTERNAL_FILESYSTEMS:
-        if f"/{i}" in path:
-            return True
-    return False
-
-
 def __query_impl_callback(hdl, state):
-    if state.eip and __is_internal_path(hdl.name):
+    if state.eip and has_internal_path(hdl.name):
         # returning False here will halt the iteration
         # entirely which is not what we want to do
         return True
@@ -96,7 +70,7 @@ def __query_impl_roots(hdl, state):
 
 def __should_exclude_internal_paths(data):
     for path in data["paths"]:
-        if __is_internal_path(path):
+        if has_internal_path(path):
             # somone is explicilty querying an
             # internal path
             return False

--- a/src/middlewared/middlewared/plugins/zfs/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs/utils.py
@@ -1,0 +1,23 @@
+from middlewared.utils import BOOT_POOL_NAME_VALID
+
+INTERNAL_PATHS = (
+    "ix-apps",
+    ".ix-virt",
+    "ix-applications",
+    ".system"
+) + tuple(BOOT_POOL_NAME_VALID)
+
+__all__ = ("has_internal_path",)
+
+
+def has_internal_path(path):
+    """
+    Check if the given path contains, is, or is under any internal system path.
+
+    Args:
+        path: A relative path string (e.g., 'tank/ix-apps/foo')
+
+    Returns:
+        bool: True if path has any internal component, False otherwise
+    """
+    return any(i in INTERNAL_PATHS for i in path.split("/"))


### PR DESCRIPTION
This will be used in future PRs as we start converting our public endpoints to calling `zfs.resource.query_impl`. This basically the replacement for the `internal_datasets_filters` method.