### PR TITLE
Increase setacl validation

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -781,11 +781,15 @@ class FilesystemService(Service):
                     method = 'group.query'
                     filters = [['group', '=', entry['who']]]
                     key = 'gid'
-                case POSIXACE_Tag.USER_OBJ | POSIXACE_Tag.GROUP_OBJ | POSIXACE_Tag.OTHER | POSIXACE_Tag.MASK:
-                    # these tags don't require an explicit uid/gid
+                case POSIXACE_Tag.USER_OBJ | POSIXACE_Tag.GROUP_OBJ:
+                    # We currently allow these because we're populating in getacl response
+                    # This may need to be re-evaluated. These tags don't require an explicit uid/gid
+                    # and so we cna just skip safely
                     continue
-                case NFS4ACE_Tag.SPECIAL_OWNER | NFS4ACE_Tag.SPECIAL_GROUP | NFS4ACE_Tag.EVERYONE:
-                    # these tags don't require an explicit uid/gid
+                case NFS4ACE_Tag.SPECIAL_OWNER | NFS4ACE_Tag.SPECIAL_GROUP:
+                    # We currently allow these because we're populating in getacl response
+                    # This may need to be re-evaluated. These tags don't require an explicit uid/gid
+                    # and so we cna just skip safely
                     continue
                 case _:
                     raise ValidationError(


### PR DESCRIPTION
Raise a validation error if user submits ACL payload specifying a username for a POSIX OTHER entry, NFSv4 everyone@ entry, or POSIX MASK entry.