### PR TITLE
add vm.device.convert

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/vm.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm.py
@@ -17,9 +17,9 @@ __all__ = [
     'VMBootloaderOvmfChoicesArgs', 'VMBootloaderOvmfChoicesResult', 'VMBootloaderOptionsArgs',
     'VMBootloaderOptionsResult', 'VMStatusArgs', 'VMStatusResult', 'VMLogFilePathArgs', 'VMLogFilePathResult',
     'VMLogFileDownloadArgs', 'VMLogFileDownloadResult', 'VMGuestArchitectureAndMachineChoicesArgs',
-    'VMGuestArchitectureAndMachineChoicesResult', 'VMCloneArgs', 'VMCloneResult', 'VMImportDiskImageArgs',
-    'VMImportDiskImageResult', 'VMExportDiskImageArgs', 'VMExportDiskImageResult', 'VMSupportsVirtualizationArgs',
-    'VMSupportsVirtualizationResult', 'VMVirtualizationDetailsArgs', 'VMVirtualizationDetailsResult',
+    'VMGuestArchitectureAndMachineChoicesResult', 'VMCloneArgs', 'VMCloneResult',
+    'VMSupportsVirtualizationArgs', 'VMSupportsVirtualizationResult',
+    'VMVirtualizationDetailsArgs', 'VMVirtualizationDetailsResult',
     'VMMaximumSupportedVcpusArgs', 'VMMaximumSupportedVcpusResult', 'VMFlagsArgs', 'VMFlagsResult', 'VMGetConsoleArgs',
     'VMGetConsoleResult', 'VMCpuModelChoicesArgs', 'VMCpuModelChoicesResult', 'VMGetMemoryUsageArgs',
     'VMGetMemoryUsageResult', 'VMPortWizardArgs', 'VMPortWizardResult', 'VMResolutionChoicesArgs',
@@ -247,34 +247,6 @@ class VMCloneArgs(BaseModel):
 class VMCloneResult(BaseModel):
     result: bool
     """Whether the virtual machine was successfully cloned."""
-
-
-@single_argument_args('vm_import_disk_image')
-class VMImportDiskImageArgs(BaseModel):
-    diskimg: NonEmptyString
-    """Path to the disk image file to import."""
-    zvol: NonEmptyString
-    """Target ZFS volume path where the disk image will be imported."""
-
-
-class VMImportDiskImageResult(BaseModel):
-    result: bool
-    """Whether the disk image import operation was successful."""
-
-
-@single_argument_args('vm_export_disk_image')
-class VMExportDiskImageArgs(BaseModel):
-    format: NonEmptyString
-    """Output format for the exported disk image (e.g., 'qcow2', 'raw')."""
-    directory: NonEmptyString
-    """Directory path where the exported disk image will be saved."""
-    zvol: NonEmptyString
-    """Source ZFS volume to export as a disk image."""
-
-
-class VMExportDiskImageResult(BaseModel):
-    result: bool
-    """Whether the disk image export operation was successful."""
 
 
 class VMSupportsVirtualizationArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -21,6 +21,7 @@ __all__ = [
     'VMDeviceUsbPassthroughDeviceArgs', 'VMDeviceUsbPassthroughDeviceResult',
     'VMDeviceUsbPassthroughChoicesArgs', 'VMDeviceUsbPassthroughChoicesResult',
     'VMDeviceUsbControllerChoicesArgs', 'VMDeviceUsbControllerChoicesResult',
+    'VMDeviceConvertArgs', 'VMDeviceConvertResult',
 ]
 
 
@@ -430,3 +431,16 @@ class VMDeviceUsbControllerChoicesArgs(BaseModel):
 class VMDeviceUsbControllerChoicesResult(BaseModel):
     model_config = ConfigDict(extra='allow')
     """Available USB controller types for virtual machines."""
+
+
+@single_argument_args('vm_convert')
+class VMDeviceConvertArgs(BaseModel):
+    source: NonEmptyString
+    """Source path for the conversion (disk image file or ZFS volume)."""
+    destination: NonEmptyString
+    """Destination path for the conversion (disk image file or ZFS volume)."""
+
+
+class VMDeviceConvertResult(BaseModel):
+    result: bool
+    """Whether the conversion operation was successful."""

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -1,26 +1,42 @@
 import copy
+import errno
 import os
 import re
+import subprocess
 
 import middlewared.sqlalchemy as sa
-
 from middlewared.api import api_method
 from middlewared.api.current import (
-    VMDeviceEntry, VMDeviceCreateArgs, VMDeviceCreateResult, VMDeviceUpdateArgs, VMDeviceUpdateResult,
-    VMDeviceDeleteArgs, VMDeviceDeleteResult, VMDeviceDiskChoicesArgs, VMDeviceDiskChoicesResult,
-    VMDeviceIotypeChoicesArgs, VMDeviceIotypeChoicesResult, VMDeviceNicAttachChoicesArgs,
-    VMDeviceNicAttachChoicesResult, VMDeviceBindChoicesArgs, VMDeviceBindChoicesResult,
+    VMDeviceConvertArgs,
+    VMDeviceConvertResult,
+    VMDeviceCreateArgs,
+    VMDeviceCreateResult,
+    VMDeviceEntry,
+    VMDeviceUpdateArgs,
+    VMDeviceUpdateResult,
+    VMDeviceDeleteArgs,
+    VMDeviceDeleteResult,
+    VMDeviceDiskChoicesArgs,
+    VMDeviceDiskChoicesResult,
+    VMDeviceIotypeChoicesArgs,
+    VMDeviceIotypeChoicesResult,
+    VMDeviceNicAttachChoicesArgs,
+    VMDeviceNicAttachChoicesResult,
+    VMDeviceBindChoicesArgs,
+    VMDeviceBindChoicesResult,
 )
-from middlewared.plugins.vm.devices.storage_devices import IOTYPE_CHOICES
-from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
-from middlewared.service import CallError, CRUDService, private
-from middlewared.utils import run
 from middlewared.async_validators import check_path_resides_within_volume
+from middlewared.plugins.zfs.utils import has_internal_path
+from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
+from middlewared.service import CallError, CRUDService, job, private
+from middlewared.service_exception import ValidationError
+from middlewared.utils import run
 
+from .devices.storage_devices import IOTYPE_CHOICES
 from .devices import DEVICES
 from .utils import ACTIVE_STATES
 
-
+VALID_DISK_FORMATS = ('qcow2', 'qed', 'raw', 'vdi', 'vhdx', 'vpc', 'vmdk')
 RE_PPTDEV_NAME = re.compile(r'([0-9]+/){2}[0-9]+')
 
 
@@ -42,6 +58,154 @@ class VMDeviceService(CRUDService):
         cli_namespace = 'service.vm.device'
         role_prefix = 'VM_DEVICE'
         entry = VMDeviceEntry
+
+    @private
+    def run_convert_cmd(self, cmd_args, job, progress_desc):
+        self.logger.info('Running command: %r', cmd_args)
+        progress_pattern = re.compile(r'(\d+\.\d+)')
+        try:
+            with subprocess.Popen(
+                cmd_args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            ) as process:
+                stderr_data = []
+                while True:
+                    output = process.stdout.readline()
+                    if not output and process.poll() is not None:
+                        break
+
+                    if output:
+                        line = output.strip()
+                        progress_match = progress_pattern.search(line)
+                        if progress_match:
+                            try:
+                                progress_value = round(float(progress_match.group(1)))
+                                job.set_progress(progress_value, progress_desc)
+                            except ValueError:
+                                self.logger.warning('Invalid progress value: %r', progress_match.group(1))
+                        else:
+                            self.logger.debug('qemu-img output: %r', line)
+
+                remaining_stderr = process.stderr.read()
+                if remaining_stderr:
+                    stderr_data.append(remaining_stderr.strip())
+
+                return_code = process.wait()
+                if return_code != 0:
+                    stderr_msg = '\n'.join(stderr_data) if stderr_data else 'No error details available'
+                    raise CallError(f'qemu-img convert failed: {stderr_msg}', return_code)
+        except (OSError, subprocess.SubprocessError) as e:
+            raise CallError(f'Failed to execute qemu-img convert: {e}')
+
+    @private
+    def validate_zvol_path(self, zvol_path: str, schema: str) -> str:
+        ptn = zvol_path.removeprefix('/dev/zvol/').replace('+', ' ')
+        ntp = os.path.join('/dev/zvol', ptn.replace(' ', '+'))
+        zv = self.middleware.call_sync('zfs.resource.query_impl', {'paths': [ptn], 'properties': None})
+        if not zv:
+            raise ValidationError(f'{schema}', f'{ptn!r} does not exist', errno.ENOENT)
+        elif not zv[0]['type'] == 'VOLUME':
+            raise ValidationError(f'{schema}', f'{ptn!r} is not a volume', errno.EINVAL)
+        elif has_internal_path(ptn):
+            raise ValidationError(f'{schema}', f'{ptn!r} is in a protected system path', errno.EACCES)
+        elif not os.path.exists(ntp):
+            raise ValidationError(f'{schema}', f'{ntp!r} does not exist', errno.ENOENT)
+        return ntp
+
+    @api_method(
+        VMDeviceConvertArgs,
+        VMDeviceConvertResult,
+        roles=['VM_DEVICE_WRITE']
+    )
+    @job(
+        lock_queue_size=1,
+        lock=lambda args: f"convert_from_{args[-1]['source']}_to_{args[-1]['destination']}"
+    )
+    def convert(self, job, data):
+        """
+        Convert between disk images and ZFS volumes. Supported disk image formats \
+        are qcow2, qed, raw, vdi, vhdx, vpc, and vmdk. The conversion direction is determined \
+        automatically based on file extension.
+        """
+        schema = 'vm.device.convert'
+        # Determine conversion direction
+        source_is_image = data['source'].endswith(VALID_DISK_FORMATS)
+        dest_is_image = data['destination'].endswith(VALID_DISK_FORMATS)
+        if (source_is_image and dest_is_image) or (not source_is_image and not dest_is_image):
+            raise ValidationError(
+                f'{schema}',
+                'One path must be a disk image and the other must be a ZFS volume',
+                errno.EINVAL
+            )
+
+        cmd_args = ['qemu-img', 'convert', '-p']
+        if source_is_image:  # converting disk image to zvol
+            if not os.path.isabs(data['source']):
+                raise ValidationError(
+                    f'{schema}.source',
+                    f'{data["source"]} must be an absolute path',
+                    errno.EINVAL
+                )
+            elif not os.path.exists(data['source']):
+                raise ValidationError(
+                    f'{schema}.source',
+                    f'{data["source"]} does not exist',
+                    errno.ENOENT
+                )
+            elif has_internal_path(data['source']):
+                raise ValidationError(
+                    f'{schema}.source',
+                    f'{data["source"]} is in a protected system path',
+                    errno.EACCES
+                )
+            zvol_path = self.validate_zvol_path(data['destination'], f'{schema}.destination')
+            cmd_args.extend(['-O', 'raw', data["source"], zvol_path])
+            progress_desc = "Convert to zvol progress"
+        else:  # converting zvol to disk image
+            if not os.path.isabs(data['destination']):
+                raise ValidationError(
+                    f'{schema}.destination',
+                    f'{data["destination"]} must be an absolute path',
+                    errno.EINVAL
+                )
+            elif has_internal_path(data['destination']):
+                raise ValidationError(
+                    f'{schema}.destination',
+                    f'{data["destination"]} is in a protected system path',
+                    errno.EACCES
+                )
+            dest_dir = os.path.dirname(data['destination'])
+            if not os.path.isdir(dest_dir):
+                raise ValidationError(
+                    f'{schema}.destination',
+                    f'Export directory {dest_dir!r} is not a directory',
+                    errno.EINVAL
+                )
+            zvol_path = self.validate_zvol_path(data['source'], f'{schema}.source')
+            dest_format = None
+            for fmt in VALID_DISK_FORMATS:
+                if data['destination'].lower().endswith(f'.{fmt}'):
+                    dest_format = fmt
+                    break
+            else:
+                raise ValidationError(
+                    f'{schema}.destination',
+                    f'Destination must have a valid format extension: {", ".join(VALID_DISK_FORMATS)}',
+                    errno.EINVAL
+                )
+
+            cmd_args.extend(['-f', 'raw', '-O', dest_format, zvol_path, data['destination']])
+            progress_desc = "Convert to disk image progress"
+
+        self.run_convert_cmd(cmd_args, job, progress_desc)
+        if not source_is_image:
+            # Get owner/group of parent directory for setting file ownership
+            parent_stat = os.stat(dest_dir)
+            os.chown(data['destination'], parent_stat.st_uid, parent_stat.st_gid)
+
+        return True
 
     @api_method(VMDeviceDiskChoicesArgs, VMDeviceDiskChoicesResult, roles=['VM_DEVICE_READ'])
     async def disk_choices(self):


### PR DESCRIPTION
Add VM disk image conversion functionality. This is a replacement (and an improvement) from a previous [commit](https://github.com/truenas/middleware/pull/13701) that attempted to add similar functionality (but was never utilized). This replaces the separate import/export operations with a unified convert method that supports bidirectional conversion between disk images and ZFS volumes. We automatically detect the direction of the conversion based on the source/destination having the file extension.