### PR TITLE
Make 4420 default for port number

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_port.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_port.py
@@ -62,7 +62,7 @@ class NVMetPortCreateTemplate(NVMetPortEntry, ABC):
 
 class NVMetPortCreateRDMATCP(NVMetPortCreateTemplate):
     addr_trtype: Literal['TCP', 'RDMA']
-    addr_trsvcid: int = Field(ge=1024, le=65535)
+    addr_trsvcid: int = Field(ge=1024, le=65535, default=4420)
     addr_traddr: IPvAnyAddress
 
     @field_validator('addr_traddr')


### PR DESCRIPTION
Make 4420 default for port number is no `addr_trsvcid` is supplied to TCP or RDMA NVMe-oF port.