### PR TITLE
NAS-137171 / 26.04 / Add 'scope' setting to support HA.

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfs.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.mako
@@ -7,6 +7,9 @@
     cltrack_storedir = NFSServicePathInfo.CLDTRKDIR.path()
     config = render_ctx["nfs.config"]
 
+    # HA requirement: Consistent server scope value between controllers
+    scope = render_ctx["system.global.id"]
+
     # Fail-safe setting is two nfsd
     num_nfsd = config['servers'] if config['servers'] > 0 else 2
 
@@ -35,6 +38,7 @@
 # TrueNAS configuration file for NFS
 #
 [nfsd]
+scope = ${scope}
 syslog = 1
 vers2 = n
 threads = ${num_nfsd}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -170,6 +170,7 @@ class EtcService(Service):
                     'args': [[('enabled', '=', True), ('locked', '=', False)]],
                 },
                 {'method': 'nfs.config'},
+                {'method': 'system.global.id'},
             ],
             'entries': [
                 {'type': 'mako', 'path': 'nfs.conf'},


### PR DESCRIPTION
NFS includes a setting, 'scope'.  The purpose of this setting is to provide a unique and consistent ID that spans a filesystem shared by multiple controllers, e.g. an HA system.

For some clients, e.g. VMware, to support failover the `scope` setting must be the same between controllers.

The backports of this depend on updates to `nfs-utils`: 
- https://github.com/truenas/nfs-utils/pull/7

Added CI test which passes on local testing.