### PR TITLE
NAS-137795 / 26.04 / fix CallError not defined in API tests

### DIFF
--- a/src/middlewared/middlewared/plugins/test/mock.py
+++ b/src/middlewared/middlewared/plugins/test/mock.py
@@ -18,10 +18,10 @@ class TestService(Service):
 
     async def set_mock(self, name, args, description):
         if isinstance(description, str):
-            local_scope = {}
-            exec(description, {}, local_scope)
+            scope = {}
+            exec(description, scope)
             try:
-                method = local_scope["mock"]
+                method = scope["mock"]
             except KeyError:
                 raise CallError("Your mock declaration must include `def mock` or `async def mock`")
         elif isinstance(description, dict):


### PR DESCRIPTION
In Python 3.13, when exec() is called with separate globals and locals dicts, imports go into the locals dict but the defined function's __globals__ points to the globals dict. This caused mock functions to fail with "name 'CallError' is not defined" because CallError was imported in locals but the function looked for it in the (empty) globals. The fix changes to using a single dict for both globals and locals in exec(). This ensures imports and the function definition share the same namespace, so the mock function can find its imported names when it executes.