### PR TITLE
NAS-137776 / 26.04 / fix reinstalling middleware on running TrueNAS

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -12,6 +12,11 @@ fi
 PACKAGES=(
     # need to make things work
     make
+    # Debian package building tools
+    dpkg-dev
+    dh-python
+    pybuild-plugin-pyproject
+    debhelper-compat
     # open-iscsi is used to test authorized networks for iscsi
     open-iscsi
     # Integration and unit test utils, python package management

--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -12,21 +12,53 @@ clean:
 	# two "middlewared" packages being on disk at
 	# same time.
 	find /usr -type d \( -path "*/dist-packages/middlewared" -o -path "*/site-packages/middlewared" \) 2>/dev/null | xargs -r rm -rf
+	rm -rf build-mw-deb/
+
+build_deb:
+	mkdir -p build-mw-deb
+	# Ignore the changes file generation error - we only need the .deb file
+	dpkg-buildpackage -b -us -uc -nc || true
+	# Check if .deb file was created and move it to build directory
+	@if DEB_FILE=$$(ls ../middlewared_*.deb 2>/dev/null | head -1) && [ -f "$$DEB_FILE" ]; then \
+		mv $$DEB_FILE build-mw-deb/; \
+		echo "$$(basename $$DEB_FILE)" > build-mw-deb/.deb_name; \
+		echo "Built: $$(basename $$DEB_FILE)"; \
+	else \
+		echo "Build failed: middlewared_*.deb file not found" >&2; \
+		exit 1; \
+	fi
 
 install:
-	pip install --no-build-isolation --break-system-packages --root-user-action=ignore .
-	cp ./debian/middlewared.service /usr/lib/systemd/system/middlewared.service
+	# Install the debian package from build directory
+	@if [ -f build-mw-deb/.deb_name ]; then \
+		DEB_FILE="build-mw-deb/$$(cat build-mw-deb/.deb_name)"; \
+		if [ -f "$$DEB_FILE" ]; then \
+			echo "Installing: $$(basename $$DEB_FILE)"; \
+			dpkg -i $$DEB_FILE || apt-get install -f -y; \
+		else \
+			echo "Package file $$DEB_FILE not found" >&2; \
+			exit 1; \
+		fi; \
+	else \
+		echo "No .deb_name file found. Run 'make build_deb' first." >&2; \
+		exit 1; \
+	fi
 
+# kept here for backwards compatibility for our internal CI
+# and builds that are Goldeye or older. Halfmoon and newer
+# dont use this.
 install_test:
 	bash install-dev-tools
 	pip install --no-build-isolation --break-system-packages --root-user-action=ignore .
 
+install_deps:
+	bash install-dev-tools
+
 migrate:
 	migrate
 
-reinstall: stop_service clean install migrate start_service
+reinstall: stop_service install_deps clean build_deb install migrate start_service
 
 # this is to be called in github actions running in a container (no systemd (pid 1))
 # so it's the same as `reinstall` but without the start/stop{_service} and migrate calls
-# FIXME: install_client is no more
-reinstall_container: clean install install_test
+reinstall_container: install_deps clean build_deb install


### PR DESCRIPTION
This changes how we reinstall the `middlewared` package to using deb only instead of fighting the myriad issues that we're experiencing by mixing pip and apt.