### PR TITLE
NAS-137063 / 25.10-BETA.1 / Raise an alert for expiration of cert selectively (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alert/source/certificates.py
+++ b/src/middlewared/middlewared/alert/source/certificates.py
@@ -64,7 +64,8 @@ class CertificateChecksAlertSource(AlertSource):
                 # check the parsed certificate(s) for expiration
                 if cert['cert_type'] == 'CERTIFICATE':
                     diff = (datetime.strptime(cert['until'], '%a %b %d %H:%M:%S %Y') - utc_now()).days
-                    if diff < 10:
+                    alert_threshold = cert.get('renew_days', 10) - 1
+                    if diff < alert_threshold:
                         if diff >= 0:
                             alerts.append(Alert(
                                 CertificateIsExpiringSoonAlertClass if diff <= 2 else CertificateIsExpiringAlertClass,


### PR DESCRIPTION
This commit adds changes to make sure that we only raise an alert that a cert is expiring if it is within it's renew days and still hasn't been renewed. For example if a cert is expiring on 10th, and renew days is 5, which means that system will start attempting to renew it from 5th. We will start raising an alert from 6th onwards as it shows that the system was not able to renew it successfully.

Original PR: https://github.com/truenas/middleware/pull/16928
