### PR TITLE
NAS-137528 / 26.04 / Refactor filters to not be object oriented

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -1,22 +1,16 @@
 from typing import Annotated, Self
 
+from pydantic import AfterValidator, model_validator
+
 from middlewared.api.base import BaseModel
-from middlewared.utils import filters
+from middlewared.utils import validate_filters, validate_options
 from middlewared.utils.cron import croniter_for_schedule
 
-from pydantic import AfterValidator, model_validator
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult"]
 
-filter_obj = filters()
 
-
-def validate_query_filters(qf: list) -> list:
-    filter_obj.validate_filters(qf)
-    return qf
-
-
-QueryFilters = Annotated[list, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[list, AfterValidator(validate_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -35,7 +29,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        filter_obj.validate_options(self.dict())
+        validate_options(self.model_dump())
         return self
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/common.py
+++ b/src/middlewared/middlewared/api/v25_04_1/common.py
@@ -1,22 +1,14 @@
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel
-from middlewared.utils import filters
-from middlewared.utils.cron import croniter_for_schedule
-
 from pydantic import AfterValidator, model_validator
+
+from middlewared.api.base import BaseModel
+from middlewared.utils import validate_filters, validate_options
+from middlewared.utils.cron import croniter_for_schedule
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult"]
 
-filter_obj = filters()
-
-
-def validate_query_filters(qf: list) -> list:
-    filter_obj.validate_filters(qf)
-    return qf
-
-
-QueryFilters = Annotated[list, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[list, AfterValidator(validate_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -35,7 +27,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        filter_obj.validate_options(self.dict())
+        validate_options(self.model_dump())
         return self
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/common.py
+++ b/src/middlewared/middlewared/api/v25_04_2/common.py
@@ -1,22 +1,14 @@
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel
-from middlewared.utils import filters
-from middlewared.utils.cron import croniter_for_schedule
-
 from pydantic import AfterValidator, Field, model_validator
+
+from middlewared.api.base import BaseModel
+from middlewared.utils import validate_filters, validate_options
+from middlewared.utils.cron import croniter_for_schedule
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult"]
 
-filter_obj = filters()
-
-
-def validate_query_filters(qf: list) -> list:
-    filter_obj.validate_filters(qf)
-    return qf
-
-
-QueryFilters = Annotated[list, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[list, AfterValidator(validate_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -54,7 +46,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        filter_obj.validate_options(self.dict())
+        validate_options(self.model_dump())
         return self
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -1,28 +1,20 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
-from middlewared.utils import filters
-from middlewared.utils.cron import croniter_for_schedule
-
 from pydantic import AfterValidator, model_validator, Field
 
+from middlewared.api.base import BaseModel, TimeString
+from middlewared.utils import validate_filters, validate_options
+from middlewared.utils.cron import croniter_for_schedule
+
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
-
-filter_obj = filters()
-
-
-def validate_query_filters(qf: list) -> list:
-    filter_obj.validate_filters(qf)
-    return qf
-
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
 QF_FIELD = Field(default=[], description=QF_DOC, examples=[
     [["name", "=", "bob"]],
     [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
 ])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -60,7 +52,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        filter_obj.validate_options(self.model_dump())
+        validate_options(self.model_dump())
         return self
 
 

--- a/src/middlewared/middlewared/api/v26_04_0/common.py
+++ b/src/middlewared/middlewared/api/v26_04_0/common.py
@@ -1,28 +1,20 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
-from middlewared.utils import filters
-from middlewared.utils.cron import croniter_for_schedule
-
 from pydantic import AfterValidator, model_validator, Field
 
+from middlewared.api.base import BaseModel, TimeString
+from middlewared.utils import validate_filters, validate_options
+from middlewared.utils.cron import croniter_for_schedule
+
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
-
-filter_obj = filters()
-
-
-def validate_query_filters(qf: list) -> list:
-    filter_obj.validate_filters(qf)
-    return qf
-
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
 QF_FIELD = Field(default=[], description=QF_DOC, examples=[
     [["name", "=", "bob"]],
     [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
 ])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -60,7 +52,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        filter_obj.validate_options(self.model_dump())
+        validate_options(self.model_dump())
         return self
 
 

--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -9,15 +9,9 @@ from sqlalchemy.sql.expression import nullsfirst, nullslast
 
 from middlewared.service import Service
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils import filters
+from middlewared.utils import do_select, validate_filters, validate_options
 from .filter import FilterMixin
 from .schema import SchemaMixin
-
-
-filters_obj = filters()
-do_select = filters_obj.do_select
-validate_filters = filters_obj.validate_filters
-validate_options = filters_obj.validate_options
 
 
 def regexp(expr, item):

--- a/src/middlewared/middlewared/utils/filter_ops.py
+++ b/src/middlewared/middlewared/utils/filter_ops.py
@@ -1,0 +1,74 @@
+import operator
+import re
+from types import MappingProxyType
+
+
+def op_in(x, y):
+    return operator.contains(y, x)
+
+
+def op_rin(x, y):
+    if x is None:
+        return False
+    return operator.contains(x, y)
+
+
+def op_nin(x, y):
+    if x is None:
+        return False
+    return not operator.contains(y, x)
+
+
+def op_rnin(x, y):
+    if x is None:
+        return False
+    return not operator.contains(x, y)
+
+
+def op_re(x, y):
+    # Some string fields are nullable. If this is the case then we will treat the null as an empty string
+    # so that the regex match doesn't raise an exception.
+    return re.match(y, x or '')
+
+
+def op_startswith(x, y):
+    if x is None:
+        return False
+    return x.startswith(y)
+
+
+def op_notstartswith(x, y):
+    if x is None:
+        return False
+    return not x.startswith(y)
+
+
+def op_endswith(x, y):
+    if x is None:
+        return False
+    return x.endswith(y)
+
+
+def op_notendswith(x, y):
+    if x is None:
+        return False
+    return not x.endswith(y)
+
+
+opmap = MappingProxyType({
+    '=': operator.eq,
+    '!=': operator.ne,
+    '>': operator.gt,
+    '>=': operator.ge,
+    '<': operator.lt,
+    '<=': operator.le,
+    '~': op_re,
+    'in': op_in,
+    'nin': op_nin,
+    'rin': op_rin,
+    'rnin': op_rnin,
+    '^': op_startswith,
+    '!^': op_notstartswith,
+    '$': op_endswith,
+    '!$': op_notendswith,
+})


### PR DESCRIPTION
This is a simple change to remove the `filters` class and instead make its methods functions of the `middlewared.utils.filter_list` module. Creating multiple `filters` objects throughout middleware is unnecessary.

* Replace all `filters` objects with direct function imports
* Create new module `middlewared.utils.filter_ops` for storing filter operations
* Other minor improvements

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5916/