### PR TITLE
NAS-137277 / 25.10-RC.1 / Fix rsync `MODULE` configuration (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/rsync_task.py
+++ b/src/middlewared/middlewared/api/v25_10_0/rsync_task.py
@@ -36,10 +36,10 @@ class RsyncTaskEntry(BaseModel):
     """Port number for SSH connection. Only applies when `mode` is SSH."""
     remotemodule: str | None = None
     """Name of remote module, this attribute should be specified when `mode` is set to MODULE."""
-    ssh_credentials: KeychainCredentialEntry | None
+    ssh_credentials: KeychainCredentialEntry | None = None
     """In SSH mode, if `ssh_credentials` (a keychain credential of `SSH_CREDENTIALS` type) is specified then it is \
     used to connect to the remote host. If it is not specified, then keys in `user`'s .ssh directory are used."""
-    remotepath: str
+    remotepath: str = ""
     """Path on the remote system to synchronize with."""
     direction: Literal["PULL", "PUSH"] = "PUSH"
     """Specify if data should be PULLED or PUSHED from the remote system."""


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c48a3baf91674be2b2745375997a3859e2c949a5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 524624f6c5f6a0ae05ab9397f46d3f8db2ec40fd



Original PR: https://github.com/truenas/middleware/pull/17109
