### PR TITLE
remove default gateway config

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/global_config.py
+++ b/src/middlewared/middlewared/plugins/network_/global_config.py
@@ -91,23 +91,12 @@ class NetworkConfigurationService(ConfigService):
             data['hosts'] = []
 
         data['state'] = {
-            'ipv4gateway': '',
-            'ipv6gateway': '',
             'nameserver1': '',
             'nameserver2': '',
             'nameserver3': '',
             'hosts': self.read_etc_hosts_file(),
         }
         summary = self.middleware.call_sync('network.general.summary')
-        for default_route in summary['default_routes']:
-            try:
-                ipaddress.IPv4Address(default_route)
-            except ValueError:
-                if not data['state']['ipv6gateway']:
-                    data['state']['ipv6gateway'] = default_route
-            else:
-                if not data['state']['ipv4gateway']:
-                    data['state']['ipv4gateway'] = default_route
         for i, nameserver in enumerate(summary['nameservers'][:3]):
             data['state'][f'nameserver{i + 1}'] = nameserver
 


### PR DESCRIPTION
Remove default gateway config, so it can accept dhcp server option 3 gateway setting.

This code will default to rewriting empty gateway configurations in webui to router addresses. This will cause the option routers issued by the DHCP server to become ineffective, as they will be overwritten by the default_router above. Specifically, it will be rewritten by the following `RouteService.sync():109 - Changing IPv4 default route from`