### PR TITLE
NAS-139267 / 26.04 / Fix validation for netbios alias change

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -531,7 +531,7 @@ class SMBService(ConfigService):
                     'NetBIOS aliases may not be changed while directory service is enabled.'
                 )
             else:
-                for idx, nbname in new['netbiosalias']:
+                for idx, nbname in enumerate(new['netbiosalias']):
                     if old['netbiosalias'][idx].casefold() != new['netbiosalias'][idx].casefold():
                         verrors.add(
                             f'smb_update.netbiosalias.{idx}',


### PR DESCRIPTION
This commit fixes a syntax error when validating netbios alias changes when directory services are enabled.