### PR TITLE
NAS-137744 / 26.04 / fix install_test make command

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -19,6 +19,7 @@ install:
 
 install_test:
 	bash install-dev-tools
+	pip install --no-build-isolation --break-system-packages --root-user-action=ignore .
 
 migrate:
 	migrate


### PR DESCRIPTION
This is needed so the CI pipelines that run from a "runner" will work. I'll push another PR in our CI repo to fix the unit test pipeline.