### PR TITLE
NAS-137050 / 25.10-RC.1 / Fix enum lookup for everyone@ (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -784,7 +784,7 @@ class FilesystemService(Service):
                 case POSIXACE_Tag.USER_OBJ | POSIXACE_Tag.GROUP_OBJ | POSIXACE_Tag.OTHER | POSIXACE_Tag.MASK:
                     # these tags don't require an explicit uid/gid
                     continue
-                case NFS4ACE_Tag.SPECIAL_OWNER | NFS4ACE_Tag.SPECIAL_GROUP | NFS4ACE_Tag.EVERYONE:
+                case NFS4ACE_Tag.SPECIAL_OWNER | NFS4ACE_Tag.SPECIAL_GROUP | NFS4ACE_Tag.SPECIAL_EVERYONE:
                     # these tags don't require an explicit uid/gid
                     continue
                 case _:


### PR DESCRIPTION
This commit fixes enum reference for EVERYONE in payload in an error-related code path. In future commit I will change backend to be more aggressive about raising ValidationError if someone specifies username or groupname for special entries, since this is an invalid payload.

Original PR: https://github.com/truenas/middleware/pull/16909
