### PR TITLE
NAS-136937 / 25.10-RC.1 / Do not get CPU model choices from libvirt (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -126,7 +126,6 @@ class VMDeviceService(Service):
     @api_method(VMDevicePassthroughDeviceArgs, VMDevicePassthroughDeviceResult, roles=['VM_DEVICE_READ'])
     def passthrough_device(self, device):
         """Retrieve details about `device` PCI device"""
-        self.middleware.call_sync('vm.check_setup_libvirt')
         if device_details := self.get_single_pci_device_details(RE_DEVICE_PATH.sub(r'\1:\2:\3.\4', device)):
             return device_details[device]
         else:

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -1,3 +1,5 @@
+import os
+from functools import cache
 from xml.etree import ElementTree as etree
 
 
@@ -38,3 +40,51 @@ def get_default_status() -> dict:
         'pid': None,
         'domain_state': 'ERROR',
     }
+
+
+@cache
+def get_cpu_model_choices():
+    """
+    Parse CPU model choices from libvirt XML files.
+    This function is cached to avoid re-parsing XML files on every call.
+    Returns a dict of {model_name: model_name} for available CPU models.
+    """
+    base_path = '/usr/share/libvirt/cpu_map'
+    index_file = os.path.join(base_path, 'index.xml')
+    with open(index_file, 'r') as f:
+        index_xml = etree.fromstring(f.read().strip())
+
+    models = {}
+
+    # Process architectures that virsh cpu-models supports
+    # Note: arm is excluded as virsh cpu-models arm fails
+    for arch in index_xml.findall('.//arch[@name]'):
+        arch_name = arch.get('name')
+        if arch_name not in ['x86', 'ppc64']:
+            continue
+
+        # Process all include elements in the architecture
+        for elem in arch.iter('include'):
+            filename = elem.get('filename')
+            if not filename:
+                continue
+
+            filepath = os.path.join(base_path, filename)
+            try:
+                with open(filepath, 'r') as f:
+                    content = f.read().strip()
+                    # Skip non-model files like features.xml, vendors.xml
+                    if '<model name=' not in content:
+                        continue
+
+                    xml = etree.fromstring(content)
+                    model = xml.find('.//model[@name]')
+                    if model is not None:
+                        name = model.get('name')
+                        if name:
+                            models[name] = name
+            except (etree.ParseError, IOError, FileNotFoundError):
+                # Skip files that can't be parsed or are not there
+                continue
+
+    return models


### PR DESCRIPTION
## Problem

We are retrieving CPU model choices from libvirt which means that when someone just navigates to VM creation wizard and UI calls cpu model choices endpoint, it ends up starting libvirt which is not ideal.

## Solution

Retrieve information directly from filesystem like libvirt itself does so that we do not have to get that information from libvirt but rather the same files libvirt itself uses, thus preventing the need to start libvirt service when there is no VM created and only CPU model choices are required.

Original PR: https://github.com/truenas/middleware/pull/16901
