### PR TITLE
NAS-133307 / 26.04 / Fix UPS shutdown bug

### DIFF
--- a/debian/debian/ix-upsshutdown.service
+++ b/debian/debian/ix-upsshutdown.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Execute UPS shutdown tasks early
+DefaultDependencies=no
+After=
+Before=ix-shutdown.service nut.target shutdown.target umount.target final.target
+Conflicts=shutdown.target umount.target final.target
+RequiresMountsFor=/etc /run
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStop=/lib/systemd/system-shutdown/nutshutdown service-shutdown
+StandardOutput=journal+console
+StandardError=journal+console
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -20,6 +20,7 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-shutdown
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-ssh-keys
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-syncdisks
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-upsshutdown
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-vendor
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-wait-on-disks
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-zfs


### PR DESCRIPTION
## Problem

NUT has a feature which is that if there is a power failure, it cleanly starts to shutdown NAS and then it will shut itself down as well. When the power is back up, it will start and also start the NAS back up.

How this is supposed to happen is that when upsmon detects this signal from UPS itself, it initiates shutdown process (if configured) and then during shutdown tells UPS itself to shut itself down as well as NAS is down to preserve battery and also to boot NAS back up when power is back.
Technically how this is done is that there is a shutdown script which is called `/lib/systemd/system-shutdown/nutshutdown` which is responsible for doing this.
What this script does is roughly the following:
1. A powerdown flag file is created at `/etc/killpower` by ups daemon when signal is detected by UPS itself
2. The script executes and it runs `upsmon -K` which tells if the UPS itself should be shutdown or not (this internally checks for the powerdown flag file)
3. If (2) says it should, it will issue that command to UPS driver and otherwise it won't

Currently what happens is that in the event of power failure, NAS shuts down and the script does execute but `upsmon -K` does not give the go ahead it expects and thus it does not tell UPS driver to shut itself down.

Now the root cause is the following:

During shutdown when systemd executes these shutdown scripts, we only have / and /usr datasets mounted i.e
```
boot-pool/ROOT/26.04.0-MASTER-20250803-185923 on / type zfs (rw,nodev,relatime,xattr,noacl,casesensitive)
boot-pool/ROOT/26.04.0-MASTER-20250803-185923/usr on /usr type zfs (ro,nodev,noatime,xattr,noacl,casesensitive)
```

Which means that `ls -l /etc/` is empty at this time. This causes following problems:
1. powerdown flag file cannot be seen by upsmon at this time so upsmon -K fails
2. We can change the file location of powerdown flag easily, however there is another problem with how upsmon -K works with this behaviour
3. Check this please
```
❯ which upsmon
/usr/sbin/upsmon
❯ ls -l /usr/sbin/upsmon
-rwxr-xr-x 1 root root 429 Jan 25  2023 /usr/sbin/upsmon
❯ cat /usr/sbin/upsmon
#!/bin/sh

# Include NUT nut.conf
[ -r /etc/nut/nut.conf ] && . /etc/nut/nut.conf

case "$MODE" in
  standalone|netserver|netclient)
    exec /lib/nut/upsmon "$@"
  ;;
  none)
    echo "upsmon disabled, please adjust the configuration to your needs"
    echo "Then set MODE to a suitable value in /etc/nut/nut.conf to enable it"
    # exit success to avoid breaking the install process!
    exit 0
  ;;
  *)
    exit 1
  ;;
esac
```
So this script includes nut conf file
```
[ -r /etc/nut/nut.conf ] && . /etc/nut/nut.conf
```
However at this point, `/etc` was already empty which means `$MODE` is not set.

So the problem to conclude we are seeing is that in power failure scenarios, UPS should shutdown as well so when power is back up, it can start back again also power cycle the NAS itself.

## Solution

When the script was being executed, it did not had access to `/etc` which was the root cause of the failure. After discussion with Caleb and discussing various fix strategies, what we have decided is to have a systemd unit file which runs late enough that it works as we want it to work but still early enough so that we have access to `/etc` so `upsmon -K` can function as intended.

The systemd unit file has also been tested on a reporter's machine to ensure it works as we want it to work.