### PR TITLE
NAS-137844 / 25.10.0 / fix USB disk detection alert on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/usb_storage.py
+++ b/src/middlewared/middlewared/alert/source/usb_storage.py
@@ -25,7 +25,7 @@ class USBStorageAlertSource(ThreadedAlertSource):
     def check_sync(self):
         alerts = []
         with os.scandir("/dev/disk/by-id") as sdir:
-            for i in filter(lambda x: "usb" in x.name.lower(), sdir):
+            for i in filter(lambda x: x.name.lower().startswith("usb-"), sdir):
                 resolved_path = os.path.realpath(i.path)
                 if resolved_path.startswith("/dev/sr"):
                     # When opening the IPMI KVM console on the


### PR DESCRIPTION
Raised by the support team. We need to ignore USB CDROM devices in this alert so false positive proactive support tickets are not created in support portal. I also switched to using `os.scandir` since this is being backported to GE which uses python 3.11 and `pathlib.Path.iterdir` on that python version is not performant compared to `os.scandir`.

Original PR: https://github.com/truenas/middleware/pull/17308
