### PR TITLE
NAS-137114 / 26.04 / fix query_pools_for_system_dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -442,7 +442,10 @@ class SystemDatasetService(ConfigService):
         """
         rv = list()
         for i in query_imported_fast_impl().values():
-            if exclude_pool and exclude_pool == i['name']:
+            if (
+                exclude_pool and exclude_pool == i['name']
+                or i['name'] in BOOT_POOL_NAME_VALID
+            ):
                 continue
 
             ds = self.middleware.call_sync(


### PR DESCRIPTION
309452c9c2bc4f40a3bd73a2e843088481a92382 introduced a subtle behavioral change by allowing the boot pool to be returned in this method. Change it so that the boot pool is always ignored (matching previous behavior).