### PR TITLE
NAS-137786 / 26.04 / Fix startup for truesearch/webshare-auth

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -40,8 +40,10 @@ systemctl disable openipmi
 systemctl disable nfs-server
 systemctl disable rpcbind
 
-# This service will be started from middleware as needed
+# These services will be started from middleware as needed
 systemctl disable ix-nvmf
+systemctl disable truenas-webshare-auth
+systemctl disable truesearch
 
 # NAS-123024: disable proftpd.socket, if it starts it will block proftpd.service
 # proftpd.socket is used in conjunction with xinetd


### PR DESCRIPTION
- Don't start truesearch / truenas-webshare-auth by default at startup, let middleware enable them as required.