### PR TITLE
NAS-137296 / 26.04 / Remove asyncio from SNMP CI

### DIFF
--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -283,7 +283,7 @@ class TestSNMP:
         validate_snmp_get_sysname_uses_same_ip(truenas_server.ip)
 
     @skip_ha_tests
-    async def test_ha_sysname_reply_uses_same_ip(self):
+    def test_ha_sysname_reply_uses_same_ip(self):
         validate_snmp_get_sysname_uses_same_ip(truenas_server.ip)
         validate_snmp_get_sysname_uses_same_ip(truenas_server.nodea_ip)
         validate_snmp_get_sysname_uses_same_ip(truenas_server.nodeb_ip)


### PR DESCRIPTION
The new `pysnmp` python library as been converted to asyncio.  This complicates using it in CI tests.
Replace the `pysnmp` calls with an `snmpwalk` call from the test runner.


Passing tests: See `test_440_snmp.py` console output [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5809/console)