### PR TITLE
NAS-137072 / 26.04 / remove zfs.dataset.query from usage.py

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/query_impl.py
@@ -74,9 +74,13 @@ def __should_exclude_internal_paths(data):
             # somone is explicilty querying an
             # internal path
             return False
-    # no paths specified or none of the paths
-    # specified are an internal path
-    return True
+    # 1. no paths specified are internal path
+    # 2. no paths specified at all (empty query)
+    # 3. or someone exclusively asks for internal paths
+    #   NOTE: (the `exclude_internal_paths` is a private
+    #   internal argument that is set internally within
+    #   middleware. It's not exposed to public.)
+    return data.get('exclude_internal_paths', True)
 
 
 def query_impl(hdl, data):


### PR DESCRIPTION
This does 3 things:
1. removes `zfs.dataset.query` in favor of `zfs.resource.query_impl`
2. removes the `snapshots_count` statistic. This was confirmed to not be used in our usage statistics.
3. adds a private `exclude_internal_paths` keyword argument that can be passed to `query_impl` _ONLY_ to allow the caller to query all zfs datasets, including the ones we hide from the public.