### PR TITLE
NAS-137866 / 26.04 / skip SNMP tests

### DIFF
--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -14,7 +14,7 @@ from middlewared.test.integration.utils.system import reset_systemd_svcs
 from auto_config import ha, interface, password, user, pool_name
 from functions import async_SSH_done, async_SSH_start
 
-pytest.mark.skip('snmp-agent is broken after upgrade to Trixie: NAS-137789')
+pytestmark = pytest.mark.skip('snmp-agent is broken after upgrade to Trixie: NAS-137789')
 
 skip_ha_tests = pytest.mark.skipif(not (ha and "virtual_ip" in os.environ), reason="Skip HA tests")
 COMMUNITY = 'public'

--- a/tests/api2/test_snmp_agent.py
+++ b/tests/api2/test_snmp_agent.py
@@ -8,7 +8,7 @@ import pytest
 from middlewared.test.integration.utils import call, host, ssh
 
 
-pytest.mark.skip('snmp-agent is broken after upgrade to Trixie: NAS-137789')
+pytestmark = pytest.mark.skip('snmp-agent is broken after upgrade to Trixie: NAS-137789')
 
 
 @pytest.fixture()


### PR DESCRIPTION
Previous commit forgot to assign this to a variable so these tests are continuing to run even though they should be skipped.