### PR TITLE
NAS-137505 / 25.10-RC.1 / Fix error when handling PAM failures (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/account/authenticator.py
+++ b/src/middlewared/middlewared/utils/account/authenticator.py
@@ -310,7 +310,7 @@ class UserPamAuthenticator(pam.PamAuthenticator):
             # file and associated audit entries.
             self.pam_set_item(self.handle, pam.PAM_RHOST, ctypes.c_char_p(origin))
         else:
-            reason = self.pam_strerror(self.handle, retval).encode()
+            reason = self.pam_strerror(self.handle, retval).decode()
 
         return TrueNASAuthenticatorResponse(TrueNASAuthenticatorStage.START, retval, reason)
 
@@ -342,7 +342,7 @@ class UserPamAuthenticator(pam.PamAuthenticator):
             self.truenas_state.passwd = passwd
             self.truenas_state.stage = TrueNASAuthenticatorStage.LOGIN
         else:
-            reason = self.pam_strerror(self.handle, retval)
+            reason = self.pam_strerror(self.handle, retval).decode()
 
         return TrueNASAuthenticatorResponse(TrueNASAuthenticatorStage.AUTH, retval, reason, passwd)
 
@@ -476,7 +476,7 @@ class UserPamAuthenticator(pam.PamAuthenticator):
         with self.TRUENAS_LOCK:
             resp = super().close_session()
 
-        reason = self.pam_strerror(self.handle, resp)
+        reason = self.pam_strerror(self.handle, resp).decode()
         return TrueNASAuthenticatorResponse(TrueNASAuthenticatorStage.CLOSE_SESSION, resp, reason)
 
     def end(self) -> None:


### PR DESCRIPTION
This commit fixes a potential edge case failure when trying to initialize a PAM context (we were encoding instead of decoding) and also makes sure we decode other places where we pam_strerror.

Original PR: https://github.com/truenas/middleware/pull/17174
