### PR TITLE
NAS-137204 / 25.10-RC.1 / Allow max_parallel_replication_tasks to be nullable (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/replication_config.py
+++ b/src/middlewared/middlewared/api/v25_10_0/replication_config.py
@@ -16,7 +16,7 @@ __all__ = [
 class ReplicationConfigEntry(BaseModel):
     id: int
     """Unique identifier for the replication configuration."""
-    max_parallel_replication_tasks: int = Field(ge=1)
+    max_parallel_replication_tasks: int | None = Field(ge=1)
     """A maximum number of parallel replication tasks running."""
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 4f935956c77e78fbea68f444bfd34bcae0cbece9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bff2bb117c915ff58b9b7e690f5db68c3c2e92dc

This PR adds changes to allow `max_parallel_replication_tasks` to be nullable as it seems like it should be allowed (and was before pydantic) and zettarepl also handles this explicitly.

Original PR: https://github.com/truenas/middleware/pull/16994
