### PR TITLE
NAS-137106 / 26.04 / Restore test_440_snmp pytest module

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,5 +13,5 @@ websocket-client>=1.4.2
 pyotp
 cython-iscsi @ git+https://github.com/truenas/cython-iscsi.git@tester
 PYSCSI @ git+https://github.com/truenas/python-scsi.git@tester
-pysnmplib
+pysnmp
 zeroconf


### PR DESCRIPTION
The CI module `test_440_snmp.py` was removed because it was incompatible with newer python libs.

This PR:

- Restores `test_440_snmp.py`
- Replaces the abandoned python snmp library with a supported branch python SNMP library: `pysnmp` (installed via pip)
- Fixup the test that uses the library. 

Successful tests were run on a non-HA VM.