### PR TITLE
NAS-137648 / 26.04 / Call dns.sync after dhcpcd obtains a lease

### DIFF
--- a/src/freenas/etc/dhcpcd.exit-hook
+++ b/src/freenas/etc/dhcpcd.exit-hook
@@ -1,0 +1,5 @@
+case "$reason" in
+BOUND|BOUND6)
+	sleep 3 && midclt call dns.sync &
+;;
+esac


### PR DESCRIPTION
After `dhcpcd` obtains a lease call `dns.sync`.  This will be a NOP unless no DNS servers have been configured, in which case the ones associated with the lease will be used.