### PR TITLE
NAS-137671 / 26.04 / MWPATH2 python 3.11 -> 3.13 update

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -1,5 +1,5 @@
 export MWPATH1=/usr/lib/python3/dist-packages/middlewared
-export MWPATH2=/usr/local/lib/python3.11/dist-packages/middlewared
+export MWPATH2=/usr/local/lib/python3.13/dist-packages/middlewared
 export BUILD=$(shell pwd)/build
 
 stop_service:


### PR DESCRIPTION
Another location that referenced python 3.11 rather than 3.13