### PR TITLE
NAS-140650 / 27.0.0-BETA.1 / Fix tn_connect.config legacy API version adaptation

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/tn_connect.py
+++ b/src/middlewared/middlewared/api/v27_0_0/tn_connect.py
@@ -42,14 +42,6 @@ class TrueNASConnectEntry(BaseModel):
     last_heartbeat_failure_datetime: str | None
     """Datetime of when the current heartbeat failure streak began. Null if heartbeat is not currently failing."""
 
-    @classmethod
-    def to_previous(cls, value):
-        value.setdefault('ips', [])
-        value.setdefault('interfaces', [])
-        value.setdefault('interfaces_ips', [])
-        value.setdefault('use_all_interfaces', False)
-        return value
-
 
 @single_argument_args('tn_connect_update')
 class TrueNASConnectUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):


### PR DESCRIPTION
The v27.0.0 TrueNASConnectEntry had an incorrect to_previous() method that added ips, interfaces, interfaces_ips, and use_all_interfaces fields when downgrading from v27 to v26. Since both v27 and v26 have identical Entry schemas (both had these fields removed in the same commit), v27's to_previous should be a no-op. The fields were being added but never cleaned up because the version adapter's cleanup only removes fields present in the current model's fields, and these fields aren't in v27's model_fields. This caused Pydantic validation to fail with Extra inputs are not permitted when serialize_result validated the adapted data against v26's Entry which also doesn't have those fields. The v26 to_previous correctly handles the v26-to-v25.10.x gap where these fields are actually needed.