### PR TITLE
configure nginx logs

### DIFF
--- a/src/freenas/etc/logrotate.d/nginx
+++ b/src/freenas/etc/logrotate.d/nginx
@@ -1,0 +1,13 @@
+/var/log/nginx/*.log
+{
+	rotate 5
+	size 5M
+	missingok
+	notifempty
+	compress
+	delaycompress
+	create 644 nginx nginx
+	postrotate
+		systemctl reload nginx
+	endscript
+}

--- a/src/freenas/etc/systemd/system/nginx.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/nginx.service.d/override.conf
@@ -1,5 +1,0 @@
-[Service]
-# nginx unconditionally opens this file and never closes, preventing us from unmounting system dataset
-ExecStartPre=-rm /var/log/nginx/error.log
-ExecStartPre=-ln -s /dev/null /var/log/nginx/error.log
-ExecStartPre=/usr/sbin/nginx -t -q -g 'daemon on; master_process on;'

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -93,8 +93,8 @@ http {
     server_tokens off;
 
     gzip  on;
-    access_log off;
-    error_log syslog:server=unix:/dev/log,nohostname;
+    access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
+    error_log /var/log/nginx/error.log;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;


### PR DESCRIPTION
We need to turn back on nginx access and error logs. This is required by DODin requirements. access.log is a bit chatty so it buffers to 32K or flushes every 5 seconds.