### PR TITLE
NAS-137113 / 26.04 / Fix start/end in temperature aggregation

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -62,8 +62,8 @@ class DiskService(Service):
         # we only keep 7 days of historical data because we keep per second information
         # which adds up to lots of used disk space quickly depending on the size of the
         # system
-        start = datetime.now()
-        end = start + timedelta(days=min(days, 7))
+        end = datetime.now()
+        start = end - timedelta(days=min(days, 7))
         opts = {'start': round(start.timestamp()), 'end': round(end.timestamp())}
         final = dict()
         for disk in self.middleware.call_sync('reporting.netdata_graph', 'disktemp', opts):


### PR DESCRIPTION
## Problem

When using the endpoint `disk.temperature_agg`, we were calculating start/end time in the future with doing roughly the following:
```
start = time right now
end = time right now + days (usually 7)
```

Which meant that we asked data from netdata from right now to 7 days in the future which is not good. Netdata in this case does not error out but roughly returns the datapoints of the last 24h in such cases.

## Solution

Make sure we use the correct start/end timestamps to reflect reality and ask about historical data as requested by the consumer.