### PR TITLE
add UpdateImplArgs to match behavior of CreateImplArgs

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -59,6 +59,18 @@ class CreateImplArgs:
     """Create ancestors for the zfs resource being created."""
 
 
+@dataclasses.dataclass(slots=True, kw_only=True)
+class UpdateImplArgs:
+    name: str
+    """The name of the resource being created."""
+    zprops: dict[str, str] = dataclasses.field(default_factory=dict)
+    """ZFS data properties to be applied during creation."""
+    uprops: dict[str, str] = dataclasses.field(default_factory=dict)
+    """ZFS user properties to be applied during creation."""
+    iprops: set = dataclasses.field(default_factory=set)
+    """ZFS properties to be inherited from parent."""
+
+
 def none_normalize(x):
     if x in (0, None):
         return 'none'


### PR DESCRIPTION
This creates an `UpdateImplArgs` class similar to what we did with `CreateImpleArgs`. This will be useful when we switch over internal calls from `zfs.dataset.update` to `pool.dataset.update_impl`. There is no change in behavior and tests pass. While I was here, I removed dead methods that weren't being used anywhere.