### PR TITLE
NAS-140630 / 27.0.0-BETA.1 / replace py-libzfs usage with truenas_pylibzfs

### DIFF
--- a/src/freenas/usr/local/bin/truenas-initrd.py
+++ b/src/freenas/usr/local/bin/truenas-initrd.py
@@ -14,16 +14,25 @@ import subprocess
 import sys
 import textwrap
 
-import libzfs
 import pyudev
 
 
 logger = logging.getLogger(__name__)
 
 
+def _iter_leaf_vdevs(vdevs):
+    for v in vdevs:
+        if v.vdev_type == 'disk':
+            yield v
+        if v.children:
+            yield from _iter_leaf_vdevs(v.children)
+
+
 def update_zfs_default(root, readonly_rootfs):
-    with libzfs.ZFS() as zfs:
-        existing_pools = [p.name for p in zfs.pools]
+    pool_names = []
+    with truenas_pylibzfs.open_handle() as lzh:
+        lzh.iter_pools(callback=lambda p, s: s.append(p.name) or True, state=pool_names)
+    existing_pools = pool_names
 
     for i in ['freenas-boot', 'boot-pool']:
         if i in existing_pools:
@@ -32,8 +41,9 @@ def update_zfs_default(root, readonly_rootfs):
     else:
         raise CallError(f'Failed to locate valid boot pool. Pools located were: {", ".join(existing_pools)}')
 
-    with libzfs.ZFS() as zfs:
-        disks = [disk.replace("/dev/", "") for disk in zfs.get(boot_pool).disks]
+    with truenas_pylibzfs.open_handle() as lzh:
+        status = lzh.open_pool(name=boot_pool).status(get_stats=False, full_path=True)
+    disks = [v.name.replace('/dev/', '') for v in _iter_leaf_vdevs(status.storage_vdevs)]
 
     mapping = {}
     for dev in filter(
@@ -219,6 +229,7 @@ if __name__ == "__main__":
 
     # BEGIN LAZY IMPORTS
     # ------------------
+    import truenas_pylibzfs
     from truenas_pylibvirt.utils.gpu import get_gpus
     from truenas_os_pyutils.io import atomic_write
 

--- a/src/freenas/usr/local/bin/truenas-initrd.py
+++ b/src/freenas/usr/local/bin/truenas-initrd.py
@@ -22,26 +22,35 @@ logger = logging.getLogger(__name__)
 
 def _iter_leaf_vdevs(vdevs):
     for v in vdevs:
-        if v.vdev_type == 'disk':
-            yield v
         if v.children:
             yield from _iter_leaf_vdevs(v.children)
+        elif v.vdev_type == 'disk':
+            yield v
+
+
+def _append_pool_name(pool, state):
+    state.append(pool.name)
+    return True
 
 
 def update_zfs_default(root, readonly_rootfs):
     pool_names = []
     lzh = truenas_pylibzfs.open_handle()
-    lzh.iter_pools(callback=lambda p, s: s.append(p.name) or True, state=pool_names)
-    existing_pools = pool_names
+    lzh.iter_pools(callback=_append_pool_name, state=pool_names)
 
     for i in ['freenas-boot', 'boot-pool']:
-        if i in existing_pools:
+        if i in pool_names:
             boot_pool = i
             break
     else:
-        raise CallError(f'Failed to locate valid boot pool. Pools located were: {", ".join(existing_pools)}')
+        raise CallError(f'Failed to locate valid boot pool. Pools located were: {", ".join(pool_names)}')
 
-    status = lzh.open_pool(name=boot_pool).status(get_stats=False, full_path=True)
+    # follow_links=False so the vdev path stays in the form stored in
+    # the pool nvlist (e.g. /dev/disk/by-partuuid/...) to match the
+    # udev-keyed mapping built below, rather than realpath()-resolved.
+    status = lzh.open_pool(name=boot_pool).status(
+        get_stats=False, follow_links=False, full_path=True,
+    )
     disks = [v.name.replace('/dev/', '') for v in _iter_leaf_vdevs(status.storage_vdevs)]
 
     mapping = {}

--- a/src/freenas/usr/local/bin/truenas-initrd.py
+++ b/src/freenas/usr/local/bin/truenas-initrd.py
@@ -30,8 +30,8 @@ def _iter_leaf_vdevs(vdevs):
 
 def update_zfs_default(root, readonly_rootfs):
     pool_names = []
-    with truenas_pylibzfs.open_handle() as lzh:
-        lzh.iter_pools(callback=lambda p, s: s.append(p.name) or True, state=pool_names)
+    lzh = truenas_pylibzfs.open_handle()
+    lzh.iter_pools(callback=lambda p, s: s.append(p.name) or True, state=pool_names)
     existing_pools = pool_names
 
     for i in ['freenas-boot', 'boot-pool']:
@@ -41,8 +41,7 @@ def update_zfs_default(root, readonly_rootfs):
     else:
         raise CallError(f'Failed to locate valid boot pool. Pools located were: {", ".join(existing_pools)}')
 
-    with truenas_pylibzfs.open_handle() as lzh:
-        status = lzh.open_pool(name=boot_pool).status(get_stats=False, full_path=True)
+    status = lzh.open_pool(name=boot_pool).status(get_stats=False, full_path=True)
     disks = [v.name.replace('/dev/', '') for v in _iter_leaf_vdevs(status.storage_vdevs)]
 
     mapping = {}

--- a/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
@@ -1,4 +1,4 @@
-import libzfs
+import truenas_pylibzfs
 
 
 def check_zvol_in_boot_pool_using_name(zvol_name: str) -> bool:
@@ -12,12 +12,12 @@ def check_zvol_in_boot_pool_using_path(zvol_path: str) -> bool:
 
 
 def validate_pool_name(name: str) -> bool:
-    return libzfs.validate_pool_name(name)
+    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_POOL)
 
 
 def validate_dataset_name(name: str) -> bool:
-    return libzfs.validate_dataset_name(name)
+    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM)
 
 
 def validate_snapshot_name(name: str) -> bool:
-    return libzfs.validate_snapshot_name(name)
+    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_SNAPSHOT)

--- a/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
@@ -12,12 +12,12 @@ def check_zvol_in_boot_pool_using_path(zvol_path: str) -> bool:
 
 
 def validate_pool_name(name: str) -> bool:
-    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_POOL)
+    return truenas_pylibzfs.name_is_valid(name=name, type=truenas_pylibzfs.ZFSType.ZFS_TYPE_POOL)
 
 
 def validate_dataset_name(name: str) -> bool:
-    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM)
+    return truenas_pylibzfs.name_is_valid(name=name, type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM)
 
 
 def validate_snapshot_name(name: str) -> bool:
-    return truenas_pylibzfs.name_is_valid(name, truenas_pylibzfs.ZFSType.ZFS_TYPE_SNAPSHOT)
+    return truenas_pylibzfs.name_is_valid(name=name, type=truenas_pylibzfs.ZFSType.ZFS_TYPE_SNAPSHOT)

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -1,6 +1,7 @@
 import os
 import pytest
-import libzfs
+import truenas_pylibzfs
+from truenas_os_pyutils.mount import statmount
 
 from middlewared.plugins.smb_.util_smbconf import (
     __parse_share_fs_acl,
@@ -93,29 +94,30 @@ EXTERNAL_SHARE = BASE_SHARE | {'path': 'EXTERNAL', 'purpose': SMBSharePurpose.EX
 @pytest.fixture(scope='module')
 def create_dataset():
     """
-    Create a dataset under /root for testing path-realated functions
-    Yields ZFS dataset handle
+    Create a dataset under /root for testing path-related functions.
+    Yields ZFS dataset handle.
     """
-    with libzfs.ZFS() as lz:
-        root_zh = lz.get_dataset_by_path('/root')
-        ds_name = os.path.join(root_zh.name, 'smb_share_test')
-        root_zh.pool.create(ds_name, {})
-        zhdl = lz.get_dataset(ds_name)
-        zhdl.mount()
-        try:
-            yield zhdl
-        finally:
-            zhdl.umount()
-            zhdl.delete()
+    sm = statmount(path='/root', as_dict=False)
+    ds_name = f'{sm.sb_source}/smb_share_test'
+
+    lz = truenas_pylibzfs.open_handle()
+    lz.create_resource(name=ds_name, type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM)
+    rsrc = lz.open_resource(name=ds_name)
+    rsrc.mount()
+    try:
+        yield rsrc
+    finally:
+        rsrc.unmount()
+        lz.destroy_resource(name=ds_name)
 
 
 @pytest.fixture(scope='function')
 def posixacl_dataset(create_dataset):
-    create_dataset.update_properties({'acltype': {'parsed': 'posix'}})
+    create_dataset.set_properties(properties={'acltype': 'posix'})
     vfs_objects = set()
-    __parse_share_fs_acl(create_dataset.mountpoint, vfs_objects)
+    __parse_share_fs_acl(create_dataset.get_mountpoint(), vfs_objects)
     assert not vfs_objects
-    yield create_dataset.mountpoint
+    yield create_dataset.get_mountpoint()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
This commit replaces py-libzfs (old python libzfs module) usage with truenas_pylibzfs in a test and some utilities. It continues the overall program of deprecating the old module.