### PR TITLE
NAS-136878 / 25.10-RC.1 / Disable `match_origin` for `core.download` called via UNIX socket (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -511,11 +511,18 @@ class CoreService(Service):
             method, serviceobj, methodobj, args, app=app,
             pipes=Pipes(output=self.middleware.pipe(buffered))
         )
+        if app.origin.is_unix_family:
+            # If `core.download` is called via UNIX socket, `match_origin` will not have sense as we don't serve
+            # HTTP connections via UNIX sockets.
+            match_origin = False
+        else:
+            match_origin = True
+
         token = await self.middleware.call(
             'auth.generate_token',
             300,  # ttl
             {'filename': filename, 'job': job.id},  # attrs
-            True,  # match origin
+            match_origin,
             True,  # single-use token
             app=app
         )


### PR DESCRIPTION
This breaks downloading job results via midcli

Original PR: https://github.com/truenas/middleware/pull/17030
