### PR TITLE
fix zfs.resource.query property CI test

### DIFF
--- a/tests/api2/test_zfs_resource_query.py
+++ b/tests/api2/test_zfs_resource_query.py
@@ -181,4 +181,4 @@ def test_zfs_resource_query_no_properties():
         assert "pool" in resource
         assert "type" in resource
         # But properties should be empty
-        assert resource["properties"] == {}
+        assert resource["properties"] is None


### PR DESCRIPTION
This test recently start failing based on changes introduced in https://github.com/truenas/middleware/pull/16988