### PR TITLE
NAS-137734 / 26.04 / Get cpu temperatures from sysfs

### DIFF
--- a/src/freenas/usr/libexec/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/libexec/netdata/python.d/cputemp.chart.py
@@ -1,11 +1,8 @@
-from bases.FrameworkServices.SimpleService import SimpleService
-from collections import defaultdict
 from copy import deepcopy
-from third_party import lm_sensors as sensors
 
-from middlewared.utils.cpu import amd_cpu_temperatures, cpu_info, generic_cpu_temperatures
+from bases.FrameworkServices.SimpleService import SimpleService
 
-CPU_TEMPERATURE_FEAT_TYPE = 2
+from middlewared.utils.cpu import get_cpu_temperatures
 
 
 ORDER = [
@@ -21,12 +18,6 @@ CHARTS = {
 }
 
 
-def cpu_temperatures(cpu_metrics):
-    if amd_metrics := cpu_metrics.get('k10temp-pci-00c3'):
-        return amd_cpu_temperatures(amd_metrics)
-    return generic_cpu_temperatures(cpu_metrics)
-
-
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
@@ -34,74 +25,9 @@ class Service(SimpleService):
         self.definitions = deepcopy(CHARTS)
 
     def get_data(self):
-        seen, data, cpu_data = dict(), dict(), defaultdict(dict)
-        try:
-            for chip in sensors.ChipIterator():
-                chip_name = sensors.chip_snprintf_name(chip)
-                seen[chip_name] = defaultdict(list)
-                if not any(chip_name.startswith(cpu_chip) for cpu_chip in ('k10temp-pci-00c3', 'coretemp-isa')):
-                    continue
-
-                cpu_d = {}
-                for feat in sensors.FeatureIterator(chip):
-                    if feat.type != CPU_TEMPERATURE_FEAT_TYPE:
-                        continue
-
-                    feat_name = str(feat.name.decode())
-                    feat_label = sensors.get_label(chip, feat)
-                    sub_feat = next(sensors.SubFeatureIterator(chip, feat))  # current value
-
-                    if not sub_feat:
-                        continue
-
-                    try:
-                        v = sensors.get_value(chip, sub_feat.number)
-                    except sensors.SensorsError:
-                        continue
-
-                    if v is None:
-                        continue
-
-                    cpu_d[f'{chip_name}_{feat_name}'] = {'name': feat_label, 'value': v}
-
-                cpu_data[chip_name] = cpu_d
-        except sensors.SensorsError as error:
-            self.error(error)
-
-        try:
-            cpu_temps = cpu_temperatures(cpu_data)
-        except Exception as error:
-            self.error(error)
-            cpu_temps = {}
-
-        data = {}
-        total_temp = 0
-        cinfo = cpu_info()
-        for core, temp in cpu_temps.items():
-            data[f'cpu{core}'] = temp
-            total_temp += temp
-            try:
-                # we follow the paradigm that htop uses
-                # for filling in the hyper-threaded ids
-                # temperatures. (i.e. we just copy the
-                # temp of the parent physical core id)
-                data[cinfo['ht_map'][f'cpu{core}']] = temp
-                total_temp += temp
-            except KeyError:
-                continue
-
-        if total_temp:
-            data['cpu'] = total_temp / len(data)
-
-        return data or ({f'cpu{i}': 0 for i in range(cinfo['core_count'])} | {'cpu': 0})
+        return get_cpu_temperatures()
 
     def check(self):
-        try:
-            sensors.init()
-        except sensors.SensorsError as error:
-            self.error(error)
-            return False
-
         data = self.get_data()
         for i in data:
             self.definitions['temperatures']['lines'].append([str(i)])

--- a/src/middlewared/middlewared/pytest/unit/utils/test_cpu_temperatures.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_cpu_temperatures.py
@@ -1,0 +1,243 @@
+from unittest.mock import patch
+
+from middlewared.utils.cpu import read_cpu_temps, get_cpu_temperatures
+
+
+@patch('middlewared.utils.cpu.sensors')
+def test_read_temps_multiple_chips(mock_sensors):
+    """Test reading temperatures from dual socket Intel system"""
+    # Mock get_cpu_temperatures to return dual socket Intel data
+    # Using realistic chip names from libsensors (with bus info, not hwmon)
+    mock_sensors.get_cpu_temperatures.return_value = {
+        'coretemp-isa-0000': {
+            'Package id 0': 36.0,
+            'Core 0': 48.0,
+            'Core 1': 49.0
+        },
+        'coretemp-isa-0001': {
+            'Package id 1': 45.0,
+            'Core 0': 55.0,
+            'Core 1': 54.0
+        }
+    }
+
+    result = read_cpu_temps()
+
+    assert result == {
+        'coretemp-isa-0000': {
+            'Package id 0': 36.0,
+            'Core 0': 48.0,
+            'Core 1': 49.0
+        },
+        'coretemp-isa-0001': {
+            'Package id 1': 45.0,
+            'Core 0': 55.0,
+            'Core 1': 54.0
+        }
+    }
+
+
+@patch('middlewared.utils.cpu.sensors')
+def test_read_temps_error_handling(mock_sensors):
+    """Test that read_cpu_temps handles errors gracefully"""
+    mock_sensors.get_cpu_temperatures.side_effect = OSError('Could not find libsensors')
+
+    result = read_cpu_temps()
+
+    assert result == {}
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_intel(mock_read_temps, mock_cpu_info):
+    """Test Intel CPU temperature processing with hyperthreading"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz',
+        'core_count': 8,
+        'physical_core_count': 4,
+        'ht_map': {'cpu0': 'cpu4', 'cpu1': 'cpu5', 'cpu2': 'cpu6', 'cpu3': 'cpu7'}
+    }
+
+    mock_read_temps.return_value = {
+        'coretemp-isa-0000': {
+            'Package id 0': 45.0,
+            'Core 0': 48.0,
+            'Core 1': 49.0,
+            'Core 2': 47.0,
+            'Core 3': 50.0
+        }
+    }
+
+    result = get_cpu_temperatures()
+
+    expected = {
+        'cpu0': 48.0,
+        'cpu1': 49.0,
+        'cpu2': 47.0,
+        'cpu3': 50.0,
+        'cpu4': 48.0,  # HT copy of cpu0
+        'cpu5': 49.0,  # HT copy of cpu1
+        'cpu6': 47.0,  # HT copy of cpu2
+        'cpu7': 50.0,  # HT copy of cpu3
+        'cpu': 48.5    # Average
+    }
+
+    assert result == expected
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_amd_with_ccd(mock_read_temps, mock_cpu_info):
+    """Test AMD Ryzen with CCD temperature"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'AMD Ryzen 5 3600 6-Core Processor',
+        'core_count': 12,
+        'physical_core_count': 6,
+        'ht_map': {
+            'cpu0': 'cpu6', 'cpu1': 'cpu7', 'cpu2': 'cpu8',
+            'cpu3': 'cpu9', 'cpu4': 'cpu10', 'cpu5': 'cpu11'
+        }
+    }
+
+    mock_read_temps.return_value = {
+        'k10temp-pci-00c3': {
+            'Tctl': 48.625,
+            'Tdie': 48.625,
+            'Tccd1': 54.750
+        }
+    }
+
+    result = get_cpu_temperatures()
+
+    # All cores should use Tccd1 temperature
+    expected = {f'cpu{i}': 54.750 for i in range(12)}
+    expected['cpu'] = 54.750
+
+    assert result == expected
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_amd_prefer_tdie(mock_read_temps, mock_cpu_info):
+    """Test AMD Threadripper that prefers Tdie over Tctl"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'AMD Ryzen Threadripper 1950X 16-Core Processor',
+        'core_count': 32,
+        'physical_core_count': 16,
+        'ht_map': {f'cpu{i}': f'cpu{i+16}' for i in range(16)}
+    }
+
+    mock_read_temps.return_value = {
+        'k10temp-pci-00c3': {
+            'Tctl': 67.0,
+            'Tdie': 40.0,
+            'Tccd1': 65.5
+        }
+    }
+
+    result = get_cpu_temperatures()
+
+    # All cores should use Tdie (40.0) due to AMD_PREFER_TDIE
+    expected = {f'cpu{i}': 40.0 for i in range(32)}
+    expected['cpu'] = 40.0
+
+    assert result == expected
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_amd_multiple_ccds(mock_read_temps, mock_cpu_info):
+    """Test AMD CPU with multiple CCDs (chiplet design)"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'AMD Ryzen 9 3950X 16-Core Processor',
+        'core_count': 32,
+        'physical_core_count': 16,
+        'ht_map': {f'cpu{i}': f'cpu{i+16}' for i in range(16)}
+    }
+
+    mock_read_temps.return_value = {
+        'k10temp-pci-00c3': {
+            'Tctl': 50.0,
+            'Tdie': 48.0,
+            'Tccd1': 52.0,
+            'Tccd2': 54.0
+        }
+    }
+
+    result = get_cpu_temperatures()
+
+    # With 2 CCDs and 16 cores, each CCD handles 8 cores
+    expected = {}
+    for i in range(8):
+        expected[f'cpu{i}'] = 52.0  # Tccd1
+        expected[f'cpu{i+16}'] = 52.0  # HT of Tccd1
+    for i in range(8, 16):
+        expected[f'cpu{i}'] = 54.0  # Tccd2
+        expected[f'cpu{i+16}'] = 54.0  # HT of Tccd2
+    expected['cpu'] = 53.0  # Average
+
+    assert result == expected
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_dual_socket_intel(mock_read_temps, mock_cpu_info):
+    """Test dual socket Intel Xeon system"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
+        'core_count': 4,
+        'physical_core_count': 4,
+        'ht_map': {}
+    }
+
+    mock_read_temps.return_value = {
+        'coretemp-isa-0000': {
+            'Package id 0': 36.0,
+            'Core 0': 48.0,
+            'Core 1': 49.0
+        },
+        'coretemp-isa-0001': {
+            'Package id 1': 45.0,
+            'Core 0': 55.0,
+            'Core 1': 54.0
+        }
+    }
+
+    result = get_cpu_temperatures()
+
+    expected = {
+        'cpu0': 48.0,
+        'cpu1': 49.0,
+        'cpu2': 55.0,
+        'cpu3': 54.0,
+        'cpu': 51.5
+    }
+
+    assert result == expected
+
+
+@patch('middlewared.utils.cpu.cpu_info')
+@patch('middlewared.utils.cpu.read_cpu_temps')
+def test_get_temperatures_no_temps_found(mock_read_temps, mock_cpu_info):
+    """Test fallback when no temperature readings are available"""
+    mock_cpu_info.return_value = {
+        'cpu_model': 'Unknown CPU',
+        'core_count': 4,
+        'physical_core_count': 4,
+        'ht_map': {}
+    }
+
+    mock_read_temps.return_value = {}
+
+    result = get_cpu_temperatures()
+
+    # Should return 0 for all CPUs when no temps available
+    expected = {
+        'cpu0': 0,
+        'cpu1': 0,
+        'cpu2': 0,
+        'cpu3': 0,
+        'cpu': 0
+    }
+
+    assert result == expected

--- a/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_amd.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_amd.py
@@ -9,48 +9,20 @@ from middlewared.utils.cpu import amd_cpu_temperatures
 @pytest.mark.parametrize("model,core_count,reading,result", [
     # k10temp has no temperature offset constant for this CPU, Tdie will be equal to Tctl, it's better to use Tccd1
     ("AMD Ryzen 5 3600 6-Core Processor", 6, {
-        "k10temp-pci-00c3_temp1": {
-            "name": "Tctl",
-            "value": 48.625
-        },
-        "k10temp-pci-00c3_temp3": {
-            "name": "Tdie",
-            "value": 48.625
-        },
-        "k10temp-pci-00c3_temp4": {
-            "name": "Tccd1",
-            "value": 54.750
-        },
+        "Tctl": 48.625,
+        "Tdie": 48.625,
+        "Tccd1": 54.750,
     }, dict(enumerate([54.750] * 6))),
     # k10temp has temperature offset constant for this CPU so we should use Tdie
     # https://jira.ixsystems.com/browse/NAS-110515
     ("AMD Ryzen Threadripper 1950X 16-Core Processor", 16, {
-        "k10temp-pci-00c3_temp1": {
-            "name": "Tctl",
-            "value": 67.0
-        },
-        "k10temp-pci-00c3_temp3": {
-            "name": "Tdie",
-            "value": 40.0
-        },
-        "k10temp-pci-00c3_temp4": {
-            "name": "Tccd1",
-            "value": 65.5
-        },
+        "Tctl": 67.0,
+        "Tdie": 40.0,
+        "Tccd1": 65.5,
     }, dict(enumerate([40] * 16))),
 
     ("AMD Opteron APU  1-Core Processor", 1, {
-        "k10temp-pci-00c3_temp1": {
-            "name": "temp1",
-            "value": 48.23
-        }
-    }, dict(enumerate([48.23] * 1))),
-
-    ("AMD Opteron APU Processor", 1, {
-        "k10temp-pci-00c3_temp1": {
-            "name": "temp1",
-            "value": {"temp1_input": 48.23}
-        },
+        "temp1": 48.23
     }, dict(enumerate([48.23] * 1))),
 ])
 def test_amd_cpu_temperatures(model, core_count, reading, result):

--- a/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_generic.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_generic.py
@@ -9,33 +9,17 @@ from middlewared.utils.cpu import generic_cpu_temperatures
 @pytest.mark.parametrize("reading,result", [
     (
         {
-            "coretemp-isa-0001": {
-                "coretemp-isa-0001_temp1": {
-                    "name": "Package id 1",
-                    "value": 45
-                },
-                "coretemp-isa-0001_temp2": {
-                    "name": "Core 0",
-                    "value": 55.0
-                },
-                "coretemp-isa-0001_temp3": {
-                    "name": "Core 1",
-                    "value": 54.0
-                }},
             "coretemp-isa-0000": {
-                "coretemp-isa-0000_temp1": {
-                    "name": "Package id 0",
-                    "value": 36
-                },
-                "coretemp-isa-0000_temp2": {
-                    "name": "Core 0",
-                    "value": 48.0
-                },
-                "coretemp-isa-0000_temp3": {
-                    "name": "Core 1",
-                    "value": 49.0
-                }
-            }},
+                "Package id 0": 36,
+                "Core 0": 48.0,
+                "Core 1": 49.0
+            },
+            "coretemp-isa-0001": {
+                "Package id 1": 45,
+                "Core 0": 55.0,
+                "Core 1": 54.0
+            }
+        },
         {
             0: 48.0,
             1: 49.0,

--- a/src/middlewared/middlewared/utils/sensors.py
+++ b/src/middlewared/middlewared/utils/sensors.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+Python ctypes wrapper for libsensors (lm-sensors) library on Linux.
+Provides access to hardware monitoring sensors (temperature, voltage, fan speed, etc.)
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import enum
+from types import TracebackType
+
+
+class SensorsFeatureType(enum.IntEnum):
+    """Sensor feature types from sensors.h"""
+
+    SENSORS_FEATURE_IN = 0x00
+    SENSORS_FEATURE_FAN = 0x01
+    SENSORS_FEATURE_TEMP = 0x02
+    SENSORS_FEATURE_POWER = 0x03
+    SENSORS_FEATURE_ENERGY = 0x04
+    SENSORS_FEATURE_CURR = 0x05
+    SENSORS_FEATURE_HUMIDITY = 0x06
+    SENSORS_FEATURE_MAX_MAIN = 0x7F
+    SENSORS_FEATURE_VID = 0x10
+    SENSORS_FEATURE_INTRUSION = 0x11
+    SENSORS_FEATURE_MAX_OTHER = 0x12
+    SENSORS_FEATURE_BEEP_ENABLE = 0x18
+    SENSORS_FEATURE_MAX = 0x1F
+    SENSORS_FEATURE_UNKNOWN = 0x7F
+
+
+class SensorsSubfeatureType(enum.IntEnum):
+    """Sensor subfeature types from sensors.h"""
+
+    SENSORS_SUBFEATURE_IN_INPUT = 0
+    SENSORS_SUBFEATURE_IN_MIN = 1
+    SENSORS_SUBFEATURE_IN_MAX = 2
+    SENSORS_SUBFEATURE_IN_LCRIT = 3
+    SENSORS_SUBFEATURE_IN_CRIT = 4
+    SENSORS_SUBFEATURE_IN_AVERAGE = 5
+    SENSORS_SUBFEATURE_IN_LOWEST = 6
+    SENSORS_SUBFEATURE_IN_HIGHEST = 7
+    SENSORS_SUBFEATURE_IN_ALARM = 0x80
+    SENSORS_SUBFEATURE_IN_MIN_ALARM = 0x81
+    SENSORS_SUBFEATURE_IN_MAX_ALARM = 0x82
+    SENSORS_SUBFEATURE_IN_BEEP = 0x83
+    SENSORS_SUBFEATURE_IN_LCRIT_ALARM = 0x84
+    SENSORS_SUBFEATURE_IN_CRIT_ALARM = 0x85
+
+    SENSORS_SUBFEATURE_FAN_INPUT = 0x100
+    SENSORS_SUBFEATURE_FAN_MIN = 0x101
+    SENSORS_SUBFEATURE_FAN_MAX = 0x102
+    SENSORS_SUBFEATURE_FAN_ALARM = 0x180
+    SENSORS_SUBFEATURE_FAN_FAULT = 0x181
+    SENSORS_SUBFEATURE_FAN_DIV = 0x182
+    SENSORS_SUBFEATURE_FAN_BEEP = 0x183
+    SENSORS_SUBFEATURE_FAN_PULSES = 0x184
+    SENSORS_SUBFEATURE_FAN_MIN_ALARM = 0x185
+    SENSORS_SUBFEATURE_FAN_MAX_ALARM = 0x186
+
+    SENSORS_SUBFEATURE_TEMP_INPUT = 0x200
+    SENSORS_SUBFEATURE_TEMP_MAX = 0x201
+    SENSORS_SUBFEATURE_TEMP_MAX_HYST = 0x202
+    SENSORS_SUBFEATURE_TEMP_MIN = 0x203
+    SENSORS_SUBFEATURE_TEMP_CRIT = 0x204
+    SENSORS_SUBFEATURE_TEMP_CRIT_HYST = 0x205
+    SENSORS_SUBFEATURE_TEMP_LCRIT = 0x206
+    SENSORS_SUBFEATURE_TEMP_EMERGENCY = 0x207
+    SENSORS_SUBFEATURE_TEMP_EMERGENCY_HYST = 0x208
+    SENSORS_SUBFEATURE_TEMP_LOWEST = 0x209
+    SENSORS_SUBFEATURE_TEMP_HIGHEST = 0x20A
+    SENSORS_SUBFEATURE_TEMP_MIN_HYST = 0x20B
+    SENSORS_SUBFEATURE_TEMP_LCRIT_HYST = 0x20C
+    SENSORS_SUBFEATURE_TEMP_ALARM = 0x280
+    SENSORS_SUBFEATURE_TEMP_MAX_ALARM = 0x281
+    SENSORS_SUBFEATURE_TEMP_MIN_ALARM = 0x282
+    SENSORS_SUBFEATURE_TEMP_CRIT_ALARM = 0x283
+    SENSORS_SUBFEATURE_TEMP_FAULT = 0x284
+    SENSORS_SUBFEATURE_TEMP_TYPE = 0x285
+    SENSORS_SUBFEATURE_TEMP_OFFSET = 0x286
+    SENSORS_SUBFEATURE_TEMP_BEEP = 0x287
+    SENSORS_SUBFEATURE_TEMP_EMERGENCY_ALARM = 0x288
+    SENSORS_SUBFEATURE_TEMP_LCRIT_ALARM = 0x289
+
+
+# C structure definitions
+class SensorsBusId(ctypes.Structure):
+    """sensors_bus_id structure"""
+
+    _fields_ = [
+        ("type", ctypes.c_short),
+        ("nr", ctypes.c_short),
+    ]
+
+
+class SensorsChipName(ctypes.Structure):
+    """sensors_chip_name structure"""
+
+    _fields_ = [
+        ("prefix", ctypes.c_char_p),
+        ("bus", SensorsBusId),
+        ("addr", ctypes.c_int),
+        ("path", ctypes.c_char_p),
+    ]
+
+
+class SensorsFeature(ctypes.Structure):
+    """sensors_feature structure"""
+
+    _fields_ = [
+        ("name", ctypes.c_char_p),
+        ("number", ctypes.c_int),
+        ("type", ctypes.c_int),  # SensorsFeatureType
+        ("first_subfeature", ctypes.c_int),
+        ("padding1", ctypes.c_int),
+    ]
+
+
+class SensorsSubfeature(ctypes.Structure):
+    """sensors_subfeature structure"""
+
+    _fields_ = [
+        ("name", ctypes.c_char_p),
+        ("number", ctypes.c_int),
+        ("type", ctypes.c_int),  # SensorsSubfeatureType
+        ("mapping", ctypes.c_int),
+        ("flags", ctypes.c_uint),
+    ]
+
+
+class SensorsWrapper:
+    """
+    Python wrapper for libsensors library.
+
+    Usage:
+        # Method 1: Manual init/cleanup
+        sensors = SensorsWrapper()
+        sensors.init()
+        readings = sensors.get_all_readings()
+        sensors.cleanup()
+
+        # Method 2: Context manager (recommended for resource management)
+        with SensorsWrapper() as sensors:
+            readings = sensors.get_all_readings()
+
+        # Method 3: Long-running process with periodic refresh
+        sensors = SensorsWrapper()
+        sensors.init()
+        while True:
+            readings = sensors.get_all_readings()
+            time.sleep(60)
+            # Optionally refresh chip detection
+            sensors.refresh()
+        sensors.cleanup()
+    """
+
+    def __init__(self, config_file: str | None = None) -> None:
+        """
+        Initialize the sensors wrapper.
+
+        Args:
+            config_file: Optional path to sensors configuration file
+        """
+        self.config_file: str | None = config_file
+        self.lib: ctypes.CDLL | None = None
+        self._initialized: bool = False
+        self._load_library()
+        self._setup_functions()
+
+    def __enter__(self) -> SensorsWrapper:
+        """Context manager entry"""
+        self.init()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Context manager exit - ensures cleanup"""
+        self.cleanup()
+
+    def _load_library(self) -> None:
+        """Load the libsensors library"""
+        # Try to find libsensors
+        lib_path: str | None = ctypes.util.find_library("sensors")
+        if not lib_path:
+            # Try common paths
+            for path in [
+                "/usr/lib/libsensors.so",
+                "/usr/lib/x86_64-linux-gnu/libsensors.so",
+            ]:
+                try:
+                    self.lib = ctypes.CDLL(path)
+                    break
+                except OSError:
+                    continue
+            if not self.lib:
+                raise OSError("Could not find libsensors. Install lm-sensors package.")
+        else:
+            self.lib = ctypes.CDLL(lib_path)
+
+    def _setup_functions(self) -> None:
+        """Setup function signatures for libsensors functions"""
+        assert self.lib is not None
+        # sensors_init
+        self.lib.sensors_init.argtypes = [ctypes.c_void_p]
+        self.lib.sensors_init.restype = ctypes.c_int
+
+        # sensors_cleanup
+        self.lib.sensors_cleanup.argtypes = []
+        self.lib.sensors_cleanup.restype = None
+
+        # sensors_get_detected_chips
+        self.lib.sensors_get_detected_chips.argtypes = [
+            ctypes.POINTER(SensorsChipName),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        self.lib.sensors_get_detected_chips.restype = ctypes.POINTER(SensorsChipName)
+
+        # sensors_get_features
+        self.lib.sensors_get_features.argtypes = [
+            ctypes.POINTER(SensorsChipName),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        self.lib.sensors_get_features.restype = ctypes.POINTER(SensorsFeature)
+
+        # sensors_get_all_subfeatures
+        self.lib.sensors_get_all_subfeatures.argtypes = [
+            ctypes.POINTER(SensorsChipName),
+            ctypes.POINTER(SensorsFeature),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        self.lib.sensors_get_all_subfeatures.restype = ctypes.POINTER(SensorsSubfeature)
+
+        # sensors_get_value
+        self.lib.sensors_get_value.argtypes = [
+            ctypes.POINTER(SensorsChipName),
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_double),
+        ]
+        self.lib.sensors_get_value.restype = ctypes.c_int
+
+        # sensors_get_label
+        self.lib.sensors_get_label.argtypes = [
+            ctypes.POINTER(SensorsChipName),
+            ctypes.POINTER(SensorsFeature),
+        ]
+        self.lib.sensors_get_label.restype = ctypes.c_char_p
+
+        # sensors_snprintf_chip_name
+        self.lib.sensors_snprintf_chip_name.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_size_t,
+            ctypes.POINTER(SensorsChipName),
+        ]
+        self.lib.sensors_snprintf_chip_name.restype = ctypes.c_int
+
+    def init(self) -> None:
+        """
+        Initialize the sensors library.
+        Must be called before using other methods.
+        """
+        if self._initialized:
+            return  # Already initialized
+
+        assert self.lib is not None
+        config: ctypes.c_char_p | None = None
+        if self.config_file:
+            config = ctypes.c_char_p(self.config_file.encode("utf-8"))
+
+        result: int = self.lib.sensors_init(config)
+        if result != 0:
+            raise RuntimeError(f"Failed to initialize sensors library: {result}")
+        self._initialized = True
+
+    def cleanup(self) -> None:
+        """Clean up the sensors library resources"""
+        if not self._initialized:
+            return  # Not initialized, nothing to cleanup
+
+        assert self.lib is not None
+        self.lib.sensors_cleanup()
+        self._initialized = False
+
+    def refresh(self) -> None:
+        """
+        Refresh sensor detection. Useful for long-running processes
+        to detect newly added/removed sensors.
+        """
+        if self._initialized:
+            self.cleanup()
+        self.init()
+
+    def get_detected_chips(self) -> list[SensorsChipName]:
+        """
+        Get list of all detected sensor chips.
+
+        Returns:
+            List of SensorsChipName structures
+        """
+        assert self.lib is not None
+        chips: list[SensorsChipName] = []
+        nr = ctypes.c_int(0)
+
+        while True:
+            chip = self.lib.sensors_get_detected_chips(None, ctypes.byref(nr))
+            if not chip:
+                break
+            chips.append(chip.contents)
+
+        return chips
+
+    def get_chip_name(self, chip: SensorsChipName) -> str:
+        """
+        Get human-readable name for a chip.
+
+        Args:
+            chip: SensorsChipName structure
+
+        Returns:
+            Chip name as string
+        """
+        assert self.lib is not None
+        buf = ctypes.create_string_buffer(200)
+        self.lib.sensors_snprintf_chip_name(buf, 200, ctypes.byref(chip))
+        return buf.value.decode("utf-8")
+
+    def get_features(self, chip: SensorsChipName) -> list[SensorsFeature]:
+        """
+        Get all features for a chip.
+
+        Args:
+            chip: SensorsChipName structure
+
+        Returns:
+            List of SensorsFeature structures
+        """
+        assert self.lib is not None
+        features: list[SensorsFeature] = []
+        nr = ctypes.c_int(0)
+
+        while True:
+            feature = self.lib.sensors_get_features(
+                ctypes.byref(chip), ctypes.byref(nr)
+            )
+            if not feature:
+                break
+            features.append(feature.contents)
+
+        return features
+
+    def get_subfeatures(
+        self, chip: SensorsChipName, feature: SensorsFeature
+    ) -> list[SensorsSubfeature]:
+        """
+        Get all subfeatures for a feature.
+
+        Args:
+            chip: SensorsChipName structure
+            feature: SensorsFeature structure
+
+        Returns:
+            List of SensorsSubfeature structures
+        """
+        assert self.lib is not None
+        subfeatures: list[SensorsSubfeature] = []
+        nr = ctypes.c_int(0)
+
+        while True:
+            subfeature = self.lib.sensors_get_all_subfeatures(
+                ctypes.byref(chip), ctypes.byref(feature), ctypes.byref(nr)
+            )
+            if not subfeature:
+                break
+            subfeatures.append(subfeature.contents)
+
+        return subfeatures
+
+    def get_value(self, chip: SensorsChipName, subfeature_nr: int) -> float:
+        """
+        Get sensor value for a subfeature.
+
+        Args:
+            chip: SensorsChipName structure
+            subfeature_nr: Subfeature number
+
+        Returns:
+            Sensor value as float
+        """
+        assert self.lib is not None
+        value = ctypes.c_double()
+        result: int = self.lib.sensors_get_value(
+            ctypes.byref(chip), subfeature_nr, ctypes.byref(value)
+        )
+        if result != 0:
+            raise RuntimeError(f"Failed to get sensor value: {result}")
+        return value.value
+
+    def get_label(self, chip: SensorsChipName, feature: SensorsFeature) -> str:
+        """
+        Get human-readable label for a feature.
+
+        Args:
+            chip: SensorsChipName structure
+            feature: SensorsFeature structure
+
+        Returns:
+            Feature label as string
+        """
+        assert self.lib is not None
+        label = self.lib.sensors_get_label(ctypes.byref(chip), ctypes.byref(feature))
+        if label:
+            result: str = label.decode("utf-8")
+            # Note: libsensors documentation says to free the label, but this can cause
+            # crashes depending on the libsensors version and build configuration.
+            # In practice, the memory leak is minimal for most use cases.
+            # If you need to free memory in a long-running process, you can try:
+            # 1. Use sensors.cleanup() and sensors.init() periodically to reset
+            # 2. Check your libsensors version compatibility
+            return result
+        return ""
+
+    def get_cpu_temperatures(self) -> dict[str, dict[str, float]]:
+        """
+        Get only CPU temperature readings in a nested format.
+
+        Note: AMD EPYC processors typically only expose Tctl (overall CPU temperature)
+        through k10temp, not per-core temperatures. Intel processors with coretemp
+        usually provide per-core temperatures. The availability of temperature sensors
+        depends on the CPU model and kernel driver support.
+
+        Returns:
+            Dictionary with chip names as keys and temperature readings as nested dicts
+            Example: {'coretemp-isa-0000': {'Core 0': 48.0}, 'k10temp-pci-00c3': {'Tctl': 67.0}}
+        """
+        cpu_temps: dict[str, dict[str, float]] = {}
+
+        # CPU sensor chip patterns - various vendors
+        cpu_chip_patterns = [
+            "coretemp",  # Intel
+            "k10temp",  # AMD Family 10h+
+            "k8temp",  # AMD Family 8
+            "via_cputemp",  # VIA
+            "cpu_thermal",  # ARM/embedded
+        ]
+
+        for chip in self.get_detected_chips():
+            chip_name = self.get_chip_name(chip)
+
+            # Check if this is a CPU sensor chip
+            if any(pattern in chip_name.lower() for pattern in cpu_chip_patterns):
+                for feature in self.get_features(chip):
+                    if feature.type == SensorsFeatureType.SENSORS_FEATURE_TEMP:
+                        label = self.get_label(chip, feature)
+
+                        # Get the input temperature value
+                        for subfeature in self.get_subfeatures(chip, feature):
+                            if subfeature.flags & 0x01:  # SENSORS_MODE_R
+                                subfeature_name = (
+                                    subfeature.name.decode("utf-8")
+                                    if subfeature.name
+                                    else ""
+                                )
+                                if "input" in subfeature_name:
+                                    try:
+                                        value = self.get_value(chip, subfeature.number)
+                                        if chip_name not in cpu_temps:
+                                            cpu_temps[chip_name] = {}
+                                        cpu_temps[chip_name][label] = value
+                                    except RuntimeError:
+                                        pass
+                                    break
+
+        return cpu_temps


### PR DESCRIPTION
## Problem

With newer netdata, we don't have netdata's bindings of `lm_sensor` anymore which means cpu temperature plugin in master is broken right now.

## Solution

We can get the same information from sysfs directly and make sure our netdata plugin reflects the temperature stats accurately.