### PR TITLE
NAS-140642 / 27.0.0-BETA.1 / Add SwitchableSimpleService base class

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -427,7 +427,7 @@ class ServiceService(CRUDService):
 
     @private
     async def generate_etc(self, object_: 'ServiceInterface'):
-        for etc in object_.etc:
+        for etc in await object_.select_etc():
             await self.middleware.call("etc.generate", etc)
 
     @private

--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -75,7 +75,9 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
             monotonic_ts = await system_dbus.get_inactive_exit_timestamp(unit_name)
             units_info = [(unit_name, ("unknown", monotonic_ts))]
 
-        return await self.middleware.run_in_thread(self._collect_failure_logs, units_info)
+        return await self.middleware.run_in_thread(
+            self._collect_failure_logs, units_info
+        )
 
     def _get_systemd_unit_name(self):
         return f"{self.systemd_unit}.service"
@@ -132,3 +134,76 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
                     "\n".join(format_journal_record(r) for r in records)
                 )
         return "\n".join(all_sections)
+
+
+class SwitchableSimpleService(SimpleService):
+    """SimpleService variant that supports runtime selection of the systemd
+    unit and etc groups.  Subclasses override `select_systemd_unit_name()`
+    and/or `select_etc()` to switch behaviour based on operating mode (e.g.
+    kernel-stack vs userspace-stack).  Returning `None` from
+    `select_systemd_unit_name()` means no systemd unit is involved; override
+    `get_state_no_unit()` to provide an alternative running-state check."""
+
+    async def select_systemd_unit_name(self) -> str | None:
+        return self.systemd_unit
+
+    async def get_state_no_unit(self) -> "ServiceState":
+        return ServiceState(False, [])
+
+    async def get_state(self):
+        unit = await self.select_systemd_unit_name()
+        if unit is None:
+            return await self.get_state_no_unit()
+        unit_name = f"{unit}.service"
+        state, main_pid = await system_dbus.get_service_state(unit_name)
+        if (
+            state == b"active"
+            or (self.systemd_async_start and state == b"activating")
+            or state == b"reloading"
+        ):
+            return ServiceState(True, list(filter(None, [main_pid])))
+        return ServiceState(False, [])
+
+    async def get_unit_state(self):
+        unit = await self.select_systemd_unit_name()
+        if unit is None:
+            return None
+        return await system_dbus.get_unit_active_state(f"{unit}.service")
+
+    async def _unit_action(self, action, wait=True):
+        unit = await self.select_systemd_unit_name()
+        if unit is None:
+            return
+        unit_name = f"{unit}.service"
+        if wait:
+            await self._call_unit_action_and_wait(unit_name, action)
+        else:
+            await system_dbus.call_unit_action(unit_name, action)
+
+    async def get_failed_sub_units(self):
+        unit = await self.select_systemd_unit_name()
+        if unit is None:
+            return {}
+        unit_name = f"{unit}.service"
+        try:
+            wants_tree = await system_dbus.get_wants_tree(unit_name)
+            return await system_dbus.get_failed_units(wants_tree)
+        except Exception:
+            logger.debug("Failed to walk Wants tree for %s", unit_name, exc_info=True)
+            return {}
+
+    async def failure_logs(self, failed_units=None):
+        unit = await self.select_systemd_unit_name()
+        if failed_units is None:
+            failed_units = await self.get_failed_sub_units()
+        if failed_units:
+            units_info = list(failed_units.items())
+        elif unit is not None:
+            unit_name = f"{unit}.service"
+            monotonic_ts = await system_dbus.get_inactive_exit_timestamp(unit_name)
+            units_info = [(unit_name, ("unknown", monotonic_ts))]
+        else:
+            return ""
+        return await self.middleware.run_in_thread(
+            self._collect_failure_logs, units_info
+        )

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -69,6 +69,9 @@ class ServiceInterface(CallMixin):
     async def after_reload(self):
         pass
 
+    async def select_etc(self) -> list:
+        return self.etc
+
     async def get_failed_sub_units(self):
         """Return dict of failed/crash-looping units in the dependency tree.
 


### PR DESCRIPTION
Subclasses can override `select_systemd_unit_name()` to switch between systemd units at runtime, or return None when no unit is involved. `select_etc()` allows mode-dependent config generation. Intended to support services with alternative kernel/userspace implementations.

This PR was generated as the result of a comment on PR #18714  