### PR TITLE
NAS-137303 / 26.04 / fix snapshot role test

### DIFF
--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -12,7 +12,7 @@ from middlewared.test.integration.utils import client
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("role", ["SNAPSHOT_READ", "SNAPSHOT_WRITE"])
+@pytest.mark.parametrize("role", ["ZFS_RESOURCE_READ"])
 def test_can_read_with_read_or_write_role(role):
     with dataset("test_snapshot_read") as ds:
         with snapshot(ds, "test"):


### PR DESCRIPTION
Querying for snapshots just needs the `ZFS_RESOURCE_READ` role. Though, this will need to be revisited on how we can mimic the existing behavior of roles where someone just wants to grant a user the ability to read/write snapshots only.