### PR TITLE
NAS-137767 / 26.04 / fix test_legacy_api CI test

### DIFF
--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -85,8 +85,8 @@ def test_config_method(legacy_api_client, config_method):
         # Not a ConfigService config method. Requires an argument.
         return
 
-    # Methods that do not exist in 25.04
     if (
+        # Methods that do not exist in 25.04
         version in {"25.04.0", "25.04.1", "25.04.2"}
         and config_method in {
             "audit.config",
@@ -107,6 +107,15 @@ def test_config_method(legacy_api_client, config_method):
             "truecommand.config",
             "update.config",
             "ups.config",
+        }
+    ):
+        return
+
+    if (
+        # Methods that do not exist in 25.10
+        version in {"25.10.0"}
+        and config_method in {
+            "lxc.config",
         }
     ):
         return


### PR DESCRIPTION
This config endpoint doesn't exist in 25.10.0 either.