### PR TITLE
NAS-137880 / 26.04 / zfs.dataset.update -> pool.dataset.update_impl

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -5,8 +5,9 @@
     from pathlib import Path
     from contextlib import suppress
     from middlewared.plugins.nfs_.utils import get_domain, leftmost_has_wildcards, get_wildcard_domain
+    from middlewared.plugins.pool_.utils import UpdateImplArgs
 
-    
+
     def do_map(share, map_type, map_ids, alert_shares):
         output = []
         invalid_name = []
@@ -130,9 +131,8 @@
             try:
                 middleware.logger.warning("%s: Disable sharenfs", ds)
                 middleware.call_sync(
-                    'zfs.dataset.update',
-                    ds,
-                    {'properties': {'sharenfs': {'value': 'off'}}}
+                    'pool.dataset.update_impl',
+                    UpdateImplArgs(name=ds, zprops={'sharenfs': 'off'})
                 )
             except Exception:
                 middleware.logger.warning("%s: Failed to disable sharenfs", ds, exc_info=True)

--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -33,7 +33,8 @@ class AppSchemaActions(Service):
                     zprops=user_wants[create_ds]['properties'] | DatasetDefaults.create_time_props(),
                 )
             )
-            await self.middleware.call('zfs.dataset.mount', create_ds)
+            # TODO: why mount? creating mounts by default so this isn't needed
+            # await self.middleware.call('zfs.dataset.mount', create_ds)
 
     async def apply_acls(self, acls_to_apply):
         bulk_job = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -33,8 +33,7 @@ class AppSchemaActions(Service):
                     zprops=user_wants[create_ds]['properties'] | DatasetDefaults.create_time_props(),
                 )
             )
-            # TODO: why mount? creating mounts by default so this isn't needed
-            # await self.middleware.call('zfs.dataset.mount', create_ds)
+            await self.middleware.call('zfs.dataset.mount', create_ds)
 
     async def apply_acls(self, acls_to_apply):
         bulk_job = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/boot_/environments.py
+++ b/src/middlewared/middlewared/plugins/boot_/environments.py
@@ -16,6 +16,7 @@ from middlewared.api.current import (
     BootEnvironmentKeepArgs,
     BootEnvironmentKeepResult,
 )
+from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.service import filterable_api_method, Service, private
 from middlewared.service_exception import CallError, ValidationError
 from middlewared.utils import filter_list
@@ -157,11 +158,11 @@ class BootEnvironmentService(Service):
     @api_method(BootEnvironmentKeepArgs, BootEnvironmentKeepResult, roles=['BOOT_ENV_WRITE'])
     def keep(self, data):
         self.middleware.call_sync(
-            "zfs.dataset.update",
-            self.validate_be("boot.environment.keep", data["id"])["dataset"],
-            {
-                "properties": {"zectl:keep": {"value": str(data["value"])}},
-            },
+            "pool.dataset.update_impl",
+            UpdateImplArgs(
+                name=self.validate_be("boot.environment.keep", data["id"])["dataset"],
+                uprops={"zectl:keep": str(data["value"])},
+            )
         )
         return self.query([["id", "=", data["id"]]], {"get": True})
 

--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -1,6 +1,7 @@
 import errno
 
 from middlewared.service import CallError, Service
+from middlewared.plugins.pool_.utils import UpdateImplArgs
 
 from .state_utils import docker_dataset_custom_props, IX_APPS_MOUNT_PATH, Status
 
@@ -53,15 +54,10 @@ class DockerFilesystemManageService(Service):
 
         # If the mount point is not at the expected location, fix it
         if ds[0]['properties']['mountpoint']['value'] != IX_APPS_MOUNT_PATH:
+            mp = docker_dataset_custom_props(docker_ds.split('/')[-1]['mountpoint'])
             await self.middleware.call(
-                'zfs.dataset.update',
-                docker_ds, {
-                    'properties': {
-                        'mountpoint': {
-                            'value': docker_dataset_custom_props(docker_ds.split('/')[-1])['mountpoint']
-                        },
-                    },
-                }
+                'pool.dataset.update_impl',
+                UpdateImplArgs(name=docker_ds, zprops={'mountpoint': mp})
             )
 
     async def ix_apps_is_mounted(self, dataset_to_check=None):

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from middlewared.service import CallError, private, Service
 from middlewared.utils.interface import wait_for_default_interface_link_state_up
-from middlewared.plugins.pool_.utils import CreateImplArgs
+from middlewared.plugins.pool_.utils import CreateImplArgs, UpdateImplArgs
 
 from .state_utils import (
     DatasetDefaults, DOCKER_DATASET_NAME, docker_datasets, IX_APPS_MOUNT_PATH, missing_required_datasets,
@@ -102,9 +102,8 @@ class DockerSetupService(Service):
                 if any(val['raw'] != update_props[name] for name, val in existing_dataset.items()):
                     # if any of the zfs properties don't match what we expect we'll update all properties
                     self.middleware.call_sync(
-                        'zfs.dataset.update', dataset_name, {
-                            'properties': {k: {'value': v} for k, v in update_props.items()}
-                        }
+                        'pool.dataset.update_impl',
+                        UpdateImplArgs(name=dataset_name, zprops=update_props)
                     )
             else:
                 self.move_conflicting_dir(dataset_name)

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -19,6 +19,7 @@ from middlewared.api.current import (
     iSCSITargetExtentUpdateResult
 )
 from middlewared.async_validators import check_path_resides_within_volume
+from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 from middlewared.service import CallError, SharingService, ValidationErrors, private
@@ -133,14 +134,11 @@ class iSCSITargetExtentService(SharingService):
         if data['type'] == 'DISK' and data['path'].startswith('zvol/'):
             zvolname = zvol_path_to_name(os.path.join('/dev', data['path']))
             await self.middleware.call(
-                'zfs.dataset.update',
-                zvolname,
-                {
-                    'properties': {
-                        'volthreading': {'value': 'off'},
-                        'readonly': {'value': 'on' if data['ro'] else 'off'}
-                    }
-                }
+                'pool.dataset.update_impl',
+                UpdateImplArgs(
+                    name=zvolname,
+                    zprops={'volthreading': 'off', 'readonly': 'on' if data['ro'] else 'off'}
+                )
             )
 
         data['id'] = await self.middleware.call(
@@ -179,13 +177,11 @@ class iSCSITargetExtentService(SharingService):
         if zvolpath is not None and zvolpath.startswith('zvol/'):
             zvolname = zvol_path_to_name(os.path.join('/dev', zvolpath))
             await self.middleware.call(
-                'zfs.dataset.update',
-                zvolname,
-                {
-                    'properties': {
-                        'readonly': {'value': 'on' if new['ro'] else 'off'}
-                    }
-                }
+                'pool.dataset.update_impl',
+                UpdateImplArgs(
+                    name=zvolname,
+                    zprops={'readonly': 'on' if new['ro'] else 'off'}
+                )
             )
 
         await self.middleware.call(
@@ -255,9 +251,11 @@ class iSCSITargetExtentService(SharingService):
                     # 2. is a volume
                     # 3. volthreading is currently off
                     await self.middleware.call(
-                        'zfs.dataset.update',
-                        zvolname,
-                        {'properties': {'volthreading': {'value': 'on'}}}
+                        'pool.dataset.update_impl',
+                        UpdateImplArgs(
+                            name=zvolname,
+                            zprops={'volthreading': 'on'}
+                        )
                     )
 
         try:
@@ -660,9 +658,11 @@ class iSCSITargetExtentService(SharingService):
         for zvol in await self.middleware.call('zfs.resource.query_impl', args):
             if zvol['properties']['volthreading']['raw'] == 'on':
                 await self.middleware.call(
-                    'zfs.dataset.update',
-                    zvol['name'],
-                    {'properties': {'volthreading': {'value': 'off'}}}
+                    'pool.dataset.update_impl',
+                    UpdateImplArgs(
+                        name=zvol['name'],
+                        zprops={'volthreading': 'off'}
+                    )
                 )
 
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -11,6 +11,7 @@ from middlewared.api.current import (
     PoolEntry, PoolCreateArgs, PoolCreateResult, PoolUpdateArgs,
     PoolUpdateResult, PoolValidateNameArgs, PoolValidateNameResult
 )
+from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.plugins.zfs_.validation_utils import validate_pool_name
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 from middlewared.utils import BOOT_POOL_NAME_VALID
@@ -448,11 +449,10 @@ class PoolService(CRUDService):
 
             # Inherit mountpoint after create because we set mountpoint on creation
             # making it a "local" source.
-            await self.middleware.call('zfs.dataset.update', data['name'], {
-                'properties': {
-                    'mountpoint': {'source': 'INHERIT'},
-                },
-            })
+            await self.middleware.call(
+                'pool.dataset.update_impl',
+                UpdateImplArgs(name=data['name'], iprops={'mountpoint'})
+            )
             await self.middleware.call('zfs.dataset.mount', data['name'])
 
             pool = {


### PR DESCRIPTION
This moves all internal callers to using pool.dataset.update_impl. It also adds `UpdateImplArgs` class keeping same approach that we did with `CreateImplArgs` for `pool.dataset.create_impl`. Ran through the test suite and all tests pass with no obvious regressions.