### PR TITLE
NAS-137766 / 26.04 / disable all virt plugin API tests

### DIFF
--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -23,6 +23,9 @@ INS3_OS = 'Ubuntu'
 INS3_IMAGE = 'ubuntu/oracular/default'
 
 
+pytestmark = pytest.mark.skip('Disable VIRT tests for the moment')
+
+
 @pytest.fixture(scope='module')
 def virt_setup():
     # ensure that any stale config from other tests is nuked

--- a/tests/api2/test_virt_instances.py
+++ b/tests/api2/test_virt_instances.py
@@ -22,6 +22,8 @@ VM_NAME = 'virt-vm'
 CONTAINER_NAME = 'virt-container'
 VNC_PORT = 6900
 
+pytestmark = pytest.mark.skip('Disable VIRT tests for the moment')
+
 
 @pytest.fixture(scope='module')
 def virt_pool():


### PR DESCRIPTION
We've got a new container plugin that replaces this and these tests are failing causing us to waste time investigating these issues.