### PR TITLE
NAS-137229 / 25.10-RC.1 / Extend stig tests to include VM plugin validation and fix rate limit issues (by Qubad786)

### DIFF
--- a/tests/stig/test_01_stig.py
+++ b/tests/stig/test_01_stig.py
@@ -456,8 +456,25 @@ class TestNotAuthorizedOps:
         pp('docker.update', {'pool': 'NotApplicable'}, True, id="Docker"),
         pp('virt.global.update', {'pool': 'NotApplicable'}, True, id="VM support"),
         pp('tn_connect.update', {'enabled': True, 'ips': ['1.2.3.4']}, False, id="TrueNAS Connect"),
+        # VM operations
+        pp('vm.create', {'name': 'test_vm', 'vcpus': 1, 'memory': 512, 'bootloader': 'UEFI'}, False, id="VM create"),
+        pp('vm.update', (1, {'vcpus': 2}), False, id="VM update"),
+        pp('vm.start', (1, {}), False, id="VM start"),
+        pp('vm.stop', (1, {}), True, id="VM stop"),
+        pp('vm.restart', 1, True, id="VM restart"),
+        pp('vm.poweroff', 1, False, id="VM poweroff"),
+        pp('vm.clone', 1, False, id="VM clone"),
+        pp('vm.delete', (1, {'delay': 0}), False, id="VM delete"),
+        # VM device operations
+        pp('vm.device.create', {'vm': 1, 'dtype': 'NIC', 'attributes': {}}, False, id="VM device create"),
+        pp('vm.device.update', (1, {'dtype': 'NIC', 'attributes': {}}), False, id="VM device update"),
+        pp('vm.device.delete', 1, False, id="VM device delete"),
     ])
     def test_stig_prevent_operation(self, stig_admin, cmd, args, is_job):
         ''' Wnen in GPOS STIG mode enabling TrueCommand is not authorized '''
         with pytest.raises(CallError, match='Not authorized'):
-            stig_admin.call(cmd, args, job=is_job)
+            time.sleep(1)
+            if isinstance(args, tuple):
+                stig_admin.call(cmd, *args, job=is_job)
+            else:
+                stig_admin.call(cmd, args, job=is_job)


### PR DESCRIPTION
## Context

We needed to extend stig tests to include VM plugin validation, however we were also seeing rate limit failures. How this has been resolved is that we are keeping a client around before enabling STIG and then using that to clear rate limit cache to avoid running into rate limit issues.

Original PR: https://github.com/truenas/middleware/pull/17159
