### PR TITLE
NAS-137805 / 25.10.0 / Fix pydantic validation error construction in apps schema validation (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_construction_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_construction_utils.py
@@ -59,6 +59,10 @@ def _make_index_validator(item_models: list[type[BaseModel]], model_name: str) -
                     # Prepend the index to the location tuple
                     loc = (idx,) + err_copy.get('loc', ())
                     err_copy['loc'] = loc
+                    if 'ctx' not in err_copy:
+                        err_copy['ctx'] = {'error': err_copy.get('msg', 'validation error')}
+                    elif 'error' not in err_copy.get('ctx', {}):
+                        err_copy['ctx']['error'] = err_copy.get('msg', 'validation error')
                     errors.append(err_copy)
                 raise ValidationError.from_exception_data(e.title, errors)
             except ValidationErrors as e:
@@ -72,6 +76,7 @@ def _make_index_validator(item_models: list[type[BaseModel]], model_name: str) -
                         'loc': loc,
                         'msg': error.errmsg,
                         'type': 'value_error',
+                        'ctx': {'error': error.errmsg},
                     })
                 raise ValidationError.from_exception_data('ValidationError', errors)
             except Exception as e:
@@ -82,13 +87,17 @@ def _make_index_validator(item_models: list[type[BaseModel]], model_name: str) -
                         err_copy = err.copy()
                         loc = (idx,) + err_copy.get('loc', ())
                         err_copy['loc'] = loc
+                        if 'ctx' not in err_copy:
+                            err_copy['ctx'] = {'error': err_copy.get('msg', 'validation error')}
+                        elif 'error' not in err_copy.get('ctx', {}):
+                            err_copy['ctx']['error'] = err_copy.get('msg', 'validation error')
                         errors.append(err_copy)
                     raise ValidationError.from_exception_data('ValidationError', errors)
                 else:
                     # Generic error at this index
                     raise ValidationError.from_exception_data(
                         'ValidationError',
-                        [{'loc': (idx,), 'msg': str(e), 'type': 'value_error'}]
+                        [{'loc': (idx,), 'msg': str(e), 'type': 'value_error', 'ctx': {'error': str(e)}}]
                     )
         return out
     return _validate

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_validation_error_ctx.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_validation_error_ctx.py
@@ -1,0 +1,67 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from middlewared.plugins.apps.schema_construction_utils import _make_index_validator
+
+
+class SimpleModel(BaseModel):
+    value: int
+    name: str
+
+
+class ExceptionWithErrors:
+    def errors(self):
+        return [
+            {'loc': ('field1',), 'msg': 'Test error', 'type': 'test_error'}
+        ]
+
+
+def test_pydantic_validation_error_ctx():
+    """Test Pydantic ValidationError gets ctx field added"""
+    validator = _make_index_validator([SimpleModel], 'TestModel')
+
+    # Invalid data to trigger Pydantic ValidationError
+    with pytest.raises(ValidationError) as exc_info:
+        validator([{'value': 'not_int', 'name': 'test'}])
+
+    # Verify ctx field exists
+    errors = exc_info.value.errors()
+    assert all('ctx' in err and 'error' in err['ctx'] for err in errors)
+
+
+def test_exception_with_errors_method():
+    """Test exceptions with errors() method get ctx field"""
+    validator = _make_index_validator([SimpleModel], 'TestModel')
+
+    # Patch to raise our custom exception
+    original_init = SimpleModel.__init__
+    SimpleModel.__init__ = lambda self, **data: (_ for _ in ()).throw(ExceptionWithErrors())
+
+    try:
+        with pytest.raises(ValidationError) as exc_info:
+            validator([{'value': 1, 'name': 'test'}])
+
+        errors = exc_info.value.errors()
+        assert all('ctx' in err and 'error' in err['ctx'] for err in errors)
+    finally:
+        SimpleModel.__init__ = original_init
+
+
+def test_generic_exception():
+    """Test generic exceptions get ctx field"""
+    validator = _make_index_validator([SimpleModel], 'TestModel')
+
+    # Patch to raise generic exception
+    original_init = SimpleModel.__init__
+    SimpleModel.__init__ = lambda self, **data: (_ for _ in ()).throw(RuntimeError("Test error"))
+
+    try:
+        with pytest.raises(ValidationError) as exc_info:
+            validator([{'value': 1, 'name': 'test'}])
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert 'ctx' in errors[0]
+        assert errors[0]['ctx']['error'] == "Test error"
+    finally:
+        SimpleModel.__init__ = original_init


### PR DESCRIPTION
This PR resolves the runtime issue caused by missing `ctx['error']` in `ValidationError.from_exception_data` calls. Pydantic v2.9.x requires all `value_error` entries to include an error key in ctx.

Original PR: https://github.com/truenas/middleware/pull/17323
