### PR TITLE
NAS-137112 / 25.10-BETA.1 / Fix API schema for reporting data (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting.py
@@ -111,7 +111,7 @@ class ReportingGetDataResponse(BaseModel):
     """Specific instance identifier for the metric. `null` for system-wide metrics."""
     data: list
     """Array of time-series data points for the requested time period."""
-    aggregations: Aggregations
+    aggregations: Aggregations | None
     """Statistical aggregations of the data over the time period."""
     start: timestamp
     """Actual start timestamp of the returned data."""

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -166,6 +166,8 @@ class GraphBase(metaclass=GraphMeta):
             }
             if self.aggregations and aggregate:
                 data = self.aggregate_metrics(data)
+            else:
+                data['aggregations'] = None
 
             results.append(data)
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e6d1fd8c9632840b46a765bf3ab291f1758929f8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d32cf33840207c003b25bbeef554c86a2707632a

## Problem

The API schema right now expects `aggregations` attribute to be always there, however that is not the case because the code does not add it if aggregations are not explicitly requested.

## Solution

If aggregations are not requested, make sure the key exists so API schema is happy.

Original PR: https://github.com/truenas/middleware/pull/16944
