### PR TITLE
NAS-137677 / 26.04 / Fix proftpd start

### DIFF
--- a/src/middlewared/middlewared/etc_files/proftpd/proftpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/proftpd/proftpd.conf.mako
@@ -19,6 +19,10 @@
 #
 # ProFTPD configuration file
 #
+
+# Includes DSO modules
+Include /etc/proftpd/modules.conf
+
 ServerName "${network_configuration['hostname_local']} FTP Server"
 ServerType standalone
 DefaultServer on

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -15,7 +15,7 @@ from assets.websocket.server import reboot
 from middlewared.test.integration.assets.account import user as ftp_user
 from middlewared.test.integration.assets.pool import dataset as dataset_asset
 from middlewared.test.integration.utils import call, ssh
-from middlewared.test.integration.utils.client import truenas_server
+from middlewared.test.integration.utils.client import truenas_server, host as init_truenas_server
 
 from auto_config import password, pool_name, user
 from functions import SSH_TEST, send_file
@@ -37,9 +37,16 @@ INIT_DIRS_AND_FILES = {
 
 # ================= Utility Functions ==================
 
+@pytest.fixture(scope='module')
+def confirm_test_config():
+    if truenas_server.ip is None:
+        # Fix-up truenas_server
+        init_truenas_server()
+    assert truenas_server.ip is not None
+
 
 @pytest.fixture(scope='module')
-def ftp_init_db_dflt():
+def ftp_init_db_dflt(confirm_test_config):
     # Get the 'default' settings from FTPModel
     ftpconf_script = '#!/usr/bin/python3\n'
     ftpconf_script += 'import json\n'


### PR DESCRIPTION
Proftpd was updated in Halfmoon and that upgrade introduced a start dependency on modules.conf.

Add include of modules.conf to the proftpd.conf.mako.
CI test fix: Add fixup of ftp test module when `truenas_server` is not configured properly.

Passed on local CI testing.