### PR TITLE
NAS-137105 / 26.04 / Adjust maximum timeout value for directory services

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -505,7 +505,7 @@ class DirectoryServicesEntry(BaseModel):
     server when necessary. """
     enable_dns_updates: bool = Field(default=True)
     """ Enable automatic DNS updates for the TrueNAS server in the domain via nsupdate and gssapi / TSIG. """
-    timeout: int = Field(default=10, ge=5, le=40)
+    timeout: int = Field(default=10, ge=5, le=60)
     """ The timeout value for DNS queries that are performed as part of the join process and NETWORK_TIMEOUT for LDAP \
     requests. """
     kerberos_realm: NonEmptyString | None = Field(default=None)

--- a/src/middlewared/middlewared/api/v26_04_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v26_04_0/directory_services.py
@@ -505,7 +505,7 @@ class DirectoryServicesEntry(BaseModel):
     server when necessary. """
     enable_dns_updates: bool = Field(default=True)
     """ Enable automatic DNS updates for the TrueNAS server in the domain via nsupdate and gssapi / TSIG. """
-    timeout: int = Field(default=10, ge=5, le=40)
+    timeout: int = Field(default=10, ge=5, le=60)
     """ The timeout value for DNS queries that are performed as part of the join process and NETWORK_TIMEOUT for LDAP \
     requests. """
     kerberos_realm: NonEmptyString | None = Field(default=None)


### PR DESCRIPTION
This commit bumps the maximum allowed directory services timeout to 60 seconds to make consistent with legacy behavior from Core.