### PR TITLE
Add tiering API

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/__init__.py
+++ b/src/middlewared/middlewared/api/v26_0_0/__init__.py
@@ -125,3 +125,4 @@ from .webui_enclosure import *
 from .webui_main_dashboard import *
 from .zfs_resource_crud import *
 from .zfs_resource_snapshot import *
+from .zfs_tier import *

--- a/src/middlewared/middlewared/api/v26_0_0/common.py
+++ b/src/middlewared/middlewared/api/v26_0_0/common.py
@@ -1,11 +1,15 @@
 from datetime import datetime, time
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import AfterValidator, model_validator, Field
 
 from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
 
-__all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
+__all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
+           "DatasetTier"]
+
+DatasetTier = Literal['REGULAR', 'PERFORMANCE']
+"""Storage performance tier. `REGULAR` uses standard-capacity drives; `PERFORMANCE` uses fast media (e.g. NVMe)."""
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
 QF_FIELD = Field(default=[], description=QF_DOC, examples=[

--- a/src/middlewared/middlewared/api/v26_0_0/common.py
+++ b/src/middlewared/middlewared/api/v26_0_0/common.py
@@ -6,9 +6,9 @@ from pydantic import AfterValidator, model_validator, Field
 from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
-           "DatasetTier"]
+           "TierClass"]
 
-DatasetTier = Literal['REGULAR', 'PERFORMANCE']
+TierClass = Literal['REGULAR', 'PERFORMANCE']
 """Storage performance tier. `REGULAR` uses standard-capacity drives; `PERFORMANCE` uses fast media (e.g. NVMe)."""
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'

--- a/src/middlewared/middlewared/api/v26_0_0/common.py
+++ b/src/middlewared/middlewared/api/v26_0_0/common.py
@@ -6,9 +6,9 @@ from pydantic import AfterValidator, model_validator, Field
 from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
-           "TierClass"]
+           "StorageTier"]
 
-TierClass = Literal['REGULAR', 'PERFORMANCE']
+StorageTier = Literal['REGULAR', 'PERFORMANCE']
 """Storage performance tier. `REGULAR` uses standard-capacity drives; `PERFORMANCE` uses fast media (e.g. NVMe)."""
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'

--- a/src/middlewared/middlewared/api/v26_0_0/nfs.py
+++ b/src/middlewared/middlewared/api/v26_0_0/nfs.py
@@ -12,6 +12,7 @@ from middlewared.api.base import (
     TcpPort,
     exclude_tcp_ports,
 )
+from .zfs_tier import SharingTierInfo
 
 __all__ = [
     "NFSGetNfs3ClientsEntry",
@@ -175,7 +176,7 @@ class SharingNFSEntry(BaseModel):
     Enterprise feature to enable access to the ZFS snapshot directory for the export.
     Export path must be the root directory of a ZFS dataset.
     """
-    tier: Literal['REGULAR', 'FAST'] | None = None
+    tier: SharingTierInfo | None = None
     """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
     managed through API endpoints in the `pool.dataset` namespace.
 

--- a/src/middlewared/middlewared/api/v26_0_0/nfs.py
+++ b/src/middlewared/middlewared/api/v26_0_0/nfs.py
@@ -175,6 +175,11 @@ class SharingNFSEntry(BaseModel):
     Enterprise feature to enable access to the ZFS snapshot directory for the export.
     Export path must be the root directory of a ZFS dataset.
     """
+    tier: Literal['REGULAR', 'FAST'] | None = None
+    """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
+    managed through API endpoints in the `pool.dataset` namespace.
+
+    NOTE: this is a licensed feature. Will be `null` if TrueNAS is unlicensed or if tiering is disabled."""
 
 
 class NfsShareCreate(SharingNFSEntry):
@@ -182,6 +187,7 @@ class NfsShareCreate(SharingNFSEntry):
     dataset: Excluded = excluded_field()
     relative_path: Excluded = excluded_field()
     locked: Excluded = excluded_field()
+    tier: Excluded = excluded_field()
 
 
 class SharingNFSCreateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/nfs.py
+++ b/src/middlewared/middlewared/api/v26_0_0/nfs.py
@@ -12,7 +12,7 @@ from middlewared.api.base import (
     TcpPort,
     exclude_tcp_ports,
 )
-from .zfs_tier import SharingTierInfo
+from .zfs_tier import TierInfo
 
 __all__ = [
     "NFSGetNfs3ClientsEntry",
@@ -176,7 +176,7 @@ class SharingNFSEntry(BaseModel):
     Enterprise feature to enable access to the ZFS snapshot directory for the export.
     Export path must be the root directory of a ZFS dataset.
     """
-    tier: SharingTierInfo | None = None
+    tier: TierInfo | None = None
     """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
     managed through API endpoints in the `pool.dataset` namespace.
 

--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -81,6 +81,8 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     """Custom user-defined ZFS properties set on this dataset as key-value pairs."""
     locked: bool
     """Whether an encrypted dataset is currently locked (key not loaded)."""
+    tier: Literal["REGULAR", "FAST"] | None
+    """Performance tier. `null` if tiering disabled or if underlying pool does not support tiering."""
     comments: PoolDatasetEntryProperty
     """ZFS comments property for storing descriptive text about the dataset."""
     quota_warning: PoolDatasetEntryProperty

--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -8,7 +8,7 @@ from middlewared.api.base import (
 )
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 
-from .common import QueryFilters, QueryOptions
+from .common import DatasetTier, QueryFilters, QueryOptions
 from .pool import PoolAttachment, PoolCreateEncryptionOptions, PoolProcess
 
 
@@ -81,7 +81,7 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     """Custom user-defined ZFS properties set on this dataset as key-value pairs."""
     locked: bool
     """Whether an encrypted dataset is currently locked (key not loaded)."""
-    tier: Literal["REGULAR", "FAST"] | None
+    tier: DatasetTier | None
     """Performance tier. `null` if tiering disabled or if underlying pool does not support tiering."""
     comments: PoolDatasetEntryProperty
     """ZFS comments property for storing descriptive text about the dataset."""

--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -8,7 +8,8 @@ from middlewared.api.base import (
 )
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 
-from .common import DatasetTier, QueryFilters, QueryOptions
+from .common import QueryFilters, QueryOptions
+from .zfs_tier import TierInfo
 from .pool import PoolAttachment, PoolCreateEncryptionOptions, PoolProcess
 
 
@@ -81,7 +82,7 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     """Custom user-defined ZFS properties set on this dataset as key-value pairs."""
     locked: bool
     """Whether an encrypted dataset is currently locked (key not loaded)."""
-    tier: DatasetTier | None
+    tier: TierInfo | None
     """Performance tier. `null` if tiering disabled or if underlying pool does not support tiering."""
     comments: PoolDatasetEntryProperty
     """ZFS comments property for storing descriptive text about the dataset."""

--- a/src/middlewared/middlewared/api/v26_0_0/smb.py
+++ b/src/middlewared/middlewared/api/v26_0_0/smb.py
@@ -21,6 +21,7 @@ from middlewared.plugins.smb_.constants import LEGACY_SHARE_FIELDS
 from middlewared.utils.lang import undefined
 from middlewared.utils.smb import SMBUnixCharset, SMBSharePurpose, SearchProtocol, validate_smb_path_suffix
 from .common import QueryFilters, QueryOptions
+from .zfs_tier import SharingTierInfo
 
 
 __all__ = [
@@ -753,7 +754,7 @@ class SharingSMBEntry(BaseModel):
     ])
     """ Additional configuration related to the configured SMB share purpose. If null, then the default \
     options related to the share purpose will be applied. """
-    tier: Literal['REGULAR', 'FAST'] | None = None
+    tier: SharingTierInfo | None = None
     """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
     managed through API endpoints in the `pool.dataset` namespace.
 

--- a/src/middlewared/middlewared/api/v26_0_0/smb.py
+++ b/src/middlewared/middlewared/api/v26_0_0/smb.py
@@ -753,6 +753,11 @@ class SharingSMBEntry(BaseModel):
     ])
     """ Additional configuration related to the configured SMB share purpose. If null, then the default \
     options related to the share purpose will be applied. """
+    tier: Literal['REGULAR', 'FAST'] | None = None
+    """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
+    managed through API endpoints in the `pool.dataset` namespace.
+
+    NOTE: this is a licensed feature. Will be `null` if TrueNAS is unlicensed or if tiering is disabled."""
 
     @classmethod
     def normalize_legacy_fields(cls, data_in: dict) -> dict:
@@ -828,6 +833,7 @@ class SmbShareCreate(SharingSMBEntry):
     dataset: Excluded = excluded_field()
     relative_path: Excluded = excluded_field()
     locked: Excluded = excluded_field()
+    tier: Excluded = excluded_field()
 
     @model_validator(mode='after')
     def check_purpose_options(self) -> Self:

--- a/src/middlewared/middlewared/api/v26_0_0/smb.py
+++ b/src/middlewared/middlewared/api/v26_0_0/smb.py
@@ -21,7 +21,7 @@ from middlewared.plugins.smb_.constants import LEGACY_SHARE_FIELDS
 from middlewared.utils.lang import undefined
 from middlewared.utils.smb import SMBUnixCharset, SMBSharePurpose, SearchProtocol, validate_smb_path_suffix
 from .common import QueryFilters, QueryOptions
-from .zfs_tier import SharingTierInfo
+from .zfs_tier import TierInfo
 
 
 __all__ = [
@@ -754,7 +754,7 @@ class SharingSMBEntry(BaseModel):
     ])
     """ Additional configuration related to the configured SMB share purpose. If null, then the default \
     options related to the share purpose will be applied. """
-    tier: SharingTierInfo | None = None
+    tier: TierInfo | None = None
     """ Storage tier in which share is located. This field is read-only. Tiering configuration is currently \
     managed through API endpoints in the `pool.dataset` namespace.
 

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -11,7 +11,7 @@ from middlewared.api.base import (
     query_result,
     single_argument_args,
 )
-from .common import QueryFilters, QueryOptions
+from .common import DatasetTier, QueryFilters, QueryOptions
 
 
 __all__ = [
@@ -22,6 +22,7 @@ __all__ = [
     'ZfsTierRewriteJobQueryArgs', 'ZfsTierRewriteJobQueryResult',
     'ZfsTierRewriteJobRecoverArgs', 'ZfsTierRewriteJobRecoverResult',
     'ZfsTierRewriteJobStatusArgs', 'ZfsTierRewriteJobStatusResult',
+    'SharingTierInfo',
 ]
 
 TierRewriteJobStatus = Literal['COMPLETE', 'RUNNING', 'QUEUED', 'CANCELLED', 'STOPPED', 'ERROR']
@@ -96,6 +97,13 @@ class ZfsTierRewriteJobEntry(BaseModel):
     * `ERROR` - Job halted due to an unrecoverable error. Use `zfs_tier_job.recover` to \
     retry failed files.
     """
+
+
+class SharingTierInfo(BaseModel):
+    tier_type: DatasetTier
+    """Storage performance tier for this share."""
+    tier_job: ZfsTierRewriteJobEntry | None = None
+    """Most recent rewrite job for this share's dataset, or `null` if no job history exists."""
 
 
 class ZfsTierRewriteJobStatusEntry(ZfsTierRewriteJobEntry):

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -1,0 +1,160 @@
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from middlewared.api.base import (
+    BaseModel,
+    Excluded,
+    excluded_field,
+    ForUpdateMetaclass,
+    NonEmptyString,
+    query_result,
+    single_argument_args,
+)
+from .common import QueryFilters, QueryOptions
+
+
+__all__ = [
+    'ZfsTierEntry', 'ZfsTierUpdateArgs', 'ZfsTierUpdateResult',
+    'ZfsTierRewriteJobStats', 'ZfsTierRewriteJobEntry', 'ZfsTierRewriteJobStatusEntry',
+    'ZfsTierRewriteJobCreateArgs', 'ZfsTierRewriteJobCreateResult',
+    'ZfsTierRewriteJobAbortArgs', 'ZfsTierRewriteJobAbortResult',
+    'ZfsTierRewriteJobQueryArgs', 'ZfsTierRewriteJobQueryResult',
+    'ZfsTierRewriteJobRecoverArgs', 'ZfsTierRewriteJobRecoverResult',
+    'ZfsTierRewriteJobStatusArgs', 'ZfsTierRewriteJobStatusResult',
+]
+
+TierRewriteJobStatus = Literal['COMPLETE', 'RUNNING', 'QUEUED', 'CANCELLED', 'STOPPED', 'ERROR']
+
+
+class ZfsTierEntry(BaseModel):
+    id: int
+    """Placeholder identifier. Not used; there is only one configuration instance."""
+    enabled: bool
+    """Whether the ZFS tier service is enabled."""
+    max_concurrent_jobs: Annotated[int, Field(ge=1, le=10)]
+    """Maximum number of rewrite jobs that execute simultaneously. Jobs submitted beyond this \
+    limit are held in a QUEUED state until a slot becomes available (1-10)."""
+    min_available_space: Annotated[int, Field(ge=0)]
+    """If available space on the dataset falls below this value (GiB), any active rewrite on \
+    that dataset is aborted. Set to 0 to disable the check."""
+
+
+@single_argument_args('zfs_tier_update')
+class ZfsTierUpdateArgs(ZfsTierEntry, metaclass=ForUpdateMetaclass):
+    id: Excluded = excluded_field()
+
+
+class ZfsTierUpdateResult(BaseModel):
+    result: ZfsTierEntry
+    """The updated ZFS tier daemon configuration."""
+
+
+class ZfsTierRewriteJobStats(BaseModel):
+    start_time: int
+    """Unix timestamp (seconds) when the current run started. Reset each time the job is \
+    resumed or recovered."""
+    initial_time: int
+    """Unix timestamp (seconds) when the job was first created. Preserved across resumes."""
+    update_time: int
+    """Unix timestamp (seconds) of the most recent statistics update."""
+    count_items: int
+    """Number of files processed in the current run. Reset to zero on each resume."""
+    count_bytes: int
+    """Bytes processed in the current run. Reset to zero on each resume."""
+    total_items: int
+    """Total number of files to process across the entire dataset."""
+    total_bytes: int
+    """Total bytes to process across the entire dataset."""
+    failures: int
+    """Cumulative count of files that failed rewriting across all runs of this job."""
+    success: int
+    """Cumulative count of files successfully rewritten across all runs of this job."""
+    parent: str
+    """Directory path of the file currently being processed. Also used as the resume \
+    checkpoint if the job is interrupted."""
+    name: str
+    """Name of the file currently being processed."""
+
+
+class ZfsTierRewriteJobEntry(BaseModel):
+    tier_job_id: NonEmptyString
+    """Rewrite job identifier in `dataset_name@job_uuid` format."""
+    dataset_name: NonEmptyString
+    """ZFS dataset this job is operating on."""
+    job_uuid: NonEmptyString
+    """Unique identifier for this rewrite job."""
+    status: TierRewriteJobStatus
+    """Current lifecycle state of the job.
+
+    * `COMPLETE` - All files in the dataset have been processed.
+    * `RUNNING` - Job is actively processing files.
+    * `QUEUED` - Job is waiting for a free execution slot (see `max_concurrent_jobs`).
+    * `CANCELLED` - Job was stopped via `zfs_tier_job.abort`. Not resumable.
+    * `STOPPED` - Job was RUNNING but its process is no longer active (e.g. daemon restart). \
+    This state is computed on read and is never written to persistent storage.
+    * `ERROR` - Job halted due to an unrecoverable error. Use `zfs_tier_job.recover` to \
+    retry failed files.
+    """
+
+
+class ZfsTierRewriteJobStatusEntry(ZfsTierRewriteJobEntry):
+    stats: ZfsTierRewriteJobStats | None
+    """Progress statistics, or `null` if no statistics have been recorded yet."""
+    error: str | None
+    """Error message describing why the job entered `ERROR` state, otherwise `null`."""
+
+
+class ZfsTierRewriteJobCreateArgs(BaseModel):
+    dataset_name: NonEmptyString
+    """ZFS dataset to rewrite (e.g. `tank/data`). Only one job may exist per dataset at \
+    a time; creating a second returns an error."""
+
+
+class ZfsTierRewriteJobCreateResult(BaseModel):
+    result: ZfsTierRewriteJobEntry
+    """The newly created rewrite job, initially in `QUEUED` state."""
+
+
+class ZfsTierRewriteJobAbortArgs(BaseModel):
+    tier_job_id: NonEmptyString
+    """Rewrite job to abort, in `dataset_name@job_uuid` format."""
+
+
+class ZfsTierRewriteJobAbortResult(BaseModel):
+    result: None
+    """Returns `null` when the job has been successfully aborted."""
+
+
+class ZfsTierRewriteJobQueryArgs(BaseModel):
+    status: list[TierRewriteJobStatus] | None = None
+    """Limit results to jobs in the specified states. Pass `null` or omit to return all jobs."""
+    query_filters: QueryFilters = Field(alias='query-filters', default=[])
+    """Additional filters to apply to the results."""
+    query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
+    """Options controlling sort order, pagination, and result format."""
+
+
+ZfsTierRewriteJobQueryResult = query_result(ZfsTierRewriteJobEntry, name='ZfsTierRewriteJobQueryResult')
+
+
+class ZfsTierRewriteJobRecoverArgs(BaseModel):
+    tier_job_id: NonEmptyString
+    """Rewrite job to recover, in `dataset_name@job_uuid` format. The job must be in \
+    `ERROR` state."""
+
+
+class ZfsTierRewriteJobRecoverResult(BaseModel):
+    result: ZfsTierRewriteJobEntry
+    """The job after recovery is initiated. Status will be `RUNNING` if failed files remain \
+    to be retried, or `COMPLETE` if all previously failed files were retried successfully."""
+
+
+class ZfsTierRewriteJobStatusArgs(BaseModel):
+    tier_job_id: NonEmptyString
+    """Rewrite job to query, in `dataset_name@job_uuid` format."""
+
+
+class ZfsTierRewriteJobStatusResult(BaseModel):
+    result: ZfsTierRewriteJobStatusEntry
+    """Current status and statistics for the requested rewrite job."""

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -17,6 +17,7 @@ from .common import DatasetTier, QueryFilters, QueryOptions
 __all__ = [
     'ZfsTierEntry', 'ZfsTierUpdateArgs', 'ZfsTierUpdateResult',
     'ZfsTierRewriteJobStats', 'ZfsTierRewriteJobEntry', 'ZfsTierRewriteJobStatusEntry',
+    'ZfsTierRewriteJobChangedEvent',
     'ZfsTierRewriteJobCreateArgs', 'ZfsTierRewriteJobCreateResult',
     'ZfsTierRewriteJobAbortArgs', 'ZfsTierRewriteJobAbortResult',
     'ZfsTierRewriteJobQueryArgs', 'ZfsTierRewriteJobQueryResult',
@@ -111,6 +112,11 @@ class ZfsTierRewriteJobStatusEntry(ZfsTierRewriteJobEntry):
     """Progress statistics, or `null` if no statistics have been recorded yet."""
     error: str | None
     """Error message describing why the job entered `ERROR` state, otherwise `null`."""
+
+
+class ZfsTierRewriteJobChangedEvent(BaseModel):
+    fields: list[ZfsTierRewriteJobStatusEntry]
+    """All rewrite jobs whose status or statistics have changed since the previous event."""
 
 
 class ZfsTierRewriteJobCreateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -11,13 +11,14 @@ from middlewared.api.base import (
     query_result,
     single_argument_args,
 )
-from .common import TierClass, QueryFilters, QueryOptions
+from .common import StorageTier, QueryFilters, QueryOptions
 
 
 __all__ = [
     'ZfsTierEntry', 'ZfsTierUpdateArgs', 'ZfsTierUpdateResult',
     'ZfsTierRewriteJobStats', 'ZfsTierRewriteJobEntry', 'ZfsTierRewriteJobStatusEntry',
-    'ZfsTierRewriteJobChangedEvent',
+    'ZfsTierRewriteJobQueryAddedEvent', 'ZfsTierRewriteJobQueryChangedEvent', 'ZfsTierRewriteJobQueryRemovedEvent',
+    'ZfsTierRewriteJobStatusEventSourceArgs', 'ZfsTierRewriteJobStatusEventSourceEvent',
     'ZfsTierRewriteJobCreateArgs', 'ZfsTierRewriteJobCreateResult',
     'ZfsTierRewriteJobAbortArgs', 'ZfsTierRewriteJobAbortResult',
     'ZfsTierRewriteJobQueryArgs', 'ZfsTierRewriteJobQueryResult',
@@ -101,7 +102,7 @@ class ZfsTierRewriteJobEntry(BaseModel):
 
 
 class TierInfo(BaseModel):
-    tier_type: TierClass
+    tier_type: StorageTier
     """Storage performance tier for this share."""
     tier_job: ZfsTierRewriteJobEntry | None = None
     """Most recent rewrite job for this share's dataset, or `null` if no job history exists."""
@@ -114,9 +115,34 @@ class ZfsTierRewriteJobStatusEntry(ZfsTierRewriteJobEntry):
     """Error message describing why the job entered `ERROR` state, otherwise `null`."""
 
 
-class ZfsTierRewriteJobChangedEvent(BaseModel):
-    fields: list[ZfsTierRewriteJobStatusEntry]
-    """All rewrite jobs whose status or statistics have changed since the previous event."""
+class ZfsTierRewriteJobQueryAddedEvent(BaseModel):
+    id: NonEmptyString
+    """Identifier of the rewrite job that was added (`dataset_name@job_uuid` format)."""
+    fields: ZfsTierRewriteJobEntry
+    """Complete job information for the newly created job."""
+
+
+class ZfsTierRewriteJobQueryChangedEvent(BaseModel):
+    id: NonEmptyString
+    """Identifier of the rewrite job that changed (`dataset_name@job_uuid` format)."""
+    fields: ZfsTierRewriteJobEntry
+    """Updated job information reflecting the latest lifecycle state."""
+
+
+class ZfsTierRewriteJobQueryRemovedEvent(BaseModel):
+    id: NonEmptyString
+    """Identifier of the rewrite job that was removed (`dataset_name@job_uuid` format)."""
+
+
+class ZfsTierRewriteJobStatusEventSourceArgs(BaseModel):
+    dataset_name: NonEmptyString
+    """ZFS dataset to subscribe to (e.g. `tank/data`). Receives updates whenever the job \
+    status or statistics change."""
+
+
+class ZfsTierRewriteJobStatusEventSourceEvent(BaseModel):
+    fields: ZfsTierRewriteJobStatusEntry
+    """Current status and statistics for the dataset's active rewrite job."""
 
 
 class ZfsTierRewriteJobCreateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -11,7 +11,7 @@ from middlewared.api.base import (
     query_result,
     single_argument_args,
 )
-from .common import DatasetTier, QueryFilters, QueryOptions
+from .common import TierClass, QueryFilters, QueryOptions
 
 
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     'ZfsTierRewriteJobQueryArgs', 'ZfsTierRewriteJobQueryResult',
     'ZfsTierRewriteJobRecoverArgs', 'ZfsTierRewriteJobRecoverResult',
     'ZfsTierRewriteJobStatusArgs', 'ZfsTierRewriteJobStatusResult',
-    'SharingTierInfo',
+    'TierInfo',
 ]
 
 TierRewriteJobStatus = Literal['COMPLETE', 'RUNNING', 'QUEUED', 'CANCELLED', 'STOPPED', 'ERROR']
@@ -100,8 +100,8 @@ class ZfsTierRewriteJobEntry(BaseModel):
     """
 
 
-class SharingTierInfo(BaseModel):
-    tier_type: DatasetTier
+class TierInfo(BaseModel):
+    tier_type: TierClass
     """Storage performance tier for this share."""
     tier_job: ZfsTierRewriteJobEntry | None = None
     """Most recent rewrite job for this share's dataset, or `null` if no job history exists."""


### PR DESCRIPTION
This commit modifies the truenas API to wrap around tiering design in the following ways:

A new namespace zfs.tier. will be added. This contains global configuration for systemwide tiering settings. Parameters include

- enabled: whether to enable tiering. This feature requries changes to global ZFS behavior and we will have various internal checks that check this value in datastore extend context methods.

- max_concurrent_jobs: the maximum number of concurrent rewrite jobs (tier migrations for existing data).

- min_available_space: point in available space for a dataset where tier migrations will error out.

The namespace will also support APIs for managing and querying tier migration jobs (which are managed by truenas_zfsrewrited)

Entries for pool.dataset.query, sharing.smb.query, and sharing.nfs.query all have a `tier` field added that indicates the current performance tier of the underlying resource. This field is currently designed to be readonly. If server is unlicensed or if tiering is disabled then these fields will always report `null`. If server is licensed and tiering is enabled, then these fields will report the respective performance tier at which it is configured.