### PR TITLE
NAS-137054 / 26.04 / Improve defaults and validation for secure boot in VMs

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/vm.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm.py
@@ -121,6 +121,8 @@ class VMCreate(VMEntry):
     id: Excluded = excluded_field()
     display_available: Excluded = excluded_field()
     devices: Excluded = excluded_field()
+    bootloader_ovmf: str | None = Field(default=None, examples=['OVMF_CODE.fd', 'OVMF_CODE.secboot.fd'])
+    """OVMF firmware file to use for UEFI boot."""
 
     @field_validator('uuid')
     def validate_uuid(cls, value):
@@ -143,7 +145,8 @@ class VMCreateResult(BaseModel):
 
 
 class VMUpdate(VMCreate, metaclass=ForUpdateMetaclass):
-    pass
+    bootloader_ovmf: Excluded = excluded_field()
+    enable_secure_boot: Excluded = excluded_field()
 
 
 class VMUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v26_04_0/vm.py
+++ b/src/middlewared/middlewared/api/v26_04_0/vm.py
@@ -121,6 +121,8 @@ class VMCreate(VMEntry):
     id: Excluded = excluded_field()
     display_available: Excluded = excluded_field()
     devices: Excluded = excluded_field()
+    bootloader_ovmf: str | None = Field(default=None, examples=['OVMF_CODE.fd', 'OVMF_CODE.secboot.fd'])
+    """OVMF firmware file to use for UEFI boot."""
 
     @field_validator('uuid')
     def validate_uuid(cls, value):
@@ -143,7 +145,8 @@ class VMCreateResult(BaseModel):
 
 
 class VMUpdate(VMCreate, metaclass=ForUpdateMetaclass):
-    pass
+    bootloader_ovmf: Excluded = excluded_field()
+    enable_secure_boot: Excluded = excluded_field()
 
 
 class VMUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -174,7 +174,9 @@ class VMService(CRUDService, VMSupervisorMixin):
 
     @private
     async def common_validation(self, verrors, schema_name, data, old=None):
-        if data['bootloader_ovmf'] not in await self.middleware.call('vm.bootloader_ovmf_choices'):
+        if data['bootloader_ovmf'] and data['bootloader_ovmf'] not in await self.middleware.call(
+            'vm.bootloader_ovmf_choices'
+        ):
             verrors.add(
                 f'{schema_name}.bootloader_ovmf',
                 'Invalid bootloader ovmf choice specified'
@@ -296,6 +298,18 @@ class VMService(CRUDService, VMSupervisorMixin):
                     f'{schema_name}.machine_type',
                     'Secure boot is only available in q35 machine type'
                 )
+
+            if data['bootloader_ovmf'] is None:
+                data['bootloader_ovmf'] = 'OVMF_CODE_4M.secboot.fd'
+
+            if 'secboot' not in data['bootloader_ovmf'].lower():
+                verrors.add(
+                    f'{schema_name}.bootloader_ovmf',
+                    'Select a bootloader_ovmf that supports secure boot i.e OVMF_CODE_4M.secboot.fd'
+                )
+
+        if data['bootloader_ovmf'] is None:
+            data['bootloader_ovmf'] = 'OVMF_CODE.fd'
 
         # TODO: Let's please implement PCI express hierarchy as the limit on devices in KVM is quite high
         # with reports of users having thousands of disks

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
@@ -70,3 +70,62 @@ async def test_vm_creation_for_licensed_and_unlicensed_systems(license_active):
     assert [e.errmsg for e in verrors.errors] == (
         [] if license_active else ['System is not licensed to use VMs']
     )
+
+
+@pytest.mark.parametrize('enable_secure_boot,bootloader_ovmf,expected_error', [
+    (True, 'OVMF_CODE.secboot.fd', None),
+    (True, 'OVMF_CODE_4M.secboot.fd', None),
+    (True, 'OVMF_CODE.fd', 'Select a bootloader_ovmf that supports secure boot i.e OVMF_CODE_4M.secboot.fd'),
+    (True, 'OVMF_CODE_4M.fd', 'Select a bootloader_ovmf that supports secure boot i.e OVMF_CODE_4M.secboot.fd'),
+    (False, 'OVMF_CODE.fd', None),
+    (False, 'OVMF_CODE_4M.fd', None),
+])
+@pytest.mark.asyncio
+async def test_vm_secure_boot_ovmf_validation(enable_secure_boot, bootloader_ovmf, expected_error):
+    m = Middleware()
+    vm_svc = VMService(m)
+    vm_payload = {
+        'name': 'test_vm',
+        'description': '',
+        'vcpus': 0,
+        'memory': 14336,
+        'min_memory': None,
+        'autostart': False,
+        'time': 'LOCAL',
+        'bootloader': 'UEFI',
+        'bootloader_ovmf': bootloader_ovmf,
+        'cores': 1,
+        'threads': 1,
+        'hyperv_enlightenments': False,
+        'shutdown_timeout': 90,
+        'cpu_mode': 'HOST-PASSTHROUGH',
+        'cpu_model': None,
+        'cpuset': None,
+        'nodeset': None,
+        'pin_vcpus': False,
+        'hide_from_msr': False,
+        'ensure_display_device': True,
+        'arch_type': None,
+        'machine_type': None,
+        'uuid': '64e31dd7-8c76-4dca-8b4b-0126b8853c5b',
+        'command_line_args': '',
+        'enable_secure_boot': enable_secure_boot,
+    }
+
+    m['vm.bootloader_ovmf_choices'] = lambda *args: {
+        'OVMF_CODE.fd': 'OVMF_CODE.fd',
+        'OVMF_CODE.secboot.fd': 'OVMF_CODE.secboot.fd',
+        'OVMF_CODE_4M.fd': 'OVMF_CODE_4M.fd',
+        'OVMF_CODE_4M.secboot.fd': 'OVMF_CODE_4M.secboot.fd',
+    }
+    m['vm.license_active'] = lambda *args: True
+    m['vm.query'] = lambda *args: []
+
+    verrors = ValidationErrors()
+    await vm_svc.common_validation(verrors, 'vm_create', vm_payload)
+
+    error_messages = [e.errmsg for e in verrors.errors]
+    if expected_error:
+        assert expected_error in error_messages
+    else:
+        assert expected_error not in error_messages


### PR DESCRIPTION
## Problem

When secure boot is enabled for a VM, we are defaulting for `OVMF_CODE.fd` which won't work for VMs who want secure boot enabled. This causes problems and for VMs which are already installed, changing `bootloader_ovmf` can actually be problematic and result in an erroneous configuration because of how nvram files for VMs are generated.

## Solution

Validation has been added to ensure that when secure boot is enabled for a VM, we do not allow configuring a `bootloader_ovmf` file which will not work with secure boot and secondly on vm update operation, we should not allow changing `bootloader_ovmf` as that can lead to the VM not booting up at all because of firmware issues.

Also when a VM is being created, we should default to a bootloader ovmf file which reflects the secure boot setting properly.