### PR TITLE
NAS-137439 / 25.04.2.4 / Simplify ACL handling in samba for POSIX ACLs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -44,7 +44,6 @@ class TrueNASVfsObjects(enum.StrEnum):
     FRUIT = 'fruit'
     STREAMS_XATTR = 'streams_xattr'
     SHADOW_COPY_ZFS = 'shadow_copy_zfs'
-    ACL_XATTR = 'acl_xattr'
     IXNAS = 'ixnas'
     WINMSA = 'winmsa'
     RECYCLE = 'recycle'
@@ -96,7 +95,8 @@ def __parse_share_fs_acl(share_path: str, vfs_objects: set) -> None:
 
     match (acltype := path_get_acltype(share_path)):
         case FS_ACL_Type.POSIX1E:
-            vfs_objects.add(TrueNASVfsObjects.ACL_XATTR)
+            # We're relying on default samba POSIX ACL processing to handle ACLs.
+            pass
         case FS_ACL_Type.NFS4:
             vfs_objects.add(TrueNASVfsObjects.IXNAS)
         case FS_ACL_Type.DISABLED:

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -152,7 +152,6 @@ def test__base_smb_posixacl(posixacl_dataset):
     assert conf['vfs objects'] == [
         TrueNASVfsObjects.STREAMS_XATTR,
         TrueNASVfsObjects.SHADOW_COPY_ZFS,
-        TrueNASVfsObjects.ACL_XATTR,
         TrueNASVfsObjects.ZFS_CORE,
         TrueNASVfsObjects.IO_URING
     ]


### PR DESCRIPTION
This commit removes the smb.conf generation step in which we add vfs_acl_xattr if POSIX ACLs are enabled. This was originally added to provide support for a somewhat richer ACL model when POSIX acltype was selected for an SMB share (non-default configuration). Unfortunately, this creates two potential sources of truth for the ACL contents and has potential to create hard-to-diagnose permissions issues on the backend.

Since we already have a rich ACL model provided by the NFSv4 acltype on ZFS, it provides a better UX to simplify the ACL implementation for POSIX ACLs by removing this module.

Original PR: https://github.com/truenas/middleware/pull/17144
