### PR TITLE
NAS-137123 / 25.10-BETA.1 / bump max_tasks_per_child to 100 so process pool doesn't crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -670,7 +670,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
     def __init_procpool(self):
         self.__procpool = concurrent.futures.ProcessPoolExecutor(
             max_workers=5,
-            max_tasks_per_child=20,
+            max_tasks_per_child=100,
             initializer=functools.partial(worker_init, self.debug_level, self.log_handler)
         )
 


### PR DESCRIPTION
Internal testing has found that sending a specific set of disk events will cause all children in the process pool to crash silently and never recover. This looks like a proper upstream bug in python. The crash occurs because we're exhausting the children in the pool AND each child will execute 20 tasks before being killed and re-created. This was reproduced by a trivial 3-5 line python script. Bumping this value to 100 prevented the script from crashing process pool and fixed the issue we were seeing on internal hardware. This is the path of least resistance and a stop-gap solution as we are rapidly working towards getting rid of our process pool entirely. This will work for now.

Original PR: https://github.com/truenas/middleware/pull/16963
