### PR TITLE
NAS-137758 / 25.10.0 / Fix issue when LUN is added to an ALUA target (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -541,6 +541,11 @@ class iSCSITargetService(CRUDService):
                 raise OSError(cp.returncode, os.strerror(cp.returncode), err)
 
     @private
+    async def rescan_iqn(self, iqn, timeout=30):
+        cmd = ['iscsiadm', '-m', 'node', '-T', iqn, '-R']
+        await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8', timeout=timeout)
+
+    @private
     def logged_in_iqns(self):
         """
         :return: dict keyed by iqn, with list of the unsurfaced disk names as the value


### PR DESCRIPTION
Perform a rescan of the internal HA target when a LUN is added to an existing target (when ALUA is already enabled).

After the Trixie rebase the test `test_alua_luns` (and more) started [failing](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/518/) reliably.  The rebase appears to have highlighted a shortcoming/fragility in the code.

----
iSCSI tests passing CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/521/).

Original PR: https://github.com/truenas/middleware/pull/17273
