### PR TITLE
NAS-137737 / 26.04 / Fix access check for group@ / GROUP_OBJ entries

### DIFF
--- a/src/middlewared/middlewared/utils/filesystem/access.py
+++ b/src/middlewared/middlewared/utils/filesystem/access.py
@@ -105,7 +105,7 @@ def check_acl_execute_impl(path: str, acl: list, uid: int, gid: int, path_must_e
             id_info['xid'] = uid
 
         elif entry['tag'] in ('group@', 'GROUP_OBJ'):
-            id_info['id_type'] = 'USER'
+            id_info['id_type'] = 'GROUP'
             id_info['xid'] = gid
 
         if (user_details := get_user_details(**id_info)) is None:


### PR DESCRIPTION
This commit fixes access checks for group@ / GROUP_OBJ ACL entries. There was a typo that crept in while refactoring this for new API that resulted in the access for the owning group being evaluated as if it were the user. This usually didn't manifest as an error because the primary heavy ACL users are in active directory environments where the NSS backend implements ID_TYPE_BOTH (so there's an identical user and group entry). In the case of local accounts though it could result in spurious validation errors (although in the ticket this is associated with the user actually was trying to set permissions that would raise a validation error even with the fix).