### PR TITLE
NAS-138359 / 26.04 / Add back in python-based audit filtering

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -178,18 +178,7 @@ class AuditService(ConfigService):
         if (select := data['query-options'].get('select')):
             for idx, entry in enumerate(select):
                 if isinstance(entry, list):
-                    verrors.add(
-                        f'audit.query.query-options.select.{idx}',
-                        '"Select as" operations are not supported in audit queries'
-                    )
-                    continue
-
-                if '.' in entry:
-                    verrors.add(
-                        f'audit.query.query-options.select.{idx}',
-                        'Selecting subkeys of audit entry fields is not supported.'
-                    )
-                    continue
+                    entry = entry[0]
 
                 if entry not in (
                     AUDIT_EVENT_MIDDLEWARE_PARAM_SET


### PR DESCRIPTION
This commit adds support for basic python filtering back into audit backend. The primary change from where we were in 25.10.0 and earlier is that the python filtering is happening on AUDIT_CHUNK_SZ groups of audit entries so that we never have to hold the DB entirely in memory.