### PR TITLE
NAS-137325 / 26.04 / use upstream nginx logrotate.d file

### DIFF
--- a/src/freenas/etc/logrotate.d/nginx
+++ b/src/freenas/etc/logrotate.d/nginx
@@ -1,13 +1,18 @@
-/var/log/nginx/*.log
-{
+/var/log/nginx/*.log {
+	missingok
 	rotate 5
 	size 5M
-	missingok
-	notifempty
 	compress
 	delaycompress
-	create 644 nginx nginx
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
 	postrotate
-		systemctl reload nginx
+		invoke-rc.d nginx rotate >/dev/null 2>&1
 	endscript
 }


### PR DESCRIPTION
This uses the upstream provided nginx log rotate file with just a couple modifications (size and rotate). This more closely aligns us with what upstream debian ships.