### PR TITLE
NAS-137684 / 26.04 / Fix containers naming regex to support backward compatibility

### DIFF
--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -17,7 +17,7 @@ from middlewared.service import CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.zfs import query_imported_fast_impl
 
-RE_NAME = re.compile(r'^[a-zA-Z_0-9]+$')
+RE_NAME = re.compile(r'^[a-zA-Z_0-9\-]+$')
 
 
 class ContainerModel(sa.Model):
@@ -172,7 +172,7 @@ class ContainerService(CRUDService):
         elif not RE_NAME.search(data['name']):
             verrors.add(
                 f'{schema_name}.name',
-                'Only alphanumeric characters are allowed.'
+                'Name can only contain alphanumeric and hyphen characters.'
             )
 
     @api_method(ContainerCreateArgs, ContainerCreateResult)


### PR DESCRIPTION
## Problem

For incus containers we support `-` as valid naming character too and in newer container implementation we don't. Which means that migration from older implemetnation to newer one breaks if we find a container containing a hyphen.

## Solution

Allow `-` in container names as well which in turn means migration from incus to new containers works just fine. Alternatively if we don't want to support `-` in container names, we can discuss how we want to rename such incus containers.