### PR TITLE
Support Fibre Channel MPIO

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -83,11 +83,9 @@
     def ha_node_wwpn_for_target(target, node):
         """Iterator that yields wwpn, fcport pairs"""
         if target['id'] in fcports_by_target_id:
+            key = 'wwpn' if not is_ha or node == 'A' else 'wwpn_b'
             for fcport in fcports_by_target_id[target['id']]:
-                if not is_ha or node == 'A':
-                    wwpn = wwn_as_colon_hex(fcport['wwpn'])
-                elif node == 'B':
-                    wwpn = wwn_as_colon_hex(fcport['wwpn_b'])
+                wwpn = wwn_as_colon_hex(fcport[key])
                 if wwpn:
                     yield wwpn, fcport
 

--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -248,10 +248,10 @@ class FCPortService(CRUDService):
 
     async def _validate(self, schema_name: str, data: dict, id_: int = None):
         verrors = ValidationErrors()
-        # Make sure we don't reuse either port.
+        # Make sure we don't reuse port.
         await self._ensure_unique(verrors, schema_name, 'port', data['port'], id_)
 
-        # We are allowed to reused the target_id, but only once per physical port
+        # We are allowed to reuse the target_id, but only once per physical port
         # i.e. fc0 and fc1/3 would be a valid combination, but fc1 and fc1/3 would not.
         filters = [['target.id', '=', data['target_id']]]
         if id_ is not None:


### PR DESCRIPTION
MPIO can be achieved by exposing a target through multiple fcports.  Some refactoring of `rel_tgt_id` was required to achieve
this, since we cannot re-use values.