### PR TITLE
NAS-140647 / 25.10.3 / Use domain sid from secrets.tdb for groupmap construction

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -7,6 +7,7 @@ from base64 import b64encode, b64decode
 from middlewared.service import Service
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils import filter_list
+from middlewared.utils.sid import raw_sid_to_str
 from middlewared.utils.tdb import (
     get_tdb_handle,
     TDBDataType,
@@ -74,6 +75,14 @@ class DomainSecrets(Service):
             return False
 
         return True
+
+    def domain_sid(self, domain):
+        """
+        Retrieve the SID for the specified domain from secrets.tdb
+        and return it as a SID string (e.g. 'S-1-5-21-x-y-z').
+        """
+        encoded_sid = fetch_secrets_entry(f"{Secrets.DOMAIN_SID.value}/{domain.upper()}")
+        return raw_sid_to_str(b64decode(encoded_sid))
 
     def last_password_change(self, domain):
         """

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -4,7 +4,7 @@ import tdb
 
 from middlewared.service import Service, job, private
 from middlewared.service_exception import CallError
-from middlewared.utils.directoryservices.constants import DSStatus, DSType
+from middlewared.utils.directoryservices.constants import DSType
 from middlewared.utils.sid import (
     db_id_to_rid,
     get_domain_rid,
@@ -127,17 +127,11 @@ class SMBService(Service):
                 self.logger.warning('%s: SMB admin group does not exist', admin_group)
 
         ds = self.middleware.call_sync('directoryservices.status')
-        match ds['type']:
-            case DSType.AD.value:
-                ad_state = ds['status']
-            case _:
-                ad_state = DSStatus.DISABLED.name
-
-        if ad_state == DSStatus.HEALTHY.name:
+        if ds['type'] == DSType.AD.value:
             try:
                 workgroup = self.middleware.call_sync('smb.config')['workgroup']
-                domain_info = self.middleware.call_sync('idmap.domain_info', workgroup)
-                domain_sid = domain_info['sid']
+                domain_sid = self.middleware.call_sync('directoryservices.secrets.domain_sid', workgroup)
+
                 # add domain account SIDS
                 entries.append((SMBGroupMembership(
                     sid=f'{domain_sid}-{DomainRid.ADMINS}',
@@ -155,7 +149,7 @@ class SMBService(Service):
                 )))
                 guests.append(f'{domain_sid}-{DomainRid.GUESTS}')
             except Exception:
-                self.logger.warning('Failed to retrieve idmap domain info', exc_info=True)
+                self.logger.warning('Failed to retrieve domain SID from secrets', exc_info=True)
 
         insert_groupmap_entries(GroupmapFile.DEFAULT, entries)
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
@@ -1,0 +1,59 @@
+import struct
+
+import pytest
+
+from middlewared.utils.sid import raw_sid_to_str
+
+
+def _build_raw_sid(revision, authority, sub_auths):
+    """Build a raw struct dom_sid (68 bytes) from components."""
+    buf = bytearray(68)
+    buf[0] = revision
+    buf[1] = len(sub_auths)
+    # identifier authority is 6 bytes big-endian
+    buf[2:8] = authority.to_bytes(6, byteorder='big')
+    for i, sa in enumerate(sub_auths):
+        struct.pack_into('<I', buf, 8 + i * 4, sa)
+    return bytes(buf)
+
+
+@pytest.mark.parametrize('revision,authority,sub_auths,expected', [
+    # Standard domain SID (S-1-5-21-x-y-z)
+    (1, 5, [21, 3988175775, 2682076922, 2633271272],
+     'S-1-5-21-3988175775-2682076922-2633271272'),
+    # Domain SID with RID
+    (1, 5, [21, 3988175775, 2682076922, 2633271272, 512],
+     'S-1-5-21-3988175775-2682076922-2633271272-512'),
+    # Well-known SID: BUILTIN\Administrators
+    (1, 5, [32, 544], 'S-1-5-32-544'),
+    # Well-known SID: Everyone (S-1-1-0)
+    (1, 1, [0], 'S-1-1-0'),
+    # Null SID
+    (1, 0, [0], 'S-1-0-0'),
+    # No sub-authorities
+    (1, 5, [], 'S-1-5'),
+])
+def test__raw_sid_to_str(revision, authority, sub_auths, expected):
+    raw = _build_raw_sid(revision, authority, sub_auths)
+    assert raw_sid_to_str(raw) == expected
+
+
+def test__raw_sid_to_str_buffer_too_short():
+    with pytest.raises(ValueError, match='too short'):
+        raw_sid_to_str(b'\x01\x01\x00\x00')
+
+
+def test__raw_sid_to_str_invalid_count():
+    # num_auths > 15 is invalid per MS-DTYP
+    buf = bytearray(68)
+    buf[0] = 1
+    buf[1] = 16
+    with pytest.raises(ValueError, match='Invalid sub-authority count'):
+        raw_sid_to_str(bytes(buf))
+
+
+def test__raw_sid_to_str_truncated_sub_auths():
+    # Claims 4 sub-auths but buffer only has room for header
+    buf = b'\x01\x04\x00\x00\x00\x00\x00\x05'
+    with pytest.raises(ValueError, match='too short'):
+        raw_sid_to_str(buf)

--- a/src/middlewared/middlewared/utils/sid.py
+++ b/src/middlewared/middlewared/utils/sid.py
@@ -1,4 +1,5 @@
 import enum
+import struct
 
 from middlewared.plugins.idmap_.idmap_constants import BASE_SYNTHETIC_DATASTORE_ID, IDType
 from middlewared.utils.secrets import randbits
@@ -97,6 +98,40 @@ class lsa_sidtype(enum.IntEnum):
     UNKNOWN = 8
     COMPUTER = 9
     LABEL = 10  # mandatory label
+
+
+def raw_sid_to_str(sid_bytes: bytes) -> str:
+    """Convert raw struct dom_sid bytes (as stored in secrets.tdb) to SID string.
+
+    Binary layout (MS-DTYP 2.4.2 / Samba's struct dom_sid):
+        uint8:     sid_rev_num
+        uint8:     num_auths
+        uint8[6]:  id_auth (big-endian)
+        uint32[15]: sub_auths (little-endian, only num_auths are meaningful)
+    """
+    if len(sid_bytes) < 8:
+        raise ValueError(f'SID buffer too short: {len(sid_bytes)} bytes')
+
+    revision = sid_bytes[0]
+    num_auths = sid_bytes[1]
+
+    if num_auths > 15:
+        raise ValueError(f'Invalid sub-authority count: {num_auths}')
+
+    required = 8 + (num_auths * 4)
+    if len(sid_bytes) < required:
+        raise ValueError(
+            f'SID buffer too short for {num_auths} sub-authorities: '
+            f'{len(sid_bytes)} < {required}'
+        )
+
+    id_auth = int.from_bytes(sid_bytes[2:8], byteorder='big')
+
+    parts = [f'S-{revision}-{id_auth}']
+    for i in range(num_auths):
+        parts.append(str(struct.unpack_from('<I', sid_bytes, 8 + i * 4)[0]))
+
+    return '-'.join(parts)
 
 
 def random_sid() -> str:

--- a/tests/directory_services/test_activedirectory_groupmap.py
+++ b/tests/directory_services/test_activedirectory_groupmap.py
@@ -1,0 +1,63 @@
+import pytest
+
+from middlewared.test.integration.assets.directory_service import directoryservice
+from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.system import reset_systemd_svcs
+
+GROUP_MAPPING_TDB = '/var/lib/truenas-samba/group_mapping.tdb'
+
+# Well-known builtin alias SIDs
+BUILTIN_ADMINISTRATORS = 'S-1-5-32-544'
+BUILTIN_USERS = 'S-1-5-32-545'
+BUILTIN_GUESTS = 'S-1-5-32-546'
+
+# Well-known domain RIDs
+DOMAIN_ADMINS_RID = 512
+DOMAIN_USERS_RID = 513
+DOMAIN_GUESTS_RID = 514
+
+
+def test_ad_foreign_group_recovery():
+    """
+    Verify that after deleting group_mapping.tdb, synchronize_group_mappings
+    restores foreign group memberships for both local and AD domain SIDs.
+
+    Domain Admins (RID 512) must be a member of BUILTIN\\Administrators (S-1-5-32-544).
+    Domain Users  (RID 513) must be a member of BUILTIN\\Users (S-1-5-32-545).
+    Domain Guests (RID 514) must be a member of BUILTIN\\Guests (S-1-5-32-546).
+    """
+    reset_systemd_svcs('winbind')
+
+    with directoryservice('ACTIVEDIRECTORY') as ad:
+        short_name = ad['domain_info']['domain_controller']['pre-win2k_domain']
+        domain_sid = call('directoryservices.secrets.domain_sid', short_name)
+
+        # Verify domain_sid looks reasonable
+        assert domain_sid.startswith('S-1-5-21-')
+
+        # Delete group_mapping.tdb to simulate data loss
+        ssh(f'rm -f {GROUP_MAPPING_TDB}')
+
+        # Memberships should be gone now
+        assert call('smb.groupmap_listmem', BUILTIN_ADMINISTRATORS) == []
+
+        # Rebuild group mappings from scratch
+        call('smb.synchronize_group_mappings', job=True)
+
+        # Verify local domain foreign memberships were restored
+        admin_members = call('smb.groupmap_listmem', BUILTIN_ADMINISTRATORS)
+        user_members = call('smb.groupmap_listmem', BUILTIN_USERS)
+        guest_members = call('smb.groupmap_listmem', BUILTIN_GUESTS)
+
+        # Local builtin_administrators (RID 512) should be member of S-1-5-32-544
+        localsid = call('smb.groupmap_list')['localsid']
+        assert f'{localsid}-{DOMAIN_ADMINS_RID}' in admin_members
+        assert f'{localsid}-{DOMAIN_GUESTS_RID}' in guest_members
+
+        # AD domain SIDs should also be present as foreign members
+        assert f'{domain_sid}-{DOMAIN_ADMINS_RID}' in admin_members, \
+            f'Domain Admins SID not in BUILTIN\\Administrators members: {admin_members}'
+        assert f'{domain_sid}-{DOMAIN_USERS_RID}' in user_members, \
+            f'Domain Users SID not in BUILTIN\\Users members: {user_members}'
+        assert f'{domain_sid}-{DOMAIN_GUESTS_RID}' in guest_members, \
+            f'Domain Guests SID not in BUILTIN\\Guests members: {guest_members}'


### PR DESCRIPTION
This commit transitions from using runtime detection of domain SID via winbindd requests to reading the stored domain SID from the secrets.tdb file. During reboot and failover process there was a window in which an unhealthy AD join could cause a failure to resolve the domain admins SID and subsequently trigger it to be removed from the group_mapping.tdb. This change robustizes the groupmap setup by not requiring a healthy AD state.

Original PR: https://github.com/truenas/middleware/pull/18719