### PR TITLE
NAS-137731 / 26.04 / fix registry mirrors

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -28,7 +28,7 @@ def render(service, middleware):
         'storage-driver': 'overlay2',
         'fixed-cidr-v6': config['cidr_v6'],
         'default-address-pools': config['address_pools'],
-        'registry-mirrors': config['secure_registry_mirrors'],
+        'registry-mirrors': config['secure_registry_mirrors'] + config['insecure_registry_mirrors'],
         'insecure-registries': [urlparse(registry_url).netloc for registry_url in config['insecure_registry_mirrors']],
         **(
             {


### PR DESCRIPTION
So what happens here:

- `insecure-registries`: Used to have things like private **registries** 
    - Insecure needs to be added here so docker "trusts" them
    - Secure do not need to be added, because it works out of the box (ie ghcr.io, quay.io, etc)

- `registry-mirrors`: Used for **mirroring** ~things like ghcr, docker hub, etc~. I got informed that it applies only to docker-hub
   - secure (https with valid certs)
   - insecure (http or https with self signed). Those have to also be added in the `insecure-registries`, so docker "trusts" them


---

Currently we only allow users to configure mirrors in the UI.
If later we allow also to configure insecure registries, we need to adjust the code like this
```diff
- 'insecure-registries': [urlparse(registry_url).netloc for registry_url in config['insecure_registry_mirrors']]
+ 'insecure-registries': [urlparse(registry_url).netloc for registry_url in (config['insecure_registry_mirrors'] + config['insecure_registires'])]
```

