### PR TITLE
NAS-137693 / 26.04 / Moving tn_connect urls from staging to production (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-09-24_21-11_tnc_prod_endpoints.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-09-24_21-11_tnc_prod_endpoints.py
@@ -6,6 +6,7 @@ Revises: 5ea9f662ced4
 Create Date: 2025-09-24 16:44:06.551471+00:00
 """
 from alembic import op
+from sqlalchemy import text
 
 
 # revision identifiers, used by Alembic.
@@ -25,9 +26,9 @@ def upgrade():
         'heartbeat_url': 'https://heartbeat-service.tys1.truenasconnect.net/'
     }
 
-    result = conn.execute(
+    result = conn.execute(text(
         'SELECT id, account_service_base_url, leca_service_base_url, tnc_base_url, heartbeat_url FROM truenas_connect'
-    ).fetchall()
+    )).fetchall()
 
     if not result:
         return
@@ -51,7 +52,7 @@ def upgrade():
         for column, new_url in production_urls.items():
             set_clauses.append(f"{column} = {new_url!r}")
 
-        update_sql = f"UPDATE truenas_connect SET {', '.join(set_clauses)} WHERE id = {row_id}"
+        update_sql = text(f"UPDATE truenas_connect SET {', '.join(set_clauses)} WHERE id = {row_id}")
         conn.execute(update_sql)
 
 

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-09-24_21-11_tnc_prod_endpoints.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-09-24_21-11_tnc_prod_endpoints.py
@@ -1,0 +1,71 @@
+"""
+Moving tn_connect url from staging to production
+
+Revision ID: 53193fbee3ee
+Revises: 5ea9f662ced4
+Create Date: 2025-09-24 16:44:06.551471+00:00
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '53193fbee3ee'
+down_revision = '5ea9f662ced4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    staging_to_production = {
+        'account_service_base_url': {
+            'staging': 'https://account-service.staging.truenasconnect.net/',
+            'production': 'https://account-service.tys1.truenasconnect.net/'
+        },
+        'leca_service_base_url': {
+            'staging': 'https://dns-service.staging.truenasconnect.net/',
+            'production': 'https://dns-service.tys1.truenasconnect.net/'
+        },
+        'tnc_base_url': {
+            'staging': 'https://web.staging.truenasconnect.net/',
+            'production': 'https://web.truenasconnect.net/'
+        },
+        'heartbeat_url': {
+            'staging': 'https://heartbeat-service.staging.truenasconnect.net/',
+            'production': 'https://heartbeat-service.tys1.truenasconnect.net/'
+        }
+    }
+
+    result = conn.execute(
+        'SELECT id, account_service_base_url, leca_service_base_url, tnc_base_url, heartbeat_url FROM truenas_connect'
+    ).fetchall()
+
+    if not result:
+        return
+
+    row = result[0]
+    row_id = row[0]
+    current_urls = {
+        'account_service_base_url': row[1],
+        'leca_service_base_url': row[2],
+        'tnc_base_url': row[3],
+        'heartbeat_url': row[4]
+    }
+
+    all_staging = all(
+        current_urls.get(column) == mapping['staging']
+        for column, mapping in staging_to_production.items()
+    )
+
+    if all_staging:
+        set_clauses = []
+        for column, mapping in staging_to_production.items():
+            set_clauses.append(f"{column} = {mapping['production']!r}")
+
+        update_sql = f"UPDATE truenas_connect SET {', '.join(set_clauses)} WHERE id = {row_id}"
+        conn.execute(update_sql)
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/26.04/2025-09-25_16-19_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/26.04/2025-09-25_16-19_merge.py
@@ -1,0 +1,25 @@
+"""
+Merge migration
+
+Revision ID: da2c571ee752
+Revises: 5d51d6e50ff2, 53193fbee3ee
+Create Date: 2025-09-25 16:19:11.534941+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'da2c571ee752'
+down_revision = ('5d51d6e50ff2', '53193fbee3ee')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -35,16 +35,16 @@ class TrueNASConnectModel(sa.Model):
     status = sa.Column(sa.String(255), default=Status.DISABLED.name, nullable=False)
     certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
     account_service_base_url = sa.Column(
-        sa.String(255), nullable=False, default='https://account-service.staging.truenasconnect.net/'
+        sa.String(255), nullable=False, default='https://account-service.tys1.truenasconnect.net/'
     )
     leca_service_base_url = sa.Column(
-        sa.String(255), nullable=False, default='https://dns-service.staging.truenasconnect.net/'
+        sa.String(255), nullable=False, default='https://dns-service.tys1.truenasconnect.net/'
     )
     tnc_base_url = sa.Column(
-        sa.String(255), nullable=False, default='https://web.staging.truenasconnect.net/'
+        sa.String(255), nullable=False, default='https://web.truenasconnect.net/'
     )
     heartbeat_url = sa.Column(
-        sa.String(255), nullable=False, default='https://heartbeat-service.staging.truenasconnect.net/'
+        sa.String(255), nullable=False, default='https://heartbeat-service.tys1.truenasconnect.net/'
     )
     last_heartbeat_failure_datetime = sa.Column(sa.String(255), nullable=True, default=None)
 


### PR DESCRIPTION
i.e
```
root@test4WJFS5WJ55[~]# midclt call datastore.config truenas_connect | jq
{
  "id": 1,
  "enabled": false,
  "jwt_token": null,
  "registration_details": {},
  "ips": [],
  "interfaces": [],
  "interfaces_ips": [],
  "use_all_interfaces": true,
  "status": "DISABLED",
  "account_service_base_url": "https://account-service.tys1.truenasconnect.net/",
  "leca_service_base_url": "https://dns-service.tys1.truenasconnect.net/",
  "tnc_base_url": "https://web.truenasconnect.net/",
  "heartbeat_url": "https://heartbeat-service.tys1.truenasconnect.net/",
  "last_heartbeat_failure_datetime": null,
  "certificate": null
}
root@test4WJFS5WJ55[~]#
```

Original PR: https://github.com/truenas/middleware/pull/17249
