### PR TITLE
NAS-137259 / 26.04 / Sanitize filepath in sharing_task_determine_locked for iSCSI and nvmet

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -83,13 +83,18 @@ class iSCSITargetExtentService(SharingService):
         """Determine if this extent is in a locked path"""
         path = await self.get_path_field(data)
         if data['type'] == 'FILE':
-            # Sanitize the path, remove non ds components that are invalid names
-            path_ = path.removeprefix('/mnt/')
-            while path_:
-                if validate_dataset_name(path_):
-                    path = path_
-                    break
-                path_ = os.path.dirname(path_)
+            for component in pathlib.Path(path.removeprefix('/mnt/')).parents:
+                c = component.as_posix()
+                # walk up the path starting from right to left
+                # if the component of the path isn't a valid
+                # zfs filesystem name, then we make the
+                # assumption that it _CANT_ be a filesystem
+                # and so we move up to the next path.
+                if validate_dataset_name(c):
+                    return await self.middleware.call(
+                        'pool.dataset.path_in_locked_datasets',
+                        c
+                    )
         return await self.middleware.call(
             'pool.dataset.path_in_locked_datasets',
             path

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -82,7 +82,7 @@ class iSCSITargetExtentService(SharingService):
     async def sharing_task_determine_locked(self, data):
         """Determine if this extent is in a locked path"""
         path = await self.get_path_field(data)
-        if data['type'] == 'FILE' and path.startswith('/mnt'):
+        if data['type'] == 'FILE':
             # Sanitize the path, remove non ds components that are invalid names
             path_ = path.removeprefix('/mnt/')
             while path_:

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -21,6 +21,7 @@ from middlewared.api.current import (
 )
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
+from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 from middlewared.service import CallError, SharingService, ValidationErrors, private
 from middlewared.utils.size import format_size
 from .utils import sanitize_extent
@@ -80,9 +81,18 @@ class iSCSITargetExtentService(SharingService):
     @private
     async def sharing_task_determine_locked(self, data):
         """Determine if this extent is in a locked path"""
+        path = await self.get_path_field(data)
+        if data['type'] == 'FILE' and path.startswith('/mnt'):
+            # Sanitize the path, remove non ds components that are invalid names
+            path_ = path.removeprefix('/mnt/')
+            while path_:
+                if validate_dataset_name(path_):
+                    path = path_
+                    break
+                path_ = os.path.dirname(path_)
         return await self.middleware.call(
             'pool.dataset.path_in_locked_datasets',
-            await self.get_path_field(data)
+            path
         )
 
     @api_method(

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -434,6 +434,12 @@ class iSCSITargetExtentService(SharingService):
                 verrors, f'{schema_name}.path', path
             )
 
+            if ' ' in path:
+                verrors.add(
+                    f'{schema_name}.path',
+                    'Filepath may not contain space characters'
+                )
+
         return data
 
     @private

--- a/src/middlewared/middlewared/plugins/nvmet/namespace.py
+++ b/src/middlewared/middlewared/plugins/nvmet/namespace.py
@@ -380,7 +380,7 @@ class NVMetNamespaceService(SharingService):
     async def sharing_task_determine_locked(self, data):
         """Determine if this namespace is in a locked path"""
         path = await self.get_path_field(data)
-        if data['device_type'] == 'FILE' and path.startswith('/mnt'):
+        if data['device_type'] == 'FILE':
             # Sanitize the path, remove non ds components that are invalid names
             path_ = path.removeprefix('/mnt/')
             while path_:


### PR DESCRIPTION
When a file is passed into `path_in_locked_datasets` the filename, (or a containing directory) can be an invalid name wrt dataset. Strip off any offending material.