### PR TITLE
NAS-140406 / 26.0.0-BETA.2 / Ensure remote disk.retaste during vrrp_master is quick (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -615,9 +615,15 @@ class FailoverEventsService(Service):
         if maybe_unlocked:
             logger.info('Done unlocking all SED disks (if any)')
             try:
-                logger.info('Retasting disks on standby node')
-                self.run_call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
-                logger.info('Done scheduling retasting disks on standby node')
+                if self.run_call("failover.remote_connected"):
+                    logger.info("Retasting disks on standby node")
+                    self.run_call(
+                        "failover.call_remote",
+                        "disk.retaste",
+                        [],
+                        {"raise_connect_error": False, "timeout": 5},
+                    )
+                    logger.info("Done scheduling retasting disks on standby node")
             except Exception:
                 logger.exception('Unexpected failure scheduling retasting disks on standby node')
 


### PR DESCRIPTION
It is possible that retasting disks in `vrrp_master` can stall failover.  Avoid.


Original PR: https://github.com/truenas/middleware/pull/18550
