### PR TITLE
NAS-137152 / 26.04 / Fix audit setup

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -466,7 +466,7 @@ class AuditService(ConfigService):
             'zfs.resource.query_impl',
             {'paths': [boot_pool], 'properties': ['refreservation'], 'get_children': True}
         ):
-            if i['name'] == cur['name'] or i['name'].startswith(f'{parent}/'):
+            if i['name'] == cur['name'] or i['name'] == parent or i['name'].startswith(f'{parent}/'):
                 continue
             elif i['properties']['refreservation']['value'] is None:
                 continue


### PR DESCRIPTION
A recent PR (#16920) broke `audit.setup`

```
[2025/08/13 08:28:05] (ERROR) middlewared.init_audit():6 - Failed to perform setup tasks for auditing. @cee:{"TNLOG": {"exception": "Traceback (most recent call last):\n  File \"/usr/lib/python3/dist-packages/middlewared/plugins/audit/__init__.py\", line 4, in init_audit\n    await middleware.call(\"audit.setup\")\n  File \"/usr/lib/python3/dist-packages/middlewared/main.py\", line 1127, in call\n    return await self._call(\n           ^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/main.py\", line 830, in _call\n    return await methodobj(*prepared_call.args)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/plugins/audit/audit.py\", line 474, in setup\n    to_remove.add(i['name'])\n    ^^^^^^^^^^^^^\nAttributeError: 'list' object has no attribute 'add'", "type": "PYTHON_EXCEPTION", "time": "2025-08-13 15:28:05.276652"}}
```
Rectify the breakage.