### PR TITLE
NAS-137446 / 26.04 / Fix handling for disabled directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/connection.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/connection.py
@@ -32,6 +32,9 @@ class DomainConnection(
 
     def _get_enabled_ds(self):
         server_type = self.middleware.call_sync('directoryservices.config')['service_type']
+        if server_type is None:
+            return None
+
         return DSType(server_type)
 
     @pass_app()


### PR DESCRIPTION
When the _get_enabled_ds function was refactored for backend datastore changes an error was introduced whereby having disabled directory services could cause certain checks to fail with ValueError because we were trying to return DSType(None).