### PR TITLE
NAS-137015 / 26.04 / Fix API for directory services cert choices

### DIFF
--- a/src/middlewared/middlewared/api/v26_04_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v26_04_0/directory_services.py
@@ -648,5 +648,5 @@ class DirectoryServicesCertificateChoicesArgs(BaseModel):
 
 
 class DirectoryServicesCertificateChoicesResult(BaseModel):
-    result: dict[int, NonEmptyString]
+    result: dict[NonEmptyString, NonEmptyString]
     """IDs of certificates mapped to their names."""


### PR DESCRIPTION
The PR to fix MTLS authentication included an API change, but it landed while we were in limbo of adding the new 26.04 APIs. This commit forward-ports the 25.10 API to 26.04 for this call.