### PR TITLE
NAS-137010 / 25.10-RC.1 / Cache function pointers to nss module functions (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/nss/nss_common.py
+++ b/src/middlewared/middlewared/utils/nss/nss_common.py
@@ -24,7 +24,7 @@ class NSSModuleFN(defaultdict):
 
 
 class NSSModuleCDLL(defaultdict):
-    """ A default dictionary that holds references loaded shared libaries for the NSS modules above.
+    """ A default dictionary that holds references to loaded shared libaries for the NSS modules above.
     For example, '/usr/lib/x86_64-linux-gnu/libnss_files.so.2'. The returned value is an NSSModuleFN
     that will hold references to lazy-initialized C function pointers."""
     def __missing__(self, key):


### PR DESCRIPTION
This commit reduces the amount of dlopen during NSS calls (for example when building directory services caches) by lazy-initializing a cache containing references to the various NSS functions on a per-module basis (files, sss, winbind).

Original PR: https://github.com/truenas/middleware/pull/16866
