### PR TITLE
NAS-137891 / 26.04 / remove last remnants of zfs.dataset.update

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -120,16 +120,13 @@ class PoolService(Service):
                 # The same applies to trueans-containers dataset, we would like to have it mounted in a custom
                 # place so user cannot unintentionally share it via SMB/NFS
                 if child == os.path.join(pool_name, 'ix-apps'):
-                    await self.middleware.call(
-                        'pool.dataset.update_impl',
-                        UpdateImplArgs(name=child, zprops={'mountpoint': f'/{IX_APPS_DIR_NAME}'})
-                    )
+                    args: UpdateImplArgs = UpdateImplArgs(name=child, zprops={'mountpoint': f'/{IX_APPS_DIR_NAME}'})
+                    await self.middleware.call('pool.dataset.update_impl', args)
                 elif child == container_dataset(pool_name):
-                    await self.middleware.call(
-                        'zfs.dataset.update', child, {
-                            'properties': {'mountpoint': {'value': container_dataset_mountpoint(pool_name)}}
-                        }
+                    args: UpdateImplArgs = UpdateImplArgs(
+                        name=child, zprops={'mountpoint': container_dataset_mountpoint(pool_name)}
                     )
+                    await self.middleware.call('pool.dataset.update_impl', args)
                 continue
             try:
                 # Reset all mountpoints

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -7,6 +7,7 @@ import re
 import typing
 
 from pathlib import Path
+from typing import TypedDict
 
 from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.service_exception import CallError
@@ -59,8 +60,19 @@ class CreateImplArgs:
     """Create ancestors for the zfs resource being created."""
 
 
+class UpdateImplArgs(TypedDict, total=False):
+    name: str
+    """The name of the resource being created."""
+    zprops: dict[str, str]
+    """ZFS data properties to be applied during creation."""
+    uprops: dict[str, str]
+    """ZFS user properties to be applied during creation."""
+    iprops: set
+    """ZFS properties to be inherited from parent."""
+
+
 @dataclasses.dataclass(slots=True, kw_only=True)
-class UpdateImplArgs:
+class UpdateImplArgsDataclass:
     name: str
     """The name of the resource being created."""
     zprops: dict[str, str] = dataclasses.field(default_factory=dict)

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -155,42 +155,6 @@ class ZFSDatasetService(CRUDService):
         else:
             return data
 
-    def update(self, id_: str, data: dict):
-        """Update a ZFS dataset or zvol.
-
-        Args:
-            id: str (i.e. "tank/dataset")
-            properties: A nested dictionary whose top-level key should be
-                `properties` and value should be a dictionary whose keys
-                    represent the properties and values represent what
-                    to update.
-                    i.e.
-                        {
-                            'properties': {
-                                'prop_name1': 'value',
-                                'prop_name2': 'value',
-                            }
-                        }
-        """
-        data.setdefault('properties', {})
-        try:
-            with libzfs.ZFS() as zfs:
-                dataset = zfs.get_dataset(id_)
-
-                if 'properties' in data:
-                    properties = data['properties'].copy()
-                    # Set these after reservations
-                    for k in ['quota', 'refquota']:
-                        if k in properties:
-                            properties[k] = properties.pop(k)  # Set them last
-                    self.update_zfs_object_props(properties, dataset)
-
-        except libzfs.ZFSException as e:
-            self.logger.error('Failed to update dataset', exc_info=True)
-            raise CallError(f'Failed to update dataset: {e}')
-        else:
-            return data
-
     def delete(self, id_: str, options: dict | None = None):
         """Delete a ZFS dataset or zvol.
 

--- a/tests/api2/test_audit_alerts.py
+++ b/tests/api2/test_audit_alerts.py
@@ -29,9 +29,11 @@ def setup_state(request):
                 ssh(f"echo 'Corrupted DB' > {path}")
             case 'AuditDatasetCleanup':
                 call(
-                    "zfs.dataset.update",
-                    "boot-pool/ROOT/24.10.0-MASTER-20240709-021413/audit",
-                    {"properties": {"org.freenas:refquota_warning": {"parsed": "70"}}}
+                    "pool.dataset.update_impl",
+                    {
+                        "name": "boot-pool/ROOT/24.10.0-MASTER-20240709-021413/audit",
+                        "uprops": {"org.freenas:refquota_warning": "70"}
+                    }
                 )
             case _:
                 pass

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -9,7 +9,9 @@ from middlewared.test.integration.utils import call
 def test__iscsi_extent__disk_choices(request):
     with dataset("test zvol", {"type": "VOLUME", "volsize": 1048576}) as ds:
         # Make snapshots available for devices
-        call("zfs.dataset.update", ds, {"properties": {"snapdev": {"parsed": "visible"}}})
+        call(
+            "pool.dataset.update_impl", {"name": ds, "zprops": {"snapdev": "visible"}}
+        )
         call("pool.snapshot.create", {"dataset": ds, "name": "snap-1"})
         assert call("iscsi.extent.disk_choices") == {
             f'zvol/{ds.replace(" ", "+")}': f'{ds} (1 MiB)',


### PR DESCRIPTION
This removes a few more calls to `zfs.dataset.update` since those crept in with recent container API changes. This converts the data class to a TypedDict because we made calls to `zfs.dataset.update` from a few API tests. This fixes the tests and removes all the call sites. Tests pass.