### PR TITLE
NAS-137200 / 25.10-BETA.1 / Make sure PCI device available flag is reflected correctly (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -81,7 +81,6 @@ class VMDeviceService(Service):
         data['critical'] = True
         # Only include number and addresses in iommu_group for API compatibility
         data['iommu_group'] = None
-        data['available'] = all(i == 'vfio-pci' for i in drivers) and not data['critical']
         data['drivers'] = drivers
         data['device_path'] = os.path.join('/sys/bus/pci/devices', obj.sys_name)
         data['reset_mechanism_defined'] = os.path.exists(os.path.join(data['device_path'], 'reset'))
@@ -94,6 +93,8 @@ class VMDeviceService(Service):
                     'addresses': igi['addresses'],
                 },
             })
+
+        data['available'] = all(i == 'vfio-pci' for i in drivers) and not data['critical']
 
         prefix = obj.sys_name + (f' {controller_type!r}' if controller_type else '')
         vendor = data['capability']['vendor'].strip()


### PR DESCRIPTION
## Problem

`available` flag of a PCI device was incorrectly being updated because `critical` at the time this ran was still pointing to the default value (of being true) instead of it's actual value which we get from iommu groups information.

## Solution

Calculate if a PCI device is `available` after `critical` has actually been updated to reflect reality

Original PR: https://github.com/truenas/middleware/pull/17009
