### PR TITLE
NAS-139851 / 26.0.0-BETA.1 / Add missing AuthRespDenied response type

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/auth.py
+++ b/src/middlewared/middlewared/api/v26_0_0/auth.py
@@ -310,7 +310,7 @@ class AuthLoginExArgs(BaseModel):
 class AuthLoginExResult(BaseModel):
     result: Union[
         AuthRespSuccess, AuthRespAuthErr, AuthRespExpired, AuthRespOTPRequired, AuthRespAuthRedirect,
-        AuthRespScram
+        AuthRespScram, AuthRespDenied
     ] = Field(discriminator='response_type')
     """Authentication response indicating success, failure, or additional steps required."""
 


### PR DESCRIPTION
This commit fixes an oversight when adding the AuthRespDenied login_ex response type. It was listed in schema for auth.login_ex_continue return values, but not auth.login_ex return values.

This commit also adds new test coverage.