### PR TITLE
NAS-137319 / 26.04 / Make `update.status` return `NETWORK_ACTIVITY_DISABLED` when network activity is disabled

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/update.py
+++ b/src/middlewared/middlewared/api/v25_10_0/update.py
@@ -101,11 +101,12 @@ class UpdateDownloadProgress(BaseModel):
 
 
 class UpdateStatus(BaseModel):
-    code: Literal['NORMAL', 'ERROR', 'REBOOT_REQUIRED', 'HA_UNAVAILABLE']
+    code: Literal['NORMAL', 'ERROR', 'NETWORK_ACTIVITY_DISABLED', 'REBOOT_REQUIRED', 'HA_UNAVAILABLE']
     """
     Status code:
     * NORMAL - normal status, see `status` dictionary for details.
     * ERROR - an error occurred, see `error` for details.
+    * NETWORK_ACTIVITY_DISABLED - network activity is disabled, see `error` for details.
     * REBOOT_REQUIRED - system update was already applied, system reboot is required.
     * HA_UNAVAILABLE - HA is configured but currently unavailable.
     """

--- a/src/middlewared/middlewared/api/v26_04_0/update.py
+++ b/src/middlewared/middlewared/api/v26_04_0/update.py
@@ -101,11 +101,12 @@ class UpdateDownloadProgress(BaseModel):
 
 
 class UpdateStatus(BaseModel):
-    code: Literal['NORMAL', 'ERROR', 'REBOOT_REQUIRED', 'HA_UNAVAILABLE']
+    code: Literal['NORMAL', 'ERROR', 'NETWORK_ACTIVITY_DISABLED', 'REBOOT_REQUIRED', 'HA_UNAVAILABLE']
     """
     Status code:
     * NORMAL - normal status, see `status` dictionary for details.
     * ERROR - an error occurred, see `error` for details.
+    * NETWORK_ACTIVITY_DISABLED - network activity is disabled, see `error` for details.
     * REBOOT_REQUIRED - system update was already applied, system reboot is required.
     * HA_UNAVAILABLE - HA is configured but currently unavailable.
     """

--- a/src/middlewared/middlewared/plugins/mail_/gmail.py
+++ b/src/middlewared/middlewared/plugins/mail_/gmail.py
@@ -9,8 +9,7 @@ import google_auth_httplib2
 import httplib2
 
 from middlewared.alert.base import Alert, AlertClass, AlertCategory, AlertLevel, OneShotAlertClass
-from middlewared.plugins.mail import DenyNetworkActivity
-from middlewared.service import CallError, private, Service
+from middlewared.service import private, Service
 
 
 class GMailConfigurationDiscardedAlertClass(AlertClass, OneShotAlertClass):
@@ -87,10 +86,7 @@ class MailService(Service):
 
     @private
     def gmail_send(self, message, config, _retry_broken_pipe=True):
-        try:
-            self.middleware.call_sync('network.general.will_perform_activity', 'mail')
-        except CallError:
-            raise DenyNetworkActivity()
+        self.middleware.call_sync('network.general.will_perform_activity', 'mail')
 
         gmail_service = self.middleware.call_sync("mail.gmail_build_service", config)
         if gmail_service == self.gmail_service:

--- a/src/middlewared/middlewared/plugins/network_/activity.py
+++ b/src/middlewared/middlewared/plugins/network_/activity.py
@@ -3,7 +3,7 @@ import logging
 
 from middlewared.api import api_method
 from middlewared.api.current import NetworkConfigurationActivityChoicesArgs, NetworkConfigurationActivityChoicesResult
-from middlewared.service import CallError, private, Service
+from middlewared.service import NetworkActivityDisabled, private, Service
 
 logger = logging.getLogger(__name__)
 
@@ -55,4 +55,4 @@ class NetworkGeneralService(Service):
     @private
     async def will_perform_activity(self, name):
         if not await self.middleware.call('network.general.can_perform_activity', name):
-            raise CallError(f'Network activity "{self.activities[name]}" is disabled')
+            raise NetworkActivityDisabled(f'Network activity "{self.activities[name]}" is disabled')

--- a/src/middlewared/middlewared/plugins/update_/status.py
+++ b/src/middlewared/middlewared/plugins/update_/status.py
@@ -1,6 +1,6 @@
 from middlewared.api import api_method, Event
 from middlewared.api.current import UpdateStatusArgs, UpdateStatusResult, UpdateStatusChangedEvent
-from middlewared.service import private, Service
+from middlewared.service import NetworkActivityDisabled, private, Service
 
 
 class UpdateService(Service):
@@ -80,6 +80,10 @@ class UpdateService(Service):
                     'new_version': new_version,
                 },
                 'update_download_progress': self.update_download_progress,
+            })
+        except NetworkActivityDisabled as e:
+            return self._result('NETWORK_ACTIVITY_DISABLED', {
+                'error': repr(e),
             })
         except Exception as e:
             self.logger.exception('Failed to get update status')

--- a/src/middlewared/middlewared/service/__init__.py
+++ b/src/middlewared/middlewared/service/__init__.py
@@ -1,5 +1,5 @@
 from middlewared.service_exception import ( # noqa
-    CallException, CallError, InstanceNotFound, ValidationError, ValidationErrors
+    CallException, CallError, InstanceNotFound, NetworkActivityDisabled, ValidationError, ValidationErrors
 )
 from middlewared.utils import filter_list # noqa
 

--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -121,3 +121,7 @@ class InstanceNotFound(ValidationError):
 class MatchNotFound(IndexError):
     """Raised when there is no matching id eg: filter_utils/datastore.query"""
     pass
+
+
+class NetworkActivityDisabled(CallError):
+    pass


### PR DESCRIPTION
While I am here, make `NetworkActivityDisabled` a separate exception and replace `DenyNetworkActivity` in `mail` plugin, which was created for the same purpose.