### PR TITLE
NAS-137103 / 25.10-RC.1 / middlewared/disk: handle udev change events for disk resize operations (by ixhamza)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -37,5 +37,17 @@ async def udev_block_devices_hook(middleware, data):
         await remove_disk(middleware, data['SYS_NAME'])
 
 
+def udev_disk_change_sync_hook(middleware, data):
+    if data.get('SUBSYSTEM') != 'block':
+        return
+    elif data.get('DEVTYPE') != 'disk':
+        return
+    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
+        return
+    elif data['ACTION'] == 'change':
+        middleware.call_sync('disk.sync_size_if_changed', data['SYS_NAME'])
+
+
 def setup(middleware):
     middleware.register_hook('udev.block', udev_block_devices_hook)
+    middleware.register_hook('udev.block', udev_disk_change_sync_hook)

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -19,35 +19,33 @@ async def added_disk(middleware, disk_name):
                 )
 
 
+async def change_disk(middleware, disk_name):
+    await middleware.call('disk.sync_size_if_changed', disk_name)
+
+
 async def remove_disk(middleware, disk_name):
     await (await middleware.call('disk.sync_all')).wait()
 
 
+async def should_ignore(data):
+    return (
+        data.get('SUBSYSTEM') != 'block'
+        or data.get('DEVTYPE') != 'disk'
+        or data['SYS_NAME'].startswith(DISKS_TO_IGNORE)
+    )
+
+
 async def udev_block_devices_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block':
-        return
-    elif data.get('DEVTYPE') != 'disk':
-        return
-    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
+    if await should_ignore(data):
         return
 
     if data['ACTION'] == 'add':
         await added_disk(middleware, data['SYS_NAME'])
     elif data['ACTION'] == 'remove':
         await remove_disk(middleware, data['SYS_NAME'])
-
-
-def udev_disk_change_sync_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block':
-        return
-    elif data.get('DEVTYPE') != 'disk':
-        return
-    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
-        return
     elif data['ACTION'] == 'change':
-        middleware.call_sync('disk.sync_size_if_changed', data['SYS_NAME'])
+        await change_disk(middleware, data['SYS_NAME'])
 
 
 def setup(middleware):
     middleware.register_hook('udev.block', udev_block_devices_hook)
-    middleware.register_hook('udev.block', udev_disk_change_sync_hook)


### PR DESCRIPTION
Handle udev `change` events to support disk resize operations. Some disk types immediately report updated sizes without requiring reboot, generating `change` events during resize. Middleware previously only handled `add`/'`emove` events, causing `disk.query` to show stale sizes while the kernel reflected correct values. This adds optimized size sync on `change` events that compares sysfs values directly with cached database values, updating only when different for accurate reporting.

**Testing**
- Verified that SAS HDDs with this patch show the correct size in the UI without needing to power cycle the drive.
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1411/).

Original PR: https://github.com/truenas/middleware/pull/16977
