### PR TITLE
NAS-137657 / 26.04 / Use lxc namespace for container configuration

### DIFF
--- a/src/middlewared/middlewared/api/v26_04_0/container_config.py
+++ b/src/middlewared/middlewared/api/v26_04_0/container_config.py
@@ -3,13 +3,13 @@ from middlewared.api.base import (
 )
 
 __all__ = [
-    "ContainerConfigEntry",
-    "ContainerConfigUpdateArgs", "ContainerConfigUpdateResult",
-    "ContainerConfigBridgeChoicesArgs", "ContainerConfigBridgeChoicesResult",
+    "LXCConfigEntry",
+    "LXCConfigUpdateArgs", "LXCConfigUpdateResult",
+    "LXCConfigBridgeChoicesArgs", "LXCConfigBridgeChoicesResult",
 ]
 
 
-class ContainerConfigEntry(BaseModel):
+class LXCConfigEntry(BaseModel):
     id: int
     """Configuration ID."""
     bridge: str | None = None
@@ -20,20 +20,20 @@ class ContainerConfigEntry(BaseModel):
     """IPv6 network CIDR for the virtualization bridge network. `null` if not configured."""
 
 
-@single_argument_args("container_config_update")
-class ContainerConfigUpdateArgs(ContainerConfigEntry, metaclass=ForUpdateMetaclass):
+@single_argument_args("lxc_config_update")
+class LXCConfigUpdateArgs(LXCConfigEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
 
 
-class ContainerConfigUpdateResult(BaseModel):
-    result: ContainerConfigEntry
-    """Updated container configuration."""
+class LXCConfigUpdateResult(BaseModel):
+    result: LXCConfigEntry
+    """Updated LXC configuration."""
 
 
-class ContainerConfigBridgeChoicesArgs(BaseModel):
+class LXCConfigBridgeChoicesArgs(BaseModel):
     pass
 
 
-class ContainerConfigBridgeChoicesResult(BaseModel):
+class LXCConfigBridgeChoicesResult(BaseModel):
     result: dict[str, str]
     """Object of available network bridge interfaces and their configurations."""

--- a/src/middlewared/middlewared/plugins/container/bridge.py
+++ b/src/middlewared/middlewared/plugins/container/bridge.py
@@ -21,7 +21,7 @@ class ContainerService(Service):
     @private
     def configure_bridge(self):
         with self.lock:
-            config = self.middleware.call_sync("container.config.config")
+            config = self.middleware.call_sync("lxc.config")
             if config["bridge"] is not None:
                 return
 
@@ -140,5 +140,5 @@ class ContainerService(Service):
 
     @private
     def bridge_name(self):
-        config = self.middleware.call_sync("container.config.config")
+        config = self.middleware.call_sync("lxc.config")
         return config["bridge"] or BRIDGE_NAME

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -112,8 +112,8 @@ ROLES = {
     # Container roles
     'CONTAINER_READ': Role(),
     'CONTAINER_WRITE': Role(includes=['CONTAINER_READ'], stig=None),
-    'CONTAINER_CONFIG_READ': Role(),
-    'CONTAINER_CONFIG_WRITE': Role(includes=['CONTAINER_CONFIG_READ'], stig=None),
+    'LXC_CONFIG_READ': Role(),
+    'LXC_CONFIG_WRITE': Role(includes=['LXC_CONFIG_READ'], stig=None),
     'CONTAINER_IMAGE_READ': Role(),
     'CONTAINER_IMAGE_WRITE': Role(includes=['CONTAINER_IMAGE_READ'], stig=None),
 

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -59,7 +59,7 @@ def bounding_set(capsh_print):
 
 @pytest.fixture(scope="module", autouse=True)
 def bridge():
-    call("container.config.update", {
+    call("lxc.update", {
         "v4_network": "10.47.214.0/24",
         "v6_network": "fd42:3656:7be9:e46c::0/64",
     })


### PR DESCRIPTION
## Context

After discussion with @yocalebo we decided that it's best to rename `container.config` to `lxc.config` as for querying configuration, the method looks like `container.config.config` which is awkward/weird.

Relevant changes have been done to accommodate this change.