### PR TITLE
NAS-137532 / 26.04 / Update `sharenfs` test

### DIFF
--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_dependency import depends
 
 from auto_config import ha, pool_name
+from middlewared.service_exception import CallError
 from middlewared.test.integration.utils import call, fail
 from middlewared.test.integration.utils.client import client
 
@@ -183,8 +184,8 @@ def test_004_verify_pool_property_unused_disk_functionality(request, ws_client, 
     """
     depends(request, ['POOL_FUNCTIONALITY1'])
     zp_name = list(pool_data.keys())[0]
-    with pytest.raises(Exception):
-        # should prevent setting this property at root dataset
+    with pytest.raises(CallError, match="cannot share"):
+        # should prevent setting this property on any dataset
         ws_client.call('zfs.dataset.update', zp_name, {'properties': {'sharenfs': {'value': 'on'}}})
 
     # export zpool


### PR DESCRIPTION
CI test `test_004_verify_pool_property_unused_disk_functionality` in `api2/test_006_pool_and_sysds.py` has been consistently failing.

To address this we disabled ZFS `sharenfs` and `sharesmb` in a ZFS [PR](https://github.com/truenas/zfs/pull/306) 

This PR modifies `api2/test_006_pool_and_sysds.py` and tailors it to the ZFS changes.
Also removed `test_sharenfs_in_exportsd` since the ZFS change makes it impossible to create it.

[CI run](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/5921/) (before removing `test_sharenfs_in_exportsd`)

NOTE:  Successful CI runs are dependent on the ZFS PR.