### PR TITLE
NAS-137926 / 26.04 / remove zfs.dataset.umount (replace with zfs.resource.unmount)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -2,6 +2,7 @@ import errno
 
 from middlewared.service import CallError, Service
 from middlewared.plugins.pool_.utils import UpdateImplArgs
+from middlewared.plugins.zfs.mount_unmount_impl import UnmountArgs
 
 from .state_utils import docker_dataset_custom_props, IX_APPS_MOUNT_PATH, Status
 
@@ -20,7 +21,10 @@ class DockerFilesystemManageService(Service):
                     await self.ensure_ix_apps_mount_point(docker_ds)
                     await self.middleware.call('zfs.dataset.mount', docker_ds, {'recursive': True, 'force_mount': True})
                 else:
-                    await self.middleware.call('zfs.dataset.umount', docker_ds, {'force': True})
+                    await self.middleware.call(
+                        'zfs.resource.unmount',
+                        UnmountArgs(filesystem=docker_ds, force=True, recursive=True)
+                    )
                 return await self.middleware.call('catalog.sync')
             except Exception as e:
                 await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
@@ -1,0 +1,43 @@
+from typing import TypedDict
+
+try:
+    import truenas_pylibzfs
+except ImportError:
+    truenas_pylibzfs = None
+
+__all__ = ("unmount_impl", "mount_impl")
+
+
+class UnmountArgs(TypedDict, total=False):
+    filesystem: str
+    """The zfs filesystem to be unmounted."""
+    mountpoint: str
+    """Optional parameter to manually specify the mountpoint at
+    which the dataset is mounted. This may be required for datasets with
+    legacy mountpoints and is benefical if the mountpoint is known apriori."""
+    recursive: bool
+    """Unmount any children inheriting the mountpoint property."""
+    force: bool
+    """Forcefully unmount the file system, even if it is currently in use.
+    Defaults to False."""
+    lazy: bool
+    """Perform a lazy unmount: make the mount unavailable for new accesses,
+    immediately disconnect the filesystem and all filesystems mounted below
+    it from each other and from the mount table, and actually perform the
+    unmount when the mount ceases to be busy. Defaults to False."""
+    unload_encryption_key: bool
+    """Unload keys for any encryption roots unmounted by this operation.
+    Defaults to False."""
+
+
+def unmount_impl(lzh, data: UnmountArgs) -> None:
+    rsrc = lzh.open_resource(name=data["filesystem"])
+    rsrc.unmount(
+        **{
+            "force": data.get("force", False),
+            "lazy": data.get("lazy", False),
+            "recursive": data.get("recursive", False),
+            "mountpoint": data.get("mountpoint", False),
+            "unload_encryption_key": data.get("unload_encryption_key", False)
+        }
+    )

--- a/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     truenas_pylibzfs = None
 
-__all__ = ("unmount_impl", "mount_impl")
+__all__ = ("unmount_impl",)
 
 
 class UnmountArgs(TypedDict, total=False):

--- a/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/mount_unmount_impl.py
@@ -1,11 +1,6 @@
 from typing import TypedDict
 
-try:
-    import truenas_pylibzfs
-except ImportError:
-    truenas_pylibzfs = None
-
-__all__ = ("unmount_impl",)
+__all__ = ("UnmountArgs",)
 
 
 class UnmountArgs(TypedDict, total=False):
@@ -28,16 +23,3 @@ class UnmountArgs(TypedDict, total=False):
     unload_encryption_key: bool
     """Unload keys for any encryption roots unmounted by this operation.
     Defaults to False."""
-
-
-def unmount_impl(lzh, data: UnmountArgs) -> None:
-    rsrc = lzh.open_resource(name=data["filesystem"])
-    rsrc.unmount(
-        **{
-            "force": data.get("force", False),
-            "lazy": data.get("lazy", False),
-            "recursive": data.get("recursive", False),
-            "mountpoint": data.get("mountpoint", False),
-            "unload_encryption_key": data.get("unload_encryption_key", False)
-        }
-    )

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -11,7 +11,7 @@ from middlewared.service import Service, private
 from middlewared.service_exception import ValidationError
 from middlewared.service.decorators import pass_thread_local_storage
 
-from .mount_unmount_impl import unmount_impl, UnmountArgs
+from .mount_unmount_impl import UnmountArgs
 from .query_impl import query_impl, ZFSPathNotFoundException
 
 
@@ -24,7 +24,8 @@ class ZFSResourceService(Service):
     @private
     @pass_thread_local_storage
     def unmount(self, tls, data: UnmountArgs) -> None:
-        unmount_impl(tls.lzh, data)
+        rsrc = tls.lzh.open_resource(name=data.pop("filesystem"))
+        rsrc.unmount(**data)
 
     @private
     def group_paths_by_parents(self, paths: list[str]) -> dict[str, list[str]]:

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -29,7 +29,7 @@ class ZFSResourceService(Service):
     @private
     @pass_thread_local_storage
     def unmount(self, tls, data: UnmountArgs) -> None:
-        fs = data.pop("filesystem")
+        fs = data.pop("filesystem", None)
         if not fs:
             raise ValidationError("zfs.resource.unmount", "'filesystem' key is required")
 

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -43,20 +43,6 @@ class ZFSDatasetService(Service):
             handle_ds_not_found(e.code, name)
             raise CallError(f'Failed to mount dataset: {e}')
 
-    def umount(self, name: str, options: dict | None = None):
-        if options is None:
-            options = dict()
-        options.setdefault('force', False)
-
-        try:
-            with libzfs.ZFS() as zfs:
-                dataset = zfs.get_dataset(name)
-                dataset.umount(force=options['force'])
-        except libzfs.ZFSException as e:
-            self.logger.error('Failed to umount dataset', exc_info=True)
-            handle_ds_not_found(e.code, name)
-            raise CallError(f'Failed to umount dataset: {e}')
-
     def rename(self, name: str, options: dict):
         options.setdefault('recursive', False)
         options.setdefault('new_name', None)


### PR DESCRIPTION
This removes the `zfs.dataset.umount` option and replaces with `zfs.resource.unmount`. This is a private API only called internally. This will help speed up unmount operations since the new endpoint does not use our process pool.

NOTE: the legacy endpoint actually unmounted datasets recursively by default (in `py-libzfs`) but the new endpoint does not recursively unmount by default.