### PR TITLE
NAS-139802 / 26.0.0-BETA.1 / Avoid PAM evaluations when internal tokens

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -244,8 +244,11 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
         This also generates utmp entry for the token-based session. """
         assert self.pam_authenticated is False
 
-        username = self.user['username'] if self.is_user_session else 'root'
-        pam_resp = self.authenticator.authenticate(username)
+        if self.is_user_session:
+            pam_resp = self.authenticator.authenticate(self.user['username'])
+        else:
+            pam_resp = TrueNASAuthenticatorResponse(code=PAMCode.PAM_SUCCESS, reason=None)
+
         self.pam_authenticated = pam_resp.code == PAMCode.PAM_SUCCESS
         return pam_resp
 


### PR DESCRIPTION
This is a protective measure against mis-administration of server ever resulting in denial of HA NODE operations.