### PR TITLE
NAS-137126 / 25.10-BETA.1 / Fix proper disk syncing in Xen VMs (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/disk/test_dev_to_ident.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/disk/test_dev_to_ident.py
@@ -53,8 +53,21 @@ BY_SERIAL = (
     },
     "{serial}AAAAAAAA",
 )
+BY_XEN_DEVICENAME = (
+    "xvdc",
+    {
+        "xvdc": {
+            "serial": None,
+            "serial_lunid": None,
+            "parts": []
+        }
+    },
+    "{devicename}xvdc",
+)
 
 
-@pytest.mark.parametrize('disk_name, sys_disks, result', [BY_UUID, BY_SERIAL_LUNID, BY_DEVICENAME, BY_SERIAL])
+@pytest.mark.parametrize('disk_name, sys_disks, result', [
+    BY_UUID, BY_SERIAL_LUNID, BY_DEVICENAME, BY_SERIAL, BY_XEN_DEVICENAME
+])
 def test_dev_to_ident(disk_name, sys_disks, result):
     assert result == OBJ.dev_to_ident(disk_name, sys_disks)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_disk_names.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_disk_names.py
@@ -13,12 +13,24 @@ from middlewared.utils.disks import get_disk_names, VALID_WHOLE_DISK
     ('vds', True),
     ('nvme0n0', True),
     ('nvme2n4', True),
+    ('xvda', True),
+    ('xvdb', True),
+    ('xvdc', True),
+    ('xvdz', True),
+    ('xvdaa', True),
     ('vda1', False),
     ('vdA', False),
     ('sd2', False),
     ('sda2', False),
     ('sda3', False),
     ('vda3', False),
+    ('xvda1', False),
+    ('xvdA', False),
+    ('xvd2', False),
+    ('xvda2', False),
+    ('xva', False),
+    ('xd', False),
+    ('xvd', False),
 ])
 def test_regex(to_test, should_work):
     if should_work:
@@ -30,11 +42,11 @@ def test_regex(to_test, should_work):
 @unittest.mock.patch('os.scandir')
 def test_get_disk_names(scandir):
     mock_devices = []
-    for name in ['vda', 'vdb', 'sda', 'sdd', 'nvme0n1', 'sdd1', 'sda2', 'vdb2']:
+    for name in ['vda', 'vdb', 'sda', 'sdd', 'nvme0n1', 'xvda', 'xvdc', 'sdd1', 'sda2', 'vdb2', 'xvda1']:
         device = unittest.mock.Mock(is_file=lambda: True)
         device.name = name  # Set the name attribute directly
         mock_devices.append(device)
 
     scandir.return_value.__enter__.return_value = mock_devices
     assert get_disk_names() is not None
-    assert get_disk_names() == ['vda', 'vdb', 'sda', 'sdd', 'nvme0n1']
+    assert get_disk_names() == ['vda', 'vdb', 'sda', 'sdd', 'nvme0n1', 'xvda', 'xvdc']

--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -6,7 +6,7 @@ import pyudev
 
 DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')
 RE_IS_PART = re.compile(r'p\d{1,3}$')
-# sda, vda, xvda, nvme0n1 but not sda1/vda1/nvme0n1p1
+# sda, vda, xvda, nvme0n1 but not sda1/vda1/xvda1/nvme0n1p1
 VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^xvd[a-z]+$|^nvme\d+n\d+$')
 
 

--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -6,8 +6,8 @@ import pyudev
 
 DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')
 RE_IS_PART = re.compile(r'p\d{1,3}$')
-# sda, vda, nvme0n1 but not sda1/vda1/nvme0n1p1
-VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$')
+# sda, vda, xvda, nvme0n1 but not sda1/vda1/nvme0n1p1
+VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^xvd[a-z]+$|^nvme\d+n\d+$')
 
 
 def safe_retrieval(prop, key, default, as_int=False):


### PR DESCRIPTION
## Problem

When truenas is virtualized using xen, disks can appear in the system as `xvdb` etc and in this case their disk identifier shows up as `''` and eventually we cannot have more then one disk in the disk table because we have a UNIQUE constraint on identifiers.

Why identifier shows up as `''` because when trying to gauge identifier, it gets available disks and if the disk in question is not found there, it skips it (it is not nice but we are going to redo this logic separately).

## Solution

Make sure the regex we have which covers the disks we support actually accounts for xen disks as well.

Original PR: https://github.com/truenas/middleware/pull/16960
