### PR TITLE
NAS-137301 / 26.04 / Fix snapshot_exists endpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -134,7 +134,7 @@ class ZFSResourceService(Service):
         """Check to see if a given snapshot exists.
         NOTE: internal method so lots of assumptions
         are made by the passed in `snap_name` arg."""
-        ds, snap_name = snap_name.split("@")
+        ds = snap_name.split("@")[0]
         rv = self.middleware.call_sync(
             "zfs.resource.query_impl",
             {"paths": [ds], "properties": None, "get_snapshots": True}

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -134,10 +134,9 @@ class ZFSResourceService(Service):
         """Check to see if a given snapshot exists.
         NOTE: internal method so lots of assumptions
         are made by the passed in `snap_name` arg."""
-        ds = snap_name.split("@")[0]
         rv = self.middleware.call_sync(
             "zfs.resource.query_impl",
-            {"paths": [ds], "properties": None, "get_snapshots": True}
+            {"paths": [snap_name.split("@")[0]], "properties": None, "get_snapshots": True}
         )
         return rv and snap_name in rv[0]["snapshots"]
 


### PR DESCRIPTION
This commit adds changes to fix snapshot_exists as when we query underlying zfs dataset snapshots, we get the full name i.e ds@snap and we were checking the latter part earlier.