### PR TITLE
NAS-137488 / 26.04 / Fix nfs start sharenfs in exports.d

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -344,7 +344,7 @@ def run_missing_usrgrp_mapping_test(data: list[str], usrgrp, tmp_path, share, us
 
 @contextlib.contextmanager
 def manage_start_nfs():
-    """ The exit state is managed by init_nfs """
+    """ Context Manager: The exit state is managed by init_nfs """
     try:
         yield set_nfs_service_state('start')
     finally:
@@ -501,11 +501,9 @@ def nfs_dataset_and_share():
 
 @pytest.fixture(scope="class")
 def start_nfs():
-    """ The exit state is managed by init_nfs """
-    try:
-        yield set_nfs_service_state('start')
-    finally:
-        set_nfs_service_state('stop')
+    """ Class Fixture: The exit state is managed by init_nfs """
+    with manage_start_nfs() as nfs_start:
+        yield nfs_start
 
 
 # =====================================================================
@@ -2105,7 +2103,8 @@ def test_sharenfs_in_exportsd():
     # Start from a stopped state
     set_nfs_service_state('stop')
 
-    with nfs_dataset('nfs') as ds:
+    # Create a dataset for the ZFS 'sharenfs'
+    with nfs_dataset('zfsnfs') as ds:
         try:
             # Get the sharenfs entries in place
             set_immutable_state('/etc/exports.d', want_immutable=False)  # Disable immutable


### PR DESCRIPTION
We do not allow NFS share configuration files, or any files, in `/etc/exports.d`.  This directory is where ZFS installs it's NFS sharing configuration.  To maintain filesystem security and integrity we allow only TrueNAS managed share configuration files.

The code enforcing this is defective.  The crux being that when ZFS generates an NFS share file, `zfs.exports` it also generates a lock file, `zfs.exports.lock`.  Before we enable NFS we generate a list of files in `/etc/exports.d` and process and delete them one by one.  If one is `zfs.exports` we do additional processing to disable NFS sharing via ZFS before deleting it.  Most of the time the file listing would place `zfs.exports` before `zfs.exports.lock`.  However, sometimes `zfs.exports.lock` is processed before `zfs.exports`.  This introduces a failure condition that ultimately results in blocking the start of NFS.

The fix is to always process `zfs.exports` first.

Ran many CI runs to make sure we test both types of list ordering.  No failure to start NFS was found.

This PR also includes: 
- Small improvements to log messages in the mako file
- A new targeted CI test
- Small code re-use optimization.