### PR TITLE
NAS-137202 / 25.10-RC.1 / Better handle closed connection case when checking docker image updates (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/client.py
+++ b/src/middlewared/middlewared/plugins/apps_images/client.py
@@ -50,6 +50,8 @@ class ContainerRegistryClientMixin:
                     response['error'] = f'Unable to parse response: {e}'
                 except asyncio.TimeoutError:
                     response['error'] = 'Timed out waiting for a response'
+                except RuntimeError as e:
+                    response['error'] = f'Connection closed before the response could be fully read ({e})'
         return response
 
     async def _get_token(self, scope, auth_url=DOCKER_AUTH_URL, service=DOCKER_AUTH_SERVICE, auth=None):


### PR DESCRIPTION
This PR adds changes to better handle an exception which `aiohttp` can raise when we do `req.json` i.e
```
    response['response'] = await req.json()
                           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/client_reqrep.py", line 744, in json
    await self.read()
  File "/usr/lib/python3/dist-packages/aiohttp/client_reqrep.py", line 686, in read
    self._body = await self.content.read()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/streams.py", line 418, in read
    block = await self.readany()
            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/streams.py", line 440, in readany
    await self._wait("readany")
  File "/usr/lib/python3/dist-packages/aiohttp/streams.py", line 332, in _wait
    raise RuntimeError("Connection closed.")
```

Original PR: https://github.com/truenas/middleware/pull/16993
