### PR TITLE
NAS-137410 / 26.04 / fix IndexError in system dataset plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -371,11 +371,10 @@ class SystemDatasetService(ConfigService):
                 else:
                     enc = get_encryption_info(ds[0]['properties'])
                     if enc.encrypted and enc.locked and enc.encryption_type != 'passphrase':
+                        msg = 'Root dataset for pool %r is not available,'
+                        msg += 'temporarily setting up system dataset on boot pool'
                         # Pool is encrypted with a key and is locked
-                        self.logger.debug(
-                            'Root dataset for pool %r is not available, temporarily setting up system dataset on boot pool',
-                            config['pool'],
-                        )
+                        self.logger.debug(msg, config['pool'])
                         self.force_pool = boot_pool
                         config = self.middleware.call_sync('systemdataset.config')
                     else:


### PR DESCRIPTION
Fix an IndexError crash
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/sysdataset.py", line 312, in setup
    return self.setup_impl(exclude_pool)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/sysdataset.py", line 375, in setup_impl
    enc = get_encryption_info(ds[0]['properties'])
                              ~~^^^
IndexError: list index out of range