### PR TITLE
NAS-136901 / 25.10-RC.1 / Fix `Downloaded update file size mismatch` on unstable connections (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/download.py
+++ b/src/middlewared/middlewared/plugins/update_/download.py
@@ -121,6 +121,12 @@ class UpdateService(Service):
                                     )
 
                                     f.write(chunk)
+
+                                size = os.path.getsize(dst)
+                                if size != total:
+                                    raise CallError(f'Downloaded update file size mismatch ({size} != {total})',
+                                                    errno.ECONNRESET)
+
                                 break
                         except Exception as e:
                             if i < 5 and progress and any(ee in str(e) for ee in ("ECONNRESET", "ETIMEDOUT")):
@@ -133,7 +139,7 @@ class UpdateService(Service):
                 size = os.path.getsize(dst)
                 if size != total:
                     os.unlink(dst)
-                    raise CallError(f'Downloaded update file mismatch ({size} != {total})')
+                    raise CallError(f'Downloaded update file size mismatch ({size} != {total})')
 
                 set_progress(1, "Update downloaded.")
                 return True


### PR DESCRIPTION
Server might silently close the connection when downloading the update file, which will result in an incomplete file being downloaded without retrying to resume the download. This PR raises an exception if server closed the connection prematurely, which will cause us to retry the download a few times before finally giving up.

Original PR: https://github.com/truenas/middleware/pull/16822
