### PR TITLE
NAS-139040 / 26.04 / Add SMB directory generation back in

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -357,6 +357,9 @@ class SMBService(ConfigService):
         local user account setup, otherwise we may end up with the incorrect
         domain SID for the guest account.
         """
+        config_job.set_progress(0, 'Setting up SMB directories.')
+        await self.setup_directories()
+
         try:
             await self.middleware.call('idmap.gencache.flush')
         except Exception:


### PR DESCRIPTION
This adds back in logic to set up SMB directories during smb.configure call to unbreak tests. This commit will be reverted once this logic is shifted to middleware startup.