### PR TITLE
NAS-137210 / 25.10-BETA.1 / VMs are not supported with STIG enabled (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -125,7 +125,7 @@ class SystemSecurityService(ConfigService):
         if vms:
             raise ValidationError(
                 'system_security_update.enable_gpos_stig',
-                'Please remove all VMs as VMs are not supported under General Purpose OS STIG compatibility mode.'
+                'Please remove all virtual machines, as they are not supported in General Purpose OS STIG compatibility mode.'
             )
 
         if (await self.middleware.call('docker.config'))['pool']:


### PR DESCRIPTION
## Context

Improve validation for STIG so that we raise a validation error if user has any VMs in place, we raise an appropriate error outlining that VMs need to be removed.

Original PR: https://github.com/truenas/middleware/pull/17007
