### PR TITLE
NAS-137905 / 26.04 / Remove zfs.dataset.create

### DIFF
--- a/src/middlewared/middlewared/plugins/container/dataset.py
+++ b/src/middlewared/middlewared/plugins/container/dataset.py
@@ -1,6 +1,8 @@
 import os
 
 from middlewared.service import CallError, private, Service
+from middlewared.plugins.pool_.utils import CreateImplArgs
+
 from .utils import container_dataset, container_dataset_mountpoint
 
 
@@ -37,12 +39,10 @@ class ContainerService(Service):
 
         if main_dataset not in existing_datasets:
             await self.middleware.call(
-                'zfs.dataset.create',
-                {
-                    'name': main_dataset,
-                    'type': 'FILESYSTEM',
-                    'properties': {'mountpoint': main_dataset_mountpoint},
-                },
+                'pool.dataset.create_impl',
+                CreateImplArgs(
+                    name=main_dataset, ztype='FILESYSTEM', zprops={'mountpoint': main_dataset_mountpoint},
+                )
             )
 
         if not os.path.exists(main_dataset_mountpoint):
@@ -51,11 +51,7 @@ class ContainerService(Service):
         for dataset in datasets:
             if dataset not in existing_datasets:
                 await self.middleware.call(
-                    'zfs.dataset.create',
-                    {
-                        'name': dataset,
-                        'type': 'FILESYSTEM',
-                    },
+                    'pool.dataset.create_impl',
+                    CreateImplArgs(name=dataset, ztype='FILESYSTEM')
                 )
-
             await self.middleware.call('zfs.dataset.mount', dataset)

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -351,6 +351,10 @@ class PoolDatasetService(CRUDService):
         kwargs = {"name": args.name, "type": None}
         if args.ztype == "FILESYSTEM":
             kwargs["type"] = ZFSType.ZFS_TYPE_FILESYSTEM
+            if "xattr" not in args.zprops:
+                # its important to set this as "sa"
+                # for performance reasons
+                args.zprops["xattr"] = "sa"
         elif args.ztype == "VOLUME":
             kwargs["type"] = ZFSType.ZFS_TYPE_VOLUME
             sparse = args.zprops.pop("sparse", None)  # not a real zfs property

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -44,8 +44,23 @@ ZPOOL_CACHE_FILE = '/data/zfs/zpool.cache'
 ZPOOL_KILLCACHE = '/data/zfs/killcache'
 
 
+class CreateImplArgs(typing.TypedDict, total=False):
+    name: str
+    """The name of the resource being created."""
+    ztype: typing.Literal["FILESYSTEM", "VOLUME"]
+    """The type of the resource to be created."""
+    zprops: dict[str, str]
+    """ZFS data properties to be applied during creation."""
+    uprops: dict[str, str] | None
+    """ZFS user properties to be applied during creation."""
+    encrypt: dict | None
+    """Encryption related properties to be applied during creation."""
+    create_ancestors: bool
+    """Create ancestors for the zfs resource being created."""
+
+
 @dataclasses.dataclass(slots=True, kw_only=True)
-class CreateImplArgs:
+class CreateImplArgsDataclass:
     name: str
     """The name of the resource being created."""
     ztype: typing.Literal["FILESYSTEM", "VOLUME"]

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -104,42 +104,6 @@ class ZFSDatasetService(CRUDService):
 
         return filter_list(datasets, filters, options)
 
-    def update(self, id_: str, data: dict):
-        """Update a ZFS dataset or zvol.
-
-        Args:
-            id: str (i.e. "tank/dataset")
-            properties: A nested dictionary whose top-level key should be
-                `properties` and value should be a dictionary whose keys
-                    represent the properties and values represent what
-                    to update.
-                    i.e.
-                        {
-                            'properties': {
-                                'prop_name1': 'value',
-                                'prop_name2': 'value',
-                            }
-                        }
-        """
-        data.setdefault('properties', {})
-        try:
-            with libzfs.ZFS() as zfs:
-                dataset = zfs.get_dataset(id_)
-
-                if 'properties' in data:
-                    properties = data['properties'].copy()
-                    # Set these after reservations
-                    for k in ['quota', 'refquota']:
-                        if k in properties:
-                            properties[k] = properties.pop(k)  # Set them last
-                    self.update_zfs_object_props(properties, dataset)
-
-        except libzfs.ZFSException as e:
-            self.logger.error('Failed to update dataset', exc_info=True)
-            raise CallError(f'Failed to update dataset: {e}')
-        else:
-            return data
-
     def delete(self, id_: str, options: dict | None = None):
         """Delete a ZFS dataset or zvol.
 

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -104,54 +104,39 @@ class ZFSDatasetService(CRUDService):
 
         return filter_list(datasets, filters, options)
 
-    def create(self, data: dict):
-        """Creates a ZFS dataset or zvol.
+    def update(self, id_: str, data: dict):
+        """Update a ZFS dataset or zvol.
 
-        Args: a dictionary with following keys
-            name: str (i.e. "tank/new-dataset")
-            create_ancestors: bool, default is False, if set to True, will
-                create any ancestors that do not exist
-            type: str default is FILESYSTEM. Can also be VOLUME to create a
-                zvol.
-            properties: dictionary with desired properties to be applied
-                to the dataset/zvol during creation.
+        Args:
+            id: str (i.e. "tank/dataset")
+            properties: A nested dictionary whose top-level key should be
+                `properties` and value should be a dictionary whose keys
+                    represent the properties and values represent what
+                    to update.
+                    i.e.
+                        {
+                            'properties': {
+                                'prop_name1': 'value',
+                                'prop_name2': 'value',
+                            }
+                        }
         """
-        data.setdefault('name', '')
-        data.setdefault('create_ancestors', False)
-        data.setdefault('type', 'FILESYSTEM')
         data.setdefault('properties', {})
-
-        verrors = ValidationErrors()
-        if not data['name']:
-            verrors.add('name', 'name must be provided')
-        elif data['name'] == '/':
-            verrors.add('name', 'Invalid name')
-        elif '/' not in data['name']:
-            verrors.add('name', 'You need a full name, e.g. pool/newdataset')
-        verrors.check()
-
-        properties = data.get('properties') or {}
-        sparse = properties.pop('sparse', False)
-        params = {}
-
-        for k, v in data['properties'].items():
-            params[k] = v
-
-        # it's important that we set xattr=sa for various
-        # performance reasons related to ea handling
-        if data['type'] == 'FILESYSTEM' and 'xattr' not in params:
-            params['xattr'] = 'sa'
-
         try:
             with libzfs.ZFS() as zfs:
-                pool = zfs.get(data['name'].split('/')[0])
-                pool.create(
-                    data['name'], params, fstype=getattr(libzfs.DatasetType, data['type']),
-                    sparse_vol=sparse, create_ancestors=data['create_ancestors'],
-                )
+                dataset = zfs.get_dataset(id_)
+
+                if 'properties' in data:
+                    properties = data['properties'].copy()
+                    # Set these after reservations
+                    for k in ['quota', 'refquota']:
+                        if k in properties:
+                            properties[k] = properties.pop(k)  # Set them last
+                    self.update_zfs_object_props(properties, dataset)
+
         except libzfs.ZFSException as e:
-            self.logger.error('Failed to create dataset', exc_info=True)
-            raise CallError(f'Failed to create dataset: {e}')
+            self.logger.error('Failed to update dataset', exc_info=True)
+            raise CallError(f'Failed to update dataset: {e}')
         else:
             return data
 


### PR DESCRIPTION
This removes zfs.dataset.create and employs the same methodology used in pool.dataset.update_impl by having a TypedDict and a dataclass for the args for pool.dataset.create_impl. Tests pass.