### PR TITLE
NAS-137213 / 25.10-RC.1 / Add reasonable defaults for vram/vgamem/ram attributes for display device (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -66,7 +66,7 @@ class DISPLAY(Device):
                     'children': [create_element(
                         'resolution', x=self.resolution().split('x')[0], y=self.resolution().split('x')[-1]
                     )]
-                })
+                }, vgamem=str(64*1024), ram=str(128*1024), vram=str(64*1024))
             ]
         })
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -52,7 +52,8 @@ def test_cdrom_xml(vm_data, expected_xml):
         },
     }]}, '<devices><graphics type="spice" port="5912"><listen type="address" address="0.0.0.0" /></graphics>'
          '<controller type="usb" model="nec-xhci" /><input type="tablet" bus="usb" /><video>'
-         '<model type="qxl"><resolution x="1024" y="768" /></model></video><channel type="spicevmc">'
+         '<model type="qxl" vgamem="65536" ram="131072" vram="65536"><resolution x="1024" y="768" /></model>'
+         '</video><channel type="spicevmc">'
          f'<target type="virtio" name="com.redhat.spice.0" /></channel>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
 ])


### PR DESCRIPTION
## Context

We have seen that on higher resolutions, the default values libvirt sets for `vgamem/ram/vram` might not be sufficient and keeping that in mind, changes have been added to have reasonable defaults for these attrs so we support all the resolutions out of the box.

Original PR: https://github.com/truenas/middleware/pull/17136
