### PR TITLE
- Update path to truesarch socket location to make systemd happy

### DIFF
--- a/src/middlewared/middlewared/utils/smb.py
+++ b/src/middlewared/middlewared/utils/smb.py
@@ -112,7 +112,7 @@ INVALID_SHARE_NAME_CHARACTERS = frozenset({
 })
 RESERVED_SHARE_NAMES = frozenset({'global', 'printers', 'homes', 'admin$', 'ipc$'})
 SUPPORTED_SMB_VARIABLES = frozenset({'U', 'G', 'D'})  # see man 5 smb.conf "VARIABLE SUBSTITUTIONS"
-TRUESEARCH_ES_PATH = '/var/run/truesearch/truesearch-es.sock'
+TRUESEARCH_ES_PATH = '/run/truesearch/truesearch-es.sock'
 
 
 def validate_smb_share_name(name: str) -> str:


### PR DESCRIPTION
Thanks Pottering!

`Sep 29 09:48:20 truenas systemd: /usr/lib/systemd/system/truesearch.socket:10: ListenStream= references a path below legacy directory /var/run/, updating /var/run/truesearch/truesearch-es.sock → /run/truesearch/truesearch-es.sock; please update the unit file accordingly.`

Updating truesearch location on the backend as well. 