### PR TITLE
NAS-137740 / 26.04 / Remove setup_middleware_tests

### DIFF
--- a/tests/run_unit_tests.py
+++ b/tests/run_unit_tests.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from collections.abc import Generator
 from dataclasses import dataclass
 from junitparser import JUnitXml
-from shutil import copytree, rmtree
 from truenas_api_client import Client
 from uuid import uuid4
 
@@ -129,19 +128,6 @@ def disable_api_test_config(path: str) -> Generator[None, None, None]:
         )
 
 
-@contextmanager
-def setup_middleware_tests(path: str) -> Generator[None, None, None]:
-    """ temporarily setup our pytest tests in the python dir """
-    try:
-        copytree(
-            os.path.join(path, MIDDLEWARE_PYTEST),
-            os.path.join(MIDDLEWARE_PYTEST_MODULE)
-        )
-        yield
-    finally:
-        rmtree(MIDDLEWARE_PYTEST_MODULE)
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument(
@@ -156,8 +142,7 @@ def main() -> None:
 
     args = parser.parse_args()
     with disable_api_test_config(args.path):
-        with setup_middleware_tests(args.path):
-            exit_code = run_unit_tests(args.path)
+        exit_code = run_unit_tests(args.path)
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
Remove `setup_middleware_tests` as the pytest dir is now included in the middlewared package.