### PR TITLE
25.10.2.1: Fix avahi crash when deny-interfaces exceeds line buffer

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -26,7 +26,7 @@
 
     ipv4_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': True, 'ipv6': False}))
     ipv6_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': False, 'ipv6': True}))
-    deny_interfaces = middleware.call_sync("interface.internal_interfaces")
+    deny_interfaces = [i for i in middleware.call_sync("interface.internal_interfaces") if not i.startswith("br-")] + ["br-*"]
     allow_interfaces = filter_list(render_ctx['interface.query'], [["name", "!^", "macvtap"]])
 %>
 


### PR DESCRIPTION
This is all above my head, but recently when trying to change my hostname on my TrueNAS server, mDNS was failing to start because the config file was failing to regenerate. I had 9 apps installed. Removing 1 app, then allowed the config file to regenerate. 

I found this thread as well: https://forums.truenas.com/t/mdns-avahi-unable-to-start-caused-by-too-long-auto-config/49188/10

With some *assistance*:

    avahi-daemon's INI parser has a ~256-char line limit. The
    deny-interfaces directive in avahi-daemon.conf.mako joins every
    docker bridge (one per installed app) onto a single line via
    interface.internal_interfaces(). With 10+ apps this exceeds the
    limit, causing avahi to crash-loop and breaking mDNS.
    
    Replace individual br-<short_id> entries with a single br-*
    glob. avahi 0.8 supports glob patterns in deny-interfaces. This
    keeps the explicit deny intent while bounding the line length
    regardless of app count.

Not sure if this is a safe change or what other implications this may have. I'm sure other things may make bridges that aren't docker apps that should NOT be in here. 