### PR TITLE
NAS-136355 / 26.04 / Add support for a second remote syslog server (by creatorcary)

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -10,6 +10,8 @@ Conflicts=reboot.target shutdown.target halt.target
 
 [Service]
 Type=notify
+# Allow child processes like syslog-ng to send notifications
+NotifyAccess=all
 ExecStart=/usr/bin/middlewared --log-handler=file
 TimeoutStartSec=900
 Restart=always

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
@@ -1,7 +1,7 @@
-"""empty message
+"""Add support for multiple remote syslog servers.
 
 Revision ID: 5ea9f662ced4
-Revises: 92a84187cbb4
+Revises: 7767afd88989
 Create Date: 2025-08-29 15:41:53.637185+00:00
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5ea9f662ced4'
-down_revision = '92a84187cbb4'
+down_revision = '7767afd88989'
 branch_labels = None
 depends_on = None
 
@@ -25,7 +25,7 @@ def upgrade():
     ).fetchone()
 
     with op.batch_alter_table('system_advanced', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('adv_syslogservers', sa.TEXT(), nullable=False))
+        batch_op.add_column(sa.Column('adv_syslogservers', sa.TEXT(), nullable=False, server_default='[]'))
         batch_op.drop_index('ix_system_advanced_adv_syslog_tls_certificate_id')
         batch_op.drop_constraint('fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate', type_='foreignkey')
         batch_op.drop_column('adv_syslog_tls_certificate_id')

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
@@ -1,0 +1,37 @@
+"""empty message
+
+Revision ID: 5ea9f662ced4
+Revises: 92a84187cbb4
+Create Date: 2025-08-29 15:41:53.637185+00:00
+
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5ea9f662ced4'
+down_revision = '92a84187cbb4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    server, transport, cert_id = conn.execute(
+        'SELECT adv_syslogserver, adv_syslog_transport, adv_syslog_tls_certificate_id FROM system_advanced'
+    ).fetchone()
+
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('adv_syslogservers', sa.TEXT(), nullable=False))
+        batch_op.drop_index('ix_system_advanced_adv_syslog_tls_certificate_id')
+        batch_op.drop_constraint('fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate', type_='foreignkey')
+        batch_op.drop_column('adv_syslog_tls_certificate_id')
+        batch_op.drop_column('adv_syslogserver')
+        batch_op.drop_column('adv_syslog_transport')
+
+    if server:
+        syslogservers = json.dumps([{'host': server, 'transport': transport, 'tls_certificate': cert_id}])
+        conn.execute(f'UPDATE system_advanced SET adv_syslogservers = {syslogservers!r}')

--- a/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
@@ -22,8 +22,13 @@ __all__ = [
 class SyslogServer(BaseModel):
     host: str
     """Remote syslog server DNS hostname or IP address.
+
     Nonstandard port numbers can be used by appending a colon and port number to the hostname, like \
-    mysyslogserver:1928. Otherwise, port 514 is used."""
+    mysyslogserver:1928.
+
+    Port 514 is used by default for TCP and UDP transports as per RFC3164; port 6514 is used by default for TLS \
+    transport as per RFC5425.
+    """
     transport: Literal['UDP', 'TCP', 'TLS'] = 'UDP'
     """Transport Protocol for the remote system log server connection. Choosing Transport Layer Security (TLS) also \
     requires selecting a preconfigured system certificate with `tls_certificate`."""

--- a/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
@@ -19,6 +19,18 @@ __all__ = [
 ]
 
 
+class SyslogServer(BaseModel):
+    host: str
+    """Remote syslog server DNS hostname or IP address.
+    Nonstandard port numbers can be used by appending a colon and port number to the hostname, like \
+    mysyslogserver:1928. Otherwise, port 514 is used."""
+    transport: Literal['UDP', 'TCP', 'TLS'] = 'UDP'
+    """Transport Protocol for the remote system log server connection. Choosing Transport Layer Security (TLS) also \
+    requires selecting a preconfigured system certificate with `tls_certificate`."""
+    tls_certificate: int | None = None
+    """Certificate ID for TLS-encrypted syslog connections or `null` for no certificate."""
+
+
 class SystemAdvancedEntry(BaseModel):
     id: int
     """Placeholder identifier.  Not used as there is only one."""
@@ -64,17 +76,10 @@ class SystemAdvancedEntry(BaseModel):
     """SED (Self-Encrypting Drive) user type for drive encryption."""
     sysloglevel: Literal['F_EMERG', 'F_ALERT', 'F_CRIT', 'F_ERR', 'F_WARNING', 'F_NOTICE', 'F_INFO', 'F_DEBUG']
     """Minimum log level for syslog messages. F_EMERG is most critical, F_DEBUG is least critical."""
-    syslogserver: str = NotRequired
-    """Remote syslog server DNS hostname or IP address. Nonstandard port numbers can be used by adding \
-    a colon and the port number to the hostname, like mysyslogserver:1928.  Setting this field enables \
-    the remote syslog function."""
-    syslog_transport: Literal['UDP', 'TCP', 'TLS']
-    """Transport Protocol for the remote system log server connection. \
-    Choosing Transport Layer Security (TLS) also requires selecting a preconfigured system Certificate."""
-    syslog_tls_certificate: int | None
-    """Certificate ID for TLS-encrypted syslog connections or `null` for no certificate."""
+    syslogservers: list[SyslogServer] = Field(default=[], max_length=2)
+    """Configurations for up to two remote syslog servers."""
     syslog_audit: bool = NotRequired
-    """The remote syslog server will also receive audit messages."""
+    """The remote syslog server(s) will also receive audit messages."""
     isolated_gpu_pci_ids: list[str]
     """List of GPU PCI IDs to isolate from the host system for VM passthrough."""
     kernel_extra_options: str
@@ -84,6 +89,10 @@ class SystemAdvancedEntry(BaseModel):
 class SystemAdvancedUpdate(SystemAdvancedEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
     anonstats_token: Excluded = excluded_field()
+    syslogservers: list[SyslogServer] = Field(default=[], max_length=2)
+    """Configurations for up to two remote syslog servers.
+
+    **If provided, will overwrite the entire array in the existing entry.**"""
     isolated_gpu_pci_ids: Excluded = excluded_field()
     sed_passwd: Secret[str]
     """Password for SED (Self-Encrypting Drive) global unlock."""

--- a/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_advanced.py
@@ -30,10 +30,13 @@ class SyslogServer(BaseModel):
     transport as per RFC5425.
     """
     transport: Literal['UDP', 'TCP', 'TLS'] = 'UDP'
-    """Transport Protocol for the remote system log server connection. Choosing Transport Layer Security (TLS) also \
-    requires selecting a preconfigured system certificate with `tls_certificate`."""
+    """Transport Protocol for the remote system log server connection."""
     tls_certificate: int | None = None
-    """Certificate ID for TLS-encrypted syslog connections or `null` for no certificate."""
+    """Applies only if `transport` is "TLS".
+
+    ID of the local certificate to send for mutual TLS (mTLS) connections. `null` indicates one-way TLS in which only \
+    the server identified by `host` will need to provide a certificate.
+    """
 
 
 class SystemAdvancedEntry(BaseModel):

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -79,9 +79,9 @@ ${textwrap.indent(get_db(svc), '  ')}
 % if not audit_custom_section(svc, 'log'):
 log {
 % if svc == 'MIDDLEWARE':
-  source(tn_middleware_src);
+  source(s_tn_middleware);
 % elif svc == 'SYSTEM':
-  source(tn_auditd_src);
+  source(s_tn_auditd);
 % else:
   source(s_src);
 % endif

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -43,8 +43,8 @@ def generate_syslog_remote_destination(advanced_config):
         remotelog_stanza += '    )\n'
 
     remotelog_stanza += '  );\n};\n'    
-    remotelog_stanza += 'log { source(tn_middleware_src); filter(f_tnremote); destination(loghost); };\n'
-    remotelog_stanza += 'log { source(tn_auditd_src); filter(f_tnremote); destination(loghost); };\n'
+    remotelog_stanza += 'log { source(s_tn_middleware); filter(f_tnremote); destination(loghost); };\n'
+    remotelog_stanza += 'log { source(s_tn_auditd); filter(f_tnremote); destination(loghost); };\n'
     remotelog_stanza += 'log { source(s_src); filter(f_tnremote); destination(loghost); };'
 
     return remotelog_stanza
@@ -73,11 +73,11 @@ options {
 ##################
 source s_src { system(); internal(); };
 
-source tn_middleware_src {
+source s_tn_middleware {
   unix-stream("${DEFAULT_SYSLOG_PATH}" create-dirs(yes) perm(0600));
 };
 
-source tn_auditd_src {
+source s_tn_auditd {
   unix-stream("/var/run/syslog-ng/auditd.sock" create-dirs(yes) perm(0600));
 };
 
@@ -119,7 +119,7 @@ log {
 ########################
 % for tnlog in ALL_LOG_FILES:
 log {
-  source(tn_middleware_src); filter(f_${tnlog.name or "middleware"});
+  source(s_tn_middleware); filter(f_${tnlog.name or "middleware"});
   destination { file(${tnlog.logfile} ${syslog_template}); };
 };
 % endfor

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -10,13 +10,16 @@ syslog_template = 'template("${MESSAGE}\\n")'
 
 def generate_syslog_remote_destination(server, d_name):
     address = server["host"]
+    transport = server["transport"].lower()
+
     if "]:" in address or (":" in address and not "]" in address): 
         host, port = address.rsplit(":", 1)
+    elif transport == "tls":
+        host, port = address, "6514"
     else:
         host, port = address, "514"
 
     host = host.replace("[", "").replace("]", "")
-    transport = server["transport"].lower()
     cert_id = server["tls_certificate"]
 
     remotelog_stanza =  f'destination {d_name} {{\n'

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -36,11 +36,10 @@ def generate_syslog_remote_destination(server, d_name):
 
         if cert_id is not None:
             # Mutual TLS
-            certificate = []
             certificate = middleware.call_sync(
                 "certificate.query", [["id", "=", cert_id]]
             )
-            if certificate is not []:
+            if certificate:
                 remotelog_stanza += f'      key-file(\"{certificate[0]["privatekey_path"]}\")\n'
                 remotelog_stanza += f'      cert-file(\"{certificate[0]["certificate_path"]}\")\n'
         remotelog_stanza += '    )\n'

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -19,12 +19,12 @@ def generate_syslog_remote_destination(server, d_name):
     transport = server["transport"].lower()
     cert_id = server["tls_certificate"]
 
-    remotelog_stanza = f'destination {d_name} {{\n'
-    remotelog_stanza += '  syslog(\n'
+    remotelog_stanza =  f'destination {d_name} {{\n'
+    remotelog_stanza +=  '  syslog(\n'
     remotelog_stanza += f'    "{host}"\n'
     remotelog_stanza += f'    port({port})\n'
-    remotelog_stanza += '    ip-protocol(6)\n'
-    remotelog_stanza += f'    transport("{transport}")\n'
+    remotelog_stanza +=  '    ip-protocol(6)\n'
+    remotelog_stanza += f'    transport({transport})\n'
 
     if transport == "tls":
         # Both mutual and one-way TLS require this

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -107,7 +107,7 @@ class AuditService(ConfigService):
     @private
     def extend(self, data):
         sys_adv = self.middleware.call_sync('system.advanced.config')
-        data['remote_logging_enabled'] = bool(sys_adv['syslogserver']) and sys_adv['syslog_audit']
+        data['remote_logging_enabled'] = bool(sys_adv['syslogservers']) and sys_adv['syslog_audit']
         ds_info = self.get_audit_dataset()
         data['space'] = {'used': None, 'used_by_snapshots': None, 'available': None}
         data['space']['used'] = ds_info['properties']['used']['value']

--- a/src/middlewared/middlewared/plugins/system/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/system/cert_attachments.py
@@ -11,10 +11,14 @@ class SystemGeneralCertificateAttachmentDelegate(CertificateServiceAttachmentDel
 
 class SystemAdvancedCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
-    CERT_FIELD = 'syslog_tls_certificate'
+    CERT_FIELD = NotImplementedError
     HUMAN_NAME = 'Syslog Service'
     NAMESPACE = 'system.advanced'
     SERVICE = 'syslogd'
+
+    async def state(self, cert_id):
+        config = await self.middleware.call('system.advanced.config')
+        return any(server['tls_certificate'] == cert_id for server in config['syslogservers'])
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -71,10 +71,6 @@ class SystemAdvancedService(ConfigService):
         if data.get('sed_user'):
             data['sed_user'] = data.get('sed_user').upper()
 
-        for server in data.get('syslogservers', []):
-            if server['tls_certificate'] is not None:
-                server['tls_certificate'] = server['tls_certificate']['id']
-
         data.pop('sed_passwd')
         data.pop('kmip_uid')
 

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -45,9 +45,7 @@ class SystemAdvancedModel(sa.Model):
     adv_sed_user = sa.Column(sa.String(120), default='user')
     adv_sed_passwd = sa.Column(sa.EncryptedText(), default='')
     adv_sysloglevel = sa.Column(sa.String(120), default='f_info')
-    adv_syslogserver = sa.Column(sa.String(120), default='')
-    adv_syslog_transport = sa.Column(sa.String(12), default='UDP')
-    adv_syslog_tls_certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
+    adv_syslogservers = sa.Column(sa.JSON(list), default=[])
     adv_syslog_audit = sa.Column(sa.Boolean(), default=False)
     adv_kmip_uid = sa.Column(sa.String(255), nullable=True, default=None)
     adv_kdump_enabled = sa.Column(sa.Boolean(), default=False)
@@ -73,8 +71,9 @@ class SystemAdvancedService(ConfigService):
         if data.get('sed_user'):
             data['sed_user'] = data.get('sed_user').upper()
 
-        if data['syslog_tls_certificate'] is not None:
-            data['syslog_tls_certificate'] = data['syslog_tls_certificate']['id']
+        for server in data.get('syslogservers', []):
+            if server['tls_certificate'] is not None:
+                server['tls_certificate'] = server['tls_certificate']['id']
 
         data.pop('sed_passwd')
         data.pop('kmip_uid')
@@ -102,31 +101,31 @@ class SystemAdvancedService(ConfigService):
                     'Serial port must be different than the port specified for UPS Service'
                 )
 
-    @settings.fields_validator('syslogserver')
-    async def _validate_syslogserver(self, verrors, syslogserver):
-        if syslogserver:
-            match = re.match(r"^\[?[\w.\-:%]+]?(:\d+)?$", syslogserver)
-            if not match:
-                verrors.add(
-                    'syslogserver',
-                    'Invalid syslog server format'
-                )
-            elif ']:' in syslogserver or (':' in syslogserver and ']' not in syslogserver):
-                port = int(syslogserver.split(':')[-1])
-                if port < 0 or port > 65535:
-                    verrors.add(
-                        'syslogserver',
-                        'Port must be in the range of 0 to 65535.'
-                    )
+    @settings.fields_validator('syslogservers')
+    async def _validate_syslogserver(self, verrors, syslogservers):
+        seen_hosts = set()
+        for i, server in enumerate(syslogservers):
+            host = server['host']
+            if host in seen_hosts:
+                verrors.add(f'syslogservers.{i}.host', 'Duplicate host in syslogservers array')
 
-    @settings.fields_validator('syslog_transport', 'syslog_tls_certificate')
-    async def _validate_syslog(self, verrors, syslog_transport, syslog_tls_certificate):
-        if syslog_transport == 'TLS':
-            if syslog_tls_certificate:
-                verrors.extend(await self.middleware.call(
-                    'certificate.cert_services_validation', syslog_tls_certificate,
-                    'syslog_tls_certificate', False
-                ))
+            elif not re.match(r"^\[?[\w.\-:%]+]?(:\d+)?$", host):
+                verrors.add(f'syslogservers.{i}.host', 'Invalid syslog server format')
+
+            elif ']:' in host or (':' in host and ']' not in host):
+                port = int(host.split(':')[-1])
+                if port < 0 or port > 65535:
+                    verrors.add(f'syslogservers.{i}.host', 'Port must be in the range of 0 to 65535.')
+
+            seen_hosts.add(host)
+
+            cert_id = server['tls_certificate']
+            if server['transport'] == 'TLS' and cert_id:
+                verrors.extend(
+                    await self.middleware.call(
+                        'certificate.cert_services_validation', cert_id, f'syslogservers.{i}.tls_certificate', False
+                    )
+                )
 
     @settings.fields_validator('kernel_extra_options')
     async def _validate_kernel_extra_options(self, verrors, kernel_extra_options):
@@ -152,6 +151,19 @@ class SystemAdvancedService(ConfigService):
             #  foot-shooting
             verrors.add('kernel_extra_options', f'Modifying {invalid_param!r} is not allowed')
 
+    def _syslogd_changes(self, orig_config: dict, new_config: dict) -> bool:
+        """Return `True` if syslogd should be restarted to apply the new configuration."""
+        if (
+            orig_config['fqdn_syslog'] != new_config['fqdn_syslog']
+            or orig_config['sysloglevel'].lower() != new_config['sysloglevel'].lower()
+            or orig_config['syslog_audit'] != new_config['syslog_audit']
+        ):
+            return True
+        # Convert syslogservers to sets to disregard ordering for the comparison
+        orig_items_set = {frozenset(d.items()) for d in orig_config['syslogservers']}
+        new_items_set = {frozenset(d.items()) for d in new_config['syslogservers']}
+        return orig_items_set != new_items_set
+
     @api_method(SystemAdvancedUpdateArgs, SystemAdvancedUpdateResult, audit='System advanced update')
     async def do_update(self, data):
         """
@@ -162,8 +174,9 @@ class SystemAdvancedService(ConfigService):
             consolemsg = data.pop('consolemsg')
             warnings.warn("`consolemsg` has been deprecated and moved to `system.general`", DeprecationWarning)
 
-        if data.get('syslog_transport', 'TLS') != 'TLS':
-            data['syslog_tls_certificate'] = None
+        for server in data.get('syslogservers', []):
+            if server['transport'] != 'TLS':
+                server['tls_certificate'] = None
 
         config_data = await self.config()
         config_data['sed_passwd'] = await self.sed_global_password()
@@ -207,16 +220,7 @@ class SystemAdvancedService(ConfigService):
             if original_data['powerdaemon'] != config_data['powerdaemon']:
                 await (await self.middleware.call('service.control', 'RESTART', 'powerd')).wait(raise_error=True)
 
-            if original_data['fqdn_syslog'] != config_data['fqdn_syslog']:
-                await (await self.middleware.call('service.control', 'RESTART', 'syslogd')).wait(raise_error=True)
-
-            if (
-                original_data['sysloglevel'].lower() != config_data['sysloglevel'].lower() or
-                original_data['syslogserver'] != config_data['syslogserver'] or
-                original_data['syslog_transport'] != config_data['syslog_transport'] or
-                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate'] or
-                original_data['syslog_audit'] != config_data['syslog_audit']
-            ):
+            if self._syslogd_changes(original_data, config_data):
                 await (await self.middleware.call('service.control', 'RESTART', 'syslogd')).wait(raise_error=True)
 
             if config_data['sed_passwd'] and original_data['sed_passwd'] != config_data['sed_passwd']:

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -19,7 +19,7 @@ class SystemAdvancedService(Service):
     )
     async def syslog_certificate_choices(self):
         """
-        Return choices of certificates which can be used for `syslog_tls_certificate`.
+        Return choices of certificates which can be used for `syslogservers.N.tls_certificate`.
         """
         return {
             i['id']: i['name']

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -6,9 +6,6 @@ from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.assets.system import standby_syslog_to_remote_syslog
 
-# Alias
-pp = pytest.param
-
 
 # ---------------------------------------
 # ---------- utility functions ----------
@@ -26,9 +23,7 @@ def do_syslog(ident, message, facility='syslog.LOG_USER', priority='syslog.LOG_I
     ssh(cmd)
 
 
-def check_syslog(log_path, message,
-                 target_user=user, target_passwd=password,
-                 remote=False, timeout=30):
+def check_syslog(log_path, message, target_user=user, target_passwd=password, remote=False, timeout=30):
     """
     Common function to check whether a particular message exists in a log file.
     This will be used to check local and remote syslog servers.
@@ -67,15 +62,19 @@ def check_syslog_state(expected_state='active'):
 # -----------------------------------
 
 
+@pytest.fixture
+def erase_syslogservers():
+    yield
+    call('system.advanced.update', {"syslogservers": []})
+    check_syslog_state()
+
+
 @pytest.fixture(scope="class")
-def tls_cert():
+def tls_cert(erase_syslogservers):
     """Placeholder for adding remote certs and Restore syslog to default after testing"""
     truenas_default_id = 1
-    try:
-        yield truenas_default_id
-    finally:
-        call('system.advanced.update', {"syslogservers": []})
-        check_syslog_state()
+    yield truenas_default_id
+
 
 # -----------------------------------
 # -------------- tests --------------
@@ -94,7 +93,7 @@ def tls_cert():
         'path': '/var/log/scst.log',  # This is just to make sure our exclude filter works as intended
     },
 ])
-def test_local_syslog_filter(request, params):
+def test_local_syslog_filter(params):
     """
     This test validates that our syslog-ng filters are correctly placing
     messages into their respective paths in /var/log
@@ -114,7 +113,7 @@ def test_local_syslog_filter(request, params):
     '/var/log/syslog',
     '/var/log/daemon.log'
 ])
-def test_filter_leak(request, log_path):
+def test_filter_leak(log_path):
     """
     This test validates that our exclude filter works properly and that
     particularly spammy applications aren't polluting useful logs.
@@ -124,23 +123,42 @@ def test_filter_leak(request, log_path):
     check_syslog_state()
 
 
-def test_set_remote_syslog(request):
+def test_set_remote_syslog(erase_syslogservers):
     """
     Basic test to validate that setting a remote syslog target
     doesn't break syslog-ng config
     """
-    try:
-        data = call('system.advanced.update', {'syslogservers': [{'host': '127.0.0.1'}]})
-        assert data['syslogservers'][0]['host'] == '127.0.0.1'
-        call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
-    finally:
-        call('system.advanced.update', {'syslogservers': []})
-        check_syslog_state()
+    data = call('system.advanced.update', {'syslogservers': [{'host': '127.0.0.1'}]})
+    assert data['syslogservers'][0]['host'] == '127.0.0.1'
+    call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
+
+
+def test_set_multiple_remote_syslog(erase_syslogservers):
+    """
+    Test to validate that setting multiple remote syslog targets
+    doesn't break syslog-ng config and generates correct destinations
+    """
+    servers = [
+        {'host': '127.0.0.1', 'transport': 'TCP', 'tls_certificate': None},
+        {'host': '192.168.1.100:5514', 'transport': 'UDP', 'tls_certificate': None}
+    ]
+    data = call('system.advanced.update', {'syslogservers': servers})
+
+    # Verify the servers were set correctly
+    assert data['syslogservers'] == servers
+
+    # Verify multiple destination blocks are generated in config
+    conf = ssh('cat /etc/syslog-ng/syslog-ng.conf', complete_response=True)
+    assert conf['result'] is True
+
+    # Count destination blocks - should have loghost0 and loghost1
+    num_remotes = conf['output'].count('destination loghost')
+    assert num_remotes == 2, conf['output']
 
 
 @pytest.mark.skip(reason="Test is unstable running from Jenkins")
 @pytest.mark.skipif(not ha, reason='Test only valid for HA')
-def test_remote_syslog_function():
+def test_remote_syslog_function(erase_syslogservers):
     """
     End to end validation of remote syslog using temporary
     reconfiguration of the syslog on the standby node.
@@ -149,47 +167,42 @@ def test_remote_syslog_function():
     """
     remote_ip = truenas_server.ha_ips()['standby']
     test_log = "/var/log/remote_log.txt"
-    try:
-        # Configure for remote syslog on the active node FIRST
-        # because it also updates the standby node with the same
-        payload = {"syslogservers": [{"host": remote_ip, "transport": "TCP"}]}
-        data = call('system.advanced.update', payload)
-        assert data['syslogservers'] == [{"host": remote_ip, "transport": "TCP", "tls_certificate": None}]
-        call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
 
-        # Make sure we don't have old test cruft and start with a zero byte file
-        if not ssh(f'rm -f {test_log}', ip=remote_ip, check=False):
-            ssh(f'rm -f {test_log}', ip=remote_ip)
+    # Configure for remote syslog on the active node FIRST
+    # because it also updates the standby node with the same
+    payload = {"syslogservers": [{"host": remote_ip, "transport": "TCP"}]}
+    data = call('system.advanced.update', payload)
+    assert data['syslogservers'] == [{"host": remote_ip, "transport": "TCP", "tls_certificate": None}]
+    call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
 
-        # Configure standby node as a remote syslog server
-        with standby_syslog_to_remote_syslog() as remote_info:
-            remote_syslog_ip, remote_log = remote_info
-            assert remote_syslog_ip == remote_ip
+    # Make sure we don't have old test cruft and start with a zero byte file
+    if not ssh(f'rm -f {test_log}', ip=remote_ip, check=False):
+        ssh(f'rm -f {test_log}', ip=remote_ip)
 
-            # Prime the remote (saves a few seconds in the wait)
-            for i in range(5):
-                sleep(0.1)
-                ssh(f"logger '({i}) prime the remote log....'")
+    # Configure standby node as a remote syslog server
+    with standby_syslog_to_remote_syslog() as remote_info:
+        remote_syslog_ip, remote_log = remote_info
+        assert remote_syslog_ip == remote_ip
 
-            # Wait for the remote log
-            cntdn = 20
-            while cntdn > 0:
-                ssh(f"logger '({cntdn}) kick the remote log'")
-                sleep(1)
-                if ssh(f"ls {remote_log}", ip=remote_ip, check=False):
-                    val = ssh(f"wc -c < {remote_log}", ip=remote_ip)
-                    if int(val) > 0:
-                        break
-                cntdn -= 1
+        # Prime the remote (saves a few seconds in the wait)
+        for i in range(5):
+            sleep(0.1)
+            ssh(f"logger '({i}) prime the remote log....'")
 
-            # Write a real message and confirm
-            do_syslog("CANARY", "In a coal mine")
-            assert check_syslog(remote_log, "In a coal mine", remote=True, timeout=20)
+        # Wait for the remote log
+        cntdn = 20
+        while cntdn > 0:
+            ssh(f"logger '({cntdn}) kick the remote log'")
+            sleep(1)
+            if ssh(f"ls {remote_log}", ip=remote_ip, check=False):
+                val = ssh(f"wc -c < {remote_log}", ip=remote_ip)
+                if int(val) > 0:
+                    break
+            cntdn -= 1
 
-    finally:
-        # Restore active node
-        call('system.advanced.update', {"syslogservers": []})
-        check_syslog_state()
+        # Write a real message and confirm
+        do_syslog("CANARY", "In a coal mine")
+        assert check_syslog(remote_log, "In a coal mine", remote=True, timeout=20)
 
 
 class TestTLS:
@@ -206,7 +219,6 @@ class TestTLS:
         remote = "127.0.0.1"
         port = "5140"
         transport = "TLS"
-        assert tls_cert is not None
 
         test_tls = [
             f'{remote}', f'port({port})', 'transport("tls")', 'ca-file("/etc/ssl/certs/ca-certificates.crt")'


### PR DESCRIPTION
This implementation would enable us to allow more than two syslog servers in the future. Two is the minimum to satisfy the STIG requirement.

Each syslog server can have its own mode of transport (TLS, TCP, or UDP). Log level and audit log settings are applied uniformly.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5742/

Original PR: https://github.com/truenas/middleware/pull/17103
