### PR TITLE
NAS-137384 / 25.10-RC.1 / Do not requires all fields to be set for alert classes (like it was before pydantic conversion) (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/alert.py
+++ b/src/middlewared/middlewared/api/v25_10_0/alert.py
@@ -3,7 +3,7 @@ from typing import Any, Literal, TypeAlias
 
 from pydantic import Field
 
-from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LongString
+from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LongString, NotRequired
 
 
 __all__ = [
@@ -70,9 +70,9 @@ class AlertCategory(BaseModel):
 
 
 class AlertClassConfiguration(BaseModel):
-    level: AlertLevel
+    level: AlertLevel = NotRequired
     """Severity level for alerts of this class."""
-    policy: Literal['IMMEDIATELY', 'HOURLY', 'DAILY', 'NEVER']
+    policy: Literal['IMMEDIATELY', 'HOURLY', 'DAILY', 'NEVER'] = NotRequired
     """Notification policy for alerts of this class.
 
     * `IMMEDIATELY`: Send notifications as soon as alerts occur
@@ -80,7 +80,7 @@ class AlertClassConfiguration(BaseModel):
     * `DAILY`: Batch notifications and send daily
     * `NEVER`: Do not send notifications for this alert class
     """
-    proactive_support: bool = False
+    proactive_support: bool = NotRequired
     """Whether to include alerts of this class in proactive support reporting."""
 
 

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -1217,7 +1217,7 @@ class AlertClassesService(ConfigService):
                 verrors.add(f"alert_class_update.classes.{k}", "This alert class does not exist")
                 continue
 
-            if not AlertClass.class_by_name[k].proactive_support and v["proactive_support"]:
+            if "proactive_support" in v and not AlertClass.class_by_name[k].proactive_support:
                 verrors.add(
                     f"alert_class_update.classes.{k}.proactive_support",
                     "Proactive support is not supported by this alert class",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 854c365336cd7c32170226fc84bbc08cb2af36e9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 560bc22d81f0a6d97328084f893ad66a42b1e429



Original PR: https://github.com/truenas/middleware/pull/17119
