### PR TITLE
Fix NFS exports mako

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -163,7 +163,7 @@
         # Remove all files in /etc/exports.d
         for file in files_in_exportsd:
 
-            if file.startswith('zfs.exports'):
+            if file == 'zfs.exports':
                 middleware.logger.warning("Disabling sharenfs ZFS property on datasets")
                 disable_sharenfs()
             else:


### PR DESCRIPTION
By design, we disable ZFS `sharenfs` and make `/etc/exports.d` immutable.  We expect the directory to be empty.
Before starting NFS we confirm the directory is empty.  If it is not we look for `zfs.exports` and process it's contents to disable `sharenfs` for that dataset.  We also delete the file and all other files in the directory and finally restore immutability to the directory.

The problem was that in a previous PR #17093 I erroneously widened the file test to include 'zfs.exports.lock`.  This caused an exception which resulted in blocking NFS start.

### The Fix:
Limit the additional zfs processing to `zfs.exports`.   

This particular problem is Halfmoon specific.