### PR TITLE
NAS-137056 / 26.04 / fix legacy API client test

### DIFF
--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,7 +1,11 @@
 def test_query_method(legacy_api_client, query_method):
     version = legacy_api_client._ws.url.split("/")[-1].lstrip("v")
     # Methods that do not exist in the previous API versions
-    if version in {"25.04.0", "25.04.1"} and query_method in {"vm.query", "vm.device.query"}:
+    if version in {"25.04.0", "25.04.1"} and query_method in {
+        "vm.query",
+        "vm.device.query",
+        "zfs.resource.query"
+    }:
         return
 
     if version in {"25.04.0", "25.04.1", "25.04.2"} and query_method in {
@@ -31,6 +35,7 @@ def test_query_method(legacy_api_client, query_method):
         "sharing.smb.query",
         "tunable.query",
         "vmware.query",
+        "zfs.resource.query"
     }:
         return
 


### PR DESCRIPTION
zfs.resource.query only exists in >= 25.10 