### PR TITLE
Fix reuse of iSCSI extent zvol or file

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -308,7 +308,7 @@ class iSCSITargetExtentService(SharingService):
     async def clean(self, data, schema_name, verrors, old=None):
         await self.clean_name(data, schema_name, verrors, old=old)
         await self.clean_serial(data, schema_name, verrors, old=old)
-        await self.middleware.call('iscsi.extent.clean_type_and_path', data, schema_name, verrors)
+        await self.middleware.call('iscsi.extent.clean_type_and_path', data, schema_name, verrors, old)
         await self.middleware.call('iscsi.extent.clean_size', data, schema_name, verrors)
 
     @private
@@ -389,7 +389,8 @@ class iSCSITargetExtentService(SharingService):
         return data[self.path_field]
 
     @private
-    def clean_type_and_path(self, data, schema_name, verrors):
+    def clean_type_and_path(self, data, schema_name, verrors, old=None):
+        not_old_id = ('id', '!=', old['id']) if old else None
         if data['type'] is None:
             return data
 
@@ -422,6 +423,13 @@ class iSCSITargetExtentService(SharingService):
             if '@' in zvol_name and not data['ro']:
                 verrors.add(f'{schema_name}.ro', 'Must be set when disk is a ZFS Snapshot')
 
+            filters = [('disk', '=', disk)]
+            if not_old_id:
+                filters.append(not_old_id)
+            if used := self.middleware.call_sync('iscsi.extent.query', filters, {'select': ['name']}):
+                verrors.add(f'{schema_name}.disk',
+                            f'Disk currently in use by extent {used[0]["name"]}')
+
         elif extent_type == 'FILE':
             if not path:
                 verrors.add(f'{schema_name}.path', 'This field is required')
@@ -444,6 +452,19 @@ class iSCSITargetExtentService(SharingService):
                     f'{schema_name}.path',
                     'Filepath may not contain space characters'
                 )
+
+            if namespaces := self.middleware.call_sync('nvmet.namespace.query', [['device_path', '=', path]]):
+                ns = namespaces[0]
+                verrors.add(f'{schema_name}.path',
+                            f'File currently in use by NVMe-oF subsystem {ns["subsys"]["name"]} NSID {ns["nsid"]}')
+                raise verrors
+
+            filters = [('path', '=', path)]
+            if not_old_id:
+                filters.append(not_old_id)
+            if used := self.middleware.call_sync('iscsi.extent.query', filters, {'select': ['name']}):
+                verrors.add(f'{schema_name}.path',
+                            f'File currently in use by extent {used[0]["name"]}')
 
         return data
 

--- a/src/middlewared/middlewared/test/integration/assets/iscsi.py
+++ b/src/middlewared/middlewared/test/integration/assets/iscsi.py
@@ -25,13 +25,13 @@ def iscsi_auth(data):
 
 
 @contextlib.contextmanager
-def iscsi_extent(data):
+def iscsi_extent(data, remove=False, force=False):
     extent = call("iscsi.extent.create", data)
 
     try:
         yield extent
     finally:
-        call("iscsi.extent.delete", extent["id"])
+        call("iscsi.extent.delete", extent["id"], remove, force)
 
 
 @contextlib.contextmanager

--- a/tests/sharing_protocols/iscsi/test_261_iscsi_cmd.py
+++ b/tests/sharing_protocols/iscsi/test_261_iscsi_cmd.py
@@ -25,7 +25,7 @@ from pyscsi.pyscsi.scsi_sense import sense_ascq_dict, sense_key_dict
 from pytest_dependency import depends
 
 from middlewared.service_exception import CallError, InstanceNotFound, ValidationError, ValidationErrors
-from middlewared.test.integration.assets.iscsi import target_login_test
+from middlewared.test.integration.assets.iscsi import iscsi_extent, target_login_test
 from middlewared.test.integration.assets.iscsi import iscsi_auth as iscsi_auth_data
 from middlewared.test.integration.assets.pool import dataset, snapshot
 from middlewared.test.integration.utils import call, ssh
@@ -1456,6 +1456,42 @@ class TestEntentNames:
                     call('iscsi.extent.update', extent2['id'], {'name': name1})
                 with assert_validation_errors('iscsi_extent_update.name', f'Extent name must be unique when flattened ({name1})'):
                     call('iscsi.extent.update', extent2['id'], {'name': bad_name2})
+
+    def test__test_reuse_extent_zvol(self):
+        """
+        Test that the ZVOL underlying an extent may not be reused in another extent.
+        """
+        zvol1_name = f'{pool_name}/reusevol1'
+        with zvol_dataset(zvol1_name, 100):
+            extent1_payload = {
+                'type': 'DISK',
+                'disk': f'zvol/{zvol1_name}',
+                'name': 'reuseext1'
+            }
+            with iscsi_extent(extent1_payload):
+                extent2_payload = extent1_payload | {'name': 'reuseext2'}
+                with assert_validation_errors('iscsi_extent_create.disk',
+                                              'Disk currently in use by extent reuseext1'):
+                    with iscsi_extent(extent2_payload):
+                        pass
+
+    def test__test_reuse_extent_file(self):
+        """
+        Test that the file underlying an extent may not be reused in another extent.
+        """
+        filepath = f'/mnt/{pool_name}/reuse_file1'
+        extent1_payload = {
+            'type': 'FILE',
+            'path': filepath,
+            'name': 'reuseext1',
+            'filesize': MB_100,
+        }
+        with iscsi_extent(extent1_payload, True, True):
+            extent2_payload = extent1_payload | {'name': 'reuseext2'}
+            with assert_validation_errors('iscsi_extent_create.path',
+                                          'File currently in use by extent reuseext1'):
+                with iscsi_extent(extent2_payload):
+                    pass
 
 
 @pytest.mark.parametrize('extent_type', ["FILE", "VOLUME"])

--- a/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
+++ b/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
@@ -759,6 +759,40 @@ class TestNVMe(NVMeRunning):
                     assert len(devices) == 1, devices
                     self.assert_subsys_namespaces(devices, subsys_nqn, [(1, 200)])
 
+                iscsi_extent_payload = {
+                    'type': 'FILE',
+                    'path': file1,
+                    'name': 'nvmet_test_extent'
+                }
+
+                # Ensure we can't create iSCSI using a FILE used by us
+                with assert_validation_errors('iscsi_extent_create.path',
+                                              'File currently in use by NVMe-oF '
+                                              f'subsystem {SUBSYS_NAME1} NSID 1'):
+                    with iscsi_extent(iscsi_extent_payload):
+                        pass
+
+                iscsi_extent_payload = {
+                    'type': 'FILE',
+                    'path': file2,
+                    'name': 'nvmet_test_extent',
+                    'filesize': MB_100
+                }
+
+                with iscsi_extent(iscsi_extent_payload, True):
+                    # Ensure we can't create using a FILE used by iSCSI
+                    in_use_msg = 'This device_path already used by iSCSI extent: nvmet_test_extent'
+                    with assert_validation_errors('nvmet_namespace_create.device_path', in_use_msg):
+                        with nvmet_namespace(subsys_id,
+                                             file2,
+                                             DEVICE_TYPE_FILE,
+                                             filesize=MB_100,
+                                             delete_options={'remove': True}):
+                            pass
+                    # Ensure we can't update using a FILE used by iSCSI
+                    with assert_validation_errors('nvmet_namespace_update.device_path', in_use_msg):
+                        call('nvmet.namespace.update', ns['id'], {'device_path': file2})
+
     def test__pool_export_import(self, fixture_port, loopback_client: NVMeCLIClient, zvol1):
         """
         Test that we can export and import a pool underlying subsystem namespaces.


### PR DESCRIPTION
Fix some gaps in prevention of reuse of the device or file underlying an iSCSI target.  (The UI was preventing ZVOLs from being reused.)

Add additional tests.  The ones pertaining to NVMe-oF / iSCSI interaction are in _test_nvmet_tcp.py_