### PR TITLE
Fix spaces in emails

### DIFF
--- a/src/middlewared/middlewared/assets/templates/mail.html
+++ b/src/middlewared/middlewared/assets/templates/mail.html
@@ -1,3 +1,3 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 
-${body}
+<p style="font-family: 'Courier New', Courier, monospace;">${body}</p>

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -161,7 +161,7 @@ class MailService(ConfigService):
 
         if add_html and 'html' not in message:
             template = get_template('assets/templates/mail.html')
-            message['html'] = template.render(body=html.escape(message['text']).replace('\n', '<br>\n'))
+            message['html'] = template.render(body=html.escape(message['text']).replace('\n', '<br>\n').replace(' ', '&nbsp;'))
 
         return self.send_raw(job, message, config)
 


### PR DESCRIPTION
When converting from plain message text to HTML in the mail service, new lines are replaced with "<br>", which is sensible.
But whoever did that forgot that in HTML consecutive spaces are counted as 1 space, causing hugely incorrect and unreadable emails whenever multiple spaces are involved (ie. basically all console outputs).

This small fix does 2 things:

1. Encodes spaces as &nbsp; (which fixes the consecutive space HTML issue)
2. Formats plain text messages as a monospaced font by default (making the now consecutive spaces actually line up)