### PR TITLE
NAS-137612 / 25.10.0 / Replace `Literal[None]` with `None` to fix API docs (by creatorcary)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Check illegal patterns
+      run: |
+        if grep -r "Literal\[None\]" src/middlewared/middlewared/api/; then
+          echo "❌ Literal[None] usage found in middlewared/api/. Use None instead."
+          exit 1
+        else
+          echo "✅ No Literal[None] usage found in middlewared/api/"
+        fi
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:

--- a/src/middlewared/middlewared/api/v25_04_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_1/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_1/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_1/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acl.py
@@ -203,7 +203,7 @@ class POSIXACL(AclBaseInfo):
 class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
-    acl: Literal[None]
+    acl: None
     trivial: Literal[True]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_2/auth.py
@@ -213,7 +213,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('generate_single_use_password')

--- a/src/middlewared/middlewared/api/v25_04_2/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_2/filesystem.py
@@ -70,7 +70,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 @single_argument_args('filesystem_setperm')
@@ -91,7 +91,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 FILESYSTEM_STATX_ATTRS = Literal[
@@ -352,7 +352,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 class FilesystemPutOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -279,7 +279,7 @@ class DISABLED_ACL(AclBaseInfo):
     # ACL response paths with ACL entirely disabled
     acltype: Literal[FS_ACL_Type.DISABLED]
     """ACL type identifier indicating access control lists are disabled."""
-    acl: Literal[None]
+    acl: None
     """Always `null` when ACLs are disabled on the filesystem."""
     trivial: Literal[True]
     """Always `true` when ACLs are disabled - only basic POSIX permissions apply."""

--- a/src/middlewared/middlewared/api/v25_10_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_10_0/auth.py
@@ -316,7 +316,7 @@ class AuthSetAttributeArgs(BaseModel):
 
 
 class AuthSetAttributeResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the attribute is successfully set."""
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -54,7 +54,7 @@ class DirectoryServicesCacheRefreshArgs(BaseModel):
 
 
 class DirectoryServicesCacheRefreshResult(BaseModel):
-    result: Literal[None]
+    result: None
 
 
 # Idmap domains are a configuration feature of winbindd when joined to an active directory or ipa domain.

--- a/src/middlewared/middlewared/api/v25_10_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_10_0/filesystem.py
@@ -80,7 +80,7 @@ class FilesystemChownArgs(FilesystemPermChownBase):
 
 
 class FilesystemChownResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the ownership change is successfully completed."""
 
 
@@ -104,7 +104,7 @@ class FilesystemSetpermArgs(FilesystemPermChownBase):
 
 
 class FilesystemSetpermResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the permission change is successfully completed."""
 
 
@@ -402,7 +402,7 @@ class FilesystemGetArgs(BaseModel):
 
 
 class FilesystemGetResult(BaseModel):
-    result: Literal[None]
+    result: None
     """Returns `null` when the file is successfully read."""
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/idmap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/idmap.py
@@ -12,4 +12,4 @@ class IdmapDomainClearIdmapCacheArgs(BaseModel):
 
 
 class IdmapDomainClearIdmapCacheResult(BaseModel):
-    result: Literal[None]
+    result: None

--- a/src/middlewared/middlewared/api/v25_10_0/idmap.py
+++ b/src/middlewared/middlewared/api/v25_10_0/idmap.py
@@ -1,5 +1,4 @@
 from middlewared.api.base import BaseModel
-from typing import Literal
 
 
 __all__ = [


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 49ddfd331fa10427a57dcf9278d091b8099eb7cc
    git cherry-pick -x e838262a9c005cae3ab46b364c1aa3ccf2480da4
    git cherry-pick -x 4b97328ebb85ec013f9261c083380f7aa97c943e
    git cherry-pick -x c538fb070ce763b4a09b30a95b386c8d1ac4ef7a
    git cherry-pick -x a41e42b9cd8899433edf952191ef8c96dcda49cd

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x e34e638f8541ee63a924fafd91eb1ccc47eb5458

Sphinx has trouble parsing our method schemas that include `Literal[None]` which is just equivalent to `None`.

<img width="968" height="298" alt="image" src="https://github.com/user-attachments/assets/d4b2cc09-089e-4654-973f-4374fad6782e" />

Original PR: https://github.com/truenas/middleware/pull/17218
