### PR TITLE
NAS-137867 / 26.04 / fix SMB crud roles API test

### DIFF
--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -27,7 +27,7 @@ def test_read_role_cant_write(unprivileged_user_fixture, role):
 
     common_checks(unprivileged_user_fixture, "sharing.smb.getacl", role, True)
     common_checks(unprivileged_user_fixture, "sharing.smb.setacl", role, False)
-    common_checks(unprivileged_user_fixture, "smb.status", role, False)
+    # common_checks(unprivileged_user_fixture, "smb.status", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])


### PR DESCRIPTION
This check has been failing for months and months and the associated conversion of this private method to public has not happened so I'm disabling it to fix false positives in our API test suite.