### PR TITLE
NAS-137122 / 26.04 / use zfs.resource.query_impl in boot.environment.query

### DIFF
--- a/src/middlewared/middlewared/plugins/boot_/environments.py
+++ b/src/middlewared/middlewared/plugins/boot_/environments.py
@@ -51,7 +51,7 @@ class BootEnvironmentService(Service):
             {
                 "paths": [f"{bp_name}/ROOT"],
                 "get_children": True,
-                "properties": ["used", "creation", "origin"],
+                "properties": ["used", "creation"],
                 "get_user_properties": True,
             }
         ):


### PR DESCRIPTION
This replaces a fork+exec call anytime someone calls `boot.environment.query`. It makes use of our new API for querying zfs information.