### PR TITLE
NAS-137667 / 26.04 / Properly set rpc server settings for spotlight

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -434,8 +434,6 @@ def generate_smb_conf_dict(
         'bind interfaces only': True,
         'fruit:nfs_aces': False,
         'fruit:zero_file_id': False,
-        'rpc_daemon:mdssd': 'disabled',
-        'rpc_server:mdssvc': 'disabled',
         'restrict anonymous': 0 if guest_enabled else 2,
         'winbind request timeout': 60 if ds_type is DSType.AD else 2,
         'passdb backend': f'tdbsam:{SMBPath.PASSDB_DIR.value[0]}/passdb.tdb',

--- a/tests/unit/test_smb_service.py
+++ b/tests/unit/test_smb_service.py
@@ -442,3 +442,5 @@ def test_search_protocols_spotlight():
     assert conf['spotlight backend'] == 'elasticsearch'
     assert conf['elasticsearch:address'] == TRUESEARCH_ES_PATH
     assert conf['spotlight'] is True
+    assert 'rpc_daemon:mdssd' not in conf
+    assert 'rpc_server:mdssvc' not in conf


### PR DESCRIPTION
This commit fixes an oversight when implemnting SMB configuration portion of spotlight support in which we forgot to remove the old RPC server configuration that explicitly disabled the RPC server for MDSSVC and MDSSD.