### PR TITLE
NAS-137146 / 26.04 / dont use zfs.pool.query_imported_fast

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -21,7 +21,7 @@ from middlewared.service import job, private
 from middlewared.service import ConfigService, ValidationErrors
 from middlewared.service_exception import CallError
 from middlewared.utils import run, BOOT_POOL_NAME_VALID
-
+from middlewared.utils.zfs import query_imported_fast_impl
 from .utils import (
     VirtGlobalStatus, incus_call, VNC_PASSWORD_DIR, TRUENAS_STORAGE_PROP_STR, INCUS_BRIDGE, INCUS_STORAGE
 )
@@ -228,7 +228,8 @@ class VirtGlobalService(ConfigService):
         Pool choices for virtualization purposes.
         """
         pools = {POOL_DISABLED: '[Disabled]'}
-        for p in (await self.middleware.call('zfs.pool.query_imported_fast')).values():
+        imported_pools = await self.middleware.run_in_thread(query_imported_fast_impl)
+        for p in imported_pools.values():
             # Do not show boot pools or pools with spaces in their name
             # Incus is not gracefully able to handle pools which have spaces in their names
             # https://ixsystems.atlassian.net/browse/NAS-134244

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -25,6 +25,7 @@ from middlewared.async_validators import resolve_hostname
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.time_utils import utc_now
+from middlewared.utils.zfs import query_imported_fast_impl
 
 NFS_VOLUME_TYPES = ('NFS', 'NFS41')
 
@@ -209,7 +210,7 @@ class VMWareService(CRUDService):
                 zvol = extent["path"][len("zvol/"):]
                 iscsi_extents[zvol].append(f"naa.{extent['naa'][2:]}")
         filesystems = []
-        zpools = [v["name"] for k, v in self.middleware.call_sync("zfs.pool.query_imported_fast").items()]
+        zpools = [i["name"] for i in query_imported_fast_impl().values()]
         options = {"extra": {"retrieve_properties": False}}
         for fs in self.middleware.call_sync("pool.dataset.query", [("pool", "in", zpools)], options):
             if fs["type"] == "FILESYSTEM":

--- a/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
@@ -6,6 +6,7 @@ import functools
 from middlewared.service import CallError, Service
 from middlewared.service_exception import ValidationError
 from middlewared.utils import BOOT_POOL_NAME_VALID
+from middlewared.utils.zfs import query_imported_fast_impl
 from .pool_utils import find_vdev, SEARCH_PATHS
 
 
@@ -236,7 +237,7 @@ class ZFSPoolService(Service):
 
     def ddt_prefetch_pools(self):
         # We have this method so to avoid making excessive calls to process pool service
-        for pool_info in (self.middleware.call_sync('zfs.pool.query_imported_fast')).values():
+        for pool_info in query_imported_fast_impl().values():
             if pool_info['name'] in BOOT_POOL_NAME_VALID:
                 continue
 


### PR DESCRIPTION
The entire point of writing `query_imported_fast_impl` was to query basic zpool status _WITHOUT_ using our process pool. However, we mistakenly added it to the `zfs.pool` namespace plugin which...uses our process pool. This removes all calls to `zfs.pool.query_imported_fast` and just calls the function directly. This will be dramatically more efficient and faster than using our process pool.