### PR TITLE
NAS-137418 / 25.10-RC.1 / NVMe-of-service is locked for sharing admin (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -114,7 +114,8 @@ class ServiceService(CRUDService):
     @api_method(
         ServiceUpdateArgs,
         ServiceUpdateResult,
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE',
+               'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
         audit='Update service configuration',
         audit_callback=True,
         pass_app=True,
@@ -146,7 +147,8 @@ class ServiceService(CRUDService):
     @api_method(
         ServiceControlArgs,
         ServiceControlResult,
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE',
+               'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
         pass_app=True,
         pass_app_rest=True,
         audit='Service Control:',

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -114,7 +114,7 @@ class ServiceService(CRUDService):
     @api_method(
         ServiceUpdateArgs,
         ServiceUpdateResult,
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
         audit='Update service configuration',
         audit_callback=True,
         pass_app=True,
@@ -146,7 +146,7 @@ class ServiceService(CRUDService):
     @api_method(
         ServiceControlArgs,
         ServiceControlResult,
-        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE'],
+        roles=['SERVICE_WRITE', 'SHARING_NFS_WRITE', 'SHARING_SMB_WRITE', 'SHARING_ISCSI_WRITE', 'SHARING_FTP_WRITE', 'SHARING_NVME_TARGET_WRITE'],
         pass_app=True,
         pass_app_rest=True,
         audit='Service Control:',

--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -7,6 +7,7 @@ class ServiceWriteRole(enum.Enum):
     NFS = 'SHARING_NFS_WRITE'
     ISCSITARGET = 'SHARING_ISCSI_WRITE'
     FTP = 'SHARING_FTP_WRITE'
+    NVMET = 'SHARING_NVME_TARGET_WRITE'
 
 
 def app_has_write_privilege_for_service(

--- a/tests/api2/test_nvmet_crud_roles.py
+++ b/tests/api2/test_nvmet_crud_roles.py
@@ -1,0 +1,57 @@
+import itertools
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+CRUD_APIS = ["host", "port", "subsys", "host_subsys", "port_subsys", "namespace"]
+
+
+@pytest.mark.parametrize(
+    "api, role",
+    itertools.product(CRUD_APIS, ["SHARING_READ", "SHARING_NVME_TARGET_READ"])
+)
+def test_read_role_can_read(unprivileged_user_fixture, api, role):
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.query", role, True, valid_role_exception=False)
+
+
+@pytest.mark.parametrize(
+    "api, role",
+    itertools.product(CRUD_APIS, ["SHARING_READ", "SHARING_NVME_TARGET_READ"])
+)
+def test_read_role_cant_write(unprivileged_user_fixture, api, role):
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.create", role, False)
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.update", role, False)
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.delete", role, False)
+
+
+@pytest.mark.parametrize(
+    "api, role",
+    itertools.product(CRUD_APIS, ["SHARING_WRITE", "SHARING_NVME_TARGET_WRITE"])
+)
+def test_write_role_can_write(unprivileged_user_fixture, api, role):
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.create", role, True)
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.update", role, True)
+    common_checks(unprivileged_user_fixture, f"nvmet.{api}.delete", role, True)
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["SHARING_WRITE", "SHARING_NVME_TARGET_WRITE"]
+)
+def test_write_role_can_change_service_state(unprivileged_user_fixture, role):
+    common_checks(
+        unprivileged_user_fixture, "service.control", role, True, method_args=["START", "nvmet"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RESTART", "nvmet"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RELOAD", "nvmet"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.control", role, True, method_args=["STOP", "nvmet"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
+    )

--- a/tests/api2/test_nvmet_misc_roles.py
+++ b/tests/api2/test_nvmet_misc_roles.py
@@ -1,0 +1,43 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+# Handle public APIs not covered by test_nvmet_crud_roles.py
+
+@pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NVME_TARGET_READ"])
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    # Global
+    common_checks(unprivileged_user_fixture, "nvmet.global.config", role, True,
+                  valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nvmet.global.sessions", role, True,
+                  valid_role_exception=False)
+
+    # Host
+    common_checks(unprivileged_user_fixture, "nvmet.host.dhchap_dhgroup_choices", role, True,
+                  valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nvmet.host.dhchap_hash_choices", role, True,
+                  valid_role_exception=False)
+
+    # Port
+    common_checks(unprivileged_user_fixture, "nvmet.port.transport_address_choices", role, True,
+                  valid_role_exception=False, method_args=['TCP'])
+
+
+@pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NVME_TARGET_READ"])
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    # Global
+    common_checks(unprivileged_user_fixture, "nvmet.global.update", role, False, method_args={})
+
+    # Host
+    common_checks(unprivileged_user_fixture, "nvmet.host.generate_key", role, False)
+
+
+@pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_NVME_TARGET_WRITE"])
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    # Global
+    common_checks(unprivileged_user_fixture, "nvmet.global.update", role, True, method_args={})
+
+    # Host
+    common_checks(unprivileged_user_fixture, "nvmet.host.generate_key", role, True,
+                  valid_role_exception=False)


### PR DESCRIPTION
- Allow `SHARING_NVME_TARGET_WRITE` role to control `nvmet` service
- Add CI tests for `nvmet` roles

----
CI tests run/pass locally

Original PR: https://github.com/truenas/middleware/pull/17131
