### PR TITLE
NAS-139297 / 26.04 / Add clustered SMB state

### DIFF
--- a/src/freenas/usr/local/libexec/ctdb_ha_reclock.py
+++ b/src/freenas/usr/local/libexec/ctdb_ha_reclock.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+# See design document at in samba repository at ctdb/doc/cluster_mutex_helper.txt for implementation details.
+# stderr output will be logged by ctdbd.
+
+import errno
+import fcntl
+import os
+import select
+import signal
+import sys
+
+from middlewared.utils import BOOT_POOL_NAME_VALID
+from middlewared.utils.ctdb import CTDB_DATA_DIR
+from middlewared.utils.mount import statmount
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
+
+MOUNTINFO = '/proc/self/mountinfo'
+LOCKFILE = os.path.join(CTDB_DATA_DIR, '.reclock')
+# reclock helpers print status codes to stdout
+ERROR_OCCURRED = 3
+CONTENTION = 1
+HOLDING = 0
+
+
+def has_sysdataset_pool():
+    mnt_src = statmount(path=SYSDATASET_PATH, as_dict=False).sb_source
+    return mnt_src.split('/')[0] not in BOOT_POOL_NAME_VALID
+
+
+def write_stdout(code):
+    sys.stdout.write(str(code))
+    sys.stdout.flush()
+
+
+def write_stderr(msg):
+    sys.stderr.write(str(msg))
+    sys.stderr.flush()
+
+
+def block_while_has_sysdataset():
+    """ Block until we no longer have the system dataset """
+    with open(MOUNTINFO, 'r') as f:
+        # Try a non-blocking lock in order to catch sanity checks
+        # that lock is held in recovery daemon. We want to catch the OSError here
+        # and return contention
+        with open(LOCKFILE, 'w') as lockfile:
+            fcntl.lockf(lockfile.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                poller = select.poll()
+                poller.register(f, select.POLLERR | select.POLLPRI)
+                write_stdout(HOLDING)
+                while True:
+                    # Block until the kernel signals a mount table change
+                    poller.poll()  # returns on mount/umount/propagation/etc.
+                    if not has_sysdataset_pool():
+                        break
+
+            finally:
+                fcntl.lockf(lockfile.fileno(), fcntl.LOCK_UN)
+
+
+def sigterm_handler(signum, frame):
+    sys.exit(1)
+
+
+def main():
+    if os.getppid == 1:
+        write_stderr("Unexpected ppid of 1")
+        sys.exit(1)
+
+    try:
+        is_master = has_sysdataset_pool()
+    except Exception as e:
+        write_stderr(e)
+        write_stdout(ERROR_OCCURRED)
+        exit_code = 1
+    else:
+        if is_master:
+            try:
+                block_while_has_sysdataset()
+            except OSError as e:
+                if e.errno in (errno.EAGAIN, errno.EACCES):
+                    # Expected lockf failure in contention case
+                    write_stdout(CONTENTION)
+                    exit_code = 0
+                else:
+                    write_stderr(e)
+                    write_stdout(ERROR_OCCURRED)
+                    exit_code = 1
+
+            except Exception as e:
+                write_stderr(e)
+                write_stdout(ERROR_OCCURRED)
+                exit_code = 1
+            else:
+                write_stdout(CONTENTION)
+                exit_code = 0
+        else:
+            write_stdout(CONTENTION)
+            exit_code = 0
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    main()

--- a/src/middlewared/middlewared/etc_files/ctdb/ctdb.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb/ctdb.conf.mako
@@ -1,0 +1,22 @@
+<%
+    from middlewared.utils import ctdb
+    if render_ctx['failover.status'] == 'SINGLE':
+        raise FileShouldNotExist
+%>
+
+[logging]
+
+	location = syslog:nonblocking
+	log level = NOTICE
+
+
+[cluster]
+
+	recovery lock = !${ctdb.RECLOCK_HELPER_SCRIPT}
+
+
+[database]
+
+	volatile database directory = ${ctdb.VOLATILE_DB}
+	persistent database directory = ${ctdb.PERSISTENT_DB}
+	state database directory = ${ctdb.STATE_DB}

--- a/src/middlewared/middlewared/etc_files/ctdb/nodes.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb/nodes.mako
@@ -1,0 +1,11 @@
+<%
+    # presence of the nodes file is ultimate arbiter of whether ctdb will start
+    from middlewared.utils.origin import HA_HEARTBEAT_IPS
+    if render_ctx['failover.status'] == 'SINGLE':
+        raise FileShouldNotExist
+
+    if not render_ctx['smb.config']['stateful_failover']:
+        raise FileShouldNotExist
+%>
+
+${'\n'.join(HA_HEARTBEAT_IPS)}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -92,6 +92,17 @@ class EtcService(Service):
         'app_registry': [
             {'type': 'py', 'path': 'docker/config.json'},
         ],
+        'ctdb': {
+            'ctx': [
+                {'method': 'failover.status'},
+                {'method': 'systemdataset.config'},
+                {'method': 'smb.config'},
+            ],
+            'entries': [
+                {'type': 'mako', 'path': 'ctdb/nodes'},
+                {'type': 'mako', 'path': 'ctdb/ctdb.conf'},
+            ]
+        },
         'docker': [
             {'type': 'py', 'path': 'docker/daemon.json'},
         ],

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -1,4 +1,5 @@
 from .cifs import CIFSService
+from .ctdb import CTDBService
 from .docker import DockerService
 from .ftp import FTPService
 from .iscsitarget import ISCSITargetService
@@ -47,6 +48,7 @@ from .pseudo.misc import (
 
 all_services = [
     CIFSService,
+    CTDBService,
     DockerService,
     FTPService,
     ISCSITargetService,

--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -1,0 +1,8 @@
+from .base import SimpleService
+
+
+class CTDBService(SimpleService):
+    name = "ctdb"
+    etc = ["ctdb"]
+
+    systemd_unit = "ctdb"

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -1,5 +1,6 @@
 import enum
 import os
+from middlewared.utils import ctdb
 from middlewared.utils import MIDDLEWARE_RUN_DIR
 from middlewared.utils.directoryservices.krb5_constants import SAMBA_KEYTAB_DIR
 
@@ -86,6 +87,12 @@ class SMBPath(enum.Enum):
     RUNDIR = ('/var/run/samba', 0o755, True)
     LOCKDIR = ('/var/run/samba-lock', 0o755, True)
     LOGDIR = ('/var/log/samba4', 0o755, True)
+    CTDB_RUNDIR = (ctdb.CTDB_RUN_DIR, 0o755, True)
+    CTDB_DATADIR = (ctdb.CTDB_DATA_DIR, 0o755, True)
+    CTDB_STATEDIR = (ctdb.STATE_DB, 0o755, True)
+    CTDB_VOLATILEDDB = (ctdb.VOLATILE_DB, 0o755, True)
+    CTDB_PERSITENTDB = (ctdb.PERSISTENT_DB, 0o755, True)
+    CTDB_LOGDIR = ('/var/log/ctdb', 0o755, True)
     IPCSHARE = ('/tmp', 0o1777, True)
     WINBINDD_PRIVILEGED = (os.path.join(SAMBA_BOOTENV_DIR, 'winbindd_privileged'), 0o750, True)
 

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -675,8 +675,8 @@ def generate_smb_conf_dict(
 
     if smb_service_config['stateful_failover']:
         smbconf.update({
-            'lock directory': SAMBA_HA_LOCKDIR,
             'truenas stateful failover': True,
+            'clustering': True,
         })
 
     # The following parameters must come after processing includes in order to

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -676,10 +676,6 @@ class SystemDatasetService(ConfigService):
             restart = ['netdata']
             if self.middleware.call_sync('service.started', 'nfs'):
                 restart.append('nfs')
-            if self.middleware.call_sync('service.started', 'cifs'):
-                if self.middleware.call_sync('smb.config')['stateful_failover']:
-                    # SMB locking dir on system dataset
-                    restart.insert(0, 'cifs')
             if self.middleware.call_sync('service.started', 'open-vm-tools'):
                 restart.append('open-vm-tools')
 

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -32,6 +32,13 @@ class UpdateService(Service):
                 "until the resilvering operation is finished."
             )
 
+        if self.middleware.call_sync("smb.config")["stateful_failover"]:
+            # CTDB will assert on version mismatch between nodes. Upgrade procedure should be:
+            # 1. disabled stateful failover
+            # 2. upgrade both nodes
+            # 3. enable stateful failover
+            raise CallError("Stateful SMB failover must be disabled prior to updating truenas")
+
         def progress_callback(progress, description):
             job.set_progress((0.5 + 0.5 * progress) * max_progress, description)
 

--- a/src/middlewared/middlewared/utils/ctdb.py
+++ b/src/middlewared/middlewared/utils/ctdb.py
@@ -1,0 +1,11 @@
+import os
+
+# CTDB state directory should be a on per-node persistent filesystem
+# This is placed on a filesystem that doesn't persist across upgrades
+CTDB_DATA_DIR = '/var/lib/ctdb'
+CTDB_RUN_DIR = '/var/run/ctdb'
+
+VOLATILE_DB = os.path.join(CTDB_RUN_DIR, 'volatile')
+PERSISTENT_DB = os.path.join(CTDB_DATA_DIR, 'persistent')
+STATE_DB = os.path.join(CTDB_DATA_DIR, 'state')
+RECLOCK_HELPER_SCRIPT = '/usr/local/libexec/ctdb_ha_reclock.py'


### PR DESCRIPTION
This commit adds working configuration for stateful SMB HA failover:

* reclock helper script - determines which node holds the cluster mutex lock based on presence of data pool system dataset.

* ctdb-related etc files. We can hard-code the nodes config based on our known HA nodes (this significantly eases past problems with gluster that we saw with dynamic nodes and ctdb stability).

* smbd will remain stopped on standby controller until it becomes
  standby.

* keepalived will continue to manage virtual IPs

During failover events, ctdbd on the new active controller will grab the cluster mutex after system dataset pool import and begin recovery operation. Administrators will need to disabling stateful failover while upgrading HA servers.

Further work will be needed to handle share ACLs, secrets.tdb, passdb, and groupmap while in this mode.

NOTE: this relies on the fact that we already had ctdb service installed and enabled. The control point for ctdb running is whether nodes file is present.