### PR TITLE
NAS-137742 / 25.10.0 / Fix nvmet zvol resize (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -787,6 +787,7 @@ class PoolDatasetService(CRUDService):
                 # means the zvol size has increased so we need to check if this zvol is shared via SCST (iscsi)
                 # and if it is, resync it so the connected initiators can see the new size of the zvol
                 await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id_)
+                await self.middleware.call('nvmet.namespace.resync_lun_size_for_zvol', id_)
 
             if 'readonly' in data:
                 # depending on the iscsi client connected to us, if someone marks a zvol

--- a/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
+++ b/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
@@ -664,6 +664,7 @@ class TestNVMe(NVMeRunning):
 
                         # Update the size of the ZVOL
                         call('pool.dataset.update', zvol_config['id'], {'volsize': ZVOL_RESIZE_END_MB * MB})
+
                         devices = nc.nvme_devices()
                         assert len(devices) == 1, devices
                         self.assert_subsys_namespaces(devices, subsys_nqn, [(1, ZVOL_RESIZE_END_MB)])


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x fbf4adf1586aa115d3ebd12d29093a8b1338bea8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x ed4769d00849e3e56bd79ab45656402c99e27d31

A test started failing recently (timing issues following Trixie rebase) revealing that the `resync_lun_size_for_zvol` mechanism that we have in place for iSCSI volumes was not implemented for NVMe-oF targets.

Rectify by adding and calling private API `nvmet.namespace.resize_namespace`.

Original PR: https://github.com/truenas/middleware/pull/17266
