### PR TITLE
NAS-136935 / 25.10-RC.1 / Add method usage stats to usage plugin (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -22,7 +22,7 @@ from middlewared.utils.debug import get_frame_details
 from middlewared.utils.lang import undefined
 from middlewared.utils.limits import MsgSizeError, MsgSizeLimit, parse_message
 from middlewared.utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
-from middlewared.utils.origin import ConnectionOrigin
+from middlewared.utils.origin import ConnectionOrigin, is_external_call
 from .base import BaseWebSocketHandler
 from ..app import App
 from ..method import Method
@@ -345,6 +345,10 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
         return False
 
     async def process_method_call(self, app: RpcWebSocketApp, id_: Any, method: Method, params: list):
+        # Track external method calls
+        if is_external_call(app):
+            self.middleware.external_method_calls[method.name] += 1
+
         try:
             async with app.softhardsemaphore:
                 result = await method.call(app, id_, params)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -135,6 +135,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         self.api_versions = None
         self.api_versions_adapter = None
         self.__audit_logger = setup_audit_logging()
+        self.external_method_calls = defaultdict(int)  # Track external API method calls
 
     def get_method(self, name, *, mocks=False, params=None):
         serviceobj, methodobj = super().get_method(name)

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -7,7 +7,6 @@ import shutil
 import time
 import uuid
 import yaml
-from collections import defaultdict
 
 from truenas_api_client import json as ejson
 
@@ -509,52 +508,3 @@ class AuditService(ConfigService):
             filters,
             options
         )
-
-    @private
-    async def get_method_stats(self, timestamp=None):
-        """
-        Get statistics for all method calls from the audit log.
-
-        Parameters:
-        - timestamp: Optional Unix timestamp to filter calls after this time
-
-        Returns:
-        Dictionary mapping method names to their statistics
-        """
-        # Build query filters
-        query_filters = [['event', '=', 'METHOD_CALL']]
-        if timestamp is not None:
-            query_filters.append(['message_timestamp', '>=', timestamp])
-
-        # Query audit log for method calls
-        audit_entries = await self.middleware.call(
-            'audit.query',
-            {
-                'services': ['MIDDLEWARE'],
-                'query-filters': query_filters,
-                'query-options': {}
-            }
-        )
-
-        # Aggregate statistics by method
-        method_stats = defaultdict(lambda: {
-            'total_calls': 0,
-            'successful_calls': 0,
-            'failed_calls': 0,
-        })
-
-        for entry in audit_entries:
-            method = entry.get('event_data', {}).get('method')
-            if not method:
-                continue
-
-            stats = method_stats[method]
-            stats['total_calls'] += 1
-
-            # Check if the call was successful
-            if entry.get('success', True):
-                stats['successful_calls'] += 1
-            else:
-                stats['failed_calls'] += 1
-
-        return method_stats

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -3,6 +3,7 @@ import json
 import os
 import random
 import subprocess
+import time
 from collections import defaultdict
 
 import aiohttp
@@ -251,6 +252,13 @@ class UsageService(Service):
                     {k: disk[k]} for disk in await self.middleware.call('disk.query') for k in ['model']
                 ]
             }
+        }
+
+    async def gather_method_stats(self, context):
+        # Get stats for the last 24 hours only
+        last_24_hours = int(time.time()) - 86400  # 86400 seconds = 24 hours
+        return {
+            'method_stats': await self.middleware.call('audit.get_method_stats', last_24_hours),
         }
 
     async def gather_network(self, context):

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -3,7 +3,6 @@ import json
 import os
 import random
 import subprocess
-import time
 from collections import defaultdict
 
 import aiohttp
@@ -255,10 +254,8 @@ class UsageService(Service):
         }
 
     async def gather_method_stats(self, context):
-        # Get stats for the last 24 hours only
-        last_24_hours = int(time.time()) - 86400  # 86400 seconds = 24 hours
         return {
-            'method_stats': await self.middleware.call('audit.get_method_stats', last_24_hours),
+            'method_stats': self.middleware.external_method_calls,
         }
 
     async def gather_network(self, context):

--- a/src/middlewared/middlewared/utils/origin.py
+++ b/src/middlewared/middlewared/utils/origin.py
@@ -132,16 +132,6 @@ class ConnectionOrigin:
         )
 
     @property
-    def is_loopback(self) -> bool:
-        """Check if this is a loopback TCP/IP connection"""
-        if self.is_tcp_ip_family and self.rem_addr:
-            try:
-                return ip_address(self.rem_addr).is_loopback
-            except Exception:
-                pass
-        return False
-
-    @property
     def secure_transport(self) -> bool:
         """Indicates whether we should treat the connection as having
         secure transport for purposes of invalidation of API keys.
@@ -151,8 +141,11 @@ class ConnectionOrigin:
         if self.ssl or self.is_unix_family or self.is_ha_connection:
             return True
 
-        if self.is_loopback:
-            return True
+        if self.is_tcp_ip_family:
+            try:
+                return ip_address(self.rem_addr).is_loopback
+            except Exception:
+                pass
 
         # By default assume that transport is insecure
         return False

--- a/src/middlewared/middlewared/utils/origin.py
+++ b/src/middlewared/middlewared/utils/origin.py
@@ -235,7 +235,8 @@ def is_external_call(app):
     External calls are those which the system is not generating internally i.e self.middleware.call().
 
     Note: We intentionally track midclt calls (Unix socket) as they can be
-    initiated by users and we want to track their usage patterns.
+    initiated by users and we want to track their usage patterns (this only applies to midclt calls
+    where user has logged in to a shell and not internal calls made by scripts).
 
     Returns True for external calls, False for internal calls.
     """
@@ -249,9 +250,4 @@ def is_external_call(app):
     if origin.is_ha_connection:
         return False
 
-    # Loopback TCP/IP connections are internal
-    if origin.is_loopback:
-        return False
-
-    # Unix socket connections (midclt) and non-loopback TCP/IP are external
-    return True
+    return origin.session_is_interactive


### PR DESCRIPTION
This PR adds changes so that we can have method usage stats in our usage plugin. This will give us something like the following:
```
❯ midclt call usage.gather_method_stats '{}' | jq
{
  "method_stats": {
    "core.set_options": 27,
    "core.subscribe": 10,
    "core.environ": 2,
    "usage.gather_method_stats": 4,
    "system.info": 1,
    "usage.gather": 1
  }
}
```

Original PR: https://github.com/truenas/middleware/pull/16845
