### PR TITLE
NAS-137259 / 25.10-RC.1 / Sanitize filepath in sharing_task_determine_locked for iSCSI and nvmet (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -81,13 +81,18 @@ class iSCSITargetExtentService(SharingService):
         """Determine if this extent is in a locked path"""
         path = await self.get_path_field(data)
         if data['type'] == 'FILE':
-            # Sanitize the path, remove non ds components that are invalid names
-            path_ = path.removeprefix('/mnt/')
-            while path_:
-                if validate_dataset_name(path_):
-                    path = path_
-                    break
-                path_ = os.path.dirname(path_)
+            for component in pathlib.Path(path.removeprefix('/mnt/')).parents:
+                c = component.as_posix()
+                # walk up the path starting from right to left
+                # if the component of the path isn't a valid
+                # zfs filesystem name, then we make the
+                # assumption that it _CANT_ be a filesystem
+                # and so we move up to the next path.
+                if validate_dataset_name(c):
+                    return await self.middleware.call(
+                        'pool.dataset.path_in_locked_datasets',
+                        c
+                    )
         return await self.middleware.call(
             'pool.dataset.path_in_locked_datasets',
             path


### PR DESCRIPTION
When a file is passed into `path_in_locked_datasets` the filename, (or a containing directory) can be an invalid name wrt dataset. Strip off any offending material.

Original PR: https://github.com/truenas/middleware/pull/17044
