### PR TITLE
Eliminate datastore threadpool executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ async def do_create(self, app, data):
 
 **Datastore Access**:
 - Via `self.middleware.call('datastore.query', 'table', filters, options)`
-- CRUD: `datastore.create()`, `datastore.update()`, `datastore.delete()`
+- CRUD: `datastore.insert()`, `datastore.update()`, `datastore.delete()`
 - Supports filtering and complex queries
 
 ### Job System

--- a/src/middlewared/middlewared/plugins/datastore/connection.py
+++ b/src/middlewared/middlewared/plugins/datastore/connection.py
@@ -1,15 +1,18 @@
-from concurrent.futures import ThreadPoolExecutor
 import re
 import shutil
+import threading
 import time
+from os import getpid
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.pool import NullPool
 
 from middlewared.service import private, Service
+from middlewared.service_exception import CallError
 
 from middlewared.utils.db import FREENAS_DATABASE
 
-thread_pool = ThreadPoolExecutor(1)
+_tls = threading.local()
 
 
 def regexp(expr, item):
@@ -20,60 +23,140 @@ def regexp(expr, item):
     return reg.search(item) is not None
 
 
+def _on_db_connect(dbapi_conn, _):
+    dbapi_conn.create_function('REGEXP', 2, regexp)
+    dbapi_conn.execute('PRAGMA foreign_keys=ON')
+
+
 class DatastoreService(Service):
 
     class Config:
         private = True
-        thread_pool = thread_pool
 
     engine = None
-    connection = None
+    write_lock = threading.Lock()
+    _generation = 0
+    _main_pid = None
+
+    def _get_conn(self):
+        """Return the thread-local SQLite connection for the current generation.
+
+        Creates a fresh connection when either no connection exists for this thread
+        or the global generation counter has advanced past what the thread last saw.
+        The typical trigger for a generation bump is a new database being uploaded,
+        after which setup() disposes the old engine and increments the counter so
+        every thread transparently reconnects on its next access.
+        The stale connection is closed before the new one is opened.
+        """
+        gen = self._generation
+        if getattr(_tls, 'db_generation', -1) != gen:
+            if (old := getattr(_tls, 'db_conn', None)) is not None:
+                try:
+                    old.close()
+                except Exception:
+                    pass
+            _tls.db_conn = self.engine.connect().execution_options(isolation_level='AUTOCOMMIT')
+            _tls.db_generation = gen
+
+        return _tls.db_conn
 
     @private
-    def handle_constraint_violation(self, row, journal):
+    def handle_constraint_violation(self, conn, row, journal):
+        """Log and remove a row that violates a foreign key constraint.
+
+        The offending DELETE statement is also appended to `journal` so that the
+        corrective actions taken at startup can be audited after the fact.
+        """
         self.logger.warning("Row %d in table %s violates foreign key constraint on table %s.",
                             row.rowid, row.table, row.parent)
 
         self.logger.warning("Deleting row %d from table %s.", row.rowid, row.table)
         op = f"DELETE FROM {row.table} WHERE rowid = {row.rowid}"
-        self.connection.execute(text(op))
+        conn.execute(text(op))
         journal.write(f'{op}\n')
 
     @private
     def setup(self):
-        # In SQLAlchemy 2.0, we must close connections before disposing the engine
-        # to avoid "Cannot operate on a closed database" errors
-        if self.connection is not None:
-            self.connection.close()
+        """Initialise (or re-initialise) the SQLite engine.
 
+        Disposes any existing engine, creates a fresh one, bumps the generation
+        counter so all threads obtain new connections on their next access, records
+        the current PID to guard against forked-child writes, repairs any
+        foreign-key violations, and runs VACUUM.
+        """
         if self.engine is not None:
             self.engine.dispose()
 
-        self.engine = create_engine(f'sqlite:///{FREENAS_DATABASE}')
-        self.connection = self.engine.connect()
-        self.connection = self.connection.execution_options(isolation_level="AUTOCOMMIT")
-        self.connection.connection.create_function("REGEXP", 2, regexp)
-        self.connection.connection.execute("PRAGMA foreign_keys=ON")
+        # We're using a NullPool here because we're manually managing per-thread connections
+        # This is because in regular workflows we expect the database to get completely replaced
+        # (like during config uploads) and we need to track the "generation" of database to
+        # invalidate our per-thread connection.
+        self.engine = create_engine(
+            f'sqlite:///{FREENAS_DATABASE}',
+            connect_args={'check_same_thread': False},
+            poolclass=NullPool,
+        )
 
-        if constraint_violations := self.connection.execute(text("PRAGMA foreign_key_check")).fetchall():
+        event.listen(self.engine, 'connect', _on_db_connect)
+
+        self._generation += 1
+        self._main_pid = getpid()
+        conn = self._get_conn()
+
+        if constraint_violations := conn.execute(text('PRAGMA foreign_key_check')).fetchall():
             ts = int(time.time())
             shutil.copy(FREENAS_DATABASE, f'{FREENAS_DATABASE}_{ts}.bak')
 
             with open(f'{FREENAS_DATABASE}_{ts}_journal.txt', 'w') as f:
                 for row in constraint_violations:
-                    self.handle_constraint_violation(row, f)
+                    self.handle_constraint_violation(conn, row, f)
 
-        self.connection.connection.execute("VACUUM")
+        conn.connection.execute('VACUUM')
+
+    def _check_main_pid(self):
+        """Raise CallError if called from a process other than the one that ran setup().
+
+        Forked child processes must not write to the database because writes in the
+        child bypass the main process write_lock and the post_execute_write hook,
+        breaking the serialization guarantees that update hooks depend on.
+        """
+        if getpid() != self._main_pid:
+            raise CallError('Datastore writes are not permitted from a forked child process')
 
     @private
     def execute(self, query, *params):
+        """Execute a raw SQL write statement under the write lock.
+
+        Accepts either positional parameters or a single list/tuple of parameters.
+        Raises CallError if called from a forked child process.
+        """
+        self._check_main_pid()
         if len(params) == 1 and isinstance(params[0], (list, tuple)):
             params = tuple(params[0])
 
-        return self.connection.exec_driver_sql(query, params)
+        with self.write_lock:
+            self._get_conn().exec_driver_sql(query, params)
 
     @private
     def execute_write(self, stmt, options=None):
+        """Compile and execute a SQLAlchemy DML statement under the write lock.
+
+        Handles bind-parameter expansion for IN clauses and type-processor coercion.
+        When `return_last_insert_rowid` is set in options the integer row ID of the
+        inserted row is returned; otherwise the raw DBAPI result is returned.
+        Raises CallError if called from a forked child process.
+
+        After each successful write, fires the `datastore.post_execute_write` hook
+        **while still holding the write_lock**. The hook is registered as inline so
+        it runs synchronously on this thread. On HA systems this is where SQL
+        replication to the backup controller happens; holding the lock during the
+        hook call is intentional — it prevents any other write from reaching the
+        local database before the same SQL has been forwarded to the remote, avoiding
+        replication race conditions. Consequently, anything invoked from within that
+        hook must not attempt to call execute() or execute_write(), as write_lock is
+        non-reentrant and doing so would deadlock. Reads via fetchall() are safe.
+        """
+        self._check_main_pid()
         options = options or {}
         options.setdefault('ha_sync', True)
         options.setdefault('return_last_insert_rowid', False)
@@ -102,18 +185,26 @@ class DatastoreService(Service):
             else:
                 binds.append(value)
 
-        result = self.connection.exec_driver_sql(sql, tuple(binds))
+        with self.write_lock:
+            conn = self._get_conn()
+            result = conn.exec_driver_sql(sql, tuple(binds))
+            if options['return_last_insert_rowid']:
+                result = conn.execute(text('SELECT last_insert_rowid() as rowid')).scalar_one()
 
-        self.middleware.call_hook_inline("datastore.post_execute_write", sql, binds, options)
-
-        if options['return_last_insert_rowid']:
-            return self.connection.execute(text("SELECT last_insert_rowid() as rowid")).scalar_one()
+            self.middleware.call_hook_inline('datastore.post_execute_write', sql, binds, options)
 
         return result
 
     @private
     def fetchall(self, query, params=None):
-        cursor = self.connection.execute(text(query) if isinstance(query, str) else query, params or {})
+        """Execute a query and return all rows as a list of mappings.
+
+        Accepts either a raw SQL string or a SQLAlchemy selectable. Read operations
+        do not acquire the write lock and are safe to call concurrently from multiple
+        threads.
+        """
+        conn = self._get_conn()
+        cursor = conn.execute(text(query) if isinstance(query, str) else query, params or {})
         try:
             return list(cursor.mappings())
         finally:

--- a/src/middlewared/middlewared/plugins/datastore/schema.py
+++ b/src/middlewared/middlewared/plugins/datastore/schema.py
@@ -5,12 +5,19 @@ from middlewared.sqlalchemy import Model
 
 class SchemaMixin:
     def _get_table(self, name):
+        """Look up the SQLAlchemy Table for a dotted datastore name (e.g. "account.bsdusers")."""
         return Model.metadata.tables[name.replace('.', '_').lower()]
 
     def _get_pk(self, table):
+        """Return the primary key Column for table."""
         return [col for col in table.c if col.primary_key][0]
 
     def _get_col(self, table, name, prefix=None):
+        """Look up a column by name, optionally retrying with prefix prepended.
+
+        Delegates to _get_col_by_django_name which also checks for a trailing _id
+        variant. Raises KeyError if the column cannot be found.
+        """
         col = self._get_col_by_django_name(table, name)
         if col is not None:
             return col
@@ -23,6 +30,11 @@ class SchemaMixin:
         raise KeyError(name)
 
     def _get_col_by_django_name(self, table, name):
+        """Return the column for `name` or `name_id`, or None if neither exists.
+
+        The _id suffix variant handles Django-style FK columns where the ORM name
+        omits the suffix but the database column carries it.
+        """
         if name in table.c:
             return table.c[name]
 
@@ -30,6 +42,7 @@ class SchemaMixin:
             return table.c[f'{name}_id']
 
     def _get_relationships(self, table):
+        """Return the SQLAlchemy relationship map for the ORM model that owns table."""
         for model in Model.registry._class_registry.values():
             if hasattr(model, "__tablename__") and model.__tablename__ == table.name:
                 break

--- a/src/middlewared/middlewared/plugins/datastore/util.py
+++ b/src/middlewared/middlewared/plugins/datastore/util.py
@@ -31,6 +31,16 @@ class DatastoreService(Service, SchemaMixin):
         return result
 
     async def sql(self, query, *args):
+        """Execute a raw SQL string, returning rows for SELECT and None for writes.
+
+        Non-SELECT statements are routed through datastore.execute, which does not
+        fire the post_execute_write hook and therefore does not replicate to the
+        backup controller on HA systems. This is intentional for its two callers:
+        pwenc issues bulk re-encryption writes that are run independently on each
+        node, and the failover datastore layer uses it to apply already-replicated
+        SQL received from the active controller without re-triggering replication.
+        Wraps exceptions in CallError.
+        """
         try:
             if query.strip().split()[0].upper() == 'SELECT':
                 return [dict(row) for row in await self.middleware.call('datastore.fetchall', query, *args)]

--- a/src/middlewared/middlewared/plugins/datastore/write.py
+++ b/src/middlewared/middlewared/plugins/datastore/write.py
@@ -147,6 +147,12 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
         return id_
 
     def _extract_relationships(self, table, prefix, data):
+        """Split data into scalar column values and many-to-many relationship entries.
+
+        Returns (insert_dict, relationships_list) where insert_dict contains
+        values for regular columns and relationships_list pairs each SQLAlchemy
+        relationship object with its list of target PKs.
+        """
         relationships = self._get_relationships(table)
 
         insert = {}
@@ -161,6 +167,11 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
         return insert, insert_relationships
 
     async def _handle_relationships(self, pk, relationships):
+        """Replace junction-table rows for pk with the new set of related PKs.
+
+        Deletes all existing rows in each junction table for this pk before
+        inserting the new values, implementing a full replace rather than a diff.
+        """
         for relationship, values in relationships:
             assert len(relationship.synchronize_pairs) == 1
             assert len(relationship.secondary_synchronize_pairs) == 1


### PR DESCRIPTION
This commit removes the datastore plugin threadpool executor that was serializing all database reads / writes inside a single thread. Instead it is replaced with per-thread SQL connection objects with generation tracking (for noting when we need to reopen the database due to config file upload). Reads are MT-safe, writes are serialized behind a threading lock primarily for the purposes of enterpise HA and cross-node database consistency.