### PR TITLE
NAS-137318 / 25.10-RC.1 / Use SSL RNG to generate sensitive IDs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/base/server/app.py
+++ b/src/middlewared/middlewared/api/base/server/app.py
@@ -1,7 +1,7 @@
 import logging
-import uuid
 
 from middlewared.auth import SessionManagerCredentials, AuthenticationContext
+from middlewared.utils.crypto import ssl_uuid4
 from middlewared.utils.origin import ConnectionOrigin
 
 logger = logging.getLogger(__name__)
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class App:
     def __init__(self, origin: ConnectionOrigin):
         self.origin = origin
-        self.session_id = str(uuid.uuid4())
+        self.session_id = str(ssl_uuid4())
         self.authenticated = False
         self.authentication_context: AuthenticationContext = AuthenticationContext()
         self.authenticated_credentials: SessionManagerCredentials | None = None

--- a/src/middlewared/middlewared/api/v25_10_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_10_0/auth.py
@@ -26,6 +26,8 @@ class BaseCredentialData(BaseModel):
 class UserCredentialData(BaseCredentialData):
     username: str
     """Username of the authenticated user."""
+    login_id: str
+    """ Unique identifier for the login. """
     login_at: datetime
     """Timestamp of when the user logged in."""
 
@@ -45,6 +47,8 @@ class APIKeyCredentialData(UserCredentialData):
 class TokenCredentialData(BaseCredentialData):
     parent: 'TokenParentCredentialsData'
     """Parent credential information that generated this token."""
+    login_id: str
+    """ Unique identifier for the login. """
     username: str | None
     """Username associated with the token. `null` if not user-specific."""
 

--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -8,7 +8,6 @@ import struct
 import termios
 import threading
 import time
-import uuid
 
 from middlewared.api.base.server.ws_handler.base import BaseWebSocketHandler
 from middlewared.service_exception import (
@@ -17,6 +16,7 @@ from middlewared.service_exception import (
     InstanceNotFound,
     MatchNotFound,
 )
+from middlewared.utils.crypto import ssl_uuid4
 from middlewared.utils.os import close_fds, terminate_pid
 from truenas_api_client import json
 
@@ -224,7 +224,7 @@ class ShellApplication:
             return ws
 
         conndata = ShellConnectionData()
-        conndata.id = str(uuid.uuid4())
+        conndata.id = str(ssl_uuid4())
 
         try:
             await self.run(ws, origin, conndata)

--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -12,6 +12,7 @@ from middlewared.utils.account.authenticator import (
 )
 from middlewared.utils.origin import ConnectionOrigin
 from middlewared.utils.auth import AuthMech, AuthenticatorAssuranceLevel
+from middlewared.utils.crypto import ssl_uuid4
 from time import monotonic
 
 
@@ -19,6 +20,7 @@ class SessionManagerCredentials:
     is_user_session = False
     may_create_auth_token = True
     allowlist = None
+    login_id = None
 
     @classmethod
     def class_name(cls):
@@ -91,6 +93,7 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
     def login(self, session_id: str) -> TrueNASAuthenticatorResponse:
         resp = self.authenticator.login(session_id)
         self.login_at = self.authenticator.login_at
+        self.login_id = str(ssl_uuid4())
         return resp
 
     def logout(self) -> TrueNASAuthenticatorResponse:
@@ -126,6 +129,7 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
     def dump(self):
         return {
             "username": self.user["username"],
+            "login_id": self.login_id,
             "login_at": self.login_at
         }
 
@@ -264,6 +268,7 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
     def login(self, session_id: str) -> TrueNASAuthenticatorResponse:
         resp = self.authenticator.login(session_id)
         self.login_at = self.authenticator.login_at
+        self.login_id = str(ssl_uuid4())
         return resp
 
     def logout(self) -> TrueNASAuthenticatorResponse:
@@ -275,6 +280,7 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
     def dump(self):
         data = {
             "parent": dump_credentials(self.token.parent_credentials),
+            "login_id": self.login_id,
             "username": None
         }
         if self.is_user_session:

--- a/src/middlewared/middlewared/plugins/kmip/connection.py
+++ b/src/middlewared/middlewared/plugins/kmip/connection.py
@@ -5,13 +5,13 @@
 
 import contextlib
 import socket
-import uuid
 
 from kmip.core import enums
 from kmip.pie.client import ProxyKmipClient
 from kmip.pie.exceptions import ClientConnectionFailure, ClientConnectionNotOpen, KmipOperationFailure
 from kmip.pie.objects import SecretData
 
+from middlewared.utils.crypto import ssl_uuid4
 from middlewared.service import CallError
 
 
@@ -88,7 +88,7 @@ class KMIPServerMixin:
 
     def _register_secret_data(self, name, key, conn):
         # Create key on the KMIP Server
-        secret_data = SecretData(key.encode(), enums.SecretDataType.PASSWORD, name=f'{name}-{str(uuid.uuid4())[:7]}')
+        secret_data = SecretData(key.encode(), enums.SecretDataType.PASSWORD, name=f'{name}-{str(ssl_uuid4())[:7]}')
         try:
             uid = conn.register(secret_data)
         except KmipOperationFailure as e:

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -1,7 +1,6 @@
 import asyncio
 import errno
 import logging
-import uuid
 from urllib.parse import urlencode
 
 from truenas_connect_utils.status import Status
@@ -11,6 +10,7 @@ from middlewared.api import api_method
 from middlewared.api.current import (
     TrueNASConnectGetRegistrationUriArgs, TrueNASConnectGetRegistrationUriResult, TrueNASConnectGenerateClaimTokenArgs, TrueNASConnectGenerateClaimTokenResult,
 )
+from middlewared.utils.crypto import ssl_uuid4
 from middlewared.service import CallError, Service
 
 from .utils import CLAIM_TOKEN_CACHE_KEY
@@ -43,7 +43,7 @@ class TrueNASConnectService(Service):
                 errno=errno.EEXIST,
             )
 
-        claim_token = str(uuid.uuid4())
+        claim_token = str(ssl_uuid4())
         # Claim token is going to be valid for 45 minutes
         await self.middleware.call('cache.put', CLAIM_TOKEN_CACHE_KEY, claim_token, 45 * 60)
         await self.middleware.call('tn_connect.set_status', Status.REGISTRATION_FINALIZATION_WAITING.name)

--- a/tests/api2/test_audit_audit.py
+++ b/tests/api2/test_audit_audit.py
@@ -44,7 +44,7 @@ def test_audit_config_audit(payload, success):
             'protocol': 'WEBSOCKET',
             'credentials': {
                 'credentials': 'LOGIN_PASSWORD',
-                'credentials_data': {'username': 'root', 'login_at': ANY},
+                'credentials_data': {'username': 'root', 'login_at': ANY, "login_id": ANY},
             },
         },
         'event': 'METHOD_CALL',

--- a/tests/api2/test_audit_rest.py
+++ b/tests/api2/test_audit_rest.py
@@ -74,14 +74,14 @@ def test_authenticated_call():
                     "protocol": "REST",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "AUTHENTICATION",
                 "event_data": {
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                     "error": None,
                 },
@@ -97,7 +97,7 @@ def test_authenticated_call():
                     "protocol": "REST",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -152,7 +152,7 @@ def test_unauthorized_call():
                     "protocol": "REST",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": ANY, "login_at": ANY},
+                        "credentials_data": {"username": ANY, "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -187,7 +187,7 @@ def test_bogus_call():
                 "protocol": "REST",
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
             },
             "event": "METHOD_CALL",
@@ -221,6 +221,7 @@ def test_api_key_auth():
                         "credentials_data": {
                             "username": "root",
                             "login_at": ANY,
+                            "login_id": ANY,
                             "api_key": {
                                 "id": ANY,
                                 "name": "RESTAUTH",
@@ -235,6 +236,7 @@ def test_api_key_auth():
                         "credentials_data": {
                             "username": "root",
                             "login_at": ANY,
+                            "login_id": ANY,
                             "api_key": {
                                 "id": ANY,
                                 "name": "RESTAUTH",

--- a/tests/api2/test_audit_websocket.py
+++ b/tests/api2/test_audit_websocket.py
@@ -78,7 +78,7 @@ def test_unauthorized_call():
                     "protocol": "WEBSOCKET",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": ANY, "login_at": ANY},
+                        "credentials_data": {"username": ANY, "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -109,7 +109,7 @@ def test_bogus_call():
                     "protocol": "WEBSOCKET",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -140,7 +140,7 @@ def test_invalid_call():
                     "protocol": "WEBSOCKET",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -171,7 +171,7 @@ def test_typo_in_secret_credential_name():
                     "protocol": "WEBSOCKET",
                     "credentials": {
                         "credentials": "LOGIN_PASSWORD",
-                        "credentials_data": {"username": "root", "login_at": ANY},
+                        "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                     },
                 },
                 "event": "METHOD_CALL",
@@ -201,7 +201,7 @@ def test_valid_call():
                 "protocol": "WEBSOCKET",
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
             },
             "event": "METHOD_CALL",
@@ -245,14 +245,14 @@ def test_password_login():
                 "protocol": "WEBSOCKET",
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
             },
             "event": "AUTHENTICATION",
             "event_data": {
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
                 "error": None,
             },
@@ -268,14 +268,14 @@ def test_password_login():
                 "protocol": "WEBSOCKET",
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
             },
             "event": "LOGOUT",
             "event_data": {
                 "credentials": {
                     "credentials": "LOGIN_PASSWORD",
-                    "credentials_data": {"username": "root", "login_at": ANY},
+                    "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                 },
             },
             "success": True,
@@ -316,8 +316,9 @@ def test_token_login():
                         "credentials_data": {
                             "parent": {
                                 "credentials": "LOGIN_PASSWORD",
-                                "credentials_data": {"username": "root", "login_at": ANY},
+                                "credentials_data": {"username": "root", "login_at": ANY, "login_id": ANY},
                             },
+                            "token_id": ANY,
                             "username": "root",
                         },
                     },
@@ -381,6 +382,7 @@ def test_api_key_login():
                             "credentials_data": {
                                 "username": "root",
                                 "login_at": ANY,
+                                "login_id": ANY,
                                 "api_key": {"id": ANY, "name": ANY},
                             },
                         },
@@ -463,6 +465,7 @@ def test_2fa_login(sharing_admin_user):
                             "credentials_data": {
                                 "username": sharing_admin_user.username,
                                 "login_at": ANY,
+                                "login_id": ANY,
                             },
                         },
                         "error": None,

--- a/tests/api2/test_job_credentials.py
+++ b/tests/api2/test_job_credentials.py
@@ -17,7 +17,12 @@ def test_job_credentials():
 
             job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
 
-            assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": c.username, "login_at": ANY}}
+            expected_creds = {
+                "type": "LOGIN_PASSWORD",
+                "data": {"username": c.username, "login_at": ANY, "login_id": ANY}
+            }
+
+            assert job["credentials"] == expected_creds
 
 
 def test_job_configservice_credentials():


### PR DESCRIPTION
This commit switches middleware to using SSL to generate the random bytes needed for uuids that are used for session IDs or other security-adjacent areas. Middleware is also slightly adjusted so that we generate a unique per-login uuid as well to differentiate between logins on the same websocket connection.

Original PR: https://github.com/truenas/middleware/pull/17074
