### PR TITLE
NAS-137440 / 25.10-RC.1 / better error message in vm.device.convert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -101,7 +101,7 @@ class VMDeviceService(CRUDService):
 
     @private
     def validate_convert_disk_image(self, dip, schema, converting_from_image_to_zvol=False):
-        if not dip.startswith("/mnt/"):
+        if not dip.startswith("/mnt/") or os.path.dirname(dip) == "/mnt":
             raise ValidationError(schema, f'{dip!r} is an invalid location', errno.EINVAL)
 
         st = None


### PR DESCRIPTION
Missed some validation here that was found by UI team during implementation. Need to ensure the disk image exists in a proper location. Raise a proper validation error message otherwise.

Original PR: https://github.com/truenas/middleware/pull/17145
