### PR TITLE
NAS-137643 / 26.04 / Fix `test.set_mock` private testing method

### DIFF
--- a/src/middlewared/middlewared/plugins/test/mock.py
+++ b/src/middlewared/middlewared/plugins/test/mock.py
@@ -18,9 +18,10 @@ class TestService(Service):
 
     async def set_mock(self, name, args, description):
         if isinstance(description, str):
-            exec(description)
+            local_scope = {}
+            exec(description, {}, local_scope)
             try:
-                method = locals()["mock"]
+                method = local_scope["mock"]
             except KeyError:
                 raise CallError("Your mock declaration must include `def mock` or `async def mock`")
         elif isinstance(description, dict):


### PR DESCRIPTION
This is a fun one. Changes to the way the built-in function `locals` behaves in Python 3.13, particularly in an async or other [optimized scope](https://docs.python.org/3.13/glossary.html#term-optimized-scope) and in conjunction with `exec`, have broken a decent chunk of our API test suite. In this instance, `locals()` no longer contains any identifiers defined in `exec(description)`. Instead, we must pass a dictionary to `exec` for it to store any local identifiers that it defines during execution.

Leisurely reading:
[Python 3.13 changelog](https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals)
[PEP 667](https://peps.python.org/pep-0667/)

Fixed audit tests:
http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/6043/