### PR TITLE
NAS-136946 / 26.04 / Make sure incus VMs do not start automatically on boot

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -774,7 +774,11 @@ class VirtGlobalService(ConfigService):
         await self.middleware.call(
             'core.bulk', 'virt.instance.start', [
                 [instance['name']] for instance in await self.middleware.call(
-                    'virt.instance.query', [['autostart', '=', True], ['status', '=', 'STOPPED']]
+                    'virt.instance.query', [
+                        ['autostart', '=', True],
+                        ['status', '=', 'STOPPED'],
+                        ['type', '=', 'CONTAINER']  # Only autostart CONTAINER type instances
+                    ]
                 )
                 # We have an explicit filter for STOPPED because old virt instances would still have
                 # incus autostart enabled and we don't want to attempt to start them again.


### PR DESCRIPTION
## Problem

Now that we have VM plugin back, we do not want incus VMs to start automatically on boot as that can be problematic and if the same zvol is being used, can lead to corruption issues.

## Solution

Make sure incus based VMs do not autostart on boot by filtering those out. However VMs created using early incus implementation, will still autostart (unless they have been modified at least once) because we were relying on incus to do that and as soon as incus starts it will start those automatically.