### PR TITLE
Improve exports.d handling in nfs exports mako

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -138,43 +138,62 @@
         return
 
     def disable_exportsd():
-        immutable_disabled = False
+
+        rv = True
 
         with suppress(FileExistsError):
             os.mkdir('/etc/exports.d', mode=0o755)
 
-        for file in os.listdir('/etc/exports.d'):
-            if not immutable_disabled:
-                middleware.call_sync('filesystem.set_zfs_attributes', {
-                    'path': '/etc/exports.d',
-                    'zfs_file_attributes': {'immutable': False}
-                })
-                immutable_disabled = True
+        if 'IMMUTABLE' not in middleware.call_sync('filesystem.stat', '/etc/exports.d')['attributes']:
+            middleware.logger.warning('/etc/exports.d: Found in mutable state, expected immutable.')
+            exportsd_is_mutable = True
 
-            if file == 'zfs.exports':
+        # The directory /etc/exports.d should be immutable.
+        # If the directory contains files, then we need to delete those files
+        # and restore immutable state
+        files_in_exportsd = os.listdir('/etc/exports.d')
+        if len(files_in_exportsd) > 0:
+            middleware.logger.error('Files found in /etc/exports.d: %s', str(files_in_exportsd))
+
+            # Temporary remove immutable to allow file deletion
+            middleware.call_sync('filesystem.set_zfs_attributes', {
+                'path': '/etc/exports.d',
+                'zfs_file_attributes': {'immutable': False}
+            })
+
+        # Remove all files in /etc/exports.d
+        for file in files_in_exportsd:
+
+            if file.startswith('zfs.exports'):
                 middleware.logger.warning("Disabling sharenfs ZFS property on datasets")
                 disable_sharenfs()
             else:
-                middleware.logger.warning("%s: unexpected file found in exports.d", file)
+                middleware.logger.warning("%s: Unexpected file found in exports.d", file)
 
             try:
+                middleware.logger.warning("Removing unexpected file found in exports.d: %s", file)
                 os.remove(os.path.join('/etc/exports.d', file))
             except Exception:
-                middleware.logger.warning(
-                    "%s: failed to remove unexpected file in exports.d",
+                middleware.logger.error(
+                    "%s: Failed to remove unexpected file in exports.d",
                     file, exc_info=True
                 )
-                return False
 
-        if not immutable_disabled:
-            if 'IMMUTABLE' in middleware.call_sync('filesystem.stat', '/etc/exports.d')['attributes']:
-                return True
+                # Block NFS start if we fail to cleanup /etc/exports.d
+                rv = False
 
+
+        # _Always_ exit with /etc/exports.d in immutable state
         middleware.call_sync('filesystem.set_zfs_attributes', {
             'path': '/etc/exports.d',
             'zfs_file_attributes': {'immutable': True}
         })
-        return True
+
+        # Confirmation
+        if 'IMMUTABLE' not in middleware.call_sync('filesystem.stat', '/etc/exports.d')['attributes']:
+            rv = False
+
+        return rv
 
     entries = []
     gaierrors = []


### PR DESCRIPTION
We don't allow any files in `/etc/exports.d`.  This includes files associated with `zfs.exports`.
We block NFS start if there are files in `/etc/exports.d` that are not properly cleaned up.

The code handing this is too rigid and does not properly handle files like `zfs.exports.lock`

This PR fixes that.
Update management of exports.d, expand special file trap to include zfs.exports.lock.

Change processing to be more resilient.
Return failure and block NFS _only if_ failed to remove files or restore immutable state.

Passes with multiple CI API runs.
See console output for `test_300_nfs.py`:  [#5717](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5717/console), [#5718](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5718/console), [#5719](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5719/consoleFull), [#5721](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5721/console)