### PR TITLE
fix API testing of using legacy URI schema URI

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v25_10_0/zfs_resource_crud.py
@@ -227,7 +227,7 @@ class ZFSResourceEntry(BaseModel):
     """The type of ZFS resource."""
     user_properties: dict[str, str] | None
     """Custom metadata properties with colon-separated names (max 256 chars)."""
-    children: list
+    children: list | None
     """The children of this zfs resource."""
 
 


### PR DESCRIPTION
This was a regression introduced in 26.04 here https://github.com/truenas/middleware/pull/16988