### PR TITLE
Restart services on becoming healthy

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -177,6 +177,10 @@ class DomainHealth(
         # for the USER service because the other node in HA is responsible for its own health checks.
         self.middleware.call_sync('etc.generate', 'user')
 
+        # We may need to restart dependent services after recovering from a problematic state
+        if self.middleware.call_sync('failover.is_single_master_node'):
+            self.middleware.call_sync('directoryservices.restart_dependent_services')
+
     def set_state(self, ds_type, ds_status, status_msg=None):
         ds = DSType(ds_type)
         status = DSStatus[ds_status]


### PR DESCRIPTION
When directory services recover from being in a FAULTED state, the dependent services such as SMB and NFS may need to be restarted in order to refresh caches / configuration and properly start serving files again.