### PR TITLE
NAS-137612 / 26.04 / Replace `Literal[None]` with `None` to fix API docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Check illegal patterns
+      run: |
+        if grep -r "Literal\[None\]" src/middlewared/middlewared/api/; then
+          echo "❌ Literal[None] usage found in middlewared/api/. Use None instead."
+          exit 1
+        else
+          echo "✅ No Literal[None] usage found in middlewared/api/"
+        fi
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:

--- a/src/middlewared/middlewared/api/v25_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_1/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_1/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_1/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_2/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_2/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_2/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -279,7 +279,7 @@ class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
     """ACL type identifier indicating access control lists are disabled."""
-    acl: Literal[None]
+    acl: None
     """Always `null` when ACLs are disabled on the filesystem."""
     trivial: Literal[True]
     """Always `true` when ACLs are disabled - only basic POSIX permissions apply."""

--- a/src/middlewared/middlewared/api/v25_10_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_10_0/auth.py
@@ -316,7 +316,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the attribute is successfully set."""
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -54,7 +54,7 @@ class DirectoryServicesCacheRefreshArgs(BaseModel):
 
 
 class DirectoryServicesCacheRefreshResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 # Idmap domains are a configuration feature of winbindd when joined to an active directory or ipa domain.

--- a/src/middlewared/middlewared/api/v25_10_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_10_0/filesystem.py
@@ -80,7 +80,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the ownership change is successfully completed."""
 
 
@@ -104,7 +104,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the permission change is successfully completed."""
 
 
@@ -402,7 +402,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the file is successfully read."""
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/idmap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/idmap.py
@@ -12,4 +12,4 @@ class IdmapDomainClearIdmapCacheArgs(BaseModel):
 
 
 class IdmapDomainClearIdmapCacheResult(BaseModel):
-    result: Literal[None]
+    result: None

--- a/src/middlewared/middlewared/api/v25_10_0/idmap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/idmap.py
@@ -1,5 +1,4 @@
 from middlewared.api.base import BaseModel
-from typing import Literal
 
 
 __all__ = [

--- a/src/middlewared/middlewared/api/v26_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v26_04_0/acl.py
@@ -279,7 +279,7 @@ class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
     """ACL type identifier indicating access control lists are disabled."""
-    acl: None
+    acl: Literal[None]
     """Always `null` when ACLs are disabled on the filesystem."""
     trivial: Literal[True]
     """Always `true` when ACLs are disabled - only basic POSIX permissions apply."""

--- a/src/middlewared/middlewared/api/v26_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v26_04_0/acl.py
@@ -279,7 +279,7 @@ class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
     """ACL type identifier indicating access control lists are disabled."""
-    acl: Literal[None]
+    acl: None
     """Always `null` when ACLs are disabled on the filesystem."""
     trivial: Literal[True]
     """Always `true` when ACLs are disabled - only basic POSIX permissions apply."""

--- a/src/middlewared/middlewared/api/v26_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v26_04_0/auth.py
@@ -316,7 +316,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the attribute is successfully set."""
 
 

--- a/src/middlewared/middlewared/api/v26_04_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v26_04_0/directory_services.py
@@ -54,7 +54,7 @@ class DirectoryServicesCacheRefreshArgs(BaseModel):
 
 
 class DirectoryServicesCacheRefreshResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 # Idmap domains are a configuration feature of winbindd when joined to an active directory or ipa domain.

--- a/src/middlewared/middlewared/api/v26_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v26_04_0/filesystem.py
@@ -80,7 +80,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the ownership change is successfully completed."""
 
 
@@ -104,7 +104,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the permission change is successfully completed."""
 
 
@@ -402,7 +402,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the file is successfully read."""
 
 

--- a/src/middlewared/middlewared/api/v26_04_0/idmap.py
+++ b/src/middlewared/middlewared/api/v26_04_0/idmap.py
@@ -12,4 +12,4 @@ class IdmapDomainClearIdmapCacheArgs(BaseModel):
 
 
 class IdmapDomainClearIdmapCacheResult(BaseModel):
-    result: Literal[None]
+    result: None

--- a/src/middlewared/middlewared/api/v26_04_0/idmap.py
+++ b/src/middlewared/middlewared/api/v26_04_0/idmap.py
@@ -1,5 +1,4 @@
 from middlewared.api.base import BaseModel
-from typing import Literal
 
 
 __all__ = [


### PR DESCRIPTION
Sphinx has trouble parsing our method schemas that include `Literal[None]` which is just equivalent to `None`.

<img width="968" height="298" alt="image" src="https://github.com/user-attachments/assets/d4b2cc09-089e-4654-973f-4374fad6782e" />