### PR TITLE
NAS-137424 / 25.10-RC.1 / call failover.become_passive in system.reboot on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/system/lifecycle.py
@@ -97,6 +97,18 @@ class SystemService(Service):
         if options["delay"] is not None:
             await asyncio.sleep(options["delay"])
 
+        if (
+            await self.middleware.call("failover.licensed")
+            and (await self.middleware.call("failover.config"))["disabled"] is False
+        ):
+            # "proper" shutdown process on linux produces
+            # an untenable situation where race conditions
+            # abound with how we've written our failover
+            # logic. Instead of battling this war, we'll
+            # employ the same tactic that we already use
+            # in the failover plugin itself. (i.e. panic ourself)
+            await self.middleware.call("failover.become_passive")
+
         await run(["/sbin/shutdown", "-r", "now"])
 
     @api_method(


### PR DESCRIPTION
We've had 2 or 3 rare situations where an HA customer will use the UI to upgrade their HA system. The UI issues the `system.reboot` API call. This works in 99.99% of all scenarios. But there are a few, incredibly hard to reproduce, scenarios where it's not working.

The "proper" shutdown process of linux is untenable for how we've written our failover logic so instead of trying to add even more fragile, unreliable code, we'll take the big hammer approach and "forcefully" ( 😉 ) reboot the active node.

NOTE: this only occurs when it's HA and HA has NOT been administratively disabled. This is a very targeted change to keep regression possibilities as low as possible.

Original PR: https://github.com/truenas/middleware/pull/17126
