### PR TITLE
NAS-137580 / 26.04 / Syslog-ng is not respecting vendor preset file

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -64,9 +64,10 @@ done
 
 #DEBHELPER#
 
-# zfs-zed is not respecting vendor preset file so we enable it explicitly
+# Following service(s) are not respecting vendor preset file so we enable them explicitly
 systemctl daemon-reload
 systemctl enable zfs-zed
+systemctl enable syslog-ng
 
 # We need to mask certain services so that they don't start automatically
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket


### PR DESCRIPTION
This PR adds changes to make sure that syslog-ng is enabled after the system boots. Currently in trixie it is not respecting the preset file we ship for some reason, hence we explicitly enable it to make sure it is enabled when the system starts as lots of things rely on it to function properly.