### PR TITLE
NAS-137685 / 26.04 / fix datastore/connection.py::setup()

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
@@ -58,19 +58,7 @@ async def datastore_test(mocked_calls=None):
                 for call_name, call_func in mocked_calls.items():
                     m[call_name] = call_func
 
-                try:
-                    yield ds
-                finally:
-                    # Properly clean up the connection and engine after each test
-                    for part in ds.parts:
-                        if hasattr(part, "connection") and part.connection is not None:
-                            if not part.connection.closed:
-                                part.connection.close()
-                            part.connection = None
-
-                        if hasattr(part, "engine") and part.engine is not None:
-                            part.engine.dispose()
-                            part.engine = None
+                yield ds
 
 
 class UserModel(Model):


### PR DESCRIPTION
Previous commit https://github.com/truenas/middleware/pull/17236 fixed a few issues, however, I was also working on the datastore connection already closed errors in the GitHub unit tests. I believe this is the proper way of fixing the unit tests.