### PR TITLE
NAS-136995 / 26.04 / Make directoryservice validation more strict

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -609,7 +609,7 @@ class DirectoryServicesUpdateArgs(DirectoryServicesEntry, metaclass=ForUpdateMet
         if self.service_type == undefined and self.enable is not False:
             raise ValueError('service_type is required in update payloads')
 
-        if self.enable is True and self.service_type is not None:
+        if self.service_type not in (None, undefined):
             if self.configuration in (None, undefined):
                 raise ValueError('Explicit configuration is required when service_type is specified')
 

--- a/src/middlewared/middlewared/api/v26_04_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v26_04_0/directory_services.py
@@ -609,7 +609,7 @@ class DirectoryServicesUpdateArgs(DirectoryServicesEntry, metaclass=ForUpdateMet
         if self.service_type == undefined and self.enable is not False:
             raise ValueError('service_type is required in update payloads')
 
-        if self.enable is True and self.service_type is not None:
+        if self.service_type not in (None, undefined):
             if self.configuration in (None, undefined):
                 raise ValueError('Explicit configuration is required when service_type is specified')
 


### PR DESCRIPTION
This commit removes ability for users to set a directoryservices.update request without providing the configuration and credential details if a service_type has been specified. This ensures that the config details are always valid. There is already a supported method for users to clear config if that's what's needed.