### PR TITLE
NAS-137602 / 26.04 / Fix reset of secret cache on receipt of pwenc secret

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -29,7 +29,7 @@ from middlewared.api.current import (
     FileFollowTailEventSourceArgs, FileFollowTailEventSourceEvent,
 )
 from middlewared.event import EventSource
-from middlewared.utils.pwenc import PWENC_FILE_SECRET, PWENC_FILE_SECRET_MODE
+from middlewared.utils.pwenc import PWENC_FILE_SECRET, PWENC_FILE_SECRET_MODE, pwenc_reset_cache
 from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
 from middlewared.service import private, CallError, filterable_api_method, Service, job
@@ -524,7 +524,7 @@ class FilesystemService(Service):
                 os.fchown(f.fileno(), options.get('uid', -1), options.get('gid', -1))
 
         if path == PWENC_FILE_SECRET:
-            self.middleware.call_sync('pwenc.reset_secret_cache')
+            pwenc_reset_cache()
 
         return True
 

--- a/src/middlewared/middlewared/utils/pwenc.py
+++ b/src/middlewared/middlewared/utils/pwenc.py
@@ -36,7 +36,7 @@ def pwenc_reset_cache():
     """ Clear reference to pwenc secret allowing reopen with possibly different
     contents. This is primarily used by the remote node in HA after syncing to
     peer. """
-    with pewnc_data['lock']:
+    with pwenc_data['lock']:
         pwenc_data['secret_ctx'] = None
 
 

--- a/src/middlewared/middlewared/utils/pwenc.py
+++ b/src/middlewared/middlewared/utils/pwenc.py
@@ -32,6 +32,14 @@ def pwenc_get_ctx():
     return pwenc_data['secret_ctx']
 
 
+def pwenc_reset_cache():
+    """ Clear reference to pwenc secret allowing reopen with possibly different
+    contents. This is primarily used by the remote node in HA after syncing to
+    peer. """
+    with pewnc_data['lock']:
+        pwenc_data['secret_ctx'] = None
+
+
 def pwenc_encrypt(data_in: bytes) -> bytes:
     """ Encrypt and base64 encode the input bytes """
     ctx = pwenc_get_ctx()


### PR DESCRIPTION
This commit fixes an ENOMETHOD failure on HA sync to peer of pwenc secret. On receipt of a new pewnce secret via private upload endpoint we'll clear the cached open of the pwenc secret and allow clients to naturally reopen it.