### PR TITLE
NAS-137502 / 26.04 / Fix migration index issue

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-03-20_11-52_drop_smart.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-03-20_11-52_drop_smart.py
@@ -115,9 +115,9 @@ def upgrade():
         except Exception:
             raise
 
-    with op.batch_alter_table('tasks_smarttest_smarttest_disks', schema=None) as batch_op:
-        batch_op.drop_index('tasks_smarttest_smarttest_disks_smarttest_id__disk_id')
-
+    # There is no need to drop tasks_smarttest_smarttest_disks indices explicitly as they will be
+    # dropped automatically when the table is dropped.
+    # https://sqlite.org/lang_droptable.html
     op.drop_table('tasks_smarttest_smarttest_disks')
     op.drop_table('services_smart')
     op.drop_table('tasks_smarttest')


### PR DESCRIPTION
## Problem

We had dropped smart related tables and in one place we were trying to drop an index of a table but for a user it errored out saying that relevant index does not exist.

This is because the user is really old and had the table created from django era where django had created a different index 
```
CREATE UNIQUE INDEX system_smarttest_smarttest_disks_smarttest_id__disk_id ON tasks_smarttest_smarttest_disks (smarttest_id, disk_id);
CREATE INDEX system_smarttest_smarttest_disks_ad111e65 ON tasks_smarttest_smarttest_disks (disk_id);
CREATE INDEX system_smarttest_smarttest_disks_ec6fbbff ON tasks_smarttest_smarttest_disks (smarttest_id);
```

Django is known to do this.

## Solution

As we do not care about the table at all because we are dropping it, we can safely choose not to drop the index manually and instead just drop the table as sqlite3 will automatically drop all indices once the table has been dropped.

I have confirmed that the migrations run nicely on the user's db after this:
```
root@test759B06CZSX[~]# migrate
+ DATABASE=/data/freenas-v1.db
+ PWENC_SECRET=/data/pwenc_secret
+ python3 -c import os; import sys; sys.path.remove("") if "" in sys.path else None; import middlewared; print(os.path.dirname(middlewared.__spec__.origin))
+ cd /usr/lib/python3/dist-packages/middlewared
+ FREENAS_DATABASE=/data/freenas-v1.db FREENAS_PWENC_SECRET=/data/pwenc_secret alembic upgrade head
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 9ada77affbb9 -> 5fda0931889d, Drop vm tables
INFO  [alembic.runtime.migration] Running upgrade 5fda0931889d -> ed9a781ec0c6, Remove disk_smartoptions
INFO  [alembic.runtime.migration] Running upgrade ed9a781ec0c6, 0257529fa6d5 -> 616c19f82016, Merge migration for adding uid/gid 568 idmap
INFO  [alembic.runtime.migration] Running upgrade 616c19f82016 -> a156968d5cbb, Remove syslog_tls_certificate_authority
INFO  [alembic.runtime.migration] Running upgrade a156968d5cbb -> 940b79ac591f, API key revoked reason
INFO  [alembic.runtime.migration] Running upgrade 940b79ac591f -> 801eb4df44ce, Rename uq_truenas_enclosurelabel_encid to uq_enclosure_label_encid
INFO  [alembic.runtime.migration] Running upgrade 801eb4df44ce, df0bffcf1595 -> a34e4c124c25, Merge migration for incus storage pools
INFO  [alembic.runtime.migration] Running upgrade a34e4c124c25 -> cf1f98f4c3b1, Remove system.general language column.
INFO  [alembic.runtime.migration] Running upgrade cf1f98f4c3b1 -> 9a5b103ec2e4, Remove CA plugin
INFO  [alembic.runtime.migration] Running upgrade 9a5b103ec2e4 -> f15312414057, Remove SMART support
INFO  [alembic.runtime.migration] Running upgrade f15312414057, 249b95f63f76 -> d7e3a916db65, Merge migration after adding account policy columns
```