### PR TITLE
NAS-137570 / 26.04 / Ban python secrets module in flake8 config

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/utils.py
+++ b/src/middlewared/middlewared/plugins/smb_/utils.py
@@ -1,4 +1,4 @@
-from secrets import randbits
+from middlewared.utils.secrets import randbits
 from middlewared.utils.smb import SMBSharePurpose
 from middlewared.plugins.smb_.constants import SMBShareField as share_field
 

--- a/src/middlewared/middlewared/test/integration/assets/directory_service.py
+++ b/src/middlewared/middlewared/test/integration/assets/directory_service.py
@@ -2,12 +2,12 @@
 import contextlib
 import logging
 import os
-import secrets
 import string
 import sys
 
 from dataclasses import dataclass
 from middlewared.test.integration.utils import call, fail
+from middlewared.utils import secrets
 
 __all__ = [
     'directoryservice', 'override_nameservers', 'get_nameservers', 'get_directory_services_account',

--- a/src/middlewared/middlewared/utils/crypto.py
+++ b/src/middlewared/middlewared/utils/crypto.py
@@ -1,12 +1,12 @@
 from base64 import b64encode
 from hashlib import pbkdf2_hmac
 from hmac import compare_digest
-from .secrets import choice, token_urlsafe, token_hex
 from ssl import RAND_bytes
 from string import ascii_letters, digits, punctuation
 from uuid import UUID
 
 from cryptit import cryptit
+from middlewared.utils.secrets import choice, token_urlsafe, token_hex
 
 from samba.crypto import md4_hash_blob
 

--- a/src/middlewared/setup.cfg
+++ b/src/middlewared/setup.cfg
@@ -21,6 +21,8 @@ previous = true
 extend-ignore = A003,LIT001,LIT003,LIT101
 per-file-ignores =
     src/middlewared/middlewared/api/**/__init__.py:F401,F403,F405
+    src/middlewared/middlewared/utils/secrets.py:I251
 max-line-length = 120
 banned-modules =
     pydantic.SecretStr = Use pydantic.Secret[str]
+    secrets = Use middlewared.utils.secrets


### PR DESCRIPTION
This commit bans the secrets module to force use of version that is backed by openssl RAND_bytes.
This helps us from regressing in an area where we need to be compliant.