### PR TITLE
Correct ErrnoMixin.EHAUNAVAILABLE (not HA_UNAVAILABLE)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/status.py
+++ b/src/middlewared/middlewared/plugins/update_/status.py
@@ -46,7 +46,7 @@ class UpdateService(Service):
                 if await self.middleware.call('failover.disabled.reasons'):
                     raise CallError(
                         'HA is configured but currently unavailable.',
-                        ErrnoMixin.HA_UNAVAILABLE,
+                        ErrnoMixin.EHAUNAVAILABLE,
                     )
 
             current_version = await self.middleware.call('system.version_short')


### PR DESCRIPTION
Recent commit (9f3d0f1) had a typo wrt ErrnoMixin.  Rectify.

(See definition of enum [here](https://github.com/truenas/api_client/blob/1c00233b5cecd04b23c170aeee9edaa9efa2dbd4/truenas_api_client/exc.py#L22).)