### PR TITLE
NAS-137121 / 26.04 / Clear authentication state on logout

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -197,6 +197,8 @@ class SessionManager:
                 }, True)
 
             del self.sessions[app.session_id]
+            app.authentication_context = None
+            app.authenticated_credentials = None
 
             await self.middleware.run_in_thread(session.credentials.logout)
 


### PR DESCRIPTION
There are some situations in which an API client may keep a websocket connection open after logout and then log back in. Due to us storing the old authenticated_credentials in the object associated with the websocket connection, this caused the audit message to be logged against the last logged-in user account rather than properly reflecting the authenticated user as "UNAUTHENTICATED" at that time. This commit clears the authentication_context (pam handle) and the autheneticated_credentials on user logout to prevent them from ever being reused.