### PR TITLE
NAS-137297 / 25.10-RC.1 / Improve exports.d handling in nfs exports mako (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -146,7 +146,6 @@
 
         if 'IMMUTABLE' not in middleware.call_sync('filesystem.stat', '/etc/exports.d')['attributes']:
             middleware.logger.warning('/etc/exports.d: Found in mutable state, expected immutable.')
-            exportsd_is_mutable = True
 
         # The directory /etc/exports.d should be immutable.
         # If the directory contains files, then we need to delete those files


### PR DESCRIPTION
We don't allow any files in `/etc/exports.d`.  This includes files associated with `zfs.exports`.
We block NFS start if there are files in `/etc/exports.d` that are not properly cleaned up.

The code handing this is too rigid and does not properly handle files like `zfs.exports.lock`

This PR fixes that.
Update management of exports.d, expand special file trap to include zfs.exports.lock.

Change processing to be more resilient.
Return failure and block NFS _only if_ failed to remove files or restore immutable state.

Passes with multiple CI API runs.
See console output for `test_300_nfs.py`:  [#5717](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5717/console), [#5718](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5718/console), [#5719](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5719/consoleFull), [#5721](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5721/console)

Original PR: https://github.com/truenas/middleware/pull/17093
