### PR TITLE
NAS-137112 / 26.04 / Fix API schema for reporting data

### DIFF
--- a/src/middlewared/middlewared/api/v26_04_0/reporting.py
+++ b/src/middlewared/middlewared/api/v26_04_0/reporting.py
@@ -111,7 +111,7 @@ class ReportingGetDataResponse(BaseModel):
     """Specific instance identifier for the metric. `null` for system-wide metrics."""
     data: list
     """Array of time-series data points for the requested time period."""
-    aggregations: Aggregations
+    aggregations: Aggregations | None
     """Statistical aggregations of the data over the time period."""
     start: timestamp
     """Actual start timestamp of the returned data."""

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -166,6 +166,8 @@ class GraphBase(metaclass=GraphMeta):
             }
             if self.aggregations and aggregate:
                 data = self.aggregate_metrics(data)
+            else:
+                data['aggregations'] = None
 
             results.append(data)
 


### PR DESCRIPTION
## Problem

The API schema right now expects `aggregations` attribute to be always there, however that is not the case because the code does not add it if aggregations are not explicitly requested.

## Solution

If aggregations are not requested, make sure the key exists so API schema is happy.