### PR TITLE
add nginx logrotate file to fix build

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -9,6 +9,7 @@ for file in \
     /usr/share/spice-html5/spice_auto.html \
     /usr/share/spice-html5/spice.css \
     /etc/logrotate.d/netdata \
+    /etc/logrotate.d/nginx \
     /usr/lib/tmpfiles.d/nut-server.conf \
     /usr/lib/tmpfiles.d/nut-client.conf \
     /usr/lib/tmpfiles.d/nut-common.tmpfiles


### PR DESCRIPTION
Build is failing with error
```
Unpacking nginx-common (1.22.1-9+deb12u2) ...
dpkg: error processing archive /tmp/apt-dpkg-install-IeK9P5/358-nginx-common_1.22.1-9+deb12u2_all.deb (--unpack):
 trying to overwrite '/etc/logrotate.d/nginx', which is also in package truenas-files 20250827032320~truenas+1
 ```