### PR TITLE
NAS-137288 / 25.10-RC.1 / Improve JBOF error message when cannot contact HA peer node (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -585,7 +585,7 @@ class JBOFService(CRUDService):
         if await self.middleware.call('failover.licensed'):
             # HA system
             if not await self.middleware.call('failover.remote_connected'):
-                verrors.add(schema, 'Unable to contact remote controller')
+                verrors.add(schema, 'Unable to contact other TrueNAS HA node')
                 return
 
             this_node = await self.middleware.call('failover.node')
@@ -703,7 +703,7 @@ class JBOFService(CRUDService):
         if await self.middleware.call('failover.licensed'):
             # HA system
             if not await self.middleware.call('failover.remote_connected'):
-                verrors.add(schema, 'Unable to contact remote controller')
+                verrors.add(schema, 'Unable to contact other TrueNAS HA node')
                 return
 
             this_node = await self.middleware.call('failover.node')

--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -585,7 +585,7 @@ class JBOFService(CRUDService):
         if await self.middleware.call('failover.licensed'):
             # HA system
             if not await self.middleware.call('failover.remote_connected'):
-                verrors.add(schema, 'Unable to contact other TrueNAS HA node')
+                verrors.add(schema, 'Unable to contact other TrueNAS HA controller')
                 return
 
             this_node = await self.middleware.call('failover.node')
@@ -703,7 +703,7 @@ class JBOFService(CRUDService):
         if await self.middleware.call('failover.licensed'):
             # HA system
             if not await self.middleware.call('failover.remote_connected'):
-                verrors.add(schema, 'Unable to contact other TrueNAS HA node')
+                verrors.add(schema, 'Unable to contact other TrueNAS HA controller')
                 return
 
             this_node = await self.middleware.call('failover.node')


### PR DESCRIPTION
Improve ambiguous JBOF error message (HA configured, but other node down).

Original PR: https://github.com/truenas/middleware/pull/17062
