### PR TITLE
NAS-139046 / 26.04 / Fix permissions on samba files during setup

### DIFF
--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -153,7 +153,7 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 {'path': '/var/db/system/samba4/state', 'uid': 0, 'gid': 0},
                 {'path': '/var/db/system/samba4/cache', 'uid': 0, 'gid': 0},
                 {'path': '/var/db/system/samba4/private', 'uid': 0, 'gid': 0, 'mode': 0o700},
-                {'path': '/var/db/system/samba4/winbindd_privileged', 'uid': 0, 'gid': 0, 'mode': 0o700},
+                {'path': '/var/db/system/samba4/winbindd_privileged', 'uid': 0, 'gid': 0, 'mode': 0o750},
             ],
         },
         {


### PR DESCRIPTION
* shift validation and setup of samba dirs to middleware startup These files are required in order for winbindd to start properly

* Remove the smb.setup_directories() method since this now occurs on middleware setup (for rundir) or system dataset setup (system dataset hierarchy).

* Fix permissions in the system dataset hiearchy for winbindd_privileged directory 0o700 -> 0o750