### PR TITLE
NAS-136955 / 25.10-BETA.1 / Fix validation and handling of MTLS cert for LDAP (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -648,5 +648,5 @@ class DirectoryServicesCertificateChoicesArgs(BaseModel):
 
 
 class DirectoryServicesCertificateChoicesResult(BaseModel):
-    result: dict[int, NonEmptyString]
+    result: dict[NonEmptyString, NonEmptyString]
     """IDs of certificates mapped to their names."""

--- a/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
@@ -42,7 +42,7 @@
         raise FileShouldNotExist
 
     if credential['credential_type'] == DSCredType.LDAP_MTLS:
-        cert = middleware.call_sync('certificate.query', [['cert_name', '=', credential['client_certificate']]], {'get': True})
+        cert = middleware.call_sync('certificate.query', [['name', '=', credential['client_certificate']]], {'get': True})
         tls_certfile = cert['certificate_path']
         tls_keyfile = cert['privatekey_path']
 

--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -19,7 +19,7 @@
         if ds_config['credential']['credential_type'] == DSCredType.LDAP_MTLS:
             try:
                 cert = middleware.call_sync('certificate.query', [
-                    ('cert_name', '=', ds_config['credential']['client_certificate'])
+                    ('name', '=', ds_config['credential']['client_certificate'])
                 ], {'get': True})
             except Exception:
                 middleware.logger.error('Failed to retrieve client certificate', exc_info=True)

--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -81,6 +81,8 @@ ldap_sasl_authid = ${ds_config['credential']['principal']}
 % endif
 % endif
 timeout = ${ds_config['timeout']}
+ldap_search_timeout = ${ds_config['timeout']}
+ldap_network_timeout = ${ds_config['timeout']}
 ldap_schema = ${ds_config['configuration']['schema'].lower()}
 min_id = ${min_uid}
 ${'\n    '.join(search_params)}

--- a/src/middlewared/middlewared/plugins/directoryservices_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cert_attachments.py
@@ -17,7 +17,7 @@ class DSCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
         match ds_config['service_type']:
             case DSType.IPA.value:
                 # IPA bind may rely on the presence of the IPA server's cacert
-                cert_name = (await self.middleware.call('certificate.get_instance', cert_id))['cert_name']
+                cert_name = (await self.middleware.call('certificate.get_instance', cert_id))['name']
                 return cert_name == IpaConfigName.IPA_CACERT
             case DSType.LDAP.value:
                 # Check is below

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -268,9 +268,9 @@ class DirectoryServices(ConfigService):
             case DSCredType.LDAP_ANONYMOUS:
                 pass
             case DSCredType.LDAP_MTLS:
-                cert_id = self.middleware.call('certificate.query', [
-                    ['cert_name', '=', data['credential']['client_certificate']]
-                ], {'get': True})
+                cert_id = self.middleware.call_sync('certificate.query', [
+                    ['name', '=', data['credential']['client_certificate']]
+                ], {'get': True})['id']
                 datastore_cred['cred_ldap_mtls_cert'] = cert_id
             case _:
                 raise ValueError(f'{data["credential"]["credential_type"]}: unhandled credential type')
@@ -375,7 +375,7 @@ class DirectoryServices(ConfigService):
         if new['credential'] and new['credential']['credential_type'] == DSCredType.LDAP_MTLS:
             cert_name = new['credential']['client_certificate']
             try:
-                self.middleware.call_sync('certificate.query', [['cert_name', '=', cert_name]], {'get': True})
+                self.middleware.call_sync('certificate.query', [['name', '=', cert_name]], {'get': True})
             except MatchNotFound:
                 verrors.add(f'{SCHEMA}.credential.client_certificate', 'Unknown client certificate.')
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -837,7 +837,7 @@ class DirectoryServices(ConfigService):
         Note that prior configuration of LDAP server is required and uploading a custom
         certificate to TrueNAS may also be required. """
         return {
-            i['id']: i['name']
+            i['name']: i['name']
             for i in await self.middleware.call(
                 'certificate.query', [
                     ['cert_type', '=', 'CERTIFICATE'],


### PR DESCRIPTION
This commit fixes several bugs related to handling of MTLS certificates in the LDAP / SSSD config as well as the datastore plugin. CI tests will be added in separate PR once we have a google domain for jenkins testing.

Original PR: https://github.com/truenas/middleware/pull/16844
