### PR TITLE
NAS-137127 / 26.04 / Fix API docs code blocks not rendering

### DIFF
--- a/src/middlewared_docs/docs/conf.py
+++ b/src/middlewared_docs/docs/conf.py
@@ -13,15 +13,15 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.intersphinx",
+    # "sphinx.ext.intersphinx",
 ]
 
-intersphinx_mapping = {
-    "rtd": ("https://docs.readthedocs.io/en/stable/", None),
-    "python": ("https://docs.python.org/3/", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-}
-intersphinx_disabled_domains = ["std"]
+# intersphinx_mapping = {
+#     "rtd": ("https://docs.readthedocs.io/en/stable/", None),
+#     "python": ("https://docs.python.org/3/", None),
+#     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+# }
+# intersphinx_disabled_domains = ["std"]
 
 templates_path = ["_templates"]
 

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -136,6 +136,7 @@ Request:
 """"""""
 
 .. code:: json
+
     {
         "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
         "msg": "method",
@@ -153,6 +154,7 @@ Response:
 """""""""
 
 .. code:: json
+
     {
         "id": "cdc8740a-336b-b0cd-b850-47568fe94223",
         "msg": "result",
@@ -190,6 +192,7 @@ It expects two values as form data, `data` and `file`.
 `data` is JSON-encoded data. It must be the first parameter provided and in this format:
 
 .. code:: json
+
     {
         "method": "config.upload",
         "params": []
@@ -210,6 +213,7 @@ Response:
 """""""""
 
 .. code:: json
+
     {
         "job_id": 20
     }

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -1,5 +1,5 @@
 Jobs
-----
+====
 
 Tasks that require significant time to execute or process a large amount of input or output are categorized as jobs.
 Job execution can be time-consuming, but its progress can be monitored.
@@ -12,7 +12,7 @@ Additionally, the client should monitor `changed` events because a `changed` eve
 may be emitted if a method call triggers a job that has already been scheduled.
 
 Example of Calling a Job Method
-###############################
+-------------------------------
 
 The client initiates a method call:
 
@@ -75,58 +75,91 @@ Finally, it sends the method execution result as usual:
     }
 
 Query Job Status
-################
+----------------
 
 Job status can be queried with the `core.get_jobs` method.
 
 Request:
+""""""""
 
-    :::javascript
+.. code:: json
+
     {
-      "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
-      "msg": "method",
-      "method": "core.get_jobs",
-      "params": [[["id", "=", 53]]]
+        "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
+        "msg": "method",
+        "method": "core.get_jobs",
+        "params": [
+            [["id", "=", 53]]
+        ]
     }
 
 Response:
+"""""""""
 
-    :::javascript
+.. code:: json
+
     {
-      "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
-      "msg": "result",
-      "result": [{"id": 53, "method": "catalog.sync_all", "arguments": [], "logs_path": null, "logs_excerpt": null, "progress": {"percent": 100, "description": "Syncing TEST catalog", "extra": null}, "result": null, "error": null, "exception": null, "exc_info": null, "state": "SUCCESS", "time_started": {"$date": 1571300596053}, "time_finished": null}]
+        "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
+        "msg": "result",
+        "result": [
+            {
+                "id": 53,
+                "method": "catalog.sync_all",
+                "arguments": [],
+                "logs_path": null,
+                "logs_excerpt": null,
+                "progress": {"percent": 100, "description": "Syncing TEST catalog", "extra": null},
+                "result": null,
+                "error": null,
+                "exception": null,
+                "exc_info": null,
+                "state": "SUCCESS",
+                "time_started": {"$date": 1571300596053},
+                "time_finished": null
+            }
+        ]
     }
 
 Uploading / Downloading Files
-#############################
+-----------------------------
 
 There are some jobs which require input or output as files which can
 be uploaded or downloaded.
 
 Downloading a File
-******************
+^^^^^^^^^^^^^^^^^^
 
 If a job gives a file as an output, this endpoint is to be used to download
 the output file.
 
 Request:
+""""""""
 
-    :::javascript
+.. code:: json
     {
         "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
         "msg": "method",
         "method": "core.download",
-        "params": ["config.save", [{}], "freenas-FreeNAS-11.3-MASTER-201910090828-20191017122016.db"]
+        "params": [
+            "config.save",
+            [
+                {}
+            ],
+            "freenas-FreeNAS-11.3-MASTER-201910090828-20191017122016.db"
+        ]
     }
 
 Response:
+"""""""""
 
-    :::javascript
+.. code:: json
     {
         "id": "cdc8740a-336b-b0cd-b850-47568fe94223",
         "msg": "result",
-        "result": [86, "/_download/86?auth_token=9WIqYg4jAYEOGQ4g319Bkr64Oj8CZk1VACfyN68M7hgjGTdeSSgZjSf5lJEshS8M"]
+        "result": [
+            86,
+            "/_download/86?auth_token=9WIqYg4jAYEOGQ4g319Bkr64Oj8CZk1VACfyN68M7hgjGTdeSSgZjSf5lJEshS8M"
+        ]
     }
 
 In the response, the first value `86` is the job id for `config.save`. This can be used to query
@@ -146,7 +179,7 @@ Note:
 3) The file can only be downloaded once.
 
 Uploading a File
-****************
+^^^^^^^^^^^^^^^^
 
 Files can be uploaded via HTTP POST request only. The upload endpoint is:
 
@@ -156,7 +189,7 @@ It expects two values as form data, `data` and `file`.
 
 `data` is JSON-encoded data. It must be the first parameter provided and in this format:
 
-    ::: json
+.. code:: json
     {
         "method": "config.upload",
         "params": []
@@ -164,12 +197,19 @@ It expects two values as form data, `data` and `file`.
 
 `file` is the URI of the file to download.
 
-This example uses `curl`,
+This example uses `curl`:
 
 Request:
+""""""""
+
+.. code:: console
 
     curl -X POST -u root:freenas -H "Content-Type: multipart/form-data" -F 'data={"method": "config.upload", "params": []}' -F "file=@/home/user/Desktop/config" http://system_ip/_upload/
 
- Response:
+Response:
+"""""""""
 
-    {"job_id": 20}
+.. code:: json
+    {
+        "job_id": 20
+    }

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -6,9 +6,9 @@ Job execution can be time-consuming, but its progress can be monitored.
 
 To monitor the progress of running jobs, subscribe to the `core.get_jobs event <api_events_core.get_jobs.html>`_.
 
-When a new job is initiated through a JSON-RPC 2.0 API call, its `message_ids` field will include the `id` of the call.
-Therefore, when starting a new job, the client should listen for the `added` event in the `core.get_jobs` subscription.
-Additionally, the client should monitor `changed` events because a `changed` event with a new `message_ids` field value
+When a new job is initiated through a JSON-RPC 2.0 API call, its ``message_ids`` field will include the ``id`` of the call.
+Therefore, when starting a new job, the client should listen for the "added" event in the ``core.get_jobs`` subscription.
+Additionally, the client should monitor "changed" events because a "changed" event with a new ``message_ids`` field value
 may be emitted if a method call triggers a job that has already been scheduled.
 
 Example of Calling a Job Method
@@ -75,7 +75,7 @@ Finally, it sends the method execution result as usual:
 Query Job Status
 ----------------
 
-Job status can be queried with the `core.get_jobs` method.
+Job status can be queried with the ``core.get_jobs`` method.
 
 .. code-block:: json
     :caption: Request
@@ -155,41 +155,38 @@ the output file.
         ]
     }
 
-In the response, the first value `86` is the job id for `config.save`. This can be used to query
+In the response, the first value "86" is the job ID for ``config.save``. This can be used to query
 the status of the job. The second value is a REST endpoint used to download the file.
 
-The download endpoint has a special format:
+The download endpoint has the special format ``http://system_ip/_download/{job_id}?auth_token={token}``
+where ``job_id`` and ``token`` are parameters being passed.
 
-`http://system_ip/_download/{job_id}?auth_token={token}`
-
-`job_id` and `token` are parameters being passed.
-
-`core.download` takes responsibility for providing the download URI with the `job_id` and `token` values.
+``core.download`` takes responsibility for providing the download URI with the ``job_id`` and ``token`` values.
 
 Note:
-1) Job output is not buffered, so execution would be blocked if a file download is not started.
-2) File download must begin within 60 seconds or the job is canceled.
-3) The file can only be downloaded once.
+#. Job output is not buffered, so execution would be blocked if a file download is not started.
+#. File download must begin within 60 seconds or the job is canceled.
+#. The file can only be downloaded once.
 
 Uploading a File
 ^^^^^^^^^^^^^^^^
 
-Files can be uploaded via HTTP POST request only. The upload endpoint is `http://system_ip/_upload`.
+Files can be uploaded via HTTP POST request only. The upload endpoint is ``http://system_ip/_upload``.
 
-It expects two values as form data, `data` and `file`.
+It expects two values as form data: ``data`` and ``file``.
 
-`data` is JSON-encoded data. It must be the first parameter provided and in this format:
+- ``data`` is JSON-encoded data. It must be the first parameter provided and in this format:
 
-.. code:: json
+    .. code:: json
 
-    {
-        "method": "config.upload",
-        "params": []
-    }
+        {
+            "method": "config.upload",
+            "params": []
+        }
 
-`file` is the URI of the file to download.
+- ``file`` is the URI of the file to download.
 
-This example uses `curl`:
+This example uses curl:
 
 .. code-block:: console
     :caption: Request

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -37,8 +37,7 @@ The server responds with the newly added job (e.g. id 101):
             "collection": "core.get_jobs",
             "fields": {
                 "id": 101,
-                "message_ids": ["6841f242-840a-11e6-a437-00e04d680384"],
-                ...
+                "message_ids": ["6841f242-840a-11e6-a437-00e04d680384"]
             }
         }
     }
@@ -58,8 +57,7 @@ Then, it updates the progress:
                 "progress": {
                     "percent": 50,
                     "description": "Copied 1000000 of 2000000 bytes"
-                },
-                ...
+                }
             }
         }
     }
@@ -79,10 +77,8 @@ Query Job Status
 
 Job status can be queried with the `core.get_jobs` method.
 
-Request:
-""""""""
-
-.. code:: json
+.. code-block:: json
+    :caption: Request
 
     {
         "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
@@ -93,10 +89,9 @@ Request:
         ]
     }
 
-Response:
-"""""""""
 
-.. code:: json
+.. code-block:: json
+    :caption: Response
 
     {
         "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
@@ -132,10 +127,8 @@ Downloading a File
 If a job gives a file as an output, this endpoint is to be used to download
 the output file.
 
-Request:
-""""""""
-
-.. code:: json
+.. code-block:: json
+    :caption: Request
 
     {
         "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
@@ -150,10 +143,8 @@ Request:
         ]
     }
 
-Response:
-"""""""""
-
-.. code:: json
+.. code-block:: json
+    :caption: Response
 
     {
         "id": "cdc8740a-336b-b0cd-b850-47568fe94223",
@@ -183,9 +174,7 @@ Note:
 Uploading a File
 ^^^^^^^^^^^^^^^^
 
-Files can be uploaded via HTTP POST request only. The upload endpoint is:
-
-`http://system_ip/_upload`
+Files can be uploaded via HTTP POST request only. The upload endpoint is `http://system_ip/_upload`.
 
 It expects two values as form data, `data` and `file`.
 
@@ -202,17 +191,14 @@ It expects two values as form data, `data` and `file`.
 
 This example uses `curl`:
 
-Request:
-""""""""
-
-.. code:: console
+.. code-block:: console
+    :caption: Request
 
     curl -X POST -u root:freenas -H "Content-Type: multipart/form-data" -F 'data={"method": "config.upload", "params": []}' -F "file=@/home/user/Desktop/config" http://system_ip/_upload/
 
-Response:
-"""""""""
 
-.. code:: json
+.. code-block:: json
+    :caption: Response
 
     {
         "job_id": 20

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -163,7 +163,8 @@ where ``job_id`` and ``token`` are parameters being passed.
 
 ``core.download`` takes responsibility for providing the download URI with the ``job_id`` and ``token`` values.
 
-Note:
+Notes:
+
 #. Job output is not buffered, so execution would be blocked if a file download is not started.
 #. File download must begin within 60 seconds or the job is canceled.
 #. The file can only be downloaded once.

--- a/src/middlewared_docs/docs/jsonrpc.rst
+++ b/src/middlewared_docs/docs/jsonrpc.rst
@@ -138,7 +138,7 @@ If the server needs to notify a connected client of an event, it sends a
 JSON-RPC Notification Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: json
+.. code-block:: javascript
    :caption: collection_update
 
     {
@@ -169,7 +169,7 @@ JSON-RPC Notification Structure
     }
 
 
-.. code-block:: json
+.. code-block:: javascript
    :caption: notify_unsubscribed
 
     {

--- a/src/middlewared_docs/docs/jsonrpc.rst
+++ b/src/middlewared_docs/docs/jsonrpc.rst
@@ -215,15 +215,15 @@ Example Notification:
 Important Notes on Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  **No Response Required**: These notifications do not require a
-   response from the client.
--  **Event-Driven**: Notifications are used for updates such as status
-   changes, new log entries, or alerts.
+- **No Response Required**: These notifications do not require a
+  response from the client.
+- **Event-Driven**: Notifications are used for updates such as status
+  changes, new log entries, or alerts.
 
 Limitations
 -----------
 
--  **Batch Requests Are Not Supported**: Each request must be sent
-   individually; batch calls are not allowed.
--  **Error Handling**: Custom error codes are provided for handling
-   specific issues.
+- **Batch Requests Are Not Supported**: Each request must be sent
+  individually; batch calls are not allowed.
+- **Error Handling**: Custom error codes are provided for handling
+  specific issues.

--- a/src/middlewared_docs/docs/jsonrpc.rst
+++ b/src/middlewared_docs/docs/jsonrpc.rst
@@ -33,7 +33,7 @@ this structure:
 
     {
       "jsonrpc": "2.0",
-      "id": number,
+      "id": number | string,
       "method": string,
       "params": array
     }
@@ -61,7 +61,7 @@ The TrueNAS API will respond with a standard JSON-RPC response:
 
     {
       "jsonrpc": "2.0",
-      "id": number,
+      "id": number | string,
       "result": any
     }
 
@@ -88,7 +88,7 @@ If an error occurs, the response format is:
 
     {
       "jsonrpc": "2.0",
-      "id": string,
+      "id": number | string,
       "error": {
         "code": number,
         "message": string | null,
@@ -111,7 +111,7 @@ If an error occurs, the response format is:
 Custom Error Codes
 ^^^^^^^^^^^^^^^^^^
 
-The following custom error codes can be returned in addition to the codes defined by the JSON-RPC 2.0 specification.
+The following custom error codes can be returned in addition to the codes defined by the `JSON-RPC 2.0 specification <https://www.jsonrpc.org/specification#:~:text=NOT%20be%20included.-,5.1%20Error%20object,-When%20a%20rpc>`_.
 
 +---------------+-------------------------------------+----------------+
 | Error Code    | Message                             | Description    |

--- a/src/middlewared_docs/docs/jsonrpc.rst
+++ b/src/middlewared_docs/docs/jsonrpc.rst
@@ -29,13 +29,13 @@ JSON-RPC Request Structure
 A typical **method call** request from the client to TrueNAS follows
 this structure:
 
-.. code:: json
+.. code:: javascript
 
     {
       "jsonrpc": "2.0",
-      "id": 1,
-      "method": "<method_name>",
-      "params": [<parameters>]
+      "id": number,
+      "method": string,
+      "params": array
     }
 
 Example Request:
@@ -57,12 +57,12 @@ JSON-RPC Response Structure
 
 The TrueNAS API will respond with a standard JSON-RPC response:
 
-.. code:: json
+.. code:: javascript
 
     {
       "jsonrpc": "2.0",
-      "id": 1,
-      "result": {<result_data>}
+      "id": number,
+      "result": any
     }
 
 Example Response:
@@ -84,7 +84,7 @@ Error Response
 
 If an error occurs, the response format is:
 
-.. code:: json
+.. code:: javascript
 
     {
       "jsonrpc": "2.0",
@@ -138,7 +138,7 @@ If the server needs to notify a connected client of an event, it sends a
 JSON-RPC Notification Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: json
+.. code-block:: json
    :caption: collection_update
 
     {
@@ -169,7 +169,7 @@ JSON-RPC Notification Structure
     }
 
 
-.. code:: json
+.. code-block:: json
    :caption: notify_unsubscribed
 
     {

--- a/src/middlewared_docs/docs/jsonrpc.rst
+++ b/src/middlewared_docs/docs/jsonrpc.rst
@@ -14,11 +14,11 @@ JSON-RPC 2.0 Protocol
 Communication Mechanism
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  Messages are exchanged using the **WebSocket protocol**.
--  The client initiates a WebSocket connection to the TrueNAS API
-   endpoint.
--  The API follows the `JSON-RPC 2.0 <https://www.jsonrpc.org/specification>`_ specification for
-   request-response messaging.
+- Messages are exchanged using the **WebSocket protocol**.
+- The client initiates a WebSocket connection to the TrueNAS API
+  endpoint.
+- The API follows the `JSON-RPC 2.0 <https://www.jsonrpc.org/specification>`_ specification for
+  request-response messaging.
 
 Request and Response Format
 ---------------------------
@@ -31,12 +31,12 @@ this structure:
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "id": 1,
-     "method": "<method_name>",
-     "params": [<parameters>]
-   }
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "<method_name>",
+      "params": [<parameters>]
+    }
 
 Example Request:
 ^^^^^^^^^^^^^^^^
@@ -45,12 +45,12 @@ Calling the ``system.info`` method:
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "id": 1,
-     "method": "system.info",
-     "params": []
-   }
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "system.info",
+      "params": []
+    }
 
 JSON-RPC Response Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,25 +59,25 @@ The TrueNAS API will respond with a standard JSON-RPC response:
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "id": 1,
-     "result": {<result_data>}
-   }
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {<result_data>}
+    }
 
 Example Response:
 ^^^^^^^^^^^^^^^^^
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "id": 1,
-     "result": {
-       "version": "TrueNAS-25.04",
-       "uptime": "15 days"
-     }
-   }
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "version": "TrueNAS-25.04",
+        "uptime": "15 days"
+      }
+    }
 
 Error Response
 ~~~~~~~~~~~~~~
@@ -86,18 +86,32 @@ If an error occurs, the response format is:
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "id": 1,
-     "error": {
-       "code": -32001,
-       "message": "method call error",
-       "data": {<error_details>}
-     }
-   }
+    {
+      "jsonrpc": "2.0",
+      "id": string,
+      "error": {
+        "code": number,
+        "message": string | null,
+        "data": {
+          "error": number,
+          "errname": string,
+          "reason": string,
+          "trace": {
+            "class": string,
+            "frames": array,
+            "formatted": string,
+            "repr": string
+          } | null,
+          "extra": array,
+          "py_exception": string
+        }
+      }
+    }
 
 Custom Error Codes
 ^^^^^^^^^^^^^^^^^^
+
+The following custom error codes can be returned in addition to the codes defined by the JSON-RPC 2.0 specification.
 
 +---------------+-------------------------------------+----------------+
 | Error Code    | Message                             | Description    |
@@ -125,30 +139,78 @@ JSON-RPC Notification Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: json
+   :caption: collection_update
 
-   {
-     "jsonrpc": "2.0",
-     "method": "collection_update",
-     "params": [<update_data>]
-   }
+    {
+      "jsonrpc": "2.0",
+      "method": "collection_update",
+      "params": {
+        "msg": string,
+        "collection": string,
+        "id": any,
+        "fields": {
+          "id": string,
+          "state": string,
+          "progress": {
+            "percent": number,
+            "description": string
+          },
+          "result": any,
+          "exc_info": {
+            "type": string,
+            "extra": array | null,
+            "repr": string
+          },
+          "error": string,
+          "exception": string
+        },
+        "extra": object
+      }
+    }
+
+
+.. code:: json
+   :caption: notify_unsubscribed
+
+    {
+      "jsonrpc": "2.0",
+      "method": "notify_unsubscribed",
+      "params": {
+        "collection": string,
+        "error": {
+          "error": number,
+          "errname": string,
+          "reason": string,
+          "trace": {
+            "class": string,
+            "frames": array,
+            "formatted": string,
+            "repr": string
+          } | null,
+          "extra": array,
+          "py_exception": string
+        }
+      }
+    }
+
 
 Example Notification:
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: json
 
-   {
-     "jsonrpc": "2.0",
-     "method": "collection_update",
-     "params": {
-       "collection": "disk.query",
-       "event": "CHANGED",
-       "fields": {
-         "name": "sda",
-         "status": "HEALTHY"
-       }
-     }
-   }
+    {
+      "jsonrpc": "2.0",
+      "method": "collection_update",
+      "params": {
+        "collection": "disk.query",
+        "event": "CHANGED",
+        "fields": {
+          "name": "sda",
+          "status": "HEALTHY"
+        }
+      }
+    }
 
 Important Notes on Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -26,10 +26,7 @@ For example, to filter the data returned by ``disk.query``, we provide a list of
     ]
 
 
-Supported Operators
-^^^^^^^^^^^^^^^^^^^
-
-.. list-table::
+.. list-table:: Supported Operators
    :header-rows: 1
    :widths: 30 40
 

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -1,78 +1,73 @@
 Query Methods
--------------
+=============
 
 TrueNAS API has multiple query methods including `pool.query`, `disk.query`, `vm.query`, and many more.
 
 The arguments for these methods support multiple options and filters that are similar to SQL queries.
 
 Query Filters
-=============
+-------------
 
 Basic Usage
-***********
+^^^^^^^^^^^
 
-Query Filters are primarily an array of conditions, with each condition also represented as an array.
+Query filters are primarily an array of conditions, with each condition also represented as an array.
 
 Each condition in the filter list should compare a field with a value.
 
-eg. Filter Syntax: `["field", "operator", value]`
+Filter Syntax: `["field", "operator", value]`
 
 For example, to filter the data returned by `disk.query`, we provide a list of conditions:
 
-Javascript:
-
 .. code:: javascript
     [
-      ["name","=","ada1"]
+      ["name", "=", "ada1"]
     ]
 
 
 Supported Operators
-*******************
+^^^^^^^^^^^^^^^^^^^
 
-========  =====================
-Operator  Javascript equivalent
-========  =====================
-``=``     ``x === y``
-``!=``    ``x !== y``
-``>``     ``x > y``
-``>=``    ``x >= y``
-``<``     ``x < y``
-``<=``    ``x <= y``
-``~``     ``y.test(x)``
-``in``    ``y.includes(x)``
-``nin``   ``!y.includes(x)``
-``rin``   ``x != null && x.includes(y)``
-``rnin``  ``x != null && !x.includes(y)``
-``^``     ``x != null && x.startsWith(y)``
-``!^``    ``x != null && !x.startsWith(y)``
-``$``     ``x != null && x.endsWith(y)``
-``!$``    ``x != null && !x.endsWith(y)``
-========  =====================
+==================  =====================
+Operation           Javascript equivalent
+==================  =====================
+``[x, "=", y]``     ``x === y``
+``[x, "!=", y]``    ``x !== y``
+``[x, ">", y]``     ``x > y``
+``[x, ">=", y]``    ``x >= y``
+``[x, "<", y]``     ``x < y``
+``[x, "<=", y]``    ``x <= y``
+``[x, "~", y]``     ``y.test(x)``
+``[x, "in", y]``    ``y.includes(x)``
+``[x, "nin", y]``   ``!y.includes(x)``
+``[x, "rin", y]``   ``x != null && x.includes(y)``
+``[x, "rnin", y]``  ``x != null && !x.includes(y)``
+``[x, "^", y]``     ``x != null && x.startsWith(y)``
+``[x, "!^", y]``    ``x != null && !x.startsWith(y)``
+``[x, "$", y]``     ``x != null && x.endsWith(y)``
+``[x, "!$", y]``    ``x != null && !x.endsWith(y)``
+==================  =====================
 
 Specifing the prefix 'C' will perform a case-insensitive version of the filter, e.g. `C=`.
 
 Multiple Filters
-****************
+^^^^^^^^^^^^^^^^
 
 We can use `disk.query` with the "type" and "rotationrate" filters to find hard drives with a rotation rate higher than 5400 RPM:
 
-Javascript:
-
 .. code:: javascript
     [
-      ["type","=","HDD"],
-      ["rotationrate",">",5400]  // Note that the value should be the correct type
+      ["type", "=", "HDD"],
+      ["rotationrate", ">", 5400]  // Note that the value should be the correct type
     ]
 
 
 Connectives
-***********
+^^^^^^^^^^^
 
 Queries with no explicitly defined logical connectives assume conjunction `AND`. The disjunction `OR` is also supported by using the syntax illustrated below. We can use `disk.query` with `OR` to filter disks by name. Note that the operand for the disjunction contains an array of conditions.
 
 The following is a valid example.
-Javascript:
 
 .. code:: javascript
     [
@@ -84,7 +79,6 @@ Javascript:
     ]
 
 The following is also a valid example that returns users that are unlocked and either have password-based authentication for SSH enabled or are SMB users.
-Javascript:
 
 .. code:: javascript
     [
@@ -100,8 +94,6 @@ Javascript:
 
 The following is valid example that returns users who are either enabled or have password authentication enabled with two-factor authentication disabled.
 
-Javascript:
-
 .. code:: javascript
     [
       "OR",
@@ -116,9 +108,7 @@ Javascript:
 
 Some additional examples of connective use are as follows.
 
-These filters when used with `user.query` finds unlocked users with password authentication enabled and two-factor authentication disabled.
-
-Javascript:
+When used with `user.query`, these filters find unlocked users with password authentication enabled and two-factor authentication disabled.
 
 .. code:: javascript
     [
@@ -127,10 +117,7 @@ Javascript:
       ["locked", "=", false]
     ]
 
-
-Sub-keys in complex JSON objects may be specified by using dot (".") to indicate the key. For example the following query-filters if passed to `user.query` endpoint will return entries with a primary group ID of 3000.
-
-Javascript:
+Sub-keys in complex JSON objects may be specified by using dot notation to indicate the key. When passed to the `user.query` endpoint, the following query filters will return entries with a primary group ID of 3000.
 
 .. code:: javascript
     [
@@ -139,28 +126,20 @@ Javascript:
 
 If a key contains a literal dot (".") in its name, then it must be escaped via a double backslash.
 
-Javascript:
-
 .. code:: javascript
     [
       ["foo\\.bar", "=", 42],
     ]
 
-
-When the path to the key contains an array, an array index may be manually specified. For example, the following query-filters
-if passed to the `privilege.query` endpoint will return entries where the first element of the local groups array has a name
-of "myuser".
-
-Javascript:
+When the path to the key contains an array, an array index may be manually specified. When passed to the `privilege.query` endpoint, the following query filters
+will return entries where the first element of the local groups array has a name of "myuser".
 
 .. code:: javascript
     [
       ["local_groups.0.name", "=", "myuser"],
     ]
 
-Alternatively, an asterisk (`*`) may be substituted for the array index, which match any entry where an array member has a key matching the value. for example, the following query-filters if passed to the `privilege.query` endpoint will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
-
-Javascript:
+Alternatively, an asterisk (`*`) may be substituted for the array index to match any array entry. When passed to the `privilege.query` endpoint, the following query filters will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
 
 .. code:: javascript
     [
@@ -169,13 +148,11 @@ Javascript:
 
 
 Datetime information
-********************
+^^^^^^^^^^^^^^^^^^^^
 
 Some query results may include datetime information encoded in JSON object via
 key with designator `.$date`. In this case, query filter using an ISO-8601
 timestamp may be used. For example:
-
-Javascript:
 
 .. code:: javascript
     [
@@ -184,18 +161,16 @@ Javascript:
 
 
 Query Options
-=============
+-------------
 
 Query Options are objects that can further customize the results returned by a Query Method.
 
 Properties of a Query Option include `extend | extend_context | prefix | extra | order_by | select | count | get | limit | offset`
 
 Count
-*****
+^^^^^
 
 Use the `count` option to get the number of results returned.
-
-Javascript:
 
 .. code:: javascript
     {
@@ -204,11 +179,9 @@ Javascript:
 
 
 Limit
-*****
+^^^^^
 
 Use the `limit` option to limit the number of results returned.
-
-Javascript:
 
 .. code:: javascript
     {
@@ -217,11 +190,9 @@ Javascript:
 
 
 Offset
-******
+^^^^^^
 
 Use the `offset` option to remove the first items from a returned list.
-
-Javascript:
 
 .. code:: javascript
     {
@@ -230,21 +201,17 @@ Javascript:
 
 
 Select
-******
+^^^^^^
 
 Use the `select` option to specify the exact fields to return. Fields must be provided in an array of strings. The dot character (".") may be used to explicitly select only subkeys of the query result.
 
 Fields returned may be renamed by specifing an array containing two strings with the first string being the field to select from results list and the second string indicating the new name to provide it.
-
-Javascript:
 
 .. code:: javascript
     {
       "select": ["devname", "size", "rotationrate"]
     }
 
-
-Javascript:
 
 .. code:: javascript
     {
@@ -255,8 +222,6 @@ Javascript:
       ]
     }
 
-
-Javascript:
 
 .. code:: javascript
     {
@@ -269,20 +234,17 @@ Javascript:
 
 
 Order By
-********
+^^^^^^^^
 
 Use the `order_by` option to specify which field determines the sort order. Fields must be provided in an
 array of strings.
 
 The following prefixes may be applied to the field name:
 
-`-` reverse sort direction.
+* `-` reverse sort direction.
+* `nulls_first:` place any NULL values at head of results list.
+* `nulls_last:` place any NULL values at tail of results list.
 
-`nulls_first:` place any NULL values at head of results list.
-
-`nulls_last:` place any NULL values at tail of results list.
-
-Javascript:
 
 .. code:: javascript
     {
@@ -290,117 +252,103 @@ Javascript:
     }
 
 
-Sample SQL statements translated into Query Filters and Query Options
-*********************************************************************
+Sample SQL Statements Translated Into Query Filters and Query Options
+---------------------------------------------------------------------
 
-NOTE: these are examples of syntax translation, they are not intended as queries
-to perform on the TrueNAS server.
+NOTE: These are examples of syntax translation. They are not intended to be executed on the TrueNAS server.
 
+#. Example 1
 
-"SELECT * FROM table;"
-^^^^^^^^^^^^^^^^^^^^^^
-
-`query-filters`
-
-Javascript:
-
-.. code:: javascript
-    []
+    .. code-block:: SQL
+        SELECT * FROM table;
 
 
-`query-options`
-
-Javascript:
-
-.. code:: javascript
-    {}
+    .. code-block:: javascript
+        :caption: query-filters
+        []
 
 
-"SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    .. code-block:: javascript
+        :caption: query-options
+        {}
 
-`query-filters`
+#. Example 2
 
-Javascript:
-
-.. code:: javascript
-    [
-      ["builtin", "=", false],
-    ]
-
-`query-options`
-
-Javascript:
-
-.. code:: javascript
-    {
-      "select": [
-        "username",
-        "uid"
-      ],
-      "order_by": [
-        "-uid"
-      ]
-    }
+    .. code-block:: SQL
+        SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;
 
 
-"SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-`query-filters`
-
-Javascript:
-
-.. code:: javascript
-    [
-      ["builtin", "=", false],
-      ["locked", "=", true]
-    ]
-
-`query-options`
-
-Javascript:
-
-.. code:: javascript
-    {
-      "select": [
-        [
-          "username",
-          "locked_user"
-        ],
-        "uid"
-      ],
-    }
-
-
-"SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-`query-filters`
-
-Javascript:
-
-.. code:: javascript
-    [
-      [
-        "OR",
+    .. code-block:: javascript
+        :caption: query-filters
         [
           ["builtin", "=", false],
-          [
-            ["locked", "=", false],
-            ["ssh", "=" true]
-          ]
         ]
-      ],
-    ]
 
-`query-options`
 
-Javascript:
+    .. code-block:: javascript
+        :caption: query-options
+        {
+          "select": [
+            "username",
+            "uid"
+          ],
+          "order_by": [
+            "-uid"
+          ]
+        }
 
-.. code:: javascript
-    {
-      "select": [
-        "username"
-      ],
-    }
+#. Example 3
+
+    .. code-block:: SQL
+        SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;
+
+
+    .. code-block:: javascript
+        :caption: query-filters
+        [
+          ["builtin", "=", false],
+          ["locked", "=", true]
+        ]
+
+
+    .. code-block:: javascript
+        :caption: query-options
+        {
+          "select": [
+            [
+              "username",
+              "locked_user"
+            ],
+            "uid"
+          ],
+        }
+
+#. Example 4
+
+    .. code-block:: SQL
+        SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);
+
+
+    .. code-block:: javascript
+        :caption: query-filters
+        [
+          [
+            "OR",
+            [
+              ["builtin", "=", false],
+              [
+                ["locked", "=", false],
+                ["ssh", "=" true]
+              ]
+            ]
+          ],
+        ]
+
+
+    .. code-block:: javascript
+        :caption: query-options
+        {
+          "select": [
+            "username"
+          ],
+        }

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -29,25 +29,42 @@ For example, to filter the data returned by `disk.query`, we provide a list of c
 Supported Operators
 ^^^^^^^^^^^^^^^^^^^
 
-==================  =====================
-Operation           Javascript equivalent
-==================  =====================
-``[x, "=", y]``     ``x === y``
-``[x, "!=", y]``    ``x !== y``
-``[x, ">", y]``     ``x > y``
-``[x, ">=", y]``    ``x >= y``
-``[x, "<", y]``     ``x < y``
-``[x, "<=", y]``    ``x <= y``
-``[x, "~", y]``     ``y.test(x)``
-``[x, "in", y]``    ``y.includes(x)``
-``[x, "nin", y]``   ``!y.includes(x)``
-``[x, "rin", y]``   ``x != null && x.includes(y)``
-``[x, "rnin", y]``  ``x != null && !x.includes(y)``
-``[x, "^", y]``     ``x != null && x.startsWith(y)``
-``[x, "!^", y]``    ``x != null && !x.startsWith(y)``
-``[x, "$", y]``     ``x != null && x.endsWith(y)``
-``[x, "!$", y]``    ``x != null && !x.endsWith(y)``
-==================  =====================
+.. list-table::
+   :header-rows: 1
+   :widths: 30 40
+
+   * - Operation
+     - Javascript equivalent
+   * - ``[x, "=", y]``
+     - ``x === y``
+   * - ``[x, "!=", y]``
+     - ``x !== y``
+   * - ``[x, ">", y]``
+     - ``x > y``
+   * - ``[x, ">=", y]``
+     - ``x >= y``
+   * - ``[x, "<", y]``
+     - ``x < y``
+   * - ``[x, "<=", y]``
+     - ``x <= y``
+   * - ``[x, "~", y]``
+     - ``y.test(x)``
+   * - ``[x, "in", y]``
+     - ``y.includes(x)``
+   * - ``[x, "nin", y]``
+     - ``!y.includes(x)``
+   * - ``[x, "rin", y]``
+     - ``x != null && x.includes(y)``
+   * - ``[x, "rnin", y]``
+     - ``x != null && !x.includes(y)``
+   * - ``[x, "^", y]``
+     - ``x != null && x.startsWith(y)``
+   * - ``[x, "!^", y]``
+     - ``x != null && !x.startsWith(y)``
+   * - ``[x, "$", y]``
+     - ``x != null && x.endsWith(y)``
+   * - ``[x, "!$", y]``
+     - ``x != null && !x.endsWith(y)``
 
 Specifing the prefix "C" will perform a case-insensitive version of the filter, e.g. `C=`.
 
@@ -275,110 +292,110 @@ Sample SQL Statements Translated Into Query Filters and Query Options
 
 NOTE: These are examples of syntax translation. They are not intended to be executed on the TrueNAS server.
 
-#. Example 1
+Example 1
 
-    .. code-block:: sql
+.. code-block:: sql
 
-        SELECT * FROM table;
-
-
-    .. code-block:: javascript
-        :caption: query-filters
-
-        []
+    SELECT * FROM table;
 
 
-    .. code-block:: javascript
-        :caption: query-options
+.. code-block:: javascript
+    :caption: query-filters
 
-        {}
-
-#. Example 2
-
-    .. code-block:: sql
-
-        SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;
+    []
 
 
-    .. code-block:: javascript
-        :caption: query-filters
+.. code-block:: javascript
+    :caption: query-options
 
+    {}
+
+Example 2
+
+.. code-block:: sql
+
+    SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;
+
+
+.. code-block:: javascript
+    :caption: query-filters
+
+    [
+      ["builtin", "=", false],
+    ]
+
+
+.. code-block:: javascript
+    :caption: query-options
+
+    {
+      "select": [
+        "username",
+        "uid"
+      ],
+      "order_by": [
+        "-uid"
+      ]
+    }
+
+Example 3
+
+.. code-block:: sql
+
+    SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;
+
+
+.. code-block:: javascript
+    :caption: query-filters
+
+    [
+      ["builtin", "=", false],
+      ["locked", "=", true]
+    ]
+
+
+.. code-block:: javascript
+    :caption: query-options
+
+    {
+      "select": [
+        [
+          "username",
+          "locked_user"
+        ],
+        "uid"
+      ],
+    }
+
+Example 4
+
+.. code-block:: sql
+
+    SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);
+
+
+.. code-block:: javascript
+    :caption: query-filters
+
+    [
+      [
+        "OR",
         [
           ["builtin", "=", false],
-        ]
-
-
-    .. code-block:: javascript
-        :caption: query-options
-
-        {
-          "select": [
-            "username",
-            "uid"
-          ],
-          "order_by": [
-            "-uid"
-          ]
-        }
-
-#. Example 3
-
-    .. code-block:: sql
-
-        SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;
-
-
-    .. code-block:: javascript
-        :caption: query-filters
-
-        [
-          ["builtin", "=", false],
-          ["locked", "=", true]
-        ]
-
-
-    .. code-block:: javascript
-        :caption: query-options
-
-        {
-          "select": [
-            [
-              "username",
-              "locked_user"
-            ],
-            "uid"
-          ],
-        }
-
-#. Example 4
-
-    .. code-block:: sql
-
-        SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);
-
-
-    .. code-block:: javascript
-        :caption: query-filters
-
-        [
           [
-            "OR",
-            [
-              ["builtin", "=", false],
-              [
-                ["locked", "=", false],
-                ["ssh", "=", true]
-              ]
-            ]
-          ],
+            ["locked", "=", false],
+            ["ssh", "=", true]
+          ]
         ]
+      ],
+    ]
 
 
-    .. code-block:: javascript
-        :caption: query-options
+.. code-block:: javascript
+    :caption: query-options
 
-        {
-          "select": [
-            "username"
-          ],
-        }
+    {
+      "select": [
+        "username"
+      ],
+    }

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -1,7 +1,7 @@
 Query Methods
 =============
 
-TrueNAS API has multiple query methods including `pool.query`, `disk.query`, `vm.query`, and many more.
+TrueNAS API has multiple query methods including ``pool.query``, ``disk.query``, ``vm.query``, and many more.
 
 The arguments for these methods support multiple options and filters that are similar to SQL queries.
 
@@ -15,9 +15,9 @@ Query filters are primarily an array of conditions, with each condition also rep
 
 Each condition in the filter list should compare a field with a value.
 
-Filter Syntax: `["field", "operator", value]`
+Filter Syntax: ``["field", "operator", value]``
 
-For example, to filter the data returned by `disk.query`, we provide a list of conditions:
+For example, to filter the data returned by ``disk.query``, we provide a list of conditions:
 
 .. code:: javascript
 
@@ -66,12 +66,12 @@ Supported Operators
    * - ``[x, "!$", y]``
      - ``x != null && !x.endsWith(y)``
 
-Specifing the prefix "C" will perform a case-insensitive version of the filter, e.g. `C=`.
+Specifing the prefix "C" will perform a case-insensitive version of the filter, e.g. ``C=``.
 
 Multiple Filters
 ^^^^^^^^^^^^^^^^
 
-We can use `disk.query` with the "type" and "rotationrate" filters to find hard drives with a rotation rate higher than 5400 RPM:
+We can use ``disk.query`` with the "type" and "rotationrate" filters to find hard drives with a rotation rate higher than 5400 RPM:
 
 .. code:: javascript
 
@@ -84,7 +84,7 @@ We can use `disk.query` with the "type" and "rotationrate" filters to find hard 
 Connectives
 ^^^^^^^^^^^
 
-Queries with no explicitly defined logical connectives assume conjunction `AND`. The disjunction `OR` is also supported by using the syntax illustrated below. We can use `disk.query` with `OR` to filter disks by name. Note that the operand for the disjunction contains an array of conditions.
+Queries with no explicitly defined logical connectives assume conjunction ``AND``. The disjunction ``OR`` is also supported by using the syntax illustrated below. We can use ``disk.query`` with ``OR`` to filter disks by name. Note that the operand for the disjunction contains an array of conditions.
 
 The following is a valid example.
 
@@ -130,7 +130,7 @@ The following is valid example that returns users who are either enabled or have
 
 Some additional examples of connective use are as follows.
 
-When used with `user.query`, these filters find unlocked users with password authentication enabled and two-factor authentication disabled.
+When used with ``user.query``, these filters find unlocked users with password authentication enabled and two-factor authentication disabled.
 
 .. code:: javascript
 
@@ -140,7 +140,7 @@ When used with `user.query`, these filters find unlocked users with password aut
       ["locked", "=", false]
     ]
 
-Sub-keys in complex JSON objects may be specified by using dot notation to indicate the key. When passed to the `user.query` endpoint, the following query filters will return entries with a primary group ID of 3000.
+Sub-keys in complex JSON objects may be specified by using dot notation to indicate the key. When passed to the ``user.query`` endpoint, the following query filters will return entries with a primary group ID of 3000.
 
 .. code:: javascript
 
@@ -156,7 +156,7 @@ If a key contains a literal dot (".") in its name, then it must be escaped via a
       ["foo\\.bar", "=", 42]
     ]
 
-When the path to the key contains an array, an array index may be manually specified. When passed to the `privilege.query` endpoint, the following query filters
+When the path to the key contains an array, an array index may be manually specified. When passed to the ``privilege.query`` endpoint, the following query filters
 will return entries where the first element of the local groups array has a name of "myuser".
 
 .. code:: javascript
@@ -165,7 +165,7 @@ will return entries where the first element of the local groups array has a name
       ["local_groups.0.name", "=", "myuser"]
     ]
 
-Alternatively, an asterisk (`*`) may be substituted for the array index to match any array entry. When passed to the `privilege.query` endpoint, the following query filters will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
+Alternatively, an asterisk ("*") may be substituted for the array index to match any array entry. When passed to the ``privilege.query`` endpoint, the following query filters will return entries where any member of the local groups array has a ``name`` key with the value of "myuser".
 
 .. code:: javascript
 
@@ -178,7 +178,7 @@ Datetime information
 ^^^^^^^^^^^^^^^^^^^^
 
 Some query results may include datetime information encoded in JSON object via
-key with designator `.$date`. In this case, query filter using an ISO-8601
+key with designator ``.$date``. In this case, query filter using an ISO-8601
 timestamp may be used. For example:
 
 .. code:: javascript
@@ -193,12 +193,12 @@ Query Options
 
 Query Options are objects that can further customize the results returned by a Query Method.
 
-Properties of a Query Option include `extend | extend_context | prefix | extra | order_by | select | count | get | limit | offset`
+Properties of a Query Option include ``extend | extend_context | prefix | extra | order_by | select | count | get | limit | offset``
 
 Count
 ^^^^^
 
-Use the `count` option to get the number of results returned.
+Use the ``count`` option to get the number of results returned.
 
 .. code:: javascript
 
@@ -210,7 +210,7 @@ Use the `count` option to get the number of results returned.
 Limit
 ^^^^^
 
-Use the `limit` option to limit the number of results returned.
+Use the ``limit`` option to limit the number of results returned.
 
 .. code:: javascript
 
@@ -222,7 +222,7 @@ Use the `limit` option to limit the number of results returned.
 Offset
 ^^^^^^
 
-Use the `offset` option to remove the first items from a returned list.
+Use the ``offset`` option to remove the first items from a returned list.
 
 .. code:: javascript
 
@@ -234,7 +234,7 @@ Use the `offset` option to remove the first items from a returned list.
 Select
 ^^^^^^
 
-Use the `select` option to specify the exact fields to return. Fields must be provided in an array of strings. The dot character (".") may be used to explicitly select only subkeys of the query result.
+Use the ``select`` option to specify the exact fields to return. Fields must be provided in an array of strings. The dot character may be used to explicitly select only subkeys of the query result.
 
 Fields returned may be renamed by specifing an array containing two strings with the first string being the field to select from results list and the second string indicating the new name to provide it.
 
@@ -270,14 +270,14 @@ Fields returned may be renamed by specifing an array containing two strings with
 Order By
 ^^^^^^^^
 
-Use the `order_by` option to specify which field determines the sort order. Fields must be provided in an
+Use the ``order_by`` option to specify which field determines the sort order. Fields must be provided in an
 array of strings.
 
 The following prefixes may be applied to the field name:
 
-* `-` reverse sort direction.
-* `nulls_first:` place any NULL values at head of results list.
-* `nulls_last:` place any NULL values at tail of results list.
+* ``-`` reverse sort direction.
+* ``nulls_first:`` place any NULL values at head of results list.
+* ``nulls_last:`` place any NULL values at tail of results list.
 
 
 .. code:: javascript
@@ -287,12 +287,13 @@ The following prefixes may be applied to the field name:
     }
 
 
-Sample SQL Statements Translated Into Query Filters and Query Options
----------------------------------------------------------------------
+SQL Statements Translated Into Filters and Options
+--------------------------------------------------
 
 NOTE: These are examples of syntax translation. They are not intended to be executed on the TrueNAS server.
 
 Example 1
+^^^^^^^^^
 
 .. code-block:: sql
 
@@ -311,6 +312,7 @@ Example 1
     {}
 
 Example 2
+^^^^^^^^^
 
 .. code-block:: sql
 
@@ -339,6 +341,7 @@ Example 2
     }
 
 Example 3
+^^^^^^^^^
 
 .. code-block:: sql
 
@@ -368,6 +371,7 @@ Example 3
     }
 
 Example 4
+^^^^^^^^^
 
 .. code-block:: sql
 

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -48,7 +48,7 @@ Operation           Javascript equivalent
 ``[x, "!$", y]``    ``x != null && !x.endsWith(y)``
 ==================  =====================
 
-Specifing the prefix 'C' will perform a case-insensitive version of the filter, e.g. `C=`.
+Specifing the prefix "C" will perform a case-insensitive version of the filter, e.g. `C=`.
 
 Multiple Filters
 ^^^^^^^^^^^^^^^^
@@ -121,14 +121,14 @@ Sub-keys in complex JSON objects may be specified by using dot notation to indic
 
 .. code:: javascript
     [
-      ["group.bsdgrp_gid", "=", 3000],
+      ["group.bsdgrp_gid", "=", 3000]
     ]
 
 If a key contains a literal dot (".") in its name, then it must be escaped via a double backslash.
 
 .. code:: javascript
     [
-      ["foo\\.bar", "=", 42],
+      ["foo\\.bar", "=", 42]
     ]
 
 When the path to the key contains an array, an array index may be manually specified. When passed to the `privilege.query` endpoint, the following query filters
@@ -136,14 +136,14 @@ will return entries where the first element of the local groups array has a name
 
 .. code:: javascript
     [
-      ["local_groups.0.name", "=", "myuser"],
+      ["local_groups.0.name", "=", "myuser"]
     ]
 
 Alternatively, an asterisk (`*`) may be substituted for the array index to match any array entry. When passed to the `privilege.query` endpoint, the following query filters will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
 
 .. code:: javascript
     [
-      ["local_groups.*.name", "=", "myuser"],
+      ["local_groups.*.name", "=", "myuser"]
     ]
 
 
@@ -156,7 +156,7 @@ timestamp may be used. For example:
 
 .. code:: javascript
     [
-      ['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']
+      ["timestamp.$date", ">", "2023-12-18T16:15:35+00:00"]
     ]
 
 
@@ -259,7 +259,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
 #. Example 1
 
-    .. code-block:: SQL
+    .. code-block:: sql
         SELECT * FROM table;
 
 
@@ -274,7 +274,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
 #. Example 2
 
-    .. code-block:: SQL
+    .. code-block:: sql
         SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;
 
 
@@ -299,7 +299,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
 #. Example 3
 
-    .. code-block:: SQL
+    .. code-block:: sql
         SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;
 
 
@@ -325,7 +325,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
 #. Example 4
 
-    .. code-block:: SQL
+    .. code-block:: sql
         SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);
 
 
@@ -338,7 +338,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
               ["builtin", "=", false],
               [
                 ["locked", "=", false],
-                ["ssh", "=" true]
+                ["ssh", "=", true]
               ]
             ]
           ],

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -21,7 +21,7 @@ For example, to filter the data returned by `disk.query`, we provide a list of c
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["name","=","ada1"]
     ]
@@ -30,23 +30,25 @@ Javascript:
 Supported Operators
 *******************
 
-| Operator       | Description     |
-| :------------- | :----------: |
-| '=' |  x == y |
-| '!=' |  x != y |
-| '>' |  x > y |
-| '>=' |  x >= y |
-| '<' |  x < y |
-| '<=' |  x <= y |
-| '~' |  re.match(y, x) |
-| 'in' |  x in y |
-| 'nin' |  x not in y |
-| 'rin' |  x is not None and y in x |
-| 'rnin' |  x is not None and y not in x |
-| '^' |  x is not None and x.startswith(y) |
-| '!^' |  x is not None and not x.startswith(y) |
-| '$' |  x is not None and x.endswith(y) |
-| '!$' |  x is not None and not x.endswith(y) |
+========  =====================
+Operator  Javascript equivalent
+========  =====================
+``=``     ``x === y``
+``!=``    ``x !== y``
+``>``     ``x > y``
+``>=``    ``x >= y``
+``<``     ``x < y``
+``<=``    ``x <= y``
+``~``     ``y.test(x)``
+``in``    ``y.includes(x)``
+``nin``   ``!y.includes(x)``
+``rin``   ``x != null && x.includes(y)``
+``rnin``  ``x != null && !x.includes(y)``
+``^``     ``x != null && x.startsWith(y)``
+``!^``    ``x != null && !x.startsWith(y)``
+``$``     ``x != null && x.endsWith(y)``
+``!$``    ``x != null && !x.endsWith(y)``
+========  =====================
 
 Specifing the prefix 'C' will perform a case-insensitive version of the filter, e.g. `C=`.
 
@@ -57,10 +59,10 @@ We can use `disk.query` with the "type" and "rotationrate" filters to find hard 
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["type","=","HDD"],
-      ["rotationrate",">",5400] // Note that the value should be the correct type
+      ["rotationrate",">",5400]  // Note that the value should be the correct type
     ]
 
 
@@ -72,20 +74,22 @@ Queries with no explicitly defined logical connectives assume conjunction `AND`.
 The following is a valid example.
 Javascript:
 
-    :::javascript
-    ["OR",
+.. code:: javascript
+    [
+      "OR",
       [
-        ["name","=", "first"],
-        ["name","=", "second"],
+        ["name", "=", "first"],
+        ["name", "=", "second"],
       ]
     ]
 
 The following is also a valid example that returns users that are unlocked and either have password-based authentication for SSH enabled or are SMB users.
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
-      ["OR",
+      [
+        "OR",
         [
           ["ssh_password_enabled", "=", true],
           ["smb", "=", true]
@@ -98,11 +102,15 @@ The following is valid example that returns users who are either enabled or have
 
 Javascript:
 
-    :::javascript
-    ["OR",
+.. code:: javascript
+    [
+      "OR",
       [
-        [["ssh_password_enabled", "=", true], ["twofactor_auth_configured", "=", false]],
-        ["enabled","=", true],
+        [
+          ["ssh_password_enabled", "=", true],
+          ["twofactor_auth_configured", "=", false]
+        ],
+        ["enabled", "=", true],
       ]
     ]
 
@@ -112,7 +120,7 @@ These filters when used with `user.query` finds unlocked users with password aut
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["ssh_password_enabled", "=", true],
       ["twofactor_auth_configured", "=", false],
@@ -124,7 +132,7 @@ Sub-keys in complex JSON objects may be specified by using dot (".") to indicate
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["group.bsdgrp_gid", "=", 3000],
     ]
@@ -133,7 +141,7 @@ If a key contains a literal dot (".") in its name, then it must be escaped via a
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["foo\\.bar", "=", 42],
     ]
@@ -145,7 +153,7 @@ of "myuser".
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["local_groups.0.name", "=", "myuser"],
     ]
@@ -154,7 +162,7 @@ Alternatively, an asterisk (`*`) may be substituted for the array index, which m
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["local_groups.*.name", "=", "myuser"],
     ]
@@ -169,7 +177,7 @@ timestamp may be used. For example:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']
     ]
@@ -189,7 +197,7 @@ Use the `count` option to get the number of results returned.
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "count": true
     }
@@ -202,7 +210,7 @@ Use the `limit` option to limit the number of results returned.
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "limit": 5
     }
@@ -215,9 +223,9 @@ Use the `offset` option to remove the first items from a returned list.
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
-      "offset": 1 // Omits the first item from the query result
+      "offset": 1  // Omits the first item from the query result
     }
 
 
@@ -230,15 +238,15 @@ Fields returned may be renamed by specifing an array containing two strings with
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
-      "select": ["devname","size","rotationrate"]
+      "select": ["devname", "size", "rotationrate"]
     }
 
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "select": [
         "Authentication.status",
@@ -250,7 +258,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "select": [
         ["Authentication.status", "status"],
@@ -276,7 +284,7 @@ The following prefixes may be applied to the field name:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "order_by": ["size", "-devname", "nulls_first:-expiretime"]
     }
@@ -296,7 +304,7 @@ to perform on the TrueNAS server.
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     []
 
 
@@ -304,7 +312,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {}
 
 
@@ -315,7 +323,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["builtin", "=", false],
     ]
@@ -324,7 +332,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "select": [
         "username",
@@ -343,7 +351,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
       ["builtin", "=", false],
       ["locked", "=", true]
@@ -353,7 +361,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "select": [
         [
@@ -372,12 +380,16 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     [
-      ["OR",
+      [
+        "OR",
         [
           ["builtin", "=", false],
-          [["locked", "=", false], ["ssh", "=" true]]
+          [
+            ["locked", "=", false],
+            ["ssh", "=" true]
+          ]
         ]
       ],
     ]
@@ -386,7 +398,7 @@ Javascript:
 
 Javascript:
 
-    :::javascript
+.. code:: javascript
     {
       "select": [
         "username"

--- a/src/middlewared_docs/docs/query_methods.rst
+++ b/src/middlewared_docs/docs/query_methods.rst
@@ -20,6 +20,7 @@ Filter Syntax: `["field", "operator", value]`
 For example, to filter the data returned by `disk.query`, we provide a list of conditions:
 
 .. code:: javascript
+
     [
       ["name", "=", "ada1"]
     ]
@@ -56,6 +57,7 @@ Multiple Filters
 We can use `disk.query` with the "type" and "rotationrate" filters to find hard drives with a rotation rate higher than 5400 RPM:
 
 .. code:: javascript
+
     [
       ["type", "=", "HDD"],
       ["rotationrate", ">", 5400]  // Note that the value should be the correct type
@@ -70,6 +72,7 @@ Queries with no explicitly defined logical connectives assume conjunction `AND`.
 The following is a valid example.
 
 .. code:: javascript
+
     [
       "OR",
       [
@@ -81,6 +84,7 @@ The following is a valid example.
 The following is also a valid example that returns users that are unlocked and either have password-based authentication for SSH enabled or are SMB users.
 
 .. code:: javascript
+
     [
       [
         "OR",
@@ -95,6 +99,7 @@ The following is also a valid example that returns users that are unlocked and e
 The following is valid example that returns users who are either enabled or have password authentication enabled with two-factor authentication disabled.
 
 .. code:: javascript
+
     [
       "OR",
       [
@@ -111,6 +116,7 @@ Some additional examples of connective use are as follows.
 When used with `user.query`, these filters find unlocked users with password authentication enabled and two-factor authentication disabled.
 
 .. code:: javascript
+
     [
       ["ssh_password_enabled", "=", true],
       ["twofactor_auth_configured", "=", false],
@@ -120,6 +126,7 @@ When used with `user.query`, these filters find unlocked users with password aut
 Sub-keys in complex JSON objects may be specified by using dot notation to indicate the key. When passed to the `user.query` endpoint, the following query filters will return entries with a primary group ID of 3000.
 
 .. code:: javascript
+
     [
       ["group.bsdgrp_gid", "=", 3000]
     ]
@@ -127,6 +134,7 @@ Sub-keys in complex JSON objects may be specified by using dot notation to indic
 If a key contains a literal dot (".") in its name, then it must be escaped via a double backslash.
 
 .. code:: javascript
+
     [
       ["foo\\.bar", "=", 42]
     ]
@@ -135,6 +143,7 @@ When the path to the key contains an array, an array index may be manually speci
 will return entries where the first element of the local groups array has a name of "myuser".
 
 .. code:: javascript
+
     [
       ["local_groups.0.name", "=", "myuser"]
     ]
@@ -142,6 +151,7 @@ will return entries where the first element of the local groups array has a name
 Alternatively, an asterisk (`*`) may be substituted for the array index to match any array entry. When passed to the `privilege.query` endpoint, the following query filters will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
 
 .. code:: javascript
+
     [
       ["local_groups.*.name", "=", "myuser"]
     ]
@@ -155,6 +165,7 @@ key with designator `.$date`. In this case, query filter using an ISO-8601
 timestamp may be used. For example:
 
 .. code:: javascript
+
     [
       ["timestamp.$date", ">", "2023-12-18T16:15:35+00:00"]
     ]
@@ -173,6 +184,7 @@ Count
 Use the `count` option to get the number of results returned.
 
 .. code:: javascript
+
     {
       "count": true
     }
@@ -184,6 +196,7 @@ Limit
 Use the `limit` option to limit the number of results returned.
 
 .. code:: javascript
+
     {
       "limit": 5
     }
@@ -195,6 +208,7 @@ Offset
 Use the `offset` option to remove the first items from a returned list.
 
 .. code:: javascript
+
     {
       "offset": 1  // Omits the first item from the query result
     }
@@ -208,12 +222,14 @@ Use the `select` option to specify the exact fields to return. Fields must be pr
 Fields returned may be renamed by specifing an array containing two strings with the first string being the field to select from results list and the second string indicating the new name to provide it.
 
 .. code:: javascript
+
     {
       "select": ["devname", "size", "rotationrate"]
     }
 
 
 .. code:: javascript
+
     {
       "select": [
         "Authentication.status",
@@ -224,6 +240,7 @@ Fields returned may be renamed by specifing an array containing two strings with
 
 
 .. code:: javascript
+
     {
       "select": [
         ["Authentication.status", "status"],
@@ -247,6 +264,7 @@ The following prefixes may be applied to the field name:
 
 
 .. code:: javascript
+
     {
       "order_by": ["size", "-devname", "nulls_first:-expiretime"]
     }
@@ -260,26 +278,31 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 #. Example 1
 
     .. code-block:: sql
+
         SELECT * FROM table;
 
 
     .. code-block:: javascript
         :caption: query-filters
+
         []
 
 
     .. code-block:: javascript
         :caption: query-options
+
         {}
 
 #. Example 2
 
     .. code-block:: sql
+
         SELECT username,uid FROM table WHERE builtin=FALSE ORDER BY -uid;
 
 
     .. code-block:: javascript
         :caption: query-filters
+
         [
           ["builtin", "=", false],
         ]
@@ -287,6 +310,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
     .. code-block:: javascript
         :caption: query-options
+
         {
           "select": [
             "username",
@@ -300,11 +324,13 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 #. Example 3
 
     .. code-block:: sql
+
         SELECT username AS locked_user,uid FROM table WHERE builtin=FALSE AND locked=TRUE;
 
 
     .. code-block:: javascript
         :caption: query-filters
+
         [
           ["builtin", "=", false],
           ["locked", "=", true]
@@ -313,6 +339,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
     .. code-block:: javascript
         :caption: query-options
+
         {
           "select": [
             [
@@ -326,11 +353,13 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 #. Example 4
 
     .. code-block:: sql
+
         SELECT username FROM table WHERE builtin=False OR (locked=FALSE AND ssh=TRUE);
 
 
     .. code-block:: javascript
         :caption: query-filters
+
         [
           [
             "OR",
@@ -347,6 +376,7 @@ NOTE: These are examples of syntax translation. They are not intended to be exec
 
     .. code-block:: javascript
         :caption: query-options
+
         {
           "select": [
             "username"


### PR DESCRIPTION
- Comment out the intersphinx extension to speed up docs generation since we don't use it.
- Use reST section notation consistent with the Python [documentation guide](https://devguide.python.org/documentation/markup/#sections).
- Use double backticks for inline code (single backticks are for italics).
- Lex code blocks for proper rendering with syntax highlighting.
- Improve table of filter operators.
- Expand schemas for error responses and notifications.

Before:
<img width="782" height="685" alt="image" src="https://github.com/user-attachments/assets/69918625-49f6-403e-a3f8-bcb6f0655951" />

After:
<img width="808" height="450" alt="image" src="https://github.com/user-attachments/assets/3cd3f931-c2c3-4ff5-9bda-7c0903e2ca66" />
