### PR TITLE
NAS-137207 / 25.10-BETA.1 / Fix conditional args for vm.device.update (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -191,7 +191,9 @@ class VMDeviceCreateResult(BaseModel):
 
 
 class VMDeviceUpdate(VMDeviceCreate, metaclass=ForUpdateMetaclass):
-    pass
+    # This will still get validated when update itself is called based off how we have
+    # logic to validate different device types
+    attributes: dict
 
 
 class VMDeviceUpdateArgs(BaseModel):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 80829cdbbbb419ad64306618a2d33faf04d17742

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8000797b26143957bfbcd7c82a96ec1e613f7314

## Problem

So we expect something like this to work (because of what we do here https://github.com/truenas/middleware/blob/f5acbe7e15387c0e6918054a4e5fd85e9fda64cc/src/middlewared/middlewared/plugins/vm/vm_devices.py#L167)
```
midclt call vm.device.update 1 '{"attributes": {"web": false}}'
```
But this fails with pydantic issue that x/y/z keys are not present etc. There are 2 issues here:

1. The above case should work
2. If an attr which is not required and is not specified on update, the default value for that attr will be set i.e

`web` was false but because of how the update happened, despite not updating it - it was updated to `true`
```
{"id": 17, "attributes": {"dtype": "DISPLAY", "resolution": "1024x768", "port": 9012, "web_port": 5900, "bind": "127.0.0.1", "wait": false, "password": "spice123", "web": false, "type": "SPICE"}, "vm": 2, "order": 1002}
❯
❯ midclt call vm.device.update 17 '{"attributes": {"dtype": "DISPLAY", "password": "spice123"}}'
{"id": 17, "attributes": {"dtype": "DISPLAY", "resolution": "1024x768", "port": 5901, "web_port": 5902, "bind": "127.0.0.1", "wait": false, "password": "spice123", "web": true, "type": "SPICE"}, "vm": 2, "order": 1002}
❯
```

## Solution

For `vm.device.update` endpoint, we should on the pydantic model itself - not validate attrs because of how `discriminator` is used for various VM device types, it will result in the above problems we just discussed.

Instead let's allow a `dict` here, we validate each device against it's model anyways and that's done properly, so let's have the validation be done at that stage instead.

Original PR: https://github.com/truenas/middleware/pull/17004
