### PR TITLE
Fix backwards compatibility of implicit config methods

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -196,7 +196,10 @@ def api_method(
 def check_model_module(model: type[BaseModel], private: bool):
     module_name = model.__module__
 
-    if module_name in ["middlewared.plugins.test.rest", "middlewared.service.crud_service"]:
+    # CRUDService and ConfigService dynamically generate models.
+    if module_name in {
+        "middlewared.plugins.test.rest", "middlewared.service.crud_service", "middlewared.service.config_service"
+    }:
         return
 
     if private:

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -16,7 +16,11 @@ get_or_insert_lock = asyncio.Lock()
 
 
 def config_args(entry: type[BaseModel]) -> type[BaseModel]:
-    return create_model(entry.__name__.removesuffix("Entry") + 'ConfigArgs', __base__=(BaseModel,))
+    return create_model(
+        entry.__name__.removesuffix("Entry") + 'ConfigArgs',
+        __base__=(BaseModel,),
+        __module__=entry.__module__,
+    )
 
 
 def config_result(entry: type[BaseModel]) -> type[BaseModel]:

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -15,6 +15,19 @@ from .service_mixin import ServiceChangeMixin
 get_or_insert_lock = asyncio.Lock()
 
 
+def config_args(entry: type[BaseModel]) -> type[BaseModel]:
+    return create_model(entry.__name__.removesuffix("Entry") + 'ConfigArgs', __base__=(BaseModel,))
+
+
+def config_result(entry: type[BaseModel]) -> type[BaseModel]:
+    return create_model(
+        entry.__name__.removesuffix('Entry') + 'ConfigResult',
+        __base__=(BaseModel,),
+        __module__=entry.__module__,
+        result=Annotated[entry, Field()],
+    )
+
+
 class ConfigServiceMetabase(ServiceBase):
 
     def __new__(cls, name, bases, attrs):
@@ -44,23 +57,20 @@ class ConfigServiceMetabase(ServiceBase):
                 raise ValueError(f'{namespace}: public ConfigService must have entry defined')
         else:
             # Decorate config method with api_method
-            accepts_model = create_model(
-                namespace.replace(".", "_").capitalize() + 'Config',
-                __base__=(BaseModel,),
-                __module__=entry.__module__,
-            )
-            result_model = create_model(
-                entry.__name__.removesuffix('Entry') + 'ConfigResult',
-                __base__=(BaseModel,),
-                __module__=entry.__module__,
-                result=Annotated[entry, Field()],
-            )
+            accepts_model = config_args(entry)
+            result_model = config_result(entry)
             klass.config = api_method(
                 accepts_model,
                 result_model,
                 private=private,
                 cli_private=config.cli_private,
             )(klass.config)
+
+            # Models must be registered with their factories for backwards compatibility.
+            klass._register_models = [
+                (accepts_model, config_args, entry.__name__),
+                (result_model, config_result, entry.__name__),
+            ]
 
         return klass
 

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -23,16 +23,17 @@ from .service_mixin import ServiceChangeMixin
 PAGINATION_OPTS = ('count', 'get', 'limit', 'offset', 'select')
 
 
-def get_instance_args(entry, primary_key="id"):
+def get_instance_args(entry: type[BaseModel], primary_key: str = "id") -> type[BaseModel]:
     return create_model(
         entry.__name__.removesuffix("Entry") + "GetInstanceArgs",
         __base__=(BaseModel,),
+        __module__=entry.__module__,
         id=Annotated[entry.model_fields[primary_key].annotation, Field()],
         options=Annotated[QueryOptions, Field(default={})],
     )
 
 
-def get_instance_result(entry):
+def get_instance_result(entry: type[BaseModel]) -> type[BaseModel]:
     return create_model(
         entry.__name__.removesuffix("Entry") + "GetInstanceResult",
         __base__=(BaseModel,),
@@ -87,6 +88,7 @@ class CRUDServiceMetabase(ServiceBase):
                 cli_private=cli_private,
             )(klass.get_instance)
 
+            # Models must be registered with their factories for backwards compatibility.
             klass._register_models = [
                 (query_result_model, query_result, entry.__name__),
                 (query_result_model.__annotations__["result"].__args__[1],


### PR DESCRIPTION
`ConfigService` config method models must be registered like `CRUDService` query and get_instance methods so that they can be called in previous API versions.