### PR TITLE
NAS-137198 / 25.10-RC.1 / Relax validation of email address in query results (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/user.py
+++ b/src/middlewared/middlewared/api/v25_10_0/user.py
@@ -1,11 +1,12 @@
 from typing import Literal
 
 from datetime import datetime
-from pydantic import EmailStr, Field, Secret
+from pydantic import Field, Secret
 
 from middlewared.api.base import (
     BaseModel,
     ContainerXID,
+    EmailString,
     Excluded,
     excluded_field,
     ForUpdateMetaclass,
@@ -105,7 +106,7 @@ class UserEntry(BaseModel):
     sudo_commands_nopasswd: list[NonEmptyString] = Field(default_factory=list)
     """ An array of commands the user may execute with elevated privileges. User is *not* prompted for password \
     when executing any command from the array. """
-    email: EmailStr | None = None
+    email: NonEmptyString | None = None
     """ Email address of the user. If the user has the `FULL_ADMIN` role, they will receive email alerts and \
     notifications. """
     local: bool
@@ -173,6 +174,7 @@ class UserCreate(UserEntry):
     """ Comment field to provide additional information about the user account. Typically, this is \
     the full name of the user or a short description of a service account. There are no character set restrictions \
     for this field. This field is for information only. """
+    email: EmailString | None = None
     group_create: bool = False
     """ If set to `true`, the TrueNAS server automatically creates a new local group as the user's primary group. """
     group: int | None = None


### PR DESCRIPTION
This commit switches email address validation so that the more restrictive checks only occur when creating / updating accounts. This is to resolve breakage of the users form in the UI for users who set email addresses under older versions of TrueNAS where we were not validating email addresses as carefully.

Original PR: https://github.com/truenas/middleware/pull/16989
