### PR TITLE
Fix `ipmi.lan.update`

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
@@ -1,9 +1,8 @@
-from ipaddress import IPv4Address
 from typing import Annotated, Literal
 
 from pydantic import AfterValidator, Field, Secret
 
-from middlewared.api.base import BaseModel, query_result, ForUpdateMetaclass
+from middlewared.api.base import BaseModel, IPv4Address, query_result, ForUpdateMetaclass
 from middlewared.api.base.validators import passwd_complexity_validator
 from .common import QueryFilters, QueryOptions
 

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
@@ -58,7 +58,7 @@ class IPMILanQuery(BaseModel):
 
 
 class IPMILanUpdateOptionsDHCP(BaseModel):
-    dhcp: Literal[True] = True
+    dhcp: Literal[True]
     """Turn on DHCP protocol for IP address management."""
     password: Secret[
         Annotated[
@@ -81,7 +81,7 @@ class IPMILanUpdateOptionsDHCP(BaseModel):
 
 
 class IPMILanUpdateOptionsStatic(IPMILanUpdateOptionsDHCP):
-    dhcp: Literal[False] = False
+    dhcp: Literal[False]
     """Provide a static IP address."""
     ipaddress: IPv4Address
     """The IPv4 address in the form of `192.168.1.150`."""


### PR DESCRIPTION
Using `ipaddress.IPv4Address` as the field type when `strict=True` in the `BaseModel` config expects a Python object to be passed, not a string. We have custom types for this reason. This is the only use of `ipaddress` types in our API schema, so no more changes are needed.