### PR TITLE
NAS-137792 / 26.04 / Fix 'kfd_device_exists' logic for non-NVIDIA gpu

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -108,7 +108,6 @@ class AppSchemaService(Service):
 
         if all(gpu['vendor'] == 'NVIDIA' for gpu in gpu_choices.values()):
             value['use_all_gpus'] = False
-            value['kfd_device_exists'] = False
 
         for nvidia_gpu_pci_slot in list(value['nvidia_gpu_selection']):
             if nvidia_gpu_pci_slot not in gpu_choices or gpu_choices[nvidia_gpu_pci_slot]['vendor'] != 'NVIDIA':

--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -103,9 +103,12 @@ class AppSchemaService(Service):
             gpu['pci_slot']: gpu
             for gpu in await self.middleware.call('app.gpu_choices_internal') if not gpu['error']
         }
+
+        value['kfd_device_exists'] = self.kfd_exists
+
         if not any(gpu['vendor'] != 'NVIDIA' for gpu in gpu_choices.values()):
             value['use_all_gpus'] = False
-            value['kfd_device_exists'] = self.kfd_exists
+            value['kfd_device_exists'] = False
 
         for nvidia_gpu_pci_slot in list(value['nvidia_gpu_selection']):
             if nvidia_gpu_pci_slot not in gpu_choices or gpu_choices[nvidia_gpu_pci_slot]['vendor'] != 'NVIDIA':

--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -106,7 +106,7 @@ class AppSchemaService(Service):
 
         value['kfd_device_exists'] = self.kfd_exists
 
-        if not any(gpu['vendor'] != 'NVIDIA' for gpu in gpu_choices.values()):
+        if all(gpu['vendor'] == 'NVIDIA' for gpu in gpu_choices.values()):
             value['use_all_gpus'] = False
             value['kfd_device_exists'] = False
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
@@ -114,12 +114,12 @@ from middlewared.pytest.unit.middleware import Middleware
         ],
         {
             'use_all_gpus': True,
-            'kfd_device_exists': True,
+            'kfd_device_exists': False,
             'nvidia_gpu_selection': {}
         },
         {
             'use_all_gpus': True,
-            'kfd_device_exists': True,
+            'kfd_device_exists': False,
             'nvidia_gpu_selection': {}
         }
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
@@ -114,12 +114,12 @@ from middlewared.pytest.unit.middleware import Middleware
         ],
         {
             'use_all_gpus': True,
-            'kfd_device_exists': False,
+            'kfd_device_exists': True,
             'nvidia_gpu_selection': {}
         },
         {
             'use_all_gpus': True,
-            'kfd_device_exists': False,
+            'kfd_device_exists': True,
             'nvidia_gpu_selection': {}
         }
 


### PR DESCRIPTION
When an AMD card exists, this code block is never run so the value of `kfd_device_exists` is always set to the default which is False.

jira:https://ixsystems.atlassian.net/browse/NAS-137145