### PR TITLE
NAS-137909 / 26.04 / Have init field for a container be optional

### DIFF
--- a/src/middlewared/middlewared/api/v26_04_0/container.py
+++ b/src/middlewared/middlewared/api/v26_04_0/container.py
@@ -76,7 +76,7 @@ class ContainerEntry(BaseModel):
     """How many seconds to wait for container to shut down before killing it."""
     dataset: str
     """Which dataset to use as the container root filesystem."""
-    init: str
+    init: str = '/sbin/init'
     """"init" process commandline."""
     initdir: str | None = None
     """"init" process working dir."""

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -81,7 +81,6 @@ def container(image, options=None, start=False, startup_script=None):
         "name": "test",
         "pool": pool,
         "image": image,
-        "init": "/sbin/init",
         **options,
     }, job=True)
     try:


### PR DESCRIPTION
## Context

We would like to not force the user to always specify `init` field. A default has been added in this case which works across all the images we offer and is the same default which is being used by incus containers as well.