### PR TITLE
NAS-139412 / 26.0.0-BETA.2 / Persist local reboot reasons (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -815,6 +815,12 @@ class FailoverEventsService(Service):
         logger.info('Done migrating interface information (if required)')
 
         try:
+            logger.info('Consuming local DB reboot reasons')
+            self.run_call('failover.reboot.consume_local_db_reasons')
+        except Exception:
+            logger.warning('Failed to consume local DB reboot reasons', exc_info=True)
+
+        try:
             logger.info('Updating HA reboot info')
             self.run_call('failover.reboot.info')
         except Exception:

--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -72,6 +72,18 @@ class FailoverRebootService(Service):
         self.remote_reboot_reasons[code] = RemoteRebootReason(boot_id, reason)
         await self.persist_remote_reboot_reasons()
 
+        # Eager push: also write to the remote node's local cache so it self-reports correctly.
+        # Best effort — if the remote is unreachable, the DB entry is the safety net
+        # and will be consumed on MASTER event.
+        if boot_id is not None:
+            try:
+                await self.middleware.call(
+                    'failover.call_remote', 'system.reboot.add_reason', [code, reason],
+                    {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2},
+                )
+            except Exception:
+                self.logger.warning('Failed to push reboot reason %r to remote node', code, exc_info=True)
+
         await self.send_event()
 
     @api_method(FailoverRebootInfoArgs, FailoverRebootInfoResult, roles=['FAILOVER_READ'])
@@ -126,6 +138,7 @@ class FailoverRebootService(Service):
                             }
 
         if other_node is not None:
+            existing_codes = {r['code'] for r in other_node['reboot_required_reasons']}
             for remote_reboot_reason_code, remote_reboot_reason in list(self._remote_reboot_reasons_items()):
                 if remote_reboot_reason.boot_id is None:
                     # This reboot reason was added while the remote node was not functional.
@@ -138,10 +151,11 @@ class FailoverRebootService(Service):
                     changed = True
 
                 if remote_reboot_reason.boot_id == other_node['boot_id']:
-                    other_node['reboot_required_reasons'].append({
-                        'code': remote_reboot_reason_code,
-                        'reason': remote_reboot_reason.reason,
-                    })
+                    if remote_reboot_reason_code not in existing_codes:
+                        other_node['reboot_required_reasons'].append({
+                            'code': remote_reboot_reason_code,
+                            'reason': remote_reboot_reason.reason,
+                        })
                 else:
                     # The system was rebooted, this reason is not valid anymore
                     self.remote_reboot_reasons.pop(remote_reboot_reason_code)
@@ -240,7 +254,7 @@ class FailoverRebootService(Service):
     def _remote_reboot_reasons_items(self):
         if self.loaded:
             return self.remote_reboot_reasons.items()
-        return {}
+        return []
 
     async def _ensure_remote_be(self, id_: str):
         try:
@@ -286,7 +300,9 @@ class FailoverRebootService(Service):
 
     @private
     async def load_remote_reboot_reasons(self):
-        self.remote_reboot_reasons_key = f'remote_reboot_reasons_{await self.middleware.call("failover.node")}'
+        self_node = await self.middleware.call('failover.node')
+        other_node = 'B' if self_node == 'A' else 'A'
+        self.remote_reboot_reasons_key = f'reboot_reasons_{other_node}'
         self.remote_reboot_reasons = {
             k: RemoteRebootReason(**v)
             for k, v in (await self.call2(self.s.keyvalue.get, self.remote_reboot_reasons_key, {})).items()
@@ -299,6 +315,23 @@ class FailoverRebootService(Service):
             k: asdict(v)
             for k, v in self.remote_reboot_reasons.items()
         })
+
+    @private
+    async def consume_local_db_reasons(self):
+        """Transfer DB-stored reasons for this node (written by previous master) into local cache."""
+        self_node = await self.middleware.call('failover.node')
+        db_key = f'reboot_reasons_{self_node}'
+        db_reasons = await self.call2(self.s.keyvalue.get, db_key, {})
+        if not db_reasons:
+            return
+
+        boot_id = await self.middleware.call('system.boot_id')
+        for code, entry in db_reasons.items():
+            if isinstance(entry, dict) and entry.get('boot_id') == boot_id:
+                await self.middleware.call('system.reboot.add_reason', code, entry['reason'])
+
+        # Clear the DB key — reasons have been consumed
+        await self.call2(self.s.keyvalue.set, db_key, {})
 
     @private
     async def discard_unbound_remote_reboot_reasons(self):

--- a/src/middlewared/middlewared/plugins/system/reboot.py
+++ b/src/middlewared/middlewared/plugins/system/reboot.py
@@ -5,6 +5,9 @@ from middlewared.api.current import SystemRebootInfoArgs, SystemRebootInfoResult
 from middlewared.service import private, Service
 
 
+CACHE_KEY = 'reboot_reasons'
+
+
 class RebootReason(enum.Enum):
     # Ensure when a reason is added here, we update disabled reasons in HA to account for the new/removed knob
     FIPS = 'FIPS configuration was changed.'
@@ -32,18 +35,13 @@ class SystemRebootService(Service):
             ),
         ]
 
-    reboot_reasons: dict[str, str] = {}
-
     @api_method(SystemRebootInfoArgs, SystemRebootInfoResult, roles=['SYSTEM_GENERAL_READ'])
     async def info(self):
         return {
             'boot_id': await self.middleware.call('system.boot_id'),
             'reboot_required_reasons': [
-                {
-                    'code': code,
-                    'reason': reason,
-                }
-                for code, reason in self.reboot_reasons.items()
+                {'code': code, 'reason': reason}
+                for code, reason in (await self._get_reasons()).items()
             ],
         }
 
@@ -54,8 +52,9 @@ class SystemRebootService(Service):
         :param code: unique identifier for the reason.
         :param reason: text explanation for the reason.
         """
-        self.reboot_reasons[code] = reason
-
+        reasons = await self._get_reasons()
+        reasons[code] = reason
+        await self._set_reasons(reasons)
         await self._send_event()
 
     @private
@@ -65,11 +64,12 @@ class SystemRebootService(Service):
         :param code: unique identifier for the reason.
         :param reason: text explanation for the reason.
         """
-        if code in self.reboot_reasons:
-            self.reboot_reasons.pop(code)
+        reasons = await self._get_reasons()
+        if code in reasons:
+            reasons.pop(code)
         else:
-            self.reboot_reasons[code] = reason
-
+            reasons[code] = reason
+        await self._set_reasons(reasons)
         await self._send_event()
 
     @private
@@ -78,7 +78,7 @@ class SystemRebootService(Service):
         List reasons code for why this system needs a reboot.
         :return: a list of reason codes
         """
-        return list(self.reboot_reasons.keys())
+        return list((await self._get_reasons()).keys())
 
     @private
     async def remove_reason(self, code: str):
@@ -86,9 +86,19 @@ class SystemRebootService(Service):
         Removes a reason for why this system needs a reboot.
         :param code: unique identifier for the reason that was used to add it.
         """
-        self.reboot_reasons.pop(code, None)
-
+        reasons = await self._get_reasons()
+        reasons.pop(code, None)
+        await self._set_reasons(reasons)
         await self._send_event()
+
+    async def _get_reasons(self) -> dict[str, str]:
+        try:
+            return await self.middleware.call('cache.get', CACHE_KEY)
+        except KeyError:
+            return {}
+
+    async def _set_reasons(self, reasons: dict[str, str]):
+        await self.middleware.call('cache.put', CACHE_KEY, reasons)
 
     async def _send_event(self):
         self.middleware.send_event('system.reboot.info', 'CHANGED', id=None, fields=await self.info())

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_system_reboot.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_system_reboot.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from middlewared.plugins.system.reboot import SystemRebootService, CACHE_KEY
+from middlewared.pytest.unit.helpers import create_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+BOOT_ID = 'test-boot-id-aaa'
+
+
+def make_service(*, cache_contents=None):
+    m = Middleware()
+    m['system.boot_id'] = AsyncMock(return_value=BOOT_ID)
+
+    store = {} if cache_contents is None else {CACHE_KEY: dict(cache_contents)}
+
+    async def cache_get(key):
+        if key not in store:
+            raise KeyError(key)
+        return store[key]
+
+    async def cache_put(key, value, *args):
+        store[key] = value
+
+    m['cache.get'] = cache_get
+    m['cache.put'] = cache_put
+
+    svc = create_service(m, SystemRebootService)
+    return svc, m, store
+
+
+# --- info() tests ---
+
+@pytest.mark.asyncio
+async def test_info_empty():
+    svc, m, store = make_service()
+    info = await svc.info()
+    assert info['boot_id'] == BOOT_ID
+    assert info['reboot_required_reasons'] == []
+
+
+@pytest.mark.asyncio
+async def test_info_with_reasons():
+    svc, m, store = make_service(cache_contents={
+        'FIPS': 'FIPS changed',
+    })
+    info = await svc.info()
+    assert len(info['reboot_required_reasons']) == 1
+    assert info['reboot_required_reasons'][0] == {'code': 'FIPS', 'reason': 'FIPS changed'}
+
+
+@pytest.mark.asyncio
+async def test_info_multiple_reasons():
+    svc, m, store = make_service(cache_contents={
+        'FIPS': 'FIPS changed',
+        'UPGRADE': 'Upgrade pending',
+    })
+    info = await svc.info()
+    assert len(info['reboot_required_reasons']) == 2
+    codes = {r['code'] for r in info['reboot_required_reasons']}
+    assert codes == {'FIPS', 'UPGRADE'}
+
+
+# --- Mutation tests ---
+
+@pytest.mark.asyncio
+async def test_add_reason():
+    svc, m, store = make_service()
+    await svc.add_reason('FIPS', 'FIPS changed')
+    assert store[CACHE_KEY] == {'FIPS': 'FIPS changed'}
+
+
+@pytest.mark.asyncio
+async def test_add_multiple():
+    svc, m, store = make_service()
+    await svc.add_reason('FIPS', 'FIPS changed')
+    await svc.add_reason('UPGRADE', 'Upgrade needed')
+    assert store[CACHE_KEY] == {
+        'FIPS': 'FIPS changed',
+        'UPGRADE': 'Upgrade needed',
+    }
+
+
+@pytest.mark.asyncio
+async def test_toggle_on():
+    svc, m, store = make_service()
+    await svc.toggle_reason('FIPS', 'FIPS changed')
+    assert 'FIPS' in store[CACHE_KEY]
+
+
+@pytest.mark.asyncio
+async def test_toggle_off():
+    svc, m, store = make_service(cache_contents={
+        'FIPS': 'FIPS changed',
+    })
+    await svc.toggle_reason('FIPS', 'FIPS changed')
+    assert 'FIPS' not in store[CACHE_KEY]
+
+
+@pytest.mark.asyncio
+async def test_remove_reason():
+    svc, m, store = make_service(cache_contents={
+        'FIPS': 'FIPS changed',
+    })
+    await svc.remove_reason('FIPS')
+    assert store[CACHE_KEY] == {}
+
+
+@pytest.mark.asyncio
+async def test_remove_nonexistent():
+    svc, m, store = make_service()
+    await svc.remove_reason('NONEXISTENT')
+    assert store[CACHE_KEY] == {}
+
+
+@pytest.mark.asyncio
+async def test_list_reasons():
+    svc, m, store = make_service(cache_contents={
+        'FIPS': 'FIPS changed',
+        'UPGRADE': 'Upgrade pending',
+    })
+    codes = await svc.list_reasons()
+    assert sorted(codes) == ['FIPS', 'UPGRADE']
+
+
+@pytest.mark.asyncio
+async def test_list_reasons_empty():
+    svc, m, store = make_service()
+    codes = await svc.list_reasons()
+    assert codes == []


### PR DESCRIPTION
## Problem

Local reboot reasons (`SystemRebootService.reboot_reasons`) were stored in an in-memory Python dict. If middleware restarted without a system reboot (crash, OOM, `systemctl restart middlewared`), all accumulated reasons were silently lost. This caused failover to be unblocked prematurely (`LOC_FIPS_REBOOT_REQ` / `LOC_UPGRADE_REBOOT_REQ` vanished from `failover.disabled.reasons`), `toggle_reason` to invert its behavior after restart, and the remote node to get a false "all clear" when querying `system.reboot.info`. Additionally, the existing keyvalue key naming for remote reboot reasons (`remote_reboot_reasons_A` meaning "reasons recorded BY Node A about the other node") was confusing.

## Solution

- **Local reasons persisted via volatile cache**: Replace the in-memory dict with the `cache` service (TDB VOLATILE at `/var/run/tdb/volatile/`). This persists across middleware restarts and automatically clears on system reboot — no `boot_id` tracking needed for local reasons.
- **Unified key naming**: Rename the remote reason DB key from `remote_reboot_reasons_{observer}` to `reboot_reasons_{subject}` — `reboot_reasons_B` now clearly means "reasons why Node B needs a reboot." Old keys are left as harmless orphaned rows (different name, no conflict).
- **Eager push**: When the master adds a remote reboot reason via `failover.reboot.add_remote_reason`, it also pushes the reason to the standby's local cache via `failover.call_remote('system.reboot.add_reason')`. This ensures the standby self-reports correctly and the reason is visible immediately on the standby.
- **MASTER event consume**: During `vrrp_master`, the new master reads the DB key `reboot_reasons_{self}` (written by the previous master's `FailoverRebootService`), transfers valid entries into its local cache, and clears the DB key. This handles the case where the eager push failed (standby was unreachable at the time).
- **Dedup in merge loop**: `failover.reboot.info()` now deduplicates when merging the remote node's self-reported reasons with locally-stored DB observations, preventing duplicate entries when both the eager push and DB have the same reason.


Original PR: https://github.com/truenas/middleware/pull/18658
