### PR TITLE
NAS-137906 / 26.04 / remove zfs.dataset.path_to_dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -10,7 +10,7 @@ import aiohttp
 from middlewared.service import Service
 from middlewared.utils.mount import getmntinfo
 from middlewared.utils.time_utils import utc_now
-
+from middlewared.plugins.zfs_.utils import path_to_dataset_impl
 
 USAGE_URL = 'https://usage.truenas.com/submit'
 
@@ -144,7 +144,7 @@ class UsageService(Service):
             opposite_namespace = 'rsynctask' if namespace == 'cloudsync' else 'cloudsync'
             for task in self.middleware.call_sync(f'{namespace}.query', filters):
                 try:
-                    task_ds = self.middleware.call_sync('zfs.dataset.path_to_dataset', task['path'], context['mntinfo'])
+                    task_ds = path_to_dataset_impl(task['path'], context['mntinfo'])
                 except Exception:
                     self.logger.error('Failed mapping path %r to dataset', task['path'], exc_info=True)
                 else:

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -3,7 +3,6 @@ import libzfs
 
 from middlewared.service import CallError, Service
 from middlewared.service_exception import ValidationError
-from middlewared.plugins.zfs_.utils import path_to_dataset_impl
 
 
 def handle_ds_not_found(error_code: int, ds_name: str):
@@ -17,23 +16,6 @@ class ZFSDatasetService(Service):
         namespace = 'zfs.dataset'
         private = True
         process_pool = True
-
-    def path_to_dataset(self, path, mntinfo=None):
-        """
-        Convert `path` to a ZFS dataset name. This
-        performs lookup through mountinfo.
-
-        Anticipated error conditions are that path is not
-        on ZFS or if the boot pool underlies the path. In
-        addition to this, all the normal exceptions that
-        can be raised by a failed call to os.stat() are
-        possible.
-        """
-        # NOTE: there is no real reason to call this method
-        # since it uses a child process in the process pool.
-        # It's more efficient to just import `path_to_dataset_impl`
-        # and call it directly.
-        return path_to_dataset_impl(path, mntinfo)
 
     def child_dataset_names(self, path):
         # return child datasets given a dataset `path`.


### PR DESCRIPTION
This removes the completely unnecessary `zfs.dataset.path_to_dataset` endpoint. It uses our process pool unnecessarily and causes confusion for developers. While I'm here I fixed two call sites.