### PR TITLE
NAS-137213 / 25.10-RC.1 / Allow configuring vram/vgamem/ram attributes for display devices

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-08-31_16-20_vm_display_vgamem_fix.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-08-31_16-20_vm_display_vgamem_fix.py
@@ -1,0 +1,53 @@
+"""Add nullable QXL memory fields to VM display devices
+
+Revision ID: f0e0a8aacb5d
+Revises: 7767afd88989
+Create Date: 2025-08-31 16:20:00.000000+00:00
+
+"""
+import json
+
+from alembic import op
+
+from middlewared.plugins.pwenc import encrypt, decrypt
+
+
+# revision identifiers, used by Alembic.
+revision = 'f0e0a8aacb5d'
+down_revision = '7767afd88989'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add nullable vgamem, ram, and vram fields to all DISPLAY devices.
+    All fields default to None to use libvirt defaults.
+    """
+    conn = op.get_bind()
+
+    for device in conn.execute("SELECT * FROM vm_device").fetchall():
+        if decrypted := decrypt(device['attributes']):
+            attributes = json.loads(decrypted)
+        else:
+            continue
+
+        if attributes.get('dtype') != 'DISPLAY':
+            continue
+
+        # Add the new nullable fields if they don't exist
+        modified = False
+        for field in ['vgamem', 'ram', 'vram']:
+            if field not in attributes:
+                attributes[field] = None
+                modified = True
+
+        if modified:
+            conn.execute(
+                "UPDATE vm_device SET attributes = ? WHERE id = ?",
+                (encrypt(json.dumps(attributes)), device['id'])
+            )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -54,6 +54,14 @@ class VMDisplayDevice(BaseModel):
     """Whether to enable web-based display access."""
     type_: Literal['SPICE', 'VNC'] = Field(alias='type', default='SPICE')
     """Display protocol type."""
+    vgamem: int | None = Field(default=None, gt=1024)
+    """QXL VGA framebuffer size in KB. If not set, uses libvirt default (16MB).
+    Recommended: 65536 (64MB) for resolutions above 1024x768."""
+    ram: int | None = Field(default=None, gt=0)
+    """QXL primary BAR size in KB. Must be at least 2 * vgamem (QEMU requirement).
+    If not set, uses libvirt default (usually 64MB)."""
+    vram: int | None = Field(default=None, gt=0)
+    """QXL secondary BAR size in KB. If not set, uses libvirt default (usually 64MB)."""
 
 
 class VMNICDevice(BaseModel):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -51,6 +51,16 @@ class DISPLAY(Device):
         # FIXME: Resolution is not respected when we have more then 1 display device as we are not able to bind
         #  video element to a graphic element
         attrs = self.data['attributes']
+
+        # Build QXL model attributes conditionally - only include if explicitly set
+        qxl_attrs = {}
+        if attrs.get('vgamem') is not None:
+            qxl_attrs['vgamem'] = str(attrs['vgamem'])
+        if attrs.get('ram') is not None:
+            qxl_attrs['ram'] = str(attrs['ram'])
+        if attrs.get('vram') is not None:
+            qxl_attrs['vram'] = str(attrs['vram'])
+
         return create_element(
             'graphics', type='spice' if self.is_spice_type() else 'vnc', port=str(self.data['attributes']['port']),
             attribute_dict={
@@ -66,7 +76,7 @@ class DISPLAY(Device):
                     'children': [create_element(
                         'resolution', x=self.resolution().split('x')[0], y=self.resolution().split('x')[-1]
                     )]
-                })
+                }, **qxl_attrs)
             ]
         })
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -55,6 +55,45 @@ def test_cdrom_xml(vm_data, expected_xml):
          '<model type="qxl"><resolution x="1024" y="768" /></model></video><channel type="spicevmc">'
          f'<target type="virtio" name="com.redhat.spice.0" /></channel>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
+        'attributes': {
+            'dtype': 'DISPLAY',
+            'bind': '0.0.0.0',
+            'password': '',
+            'web': True,
+            'type': 'SPICE',
+            'resolution': '1920x1080',
+            'port': 5912,
+            'web_port': 5913,
+            'wait': False,
+            'vgamem': 65536,  # 64MB
+        },
+    }]}, '<devices><graphics type="spice" port="5912"><listen type="address" address="0.0.0.0" /></graphics>'
+         '<controller type="usb" model="nec-xhci" /><input type="tablet" bus="usb" /><video>'
+         '<model type="qxl" vgamem="65536"><resolution x="1920" y="1080" /></model></video><channel type="spicevmc">'
+         f'<target type="virtio" name="com.redhat.spice.0" /></channel>{GUEST_CHANEL}<serial type="pty" /></devices>'
+    ),
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
+        'attributes': {
+            'dtype': 'DISPLAY',
+            'bind': '0.0.0.0',
+            'password': '',
+            'web': True,
+            'type': 'SPICE',
+            'resolution': '1920x1080',
+            'port': 5912,
+            'web_port': 5913,
+            'wait': False,
+            'vgamem': 65536,  # 64MB
+            'ram': 131072,    # 128MB
+            'vram': 131072,   # 128MB
+        },
+    }]}, '<devices><graphics type="spice" port="5912"><listen type="address" address="0.0.0.0" /></graphics>'
+         '<controller type="usb" model="nec-xhci" /><input type="tablet" bus="usb" /><video>'
+         '<model type="qxl" vgamem="65536" ram="131072" vram="131072"><resolution x="1920" y="1080" /></model></video>'
+         f'<channel type="spicevmc"><target type="virtio" name="com.redhat.spice.0" /></channel>{GUEST_CHANEL}'
+         '<serial type="pty" /></devices>'
+    ),
 ])
 def test_display_xml(vm_data, expected_xml):
     m = Middleware()


### PR DESCRIPTION
## Problem

When configuring higher resolutions for display devices, a VM might crash/refuse to start if it does not has enough memory.

## Solutions

Allow configuring `vram/vgamem/ram` attributes for display devices but by default to `null` so we resort to libvirt defaults in that case.