### PR TITLE
NAS-139989 / 25.10.2.2 / Enforce server signing when encryption mandatory (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -655,6 +655,10 @@ def generate_smb_conf_dict(
             'ntlm auth': 'disabled'
         })
 
+    # Some third-party security scanners alert if encryption is required but signing is not mandatory.
+    if smb_service_config['encryption'] == 'REQUIRED':
+        smbconf['server signing'] = 'mandatory'
+
     # The following parameters must come after processing includes in order to
     # prevent auxiliary parameters from overriding them
     smbconf.update({

--- a/tests/unit/test_smb_service.py
+++ b/tests/unit/test_smb_service.py
@@ -397,6 +397,16 @@ def test__encryption_required():
         BIND_IP_CHOICES, False, SYSTEM_SECURITY_DEFAULT
     )
     assert conf['server smb encrypt'] == 'required'
+    assert conf['server signing'] == 'mandatory'
+
+
+def test__encryption_not_required__no_mandatory_signing():
+    for config in (BASE_SMB_CONFIG, SMB_ENCRYPTION_NEGOTIATE, SMB_ENCRYPTION_DESIRED):
+        conf = generate_smb_conf_dict(
+            DISABLED_DS_CONFIG, config, [],
+            BIND_IP_CHOICES, False, SYSTEM_SECURITY_DEFAULT
+        )
+        assert conf.get('server signing') != 'mandatory'
 
 
 def test__ipa_base():


### PR DESCRIPTION
This commit changes the TrueNAS SMB server so that it also requires signing when encryption is mandatory. Contrary to how it may appear this does not have a significant security impact. We are just enabling it so that security scanners will avoid dinging us by reporting a "vulnerability" when the server actually enforces something more robust.

Original PR: https://github.com/truenas/middleware/pull/18301
