### PR TITLE
NAS-137696 / 26.04 / Fix API call to unset 2FA secret

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -152,6 +152,10 @@ class UserService(Service):
             }
         )
 
+        # We need to regenerate the users.oath file in order to remove
+        # 2FA requirement for the user
+        await self.middleware.call('etc.generate', 'user')
+
     @api_method(
         UserRenew2faSecretArgs,
         UserRenew2faSecretResult,


### PR DESCRIPTION
This commit forces regeneration of the users oath file on unsetting 2FA secret for a user. If we don't do this then the user will continue to receive spurious error messages that OTP_REQUIRED on login.