### PR TITLE
NAS-137468 / 25.10.0 / Fix backwards compatibility of implicit config methods (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -166,7 +166,10 @@ def api_method(
 def check_model_module(model: type[BaseModel], private: bool):
     module_name = model.__module__
 
-    if module_name in ["middlewared.plugins.test.rest", "middlewared.service.crud_service"]:
+    # CRUDService and ConfigService dynamically generate models.
+    if module_name in {
+        "middlewared.plugins.test.rest", "middlewared.service.crud_service", "middlewared.service.config_service"
+    }:
         return
 
     if private:

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -23,16 +23,17 @@ from .service_mixin import ServiceChangeMixin
 PAGINATION_OPTS = ('count', 'get', 'limit', 'offset', 'select')
 
 
-def get_instance_args(entry, primary_key="id"):
+def get_instance_args(entry: type[BaseModel], primary_key: str = "id") -> type[BaseModel]:
     return create_model(
         entry.__name__.removesuffix("Entry") + "GetInstanceArgs",
         __base__=(BaseModel,),
+        __module__=entry.__module__,
         id=Annotated[entry.model_fields[primary_key].annotation, Field()],
         options=Annotated[QueryOptions, Field(default={})],
     )
 
 
-def get_instance_result(entry):
+def get_instance_result(entry: type[BaseModel]) -> type[BaseModel]:
     return create_model(
         entry.__name__.removesuffix("Entry") + "GetInstanceResult",
         __base__=(BaseModel,),
@@ -87,6 +88,7 @@ class CRUDServiceMetabase(ServiceBase):
                 cli_private=cli_private,
             )(klass.get_instance)
 
+            # Models must be registered with their factories for backwards compatibility.
             klass._register_models = [
                 (query_result_model, query_result, entry.__name__),
                 (query_result_model.__annotations__["result"].__args__[1],

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -1,3 +1,39 @@
+import pytest
+
+from middlewared.test.integration.utils import client, session, url
+
+
+def get_api_versions():
+    with session() as s:
+        return s.get(f"{url()}/api/versions").json()
+
+
+@pytest.fixture(scope="module", params=get_api_versions(), ids=lambda v: f"legacy_api_client={v}")
+def legacy_api_client(request):
+    with client(version=request.param) as c:
+        yield c
+
+
+def get_methods(name: str | None = None):
+    with client() as c:
+        methods = c.call("core.get_methods")
+
+    if name:
+        return filter(lambda m: m.endswith(f".{name}"), methods)
+
+    return methods
+
+
+@pytest.fixture(scope="module", params=get_methods("query"), ids=lambda m: f"query_method={m}")
+def query_method(request):
+    yield request.param
+
+
+@pytest.fixture(scope="module", params=get_methods("config"), ids=lambda m: f"config_method={m}")
+def config_method(request):
+    yield request.param
+
+
 def test_query_method(legacy_api_client, query_method):
     version = legacy_api_client._ws.url.split("/")[-1].lstrip("v")
     # Methods that do not exist in the previous API versions
@@ -35,3 +71,37 @@ def test_query_method(legacy_api_client, query_method):
         return
 
     legacy_api_client.call(query_method)
+
+
+def test_config_method(legacy_api_client, config_method):
+    version = legacy_api_client._ws.url.split("/")[-1].lstrip("v")
+    if config_method == "app.config":
+        # Not a ConfigService config method. Requires an argument.
+        return
+
+    # Methods that do not exist in 25.04
+    if (
+        version in {"25.04.0", "25.04.1", "25.04.2"}
+        and config_method in {
+            "audit.config",
+            "auth.twofactor.config",
+            "directoryservices.config",
+            "kerberos.config",
+            "kmip.config",
+            "mail.config",
+            "network.configuration.config",
+            "nvmet.global.config",
+            "replication.config.config",
+            "ssh.config",
+            "support.config",
+            "system.advanced.config",
+            "system.general.config",
+            "systemdataset.config",
+            "truecommand.config",
+            "update.config",
+            "ups.config",
+        }
+    ):
+        return
+
+    legacy_api_client.call(config_method)

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -67,6 +67,7 @@ def test_query_method(legacy_api_client, query_method):
         "sharing.smb.query",
         "tunable.query",
         "vmware.query",
+        "zfs.resource.query",
     }:
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import os
 import pytest
 
 from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
-from middlewared.test.integration.utils import client, session, url
 from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.pytest import failed
 
@@ -60,41 +59,6 @@ def mock_role():
     if not STIG_ENABLED:
         truenas_server.client.call("test.add_mock_role")
     yield
-
-
-def pytest_generate_tests(metafunc):
-    if "legacy_api_client" in metafunc.fixturenames:
-        with session() as s:
-            versions = s.get(f"{url()}/api/versions").json()
-
-        metafunc.parametrize(
-            "legacy_api_client",
-            versions,
-            indirect=True,
-            ids=[f"legacy_api_client={version}" for version in versions],
-        )
-
-    if "query_method" in metafunc.fixturenames:
-        with client() as c:
-            methods = [name for name in c.call("core.get_methods") if name.endswith(".query")]
-
-        metafunc.parametrize(
-            "query_method",
-            methods,
-            indirect=True,
-            ids=[f"query_method={method}" for method in methods],
-        )
-
-
-@pytest.fixture(scope="module")
-def legacy_api_client(request):
-    with client(version=request.param) as c:
-        yield c
-
-
-@pytest.fixture
-def query_method(request):
-    yield request.param
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 15784fcb78ad8925ae743cfd733e9054877d6cff
    git cherry-pick -x 68d6de36d582348be48e3183150017bd456f00d9
    git cherry-pick -x 59c6ed534fab6ace1e910d5e042129042a515938
    git cherry-pick -x ec276c456308268f843117d3c63e9e09f5e9187c
    git cherry-pick -x 929b8b87092cac38cfee0acf4f5cf8247655f055

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 81fbf73db563f6cc05b93a6fa3e9bf83ddb30b81

`ConfigService` config method models must be registered like `CRUDService` query and get_instance methods so that they can be called in previous API versions.

Original PR: https://github.com/truenas/middleware/pull/17215
