### PR TITLE
NAS-140634 / 27.0.0-BETA.1 / fix R50 drive identify light

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -121,7 +121,7 @@ class Enclosure2Service(Service):
                     'enclosure2.set_slot_status', f'Slot {data["slot"]} does not support identification'
                 )
             else:
-                if enc_info['model'].startswith('V'):
+                if enc_info['model'].startswith(('V', 'R50')):
                     bsg = enc_info['elements']['Array Device Slot'][data['slot']]['original']['enclosure_bsg']
                     pci = bsg.rsplit('/', 1)[-1]
                 else:


### PR DESCRIPTION
## Summary

On R50BM (and R50/R50B), the front 48 drive bays are split across two SAS expanders. The middleware merges both into a single enclosure, but `set_slot_status` used the top-level enclosure PCI path for all 48 slots. Slots 25-48 live on a different expander, so identifying any of those slots lit up the wrong drive (slot N-24 on the first expander).

The fix uses the per-slot `original.enclosure_bsg` to resolve the correct sysfs path for R50-series, matching the existing V-series approach.