### PR TITLE
Disable systemd-sysusers

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -94,7 +94,7 @@ systemctl mask lvm2-monitor.service
 systemctl mask ipa-epn.service
 
 # Prevent systemd management of users and accounts: NAS-137910
-systemctl mask systemd-sysusers.servics
+systemctl mask systemd-sysusers.service
 
 systemctl set-default truenas.target
 

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -93,6 +93,9 @@ systemctl mask lvm2-monitor.service
 # ipa-epn.service is in conflict with our implementation of support for IPA
 systemctl mask ipa-epn.service
 
+# Prevent systemd management of users and accounts: NAS-137910
+systemctl mask systemd-sysusers.servics
+
 systemctl set-default truenas.target
 
 sed -i.bak 's/CHARMAP="ISO-8859-15"/CHARMAP="UTF-8"/' /etc/default/console-setup

--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -49,3 +49,6 @@ disable apt-daily-upgrade.service
 disable apt-daily-upgrade.timer
 disable apt-daily.service
 disable apt-daily.timer
+
+# Prevent systemd management of users and accounts: NAS-137910
+disable systemd-sysusers

--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -51,4 +51,4 @@ disable apt-daily.service
 disable apt-daily.timer
 
 # Prevent systemd management of users and accounts: NAS-137910
-disable systemd-sysusers
+disable systemd-sysusers.service

--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -49,6 +49,3 @@ disable apt-daily-upgrade.service
 disable apt-daily-upgrade.timer
 disable apt-daily.service
 disable apt-daily.timer
-
-# Prevent systemd management of users and accounts: NAS-137910
-disable systemd-sysusers.service

--- a/tests/unit/test_after_boot_services.py
+++ b/tests/unit/test_after_boot_services.py
@@ -34,7 +34,7 @@ def process_svc_data(svc_entry: str):
 @pytest.mark.parametrize('svc_name,expected', [
     ("nscd", {"state": "listed", "alarm": None, "status": ("loaded", "active", "running")}),
     ("rpcbind", {"state": "listed", "alarm": None, "status": ("loaded", "inactive", "dead")}),
-    ("systemd-sysusers", {"state": "listed", "alarm": None, "status": ("loaded", "inactive", "dead")}),
+    ("systemd-sysusers", {"state": "listed", "alarm": None, "status": ("masked", "inactive", "dead")}),
 ])
 def test__systemctl_unit_state(systemctl_service_status, svc_name, expected):
     """ Confirm status of services at boot """

--- a/tests/unit/test_after_boot_services.py
+++ b/tests/unit/test_after_boot_services.py
@@ -34,6 +34,7 @@ def process_svc_data(svc_entry: str):
 @pytest.mark.parametrize('svc_name,expected', [
     ("nscd", {"state": "listed", "alarm": None, "status": ("loaded", "active", "running")}),
     ("rpcbind", {"state": "listed", "alarm": None, "status": ("loaded", "inactive", "dead")}),
+    ("systemd-sysusers", {"state": "listed", "alarm": None, "status": ("loaded", "inactive", "dead")}),
 ])
 def test__systemctl_unit_state(systemctl_service_status, svc_name, expected):
     """ Confirm status of services at boot """


### PR DESCRIPTION
Introduced in the Trixie release is a systemd daemon to manage system users.   This is in conflict with TrueNAS user management.
This PR disables (masks) `systemd-sysusers`.

CI unit test is included.

Successful run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/unit_tests/2272/).