### PR TITLE
NAS-137471 / 26.04 / Revert NAS-137424 call failover.become_passive in system.reboot on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/system/lifecycle.py
@@ -97,18 +97,6 @@ class SystemService(Service):
         if options["delay"] is not None:
             await asyncio.sleep(options["delay"])
 
-        if (
-            await self.middleware.call("failover.licensed")
-            and (await self.middleware.call("failover.config"))["disabled"] is False
-        ):
-            # "proper" shutdown process on linux produces
-            # an untenable situation where race conditions
-            # abound with how we've written our failover
-            # logic. Instead of battling this war, we'll
-            # employ the same tactic that we already use
-            # in the failover plugin itself. (i.e. panic ourself)
-            await self.middleware.call("failover.become_passive")
-
         await run(["/sbin/shutdown", "-r", "now"])
 
     @api_method(


### PR DESCRIPTION
This reverts commit 52eaaea6027f54aa468e8a186d9023a519fcae08. This has introduced 2 new regressions that are easily solved but the risk is not worth the payout for 25.04.2.4 especially since this is related to HA.

Original PR: https://github.com/truenas/middleware/pull/17156
