### PR TITLE
NAS-137549 / 25.10.0 / Allow workgroups named "DOMAIN" in SMB configuration (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/netbios.py
+++ b/src/middlewared/middlewared/utils/netbios.py
@@ -12,7 +12,10 @@ MS_RESERVED_WORDS = frozenset([
     'BATCH'.casefold(),
     'BUILTIN'.casefold(),
     'DIALUP'.casefold(),
-    'DOMAIN'.casefold(),
+    # Although DOMAIN is a reserved keyword per microsoft documentation, we have a customer
+    # who decided to name their AD domain "DOMAIN". Hence, this part of validation is removed
+    # but left commented-out to avoid someone re-introducing the validation in the future.
+    # 'DOMAIN'.casefold(),
     'ENTERPRISE'.casefold(),
     'INTERACTIVE'.casefold(),
     'INTERNET'.casefold(),


### PR DESCRIPTION
This commit relaxes validation to allow a customer to use a microsoft reserved keyword for the workgroup / AD domain although this technically should not be used. This is because re-deploying an AD domain to fix a violation of MS
naming rules is onerous.

Original PR: https://github.com/truenas/middleware/pull/17195
