### PR TITLE
NAS-137255 / 25.10-RC.1 / Update nvmet become_active to start the service if necessary (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -213,13 +213,19 @@ class NVMETargetService(PseudoServiceBase):
         pass
 
     async def become_active(self):
-        # If necessary we can optimize to *just* poke the
-        # 1. port ANA group state
-        # 2. namespace enabled
-        await self.middleware.call('etc.generate', self.name)
+        if await self.middleware.call('nvmet.global.running'):
+            # If necessary we can optimize to *just* poke the
+            # 1. port ANA group state
+            # 2. namespace enabled
+            await self.middleware.call('etc.generate', self.name)
+        else:
+            await self.start()
 
     async def get_state(self):
         return ServiceState(
             (await self.middleware.call('nvmet.global.running')),
             [],
         )
+
+    async def failure_logs(self):
+        return None


### PR DESCRIPTION
The `NVMETargetService.become_active` had been written to optimize the case where ANA was enabled, but was broken when it was not.  Rectify.

Original PR: https://github.com/truenas/middleware/pull/17041
