### PR TITLE
NAS-137082 / 25.10-BETA.1 / nvme-of: add power recovery service for shelf power cycles (by ixhamza)

### DIFF
--- a/src/freenas/usr/local/bin/nvmf-connect.sh
+++ b/src/freenas/usr/local/bin/nvmf-connect.sh
@@ -33,15 +33,45 @@ while [ -s $queue ]; do
     fi
   done
 
+  # Handle Power Recovery: Detect power restoration scenarios and manage recovery service
+  # 
+  # During shelf power cycle, after the shelf comes back online, the remote
+  # sends a series of discovery change events for all the drives at once.
+  # However, discovery change events are sent before the discovery page has
+  # entries for the drives, and it takes around 30 seconds for all drives to
+  # show properly in the discovery page and become connectable. The previous
+  # 5-second timeout was insufficient for full shelves, causing nvme
+  # connect-all to execute before all drives were discoverable.
+  #
+  # Power restoration detection:
+  # - If no local NQNs exist and no disconnections occurred: power restored or first device added
+  # - If disconnections occurred with no local NQNs and queue has events: power recovery needed
+  # - If power recovery service is already active: reset timer for additional drives during recovery
+  #
+  # The power recovery service attempts connect-all 12 times at 5-second intervals.
+  # This provides 60+ seconds total as connect-all execution adds additional time.
+  # Multiple connect-all calls are safe when drives are already connected.
+  power_recovery_queue="/var/run/${discovery_dev}-power-recovery-queue"
+  if [[ -f "$power_recovery_queue" || \
+       ($disconnected -eq 1 && -z "$local_nqns" && -s "$queue") || \
+       ($disconnected -eq 0 && -z "$local_nqns") ]]; then
+    if systemctl is-active --quiet ${discovery_dev}-power-recovery.service; then
+      echo "RESET" > $power_recovery_queue
+    else
+      echo "START" > $power_recovery_queue
+      systemd-run --unit=${discovery_dev}-power-recovery.service \
+        /bin/bash -c "/usr/local/bin/nvmf-power-recovery.sh $args"
+    fi
+    continue
+  fi
+
   if [ $disconnected -eq 0 ]; then
     counter=0
     local_nqns=$(echo -e "$local_nqns" | tr -s '\n' | sort)
-
     while [ $counter -lt $RECONNECT_TIMEOUT_SEC ]; do
       connect_nqns=$(nvme discover $args | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1' \
           | tr -s '\n' | sort)
-
-      if [[ -n "$local_nqns" && "$local_nqns" != "$connect_nqns" ]]; then
+      if [[ "$local_nqns" != "$connect_nqns" ]]; then
         break
       fi
 

--- a/src/freenas/usr/local/bin/nvmf-power-recovery.sh
+++ b/src/freenas/usr/local/bin/nvmf-power-recovery.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+args="$*"
+discovery_dev=$(echo "$args" | grep -oP '(?<=--device=)\w+')
+power_recovery_queue="/var/run/${discovery_dev}-power-recovery-queue"
+
+# Default timeout for power recovery (in attempts, ~5s each)
+MAX_ATTEMPTS=12
+attempt=0
+
+while [ $attempt -lt $MAX_ATTEMPTS ]; do
+  # Check queue for reset command
+  if [ -s "$power_recovery_queue" ]; then
+    command=$(<"$power_recovery_queue")
+    if [ "$command" = "RESET" ]; then
+      attempt=0
+      truncate -s 0 "$power_recovery_queue"
+    fi
+  fi
+  attempt=$((attempt + 1))
+  nvme connect-all $args
+  sleep 5
+done
+
+rm -f "$power_recovery_queue"


### PR DESCRIPTION
During shelf power cycles, discovery events arrive before the discovery page is populated (~30s delay), causing missed connections. Implement dedicated power recovery service that detects power restoration scenarios and attempts connect-all 12 times over 60+ seconds with timer reset for hotplug events during recovery.

[Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1408/)
Under testing by @jervin777.

Original PR: https://github.com/truenas/middleware/pull/16938
