### PR TITLE
NAS-137266 / 25.10-RC.1 / Make sure create paths properly get executed (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -506,22 +506,22 @@ class SystemDatasetService(ConfigService):
                         {'properties': update_props_dict},
                     )
 
-            try:
-                await self.middleware.run_in_thread(self.__create_relevant_paths, config.get('create_paths', []))
-            except Exception:
-                self.logger.error('Failed to create relevant paths for %r', dataset, exc_info=True)
-
-    def __create_relevant_paths(self, create_paths):
+    def __create_relevant_paths(self, ds_name, create_paths):
         for create_path_config in create_paths:
-            os.makedirs(create_path_config['path'], exist_ok=True)
-            cpath_stat = os.stat(create_path_config['path'])
-            if all(create_path_config[k] for k in ('uid', 'gid')) and (
-                cpath_stat.st_uid != create_path_config['uid'] or cpath_stat.st_gid != create_path_config['gid']
-            ):
-                os.chown(create_path_config['path'], create_path_config['uid'], create_path_config['gid'])
+            try:
+                os.makedirs(create_path_config['path'], exist_ok=True)
+                cpath_stat = os.stat(create_path_config['path'])
+                if all(create_path_config[k] for k in ('uid', 'gid')) and (
+                    cpath_stat.st_uid != create_path_config['uid'] or cpath_stat.st_gid != create_path_config['gid']
+                ):
+                    os.chown(create_path_config['path'], create_path_config['uid'], create_path_config['gid'])
 
-            if (mode := create_path_config.get('mode')) and (cpath_stat.st_mode & 0o777) != mode:
-                os.chmod(create_path_config['path'], mode)
+                if (mode := create_path_config.get('mode')) and (cpath_stat.st_mode & 0o777) != mode:
+                    os.chmod(create_path_config['path'], mode)
+            except Exception:
+                self.logger.exception(
+                    'Failed to ensure %r path for %r dataset', create_path_config['path'], ds_name,
+                )
 
     def __mount(self, pool, uuid, path=SYSDATASET_PATH):
         """
@@ -553,6 +553,7 @@ class SystemDatasetService(ConfigService):
 
             mounted = True
             if path == SYSDATASET_PATH:
+                self.__create_relevant_paths(ds_config['name'], ds_config.get('create_paths', []))
                 self.__post_mount_actions(ds_config['name'], ds_config.get('post_mount_actions', []))
 
         if mounted and path == SYSDATASET_PATH:


### PR DESCRIPTION
## Problem

`create_paths` in system dataset spec definition is applied EACH time system dataset setup is executed. The problem happens when a new sub-dataset is defined in system dataset setup and it has `create_paths` defined, by default these datasets have legacy mountpoint set. Which means if the create paths refer to a path on the just created dataset, that would get created on the _parent_ dataset instead of the actual dataset because the dataset which was created just right now had not been mounted.

## Solution

Make sure that we execute create relevant paths endpoint when the dataset in question has already mounted.
One of the key changes here apart from having it execute once the dataset is already mounted is that this will not be executed if the dataset in question is already mounted. Earlier in `setup_datasets` func, it gets called regardless and it always runs create paths function.

We could optionally also run this even if the dataset is already mounted but it would/should be redundant in that case.

Original PR: https://github.com/truenas/middleware/pull/17057
