### PR TITLE
NAS-137029 / 26.04 / Remove global 2fa check to unset 2FA token

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -144,12 +144,6 @@ class UserService(Service):
             # in this case we don't do anything and the secret is already unset
             return
 
-        twofactor_config = await self.middleware.call('auth.twofactor.config')
-        if twofactor_config['enabled']:
-            # TODO: Let's try to stream line exception behaviour where we change this to either validation error
-            #  when this starts being used in a form or UI changes how they handle call errors
-            raise CallError('Please disable Two Factor Authentication first')
-
         await self.middleware.call(
             'datastore.update',
             'account.twofactor_user_auth',


### PR DESCRIPTION
This commit removes the requirement for global 2FA to be disabled before unsetting a user's 2FA token. The reason to remove this is that otherwise there is no mechanism for a system administrator to completely remove 2FA for an existing user without toggling the global 2FA settings and downgrading system-wide security.