### PR TITLE
NAS-137498 / 26.04 / Allow include key for custom apps

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
@@ -20,9 +20,12 @@ def validate_payload(data: dict, schema: str) -> dict:
         else:
             if not isinstance(compose_config, dict):
                 verrors.add(f'{schema}.custom_compose_config_string', 'YAML must represent a dictionary/object')
-            elif 'services' not in compose_config:
-                verrors.add(f'{schema}.custom_compose_config_string', 'YAML is missing required \"services\" key')
-
+            elif 'services' not in compose_config and 'include' not in compose_config:
+                verrors.add(
+                    f'{schema}.custom_compose_config_string',
+                    'YAML is missing required "services" key or '
+                    '"include" key which points to a file that has services'
+                )
     verrors.check()
 
     return compose_config


### PR DESCRIPTION
## Context

@gfeldman added some changes to allow using `include` in custom apps for users who want to manage their own docker compose files.

Addressing the feedback https://github.com/truenas/middleware/pull/17056 here in this PR.

Thank you @gfeldman for your contribution.

(This has been tested and it works nicely for custom apps)