### PR TITLE
NAS-137728 / 26.04 / Do not try to revoke cert if there is none

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/acme.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/acme.py
@@ -124,6 +124,11 @@ class TNCACMEService(Service):
 
     async def revoke_cert(self):
         tnc_config = await self.middleware.call('tn_connect.config_internal')
+        if tnc_config['certificate'] is None:
+            # If cert generation had failed, there won't be any cert to revoke
+            logger.debug('No TNC certificate configured, skipping revocation')
+            return
+
         certificate = await self.middleware.call('certificate.get_instance', tnc_config['certificate'])
         acme_config = await self.middleware.call('tn_connect.acme.config')
         if acme_config['error']:


### PR DESCRIPTION
This commit adds changes to not attempt to revoke a cert if there is none configured as trying to fetch one will error out in that case.