### PR TITLE
NAS-136353 / 25.10-RC.1 / add more security headers to nginx.conf (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -98,11 +98,13 @@ http {
 % endif
 
     gzip  on;
+% if fips_enabled:
     # Disable gzip for responses with cookies (BREACH attack mitigation)
     # NOTE: will be controlled per-response based on Set-Cookie header
     gzip_vary on;
     gzip_proxied any;
     gzip_disable "msie6";
+% endif
 
     access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
     error_log /var/log/nginx/error.log;


### PR DESCRIPTION
Added for general best practices but also to appease the DoDIN requirements.

While I'm here, I fixed the formatting so the security header entries are indented underneath the {} blocks and line up with everything else.

Original PR: https://github.com/truenas/middleware/pull/17089
