### PR TITLE
NAS-137180 / 25.10-BETA.1 / Properly fix disk syncing in xen VMs (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -3,11 +3,10 @@ import re
 
 import pyudev
 
+from .disks_.disk_class import VALID_WHOLE_DISK
 
 DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')
 RE_IS_PART = re.compile(r'p\d{1,3}$')
-# sda, vda, xvda, nvme0n1 but not sda1/vda1/xvda1/nvme0n1p1
-VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^xvd[a-z]+$|^nvme\d+n\d+$')
 
 
 def safe_retrieval(prop, key, default, as_int=False):

--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -13,10 +13,10 @@ import uuid
 from .disk_io import read_gpt, wipe_disk_quick, create_gpt_partition
 from .gpt_parts import GptPartEntry, PART_TYPES
 
-__all__ = ("DiskEntry", "iterate_disks")
+__all__ = ("DiskEntry", "iterate_disks", "VALID_WHOLE_DISK")
 
-# sda, pmem0, vda, nvme0n1 but not sda1/vda1/nvme0n1p1
-VALID_WHOLE_DISK = re.compile(r"^pmem\d+$|^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$")
+# sda, pmem0, vda, xvda, nvme0n1 but not sda1/vda1/xvda1/nvme0n1p1
+VALID_WHOLE_DISK = re.compile(r"^pmem\d+$|sd[a-z]+$|^vd[a-z]+$|^xvd[a-z]+$|^nvme\d+n\d+$")
 
 
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)


### PR DESCRIPTION
## Problem

We had fixed the regex for `VALID_WHOLE_DISK` but however there were 2 different instances of it and the other was still outdated and skipped xen based disks.

## Solution

Make sure we don't have 2 different regex around and use 1 source of truth which also accounts for xen based disks.

Original PR: https://github.com/truenas/middleware/pull/16984
