### PR TITLE
Add include into check

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
@@ -20,8 +20,8 @@ def validate_payload(data: dict, schema: str) -> dict:
         else:
             if not isinstance(compose_config, dict):
                 verrors.add(f'{schema}.custom_compose_config_string', 'YAML must represent a dictionary/object')
-            elif 'services' not in compose_config:
-                verrors.add(f'{schema}.custom_compose_config_string', 'YAML is missing required \"services\" key')
+            elif 'services' not in compose_config or 'include' not in compose_config:
+                verrors.add(f'{schema}.custom_compose_config_string', 'YAML is missing required \"services\" key or \"include\" key which points to a file that has services')
 
     verrors.check()
 


### PR DESCRIPTION
To accommodate people who use the include stanza and manage their docker compose files outside of the UI, allow configs that have the include stanza which points to a file that has the services section.