### PR TITLE
NAS-137803 / 25.10.0 / Do not use trains redirect to find which train has current version profile (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/profile_.py
+++ b/src/middlewared/middlewared/plugins/update_/profile_.py
@@ -76,12 +76,9 @@ class UpdateService(Service):
         return UpdateProfiles[name] >= UpdateProfiles[selected_name]
 
     @private
-    async def current_version_profile(self, trains=None):
-        if trains is None:
-            trains = await self.middleware.call('update.get_trains')
-
-        current_train_name = await self.middleware.call('update.get_current_train_name', trains)
-        current_train_releases = await self.middleware.call('update.get_train_releases', current_train_name)
+    async def current_version_profile(self):
+        manifest = await self.middleware.call('update.get_manifest_file')
+        current_train_releases = await self.middleware.call('update.get_train_releases', manifest['train'])
         current_version = await self.middleware.call('system.version_short')
         if (current_release := current_train_releases.get(current_version)) is None:
             if any(substring in current_version for substring in ('CUSTOM', 'INTERNAL', 'MASTER')):

--- a/src/middlewared/middlewared/plugins/update_/status.py
+++ b/src/middlewared/middlewared/plugins/update_/status.py
@@ -54,7 +54,7 @@ class UpdateService(Service):
             trains = await self.middleware.call('update.get_trains')
 
             current_train_name = await self.middleware.call('update.get_current_train_name', trains)
-            current_profile = await self.middleware.call('update.current_version_profile', trains)
+            current_profile = await self.middleware.call('update.current_version_profile')
             matches_profile = await self.middleware.call('update.profile_matches', current_profile, config['profile'])
 
             new_version = None


### PR DESCRIPTION
We were erroneously using train redirection to find which train's `releases.json` file will have the current release update profile.

Original PR: https://github.com/truenas/middleware/pull/17304
