### PR TITLE
NAS-137658 / 26.04 / Make sure containers dataset mountpoint is properly set

### DIFF
--- a/src/middlewared/middlewared/plugins/container/dataset.py
+++ b/src/middlewared/middlewared/plugins/container/dataset.py
@@ -1,8 +1,7 @@
 import os
 
 from middlewared.service import CallError, private, Service
-
-REGISTRY_URL = "http://pivnoy.thelogin.ru"
+from .utils import container_dataset, container_dataset_mountpoint
 
 
 class ContainerService(Service):
@@ -13,8 +12,8 @@ class ContainerService(Service):
 
     @private
     async def ensure_datasets(self, pool):
-        main_dataset = f'{pool}/.truenas_containers'
-        main_dataset_mountpoint = f'/.truenas_containers/{pool}'
+        main_dataset = container_dataset(pool)
+        main_dataset_mountpoint = container_dataset_mountpoint(pool)
 
         datasets = [f'{main_dataset}/containers', f'{main_dataset}/images']
 

--- a/src/middlewared/middlewared/plugins/container/utils.py
+++ b/src/middlewared/middlewared/plugins/container/utils.py
@@ -1,0 +1,6 @@
+def container_dataset(pool: str) -> str:
+    return f'{pool}/.truenas_containers'
+
+
+def container_dataset_mountpoint(pool: str) -> str:
+    return f'/.truenas_containers/{pool}'


### PR DESCRIPTION
## Problem

Currently, container pool mount points are **not persisted** after a pool export/import. This causes issues when the pool is re-imported, as the mount points are lost.

## Solution

Ensure that container pool mount points are made **persistent** across pool export/import operations.