### PR TITLE
NAS-137078 / 26.04 / fix another KeyEror in sysdataset.py

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -485,7 +485,7 @@ class SystemDatasetService(ConfigService):
                 'zfs.resource.query_impl',
                 {
                     'paths': list(datasets),
-                    'properties': ['quota', 'used', 'mountpoint', 'readonly', 'snapdir', 'canmount']
+                    'properties': ['encryption', 'quota', 'used', 'mountpoint', 'readonly', 'snapdir', 'canmount']
                 }
             )
         }


### PR DESCRIPTION
Tests were failing here when trying to migrate system dataset to a root encrypted pool. This fixes it and resolve the test failures.