### PR TITLE
NAS-121593 / 26.04 / Add logic for renewing DNS entries

### DIFF
--- a/src/middlewared/middlewared/alert/source/directory_services.py
+++ b/src/middlewared/middlewared/alert/source/directory_services.py
@@ -1,3 +1,4 @@
+import errno
 from datetime import timedelta
 from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource
 from middlewared.alert.schedule import IntervalSchedule
@@ -5,12 +6,20 @@ from middlewared.utils.directoryservices.constants import DSStatus
 from middlewared.utils.directoryservices.health import (
     DSHealthObj, ADHealthError, IPAHealthError, KRB5HealthError, LDAPHealthError,
 )
+from middlewared.service_exception import CallError
 
 
 class DirectoryServiceBindAlertClass(AlertClass):
     category = AlertCategory.DIRECTORY_SERVICE
     level = AlertLevel.WARNING
     title = "DirectoryService Bind Is Not Healthy"
+    text = "%(err)s."
+
+
+class DirectoryServiceDnsUpdateAlertClass(AlertClass):
+    category = AlertCategory.DIRECTORY_SERVICE
+    level = AlertLevel.WARNING
+    title = "DirectoryService DNS Update Failed"
     text = "%(err)s."
 
 
@@ -39,3 +48,50 @@ class DirectoryServiceDomainBindAlertSource(AlertSource):
         except Exception:
             # We shouldn't be raising other sorts of errors
             self.logger.error("Unexpected error while performing health check.", exc_info=True)
+
+
+class DirectoryServiceDnsUpdateAlertSource(AlertSource):
+    # The DNS updates are potentially going to happen every 7 days, but we check whether it's
+    # needed more frequently. The reason for this is that users get a bit antsy if there's a
+    # long-lived alert. The actual test itself (directoryservices.connection.refresh_dns) is not
+    # expensive (a few datastore queries and reading a state file) and so once-per-hour isn't
+    # going to generate excessive load.
+    schedule = IntervalSchedule(timedelta(hours=1))
+    run_on_backup_node = False
+
+    async def check(self):
+        if DSHealthObj.dstype is None:
+            return
+
+        try:
+            # checks for enabled DS and whether DNS updates are enabled occur in this method
+            await self.middleware.call('directoryservices.connection.refresh_dns')
+        except RuntimeError as exc:
+            # This most likely means somehow someone has cleared the kerberos realm without
+            # disabling directory services. Most likely scenario is playing around with datastore
+            # plugin or sqlite3 commands.
+            self.middleware.logger.warning('Periodic DNS update failed due to misconfiguration.', exc_info=True)
+            return Alert(DirectoryServiceDnsUpdateAlertClass, {'err', str(exc)}, key=None)
+        except FileNotFoundError:
+            # This happens if the system dataset is not mounted. We'll log an error but not
+            # raise an alert because there are probably many other things hollering about the
+            # broken sytsem dataset.
+            self.middleware.logger.warning('Periodic DNS update failed due to broken system dataset.', exc_info=True)
+        except CallError as exc:
+            self.middleware.logger.warning('Periodic DNS update failed.', exc_info=True)
+
+            if exc.errno == errno.ENOKEY:
+                # No kerberos ticket
+                errmsg = (
+                    'Unable to perform DNS update because no kerberos ticket is available. '
+                    'See the DirectoryServiceBindAlert for more information. This alert will clear itself during the '
+                    'next check after directory services are healthy again.'
+                )
+            else:
+                errmsg = exc.errmsg
+
+            return Alert(DirectoryServiceDnsUpdateAlertClass, {'err', errmsg}, key=None)
+        except Exception as exc:
+            # If needed we can enhance this in the future to parse CallError
+            self.middleware.logger.warning('Periodic DNS update failed.', exc_info=True)
+            return Alert(DirectoryServiceDnsUpdateAlertClass, {'err', str(exc)}, key=None)

--- a/src/middlewared/middlewared/alert/source/directory_services.py
+++ b/src/middlewared/middlewared/alert/source/directory_services.py
@@ -65,7 +65,7 @@ class DirectoryServiceDnsUpdateAlertSource(AlertSource):
 
         try:
             # checks for enabled DS and whether DNS updates are enabled occur in this method
-            await self.middleware.call('directoryservices.connection.refresh_dns')
+            await self.middleware.call('directoryservices.connection.renew_dns')
         except RuntimeError as exc:
             # This most likely means somehow someone has cleared the kerberos realm without
             # disabling directory services. Most likely scenario is playing around with datastore

--- a/src/middlewared/middlewared/utils/directoryservices/constants.py
+++ b/src/middlewared/middlewared/utils/directoryservices/constants.py
@@ -1,4 +1,9 @@
 import enum
+import os
+
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
+
+DS_HA_STATE_DIR = os.path.join(SYSDATASET_PATH, "directory_services")
 
 
 class DSStatus(enum.StrEnum):

--- a/src/middlewared/middlewared/utils/directoryservices/dns.py
+++ b/src/middlewared/middlewared/utils/directoryservices/dns.py
@@ -1,0 +1,87 @@
+import os
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+from threading import Lock
+from middlewared.utils.io import write_if_changed
+from middlewared.utils.time_utils import utc_now
+from truenas_api_client import ejson as json
+from .constants import DS_HA_STATE_DIR
+
+
+DS_DNS_STATE_FILE = os.path.join(DS_HA_STATE_DIR, '.nsupdate_state.json')
+# When DNS scavenging is enabled in AD, the default refresh interval in AD DNS is 7 days.
+# Then after an additional 7 days by default (the 14 day mark) the DC will remove the record.
+DEFAULT_RECORD_EXPIRY = timedelta(days=7)
+NSUPDATE_LOCK = Lock()
+NSUPDATE_STATE_VERSION = 1
+
+
+@dataclass()
+class NSUpdateState:
+    fqdn: str
+    expiry: datetime
+    version: int
+
+
+def __get_nsupdate_state(fqdn: str) -> NSUpdateState | None:
+    try:
+        with open(DS_DNS_STATE_FILE, 'r') as f:
+            data = NSUpdateState(**json.loads(f.read()))
+    except FileNotFoundError:
+        # File doesn't exist, ergo no state
+        return None
+    except JSONDecodeError:
+        # File for some reason has invalid JSON. Nothing we can do about this other than treat as having no state.
+        return None
+    except TypeError:
+        # Contents of file does not match the expected schema. This most likely means we updated and the schema changed.
+        # It should be safe to discard the info and require a renewal
+        return None
+
+    # Make sure data version and types are correct.
+    if data.version != NSUPDATE_STATE_VERSION:
+        return None
+
+    elif not isinstance(data.fqdn, str):
+        return None
+
+    elif not isinstance(data.expiry, datetime):
+        return None
+
+    elif data.fqdn.casefold() != fqdn.casefold():
+        return None
+
+    return data
+
+
+def remove_dns_record_state() -> None:
+    """ Remove the state file from the state directory. NSUPDATE_LOCK must be held. """
+    try:
+        os.unlink(DS_DNS_STATE_FILE)
+    except FileNotFoundError:
+        pass
+
+
+def dns_record_is_expired(fqdn: str) -> bool:
+    """ Check whether our state is expired. NSUPDATE_LOCK must be held. """
+    if not isinstance(fqdn, str):
+        raise ValueError(f'{type(fqdn)}: unexpected type for host when checking DNS record expiration')
+
+    if (data := __get_nsupdate_state(fqdn)) is None:
+        # Either no nsupdate data or invalid data
+        return True
+
+    now = utc_now(False)
+    return now > data.expiry
+
+
+def update_dns_record_state(fqdn: str, expiry_time_delta: timedelta = DEFAULT_RECORD_EXPIRY) -> None:
+    """ Update our state. NSUPDATE_LOCK must be held. """
+    if not isinstance(fqdn, str):
+        raise ValueError(f'{type(fqdn)}: unexpected type for host when updating DNS record state.')
+
+    expiry = utc_now(False) + expiry_time_delta
+    data = NSUpdateState(fqdn=fqdn, expiry=expiry, version=NSUPDATE_STATE_VERSION)
+    write_if_changed(DS_DNS_STATE_FILE, json.dumps(asdict(data)))

--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -67,7 +67,7 @@ class ADHealthError(DirectoryServiceHealthError):
 
 
 class LDAPHealthError(DirectoryServiceHealthError):
-    reasons = ADHealthCheckFailReason
+    reasons = LDAPHealthCheckFailReason
 
 
 class DirectoryServiceHealth:


### PR DESCRIPTION
This commit adds logic for automatically renewing DNS entries when the administrator has configured TrueNAS to do such. This is required for some AD environments where the system administrator has configured AD to automatically scavenge records that haven't been updated for a while.

This commit also introduces a threading lock NSUPDATE_LOCK that is held whenever middleware registers / deregisters / renews DNS entries for directory services.