### PR TITLE
NAS-137307 / 25.10-RC.1 / Remove ana_enabled and rdma_enabled from nvmet.global public API

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_global.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_global.py
@@ -4,10 +4,6 @@ __all__ = [
     "NVMetGlobalEntry",
     "NVMetGlobalUpdateArgs",
     "NVMetGlobalUpdateResult",
-    "NVMetGlobalAnaEnabledArgs",
-    "NVMetGlobalAnaEnabledResult",
-    "NVMetGlobalRdmaEnabledArgs",
-    "NVMetGlobalRdmaEnabledResult",
     "NVMetGlobalSessionsItem"
 ]
 
@@ -56,24 +52,6 @@ class NVMetGlobalUpdateArgs(NVMetGlobalEntry, metaclass=ForUpdateMetaclass):
 class NVMetGlobalUpdateResult(BaseModel):
     result: NVMetGlobalEntry
     """The updated NVMe-oF global configuration."""
-
-
-class NVMetGlobalAnaEnabledArgs(BaseModel):
-    pass
-
-
-class NVMetGlobalAnaEnabledResult(BaseModel):
-    result: bool
-    """ `True` if Asymmetric Namespace Access (ANA) is enabled. """
-
-
-class NVMetGlobalRdmaEnabledArgs(BaseModel):
-    pass
-
-
-class NVMetGlobalRdmaEnabledResult(BaseModel):
-    result: bool
-    """ `True` if Remote Direct Memory Access (RDMA) is enabled for NVMe-oF. """
 
 
 class NVMetGlobalSessionsItem(BaseModel):

--- a/src/middlewared/middlewared/plugins/nvmet/global.py
+++ b/src/middlewared/middlewared/plugins/nvmet/global.py
@@ -2,11 +2,7 @@ import pathlib
 
 import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
-from middlewared.api.current import (NVMetGlobalAnaEnabledArgs,
-                                     NVMetGlobalAnaEnabledResult,
-                                     NVMetGlobalEntry,
-                                     NVMetGlobalRdmaEnabledArgs,
-                                     NVMetGlobalRdmaEnabledResult,
+from middlewared.api.current import (NVMetGlobalEntry,
                                      NVMetGlobalUpdateArgs,
                                      NVMetGlobalUpdateResult,
                                      NVMetGlobalSessionsItem)
@@ -86,11 +82,7 @@ class NVMetGlobalService(SystemServiceService, NVMetStandbyMixin):
                     'This platform does not support Asymmetric Namespace Access(ANA).'
                 )
 
-    @api_method(
-        NVMetGlobalAnaEnabledArgs,
-        NVMetGlobalAnaEnabledResult,
-        roles=['SHARING_NVME_TARGET_READ']
-    )
+    @private
     async def ana_enabled(self):
         """
         Returns whether NVMe target ANA is enabled or not.
@@ -115,11 +107,7 @@ class NVMetGlobalService(SystemServiceService, NVMetStandbyMixin):
 
         return False
 
-    @api_method(
-        NVMetGlobalRdmaEnabledArgs,
-        NVMetGlobalRdmaEnabledResult,
-        roles=['SHARING_NVME_TARGET_READ']
-    )
+    @private
     async def rdma_enabled(self):
         """
         Returns whether RDMA is enabled or not.


### PR DESCRIPTION
Remove `nvmet.global.ana_enabled` and `nvmet.global.rdma_enabled` from public 25.10 API.  These are only used internally.