### PR TITLE
NAS-137593 / 25.10-RC.1 / Fix `ipmi.lan.update` (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
@@ -1,9 +1,8 @@
-from ipaddress import IPv4Address
 from typing import Annotated, Literal
 
 from pydantic import AfterValidator, Field, Secret
 
-from middlewared.api.base import BaseModel, query_result, ForUpdateMetaclass
+from middlewared.api.base import BaseModel, IPv4Address, query_result, ForUpdateMetaclass
 from middlewared.api.base.validators import passwd_complexity_validator
 from .common import QueryFilters, QueryOptions
 


### PR DESCRIPTION
Using `ipaddress.IPv4Address` as the field type when `strict=True` in the `BaseModel` config expects a Python object to be passed, not a string. We have custom types for this reason. This is the only use of `ipaddress` types in our API schema, so no more changes are needed.

Original PR: https://github.com/truenas/middleware/pull/17221
