### PR TITLE
NAS-137179 / 25.10-RC.1 / Fix default value for WORM grace period (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1308,7 +1308,7 @@ class SharingSMBService(SharingService):
                 }
             case SMBSharePurpose.TIME_LOCKED_SHARE:
                 out[share_field.OPTS] = {
-                    share_field.WORM_GRACE: data['worm_grace_period'],
+                    share_field.WORM_GRACE: data['worm_grace_period'] or 900,
                     share_field.AAPL_MANGLING: data[share_field.AAPL_MANGLING],
                 }
             case SMBSharePurpose.PRIVATE_DATASETS_SHARE:


### PR DESCRIPTION
This commit alters the SMB share datastore extend method to interpret a zero value for grace period as the current default for the share.

Original PR: https://github.com/truenas/middleware/pull/16979
