### PR TITLE
NAS-137434 / 26.04 / Fix disk temps when empty SD card readers are present

### DIFF
--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -111,20 +111,10 @@ class DiskService(CRUDService):
             context['disks_keys'] = await self.middleware.call('kmip.retrieve_sed_disks_keys')
 
         if context['real_names']:
-            context['identifier_to_name'] = dict()
-            for disk in await self.middleware.call('disk.get_disks'):
-                try:
-                    context['identifier_to_name'][disk.identifier] = disk.name
-                except Exception:
-                    # when we access the "identifier" attribute of the disk object
-                    # we try to read partitions on the devices which requires
-                    # opening the underlying device. Our users run TrueNAS
-                    # on extravagant hardware and, sometimes, the devices dont
-                    # respond very well to even opening them in RD_ONLY mode.
-                    # For example, opening an empty sd-card reader device
-                    # raises errno 123 (no medimum found). In this scenario
-                    # and any other, we should not crash here.
-                    context['identifier_to_name'][disk.name] = disk.name
+            context['identifier_to_name'] = {
+                disk.identifier: disk.name
+                for disk in await self.middleware.call('disk.get_disks')
+            }
 
         if context['pools']:
             context['boot_pool_disks'] = await self.middleware.call('boot.get_disks')


### PR DESCRIPTION
In previous commit 294a283408bfa4ba9a01b845bef83ab15cb81f06, the ability to create zpools when an EMPTY SD card reader was present was resolved. However, the underlying issue is still present in other parts of the stack because we also use this for gathering temperature information.

The issue is that in the `identifier` property of `DiskEntry` class goes through a process to try and determine a unique identifier for every disk on a system. This is important for obvious reasons. One of the steps for determining the unique identifier is to read the disk for partitions since we use GPT (they have GUID's). What's happening, however, is that empty SD card readers aren't reporting a serial number so we fallback to reading partitions. However, when the SD card reader is empty the `open` syscall is failing with errno 123 (no medium found) and we're not expecting the crash.

To remedy this situation we'll check for this errno specifically and log all others. It's important that we don't crash here since this functionality is tied to various other parts of the system in general and crashing here causes a cascading set of failures.