### PR TITLE
NAS-137353 / 26.04 / Add nfs.conf stub file to satisfy systemd generated rpc daemon start.

### DIFF
--- a/src/freenas/etc/nfs.conf
+++ b/src/freenas/etc/nfs.conf
@@ -1,0 +1,7 @@
+
+#
+# TrueNAS configuration file for NFS
+#
+[general]
+pipefs-directory = /run/rpc_pipefs
+


### PR DESCRIPTION
### DO NOT BACKPORT
The new `nfs-utils` moved systemd management of the NFS rpc daemon to a 'generated' method.  Generated systemd unit files are managed by a compiled binary.  These are run _very_ early in boot.  The NFS rpc module depends on a setting in `/etc/nfs.conf`.   This file is managed and created by middleware with mako scripts.  It doesn't get created until NFS has been started.  Under this condition, systemd generates the rpc files, but finds no rpc setting which results in no rpc daemon.
This fixes the NFS `test_service_update` failures in `test_300_nfs.py`

**The Fix:**
There are two PRs associated with this fix.  One for `middleware` (this PR) and one for `scale-build`
This PR adds a stub file, `/etc/nfs.conf`  with a single hardcoded setting to enable systemd to generate the proper rpc files.
The `scale-build` PR excludes the file from truenas_verify (mtree).

Passing CI tests [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5736/).