### PR TITLE
NAS-137754 / 25.10-RC.1 / Fix CORS for TNC production (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -138,7 +138,7 @@ http {
     }
 
     map $http_origin $allow_origin {
-        ~^https://truenas.connect.(dev.|staging.)?ixsystems.net$ $http_origin;
+        ~^${tn_connect_config['tnc_base_url'].rstrip("/")}$ $http_origin;
         default "";
     }
 


### PR DESCRIPTION
Current nginx after these changes
```
root@testD293SDM042[~]# grep -A 2 -B 2 -rin "allow_origin" /etc/nginx/nginx.conf
55-    }
56-
57:    map $http_origin $allow_origin {
58-        ~^https://web.truenasconnect.net$ $http_origin;
59-        default "";
root@testD293SDM042[~]#
```

Original PR: https://github.com/truenas/middleware/pull/17270
