### PR TITLE
NAS-138380 / 26.04 / Do not store datetime offsets in the configuration database

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -3,6 +3,7 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
+from datetime import datetime
 import os
 import time
 
@@ -31,6 +32,10 @@ class FailoverDatastoreService(Service):
             # We can't query failover.status on `MASTER` node (please see `hook_datastore_execute_write` for
             # explanations). Non-BACKUP nodes are responsible for checking their failover status.
             return
+
+        # TrueNAS API client JSON parser unparses all datetimes as offset-aware. We don't want to store offset-aware
+        # datetimes in the database, so let's strip `tzinfo`.
+        params = [p.replace(tzinfo=None) if isinstance(p, datetime) else p for p in params]
 
         await self.middleware.call('datastore.execute', sql, params)
 

--- a/src/middlewared/middlewared/sqlalchemy.py
+++ b/src/middlewared/middlewared/sqlalchemy.py
@@ -3,7 +3,7 @@ import datetime
 import isodate
 from sqlalchemy import (
     Table, Column as _Column, ForeignKey, Index,
-    Boolean, CHAR, DateTime, Integer, SmallInteger, String, Text, UniqueConstraint
+    Boolean, CHAR, DateTime as _DateTime, Integer, SmallInteger, String, Text, UniqueConstraint
 )  # noqa
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship  # noqa
@@ -115,6 +115,23 @@ class MultiSelectField(UserDefinedType):
 
     def result_processor(self, dialect, coltype):
         return self._result_processor
+
+
+class DateTime(TypeDecorator):
+    impl = _DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is not None and getattr(value, "tzinfo", None):
+            return value.replace(tzinfo=None)
+
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None and getattr(value, "tzinfo", None):
+            return value.replace(tzinfo=None)
+
+        return value
 
 
 class Time(UserDefinedType):


### PR DESCRIPTION
Switching to SQLAlchemy 2.0, which stores datetime offset in the SQLite database, introduced the crash:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 571, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 618, in __run_body
    rv = await self.middleware.run_in_thread(self.method, *args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 692, in run_in_thread
    return await self.run_in_executor(io_thread_pool_executor, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 689, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/sync.py", line 144, in sync_all
    elif disk['disk_expiretime'] < utc_now():
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

All our codebase was written with the assumption that datetime offsets are not stored in the database. Let's keep this behavior.