### PR TITLE
NAS-136978 / 26.04 / Fix link aggregation

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -66,6 +66,17 @@ class LaggMixin:
         run(["ip", "link", "set", self.name, "type", "bond", "primary", value])
 
     @property
+    def miimon(self):
+        try:
+            return int(self._sysfs_read(self.get_options_path("miimon")).strip())
+        except FileNotFoundError:
+            return None
+
+    @miimon.setter
+    def miimon(self, value):
+        run(["ip", "link", "set", self.name, "type", "bond", "miimon", str(value)])
+
+    @property
     def ports(self):
         ports = []
         for port in self._sysfs_read(f"/sys/devices/virtual/net/{self.name}/bonding/slaves").split():


### PR DESCRIPTION
## Problem

The bond (LAG) interface is not being configured correctly, which causes issues during failover. Currently, the `miimon` parameter is disabled. As a result, the bond interface cannot switch to a working interface if the active slave fails. The `miimon` parameter continuously monitors the state of inactive interfaces and triggers a switch when the primary interface goes down.

## Solution

Set the `miimon` value to `100`, as recommended in the [Linux kernel bonding documentation](https://www.kernel.org/doc/html/latest/networking/bonding.html), to ensure proper bond interface handling.

It is essential to have this or `arp_interval` params set to have link monitoring in place.