### PR TITLE
NAS-137565 / 26.04 / Use openssl for generating cryptographic secrets

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import pathlib
-import secrets
 import subprocess
 import uuid
 from collections import defaultdict
@@ -23,6 +22,7 @@ from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 from middlewared.service import CallError, SharingService, ValidationErrors, private
+from middlewared.utils import secrets
 from middlewared.utils.size import format_size
 from .utils import sanitize_extent
 

--- a/src/middlewared/middlewared/plugins/nvmet/subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/subsys.py
@@ -1,4 +1,3 @@
-import secrets
 from functools import cache
 
 import middlewared.sqlalchemy as sa
@@ -11,6 +10,7 @@ from middlewared.api.current import (NVMetSubsysCreateArgs,
                                      NVMetSubsysUpdateArgs,
                                      NVMetSubsysUpdateResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
+from middlewared.utils import secrets
 from .mixin import NVMetStandbyMixin
 
 SERIAL_RETRIES = 10

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
@@ -1,5 +1,3 @@
-import secrets
-
 from middlewared.api import api_method
 from middlewared.api.current import (
     PoolDatasetInsertOrUpdateEncryptedRecordArgs, PoolDatasetInsertOrUpdateEncryptedRecordResult,
@@ -7,6 +5,7 @@ from middlewared.api.current import (
     PoolDatasetInheritParentEncryptionPropertiesResult
 )
 from middlewared.service import CallError, job, private, Service, ValidationErrors
+from middlewared.utils import secrets
 
 from .utils import DATASET_DATABASE_MODEL_NAME, ZFSKeyFormat
 

--- a/src/middlewared/middlewared/utils/crypto.py
+++ b/src/middlewared/middlewared/utils/crypto.py
@@ -1,6 +1,7 @@
 from base64 import b64encode
 from hashlib import pbkdf2_hmac
-from secrets import choice, compare_digest, token_urlsafe, token_hex
+from hmac import compare_digest
+from .secrets import choice, token_urlsafe, token_hex
 from ssl import RAND_bytes
 from string import ascii_letters, digits, punctuation
 from uuid import UUID

--- a/src/middlewared/middlewared/utils/secrets.py
+++ b/src/middlewared/middlewared/utils/secrets.py
@@ -41,6 +41,7 @@ class SSLRandom(Random):
 
 _sslrand = SSLRandom()
 choice = _sslrand.choice
+randbits = _sslrand.getrandbits
 
 
 def token_bytes(nbytes=None):

--- a/src/middlewared/middlewared/utils/secrets.py
+++ b/src/middlewared/middlewared/utils/secrets.py
@@ -30,11 +30,11 @@ class SSLRandom(Random):
         return RAND_bytes(n)
 
     def seed(self, *args, **kwds):
-        "Stub method.  Not used for a system random number generator."
+        """Stub method.  Not used for a system random number generator."""
         return None
 
     def _notimplemented(self, *args, **kwds):
-        "Method should not be called for a system random number generator."
+        """Method should not be called for a system random number generator."""
         raise NotImplementedError('System entropy source does not have state.')
     getstate = setstate = _notimplemented
 

--- a/src/middlewared/middlewared/utils/secrets.py
+++ b/src/middlewared/middlewared/utils/secrets.py
@@ -1,0 +1,86 @@
+# Python secrets module equalivalent based on openssl RAND_bytes rather than os.urandom
+
+from random import Random, RECIP_BPF
+from secrets import DEFAULT_ENTROPY
+from ssl import RAND_bytes
+
+
+class SSLRandom(Random):
+    """
+    Alternate random number generator using ssl RAND_bytes.
+    Based on SystemRandom class in cpython/Lib/random.py
+    """
+
+    def random(self):
+        """Get the next random number in the range 0.0 <= X < 1.0."""
+        return (int.from_bytes(RAND_bytes(7)) >> 3) * RECIP_BPF
+
+    def getrandbits(self, k):
+        """getrandbits(k) -> x.  Generates an int with k random bits."""
+        if k < 0:
+            raise ValueError('number of bits must be non-negative')
+        numbytes = (k + 7) // 8                       # bits / 8 and rounded up
+        x = int.from_bytes(RAND_bytes(numbytes))
+        return x >> (numbytes * 8 - k)                # trim excess bits
+
+    def randbytes(self, n):
+        """Generate n random bytes."""
+        # os.urandom(n) fails with ValueError for n < 0
+        # and returns an empty bytes string for n == 0.
+        return RAND_bytes(n)
+
+    def seed(self, *args, **kwds):
+        "Stub method.  Not used for a system random number generator."
+        return None
+
+    def _notimplemented(self, *args, **kwds):
+        "Method should not be called for a system random number generator."
+        raise NotImplementedError('System entropy source does not have state.')
+    getstate = setstate = _notimplemented
+
+
+_sslrand = SSLRandom()
+choice = _sslrand.choice
+
+
+def token_bytes(nbytes=None):
+    """Return a random byte string containing *nbytes* bytes.
+
+    If *nbytes* is ``None`` or not supplied, a reasonable
+    default is used.
+
+    >>> token_bytes(16)
+    b'\\xebr\\x17D*t\\xae\\xd4\\xe3S\\xb6\\xe2\\xebP1\\x8b'
+
+    """
+    if nbytes is None:
+        nbytes = DEFAULT_ENTROPY
+    return _sslrand.randbytes(nbytes)
+
+
+def token_hex(nbytes=None):
+    """Return a random text string, in hexadecimal.
+
+    The string has *nbytes* random bytes, each byte converted to two
+    hex digits.  If *nbytes* is ``None`` or not supplied, a reasonable
+    default is used.
+
+    >>> token_hex(16)
+    'f9bf78b9a18ce6d46a0cd2b0b86df9da'
+
+    """
+    return token_bytes(nbytes).hex()
+
+
+def token_urlsafe(nbytes=None):
+    """Return a random URL-safe text string, in Base64 encoding.
+
+    The string has *nbytes* random bytes.  If *nbytes* is ``None``
+    or not supplied, a reasonable default is used.
+
+    >>> token_urlsafe(16)
+    'Drmhze6EPcv0fN_81Bj-nA'
+
+    """
+    tok = token_bytes(nbytes)
+    return base64.urlsafe_b64encode(tok).rstrip(b'=').decode('ascii')

--- a/src/middlewared/middlewared/utils/sid.py
+++ b/src/middlewared/middlewared/utils/sid.py
@@ -1,7 +1,7 @@
 import enum
 
-from secrets import randbits
 from middlewared.plugins.idmap_.idmap_constants import BASE_SYNTHETIC_DATASTORE_ID, IDType
+from middlewared.utils.secrets import randbits
 
 
 DOM_SID_PREFIX = 'S-1-5-21-'


### PR DESCRIPTION
This commit switches the middleware crypto utils from using the cpython secrets file based on os.urandom to an equivalent based on SSL RAND_bytes.

For reference see:
https://github.com/python/cpython/blob/3.13/Lib/random.py
https://github.com/python/cpython/blob/3.13/Lib/secrets.py
