### PR TITLE
NAS-140643 / 26.0.0-BETA.2 / Use truenas_pylibzfs.kstat module (by anodos325)

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -293,10 +293,13 @@ class DiskTempThread(threading.Thread):
 
 
 def gather_zpool_iostat_info(prev_data, name, pool_status):
-    r_ops = sum(v.stats.ops_read for v in pool_status.storage_vdevs if v.stats is not None)
-    w_ops = sum(v.stats.ops_write for v in pool_status.storage_vdevs if v.stats is not None)
-    r_bytes = sum(v.stats.bytes_read for v in pool_status.storage_vdevs if v.stats is not None)
-    w_bytes = sum(v.stats.bytes_write for v in pool_status.storage_vdevs if v.stats is not None)
+    r_ops = w_ops = r_bytes = w_bytes = 0
+    for v in pool_status.storage_vdevs:
+        if v.stats is not None:
+            r_ops += v.stats.ops_read
+            w_ops += v.stats.ops_write
+            r_bytes += v.stats.bytes_read
+            w_bytes += v.stats.bytes_write
 
     # the current values as reported by libzfs
     values_overall = {name: {

--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -4,49 +4,37 @@ import time
 import contextlib
 import os
 
-import libzfs
+import truenas_pylibzfs
+from truenas_pylibzfs import kstat
 import netsnmpagent
 
 from truenas_api_client import Client
 from middlewared.utils.disk_temperatures import get_disks_temperatures_for_snmp
 
 
-def get_kstat():
-    kstat = {}
+def get_arcstats():
     try:
-        with open("/proc/spl/kstat/zfs/arcstats") as f:
-            for lineno, line in enumerate(f, start=1):
-                if lineno > 2 and (info := line.strip()):
-                    name, _, data = info.split()
-                    kstat[f"kstat.zfs.misc.arcstats.{name}"] = int(data)
+        return kstat.get_arcstats()
     except Exception:
-        return kstat
-    else:
-        kstat["vfs.zfs.version.spa"] = 5000
-
-    return kstat
+        return None
 
 
-def get_arc_efficiency(kstat):
-    if not kstat.get("vfs.zfs.version.spa"):
-        return
-
+def get_arc_efficiency(arcstats):
     output = {}
-    prefix = 'kstat.zfs.misc.arcstats'
-    arc_hits = kstat[f"{prefix}.hits"]
-    arc_misses = kstat[f"{prefix}.misses"]
-    demand_data_hits = kstat[f"{prefix}.demand_data_hits"]
-    demand_data_misses = kstat[f"{prefix}.demand_data_misses"]
-    demand_metadata_hits = kstat[f"{prefix}.demand_metadata_hits"]
-    demand_metadata_misses = kstat[f"{prefix}.demand_metadata_misses"]
-    mfu_ghost_hits = kstat[f"{prefix}.mfu_ghost_hits"]
-    mfu_hits = kstat[f"{prefix}.mfu_hits"]
-    mru_ghost_hits = kstat[f"{prefix}.mru_ghost_hits"]
-    mru_hits = kstat[f"{prefix}.mru_hits"]
-    prefetch_data_hits = kstat[f"{prefix}.prefetch_data_hits"]
-    prefetch_data_misses = kstat[f"{prefix}.prefetch_data_misses"]
-    prefetch_metadata_hits = kstat[f"{prefix}.prefetch_metadata_hits"]
-    prefetch_metadata_misses = kstat[f"{prefix}.prefetch_metadata_misses"]
+    arc_hits = arcstats.hits
+    arc_misses = arcstats.misses
+    demand_data_hits = arcstats.demand_data_hits
+    demand_data_misses = arcstats.demand_data_misses
+    demand_metadata_hits = arcstats.demand_metadata_hits
+    demand_metadata_misses = arcstats.demand_metadata_misses
+    mfu_ghost_hits = arcstats.mfu_ghost_hits
+    mfu_hits = arcstats.mfu_hits
+    mru_ghost_hits = arcstats.mru_ghost_hits
+    mru_hits = arcstats.mru_hits
+    prefetch_data_hits = arcstats.prefetch_data_hits
+    prefetch_data_misses = arcstats.prefetch_data_misses
+    prefetch_metadata_hits = arcstats.prefetch_metadata_hits
+    prefetch_metadata_misses = arcstats.prefetch_metadata_misses
 
     anon_hits = arc_hits - (mfu_hits + mru_hits + mfu_ghost_hits + mru_ghost_hits)
     arc_accesses_total = (arc_hits + arc_misses)
@@ -180,9 +168,9 @@ def fPerc(lVal=0, rVal=0, Decimal=2):
         return str("%0." + str(Decimal) + "f") % 100 + "%"
 
 
-def get_zfs_arc_miss_percent(kstat):
-    arc_hits = kstat["kstat.zfs.misc.arcstats.hits"]
-    arc_misses = kstat["kstat.zfs.misc.arcstats.misses"]
+def get_zfs_arc_miss_percent(arcstats):
+    arc_hits = arcstats.hits
+    arc_misses = arcstats.misses
     arc_read = arc_hits + arc_misses
     if arc_read > 0:
         hit_percent = float(100 * arc_hits / arc_read)
@@ -259,13 +247,8 @@ zfs_zilstat_ops10 = agent.Counter64(oidstr="TRUENAS-MIB::zfsZilstatOps10sec")
 
 
 def readZilOpsCount() -> int:
-    total = 0
-    with open("/proc/spl/kstat/zfs/zil") as f:
-        for line in f:
-            var, _size, val, *_ = line.split()
-            if var in ("zil_itx_metaslab_normal_count", "zil_itx_metaslab_slog_count"):
-                total += int(val)
-    return total
+    zilstats = kstat.get_zilstats()
+    return zilstats.zil_itx_metaslab_normal_count + zilstats.zil_itx_metaslab_slog_count
 
 
 class ZilstatThread(threading.Thread):
@@ -309,11 +292,11 @@ class DiskTempThread(threading.Thread):
             time.sleep(self.interval)
 
 
-def gather_zpool_iostat_info(prev_data, name, zpoolobj):
-    r_ops = zpoolobj.root_vdev.stats.ops[libzfs.ZIOType.READ]
-    w_ops = zpoolobj.root_vdev.stats.ops[libzfs.ZIOType.WRITE]
-    r_bytes = zpoolobj.root_vdev.stats.bytes[libzfs.ZIOType.READ]
-    w_bytes = zpoolobj.root_vdev.stats.bytes[libzfs.ZIOType.WRITE]
+def gather_zpool_iostat_info(prev_data, name, pool_status):
+    r_ops = sum(v.stats.ops_read for v in pool_status.storage_vdevs if v.stats is not None)
+    w_ops = sum(v.stats.ops_write for v in pool_status.storage_vdevs if v.stats is not None)
+    r_bytes = sum(v.stats.bytes_read for v in pool_status.storage_vdevs if v.stats is not None)
+    w_bytes = sum(v.stats.bytes_write for v in pool_status.storage_vdevs if v.stats is not None)
 
     # the current values as reported by libzfs
     values_overall = {name: {
@@ -345,39 +328,54 @@ def fill_in_zpool_snmp_row_info(idx, name, health, io_overall, io_1s):
     row.setRowCell(11, agent.Counter64(io_1s[name]["write_bytes"]))
 
 
-def fill_in_zvol_snmp_row_info(idx, info):
+def fill_in_zvol_snmp_row_info(idx, name, props):
     row = zvol_table.addRow([agent.Integer32(idx)])
     row.setRowCell(1, agent.Integer32(idx))
-    row.setRowCell(2, agent.DisplayString(info["name"]))
-    row.setRowCell(3, agent.Counter64(info["properties"]["used"]["parsed"]))
-    row.setRowCell(4, agent.Counter64(info["properties"]["available"]["parsed"]))
-    row.setRowCell(5, agent.Counter64(info["properties"]["referenced"]["parsed"]))
+    row.setRowCell(2, agent.DisplayString(name))
+    row.setRowCell(3, agent.Counter64(props.used.value))
+    row.setRowCell(4, agent.Counter64(props.available.value))
+    row.setRowCell(5, agent.Counter64(props.referenced.value))
 
 
 def report_zfs_info(prev_zpool_info):
     zpool_table.clear()
     zvol_table.clear()
 
-    # zpool related information
-    with libzfs.ZFS() as z:
-        for idx, zpool in enumerate(z.pools, start=1):
-            name = zpool.name
-            health = zpool.properties["health"].value
-            io_overall, io_1s = gather_zpool_iostat_info(prev_zpool_info, name, zpool)
-            fill_in_zpool_snmp_row_info(idx, name, health, io_overall, io_1s)
-            # be sure and update our zpool io data so next time it's called
-            # we calculate the 1sec values properly
-            prev_zpool_info.update(io_overall)
+    lz = truenas_pylibzfs.open_handle()
 
-        zvols = get_list_of_zvols()
-        kwargs = {
-            'user_props': False,
-            'props': ['used', 'available', 'referenced'],
-            'retrieve_children': False,
-            'datasets': zvols,
-        }
-        for idx, ds_info in enumerate(z.datasets_serialized(**kwargs), start=1):
-            fill_in_zvol_snmp_row_info(idx, ds_info)
+    # zpool related information
+    pools = []
+
+    def collect_pool(pool, state):
+        state.append(pool)
+        return True
+
+    lz.iter_pools(callback=collect_pool, state=pools)
+
+    for idx, pool in enumerate(pools, start=1):
+        name = pool.name
+        health = pool.get_properties(
+            properties={truenas_pylibzfs.ZPOOLProperty.HEALTH}
+        ).health.value
+        pool_status = pool.status(get_stats=True)
+        io_overall, io_1s = gather_zpool_iostat_info(prev_zpool_info, name, pool_status)
+        fill_in_zpool_snmp_row_info(idx, name, health, io_overall, io_1s)
+        # be sure and update our zpool io data so next time it's called
+        # we calculate the 1sec values properly
+        prev_zpool_info.update(io_overall)
+
+    zvol_props = {
+        truenas_pylibzfs.ZFSProperty.USED,
+        truenas_pylibzfs.ZFSProperty.AVAILABLE,
+        truenas_pylibzfs.ZFSProperty.REFERENCED,
+    }
+    for idx, zvol_name in enumerate(get_list_of_zvols(), start=1):
+        try:
+            rsrc = lz.open_resource(name=zvol_name)
+            props = rsrc.get_properties(properties=zvol_props)
+            fill_in_zvol_snmp_row_info(idx, zvol_name, props)
+        except truenas_pylibzfs.ZFSException:
+            continue
 
 
 def get_list_of_zvols():
@@ -426,25 +424,28 @@ if __name__ == "__main__":
                         row.setRowCell(2, agent.DisplayString(name))
                         row.setRowCell(3, agent.Unsigned32(temp))
 
-            kstat = get_kstat()
-            arc_efficiency = get_arc_efficiency(kstat)
+            arcstats = get_arcstats()
+            if arcstats is None:
+                last_update_at = int(time.monotonic())
+                continue
 
-            prefix = "kstat.zfs.misc.arcstats"
-            zfs_arc_size.update(kstat[f"{prefix}.size"] // 1024)
-            zfs_arc_meta.update(kstat[f"{prefix}.arc_meta_used"] // 1024)
-            zfs_arc_data.update(kstat[f"{prefix}.data_size"] // 1024)
-            zfs_arc_hits.update(int(kstat[f"{prefix}.hits"] % 2 ** 32))
-            zfs_arc_misses.update(int(kstat[f"{prefix}.misses"] % 2 ** 32))
-            zfs_arc_c.update(kstat[f"{prefix}.c"] // 1024)
-            zfs_arc_miss_percent.update(str(get_zfs_arc_miss_percent(kstat)).encode("ascii"))
+            arc_efficiency = get_arc_efficiency(arcstats)
+
+            zfs_arc_size.update(arcstats.size // 1024)
+            zfs_arc_meta.update(arcstats.arc_meta_used // 1024)
+            zfs_arc_data.update(arcstats.data_size // 1024)
+            zfs_arc_hits.update(int(arcstats.hits % 2 ** 32))
+            zfs_arc_misses.update(int(arcstats.misses % 2 ** 32))
+            zfs_arc_c.update(arcstats.c // 1024)
+            zfs_arc_miss_percent.update(str(get_zfs_arc_miss_percent(arcstats)).encode("ascii"))
             zfs_arc_cache_hit_ratio.update(str(arc_efficiency["cache_hit_ratio"]["per"][:-1]).encode("ascii"))
             zfs_arc_cache_miss_ratio.update(str(arc_efficiency["cache_miss_ratio"]["per"][:-1]).encode("ascii"))
 
-            zfs_l2arc_hits.update(int(kstat[f"{prefix}.l2_hits"] % 2 ** 32))
-            zfs_l2arc_misses.update(int(kstat[f"{prefix}.l2_misses"] % 2 ** 32))
-            zfs_l2arc_read.update(kstat[f"{prefix}.l2_read_bytes"] // 1024 % 2 ** 32)
-            zfs_l2arc_write.update(kstat[f"{prefix}.l2_write_bytes"] // 1024 % 2 ** 32)
-            zfs_l2arc_size.update(kstat[f"{prefix}.l2_asize"] // 1024)
+            zfs_l2arc_hits.update(int(arcstats.l2_hits % 2 ** 32))
+            zfs_l2arc_misses.update(int(arcstats.l2_misses % 2 ** 32))
+            zfs_l2arc_read.update(arcstats.l2_read_bytes // 1024 % 2 ** 32)
+            zfs_l2arc_write.update(arcstats.l2_write_bytes // 1024 % 2 ** 32)
+            zfs_l2arc_size.update(arcstats.l2_asize // 1024)
 
             if zilstat_1_thread:
                 zfs_zilstat_ops1.update(zilstat_1_thread.value)

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -1,5 +1,7 @@
 import os
 
+from truenas_pylibzfs import kstat
+
 from middlewared.service import CallError, Service
 from middlewared.utils import run, MIDDLEWARE_RUN_DIR
 
@@ -22,7 +24,7 @@ class SysctlService(Service):
         """This method should be called _BEFORE_ we initialize any VMs
         so that we can capture what the ARC max value was before we start
         changing the various ARC sysctls based on VM memory configurations"""
-        val = self.get_arcstats()['c_max']
+        val = kstat.get_arcstats().c_max
         try:
             with open(DEFAULT_ARC_MAX_FILE, 'x') as f:
                 f.write(str(val))
@@ -40,10 +42,10 @@ class SysctlService(Service):
             return self.store_default_arc_max()
 
     def get_arc_max(self):
-        return self.get_arcstats()['c_max']
+        return kstat.get_arcstats().c_max
 
     def get_arc_min(self):
-        return self.get_arcstats()['c_min']
+        return kstat.get_arcstats().c_min
 
     async def get_pagesize(self):
         cp = await run(['getconf', 'PAGESIZE'], check=False)
@@ -52,22 +54,11 @@ class SysctlService(Service):
         return int(cp.stdout.decode().strip())
 
     def get_arcstats(self):
-        stats = {}
-        with open('/proc/spl/kstat/zfs/arcstats') as f:
-            for lineno, line in enumerate(f, start=1):
-                if lineno > 2:  # skip first 2 lines
-                    try:
-                        key, _, value = line.strip().split()
-                        key, value = key.strip(), value.strip()
-                    except ValueError:
-                        continue
-                    else:
-                        stats[key] = int(value) if value.isdigit() else value
-
-        return stats
+        arcstats = kstat.get_arcstats()
+        return {name: getattr(arcstats, name) for name in kstat.ArcStats.__match_args__}
 
     def get_arcstats_size(self):
-        return self.get_arcstats()['size']
+        return kstat.get_arcstats().size
 
     async def set_value(self, key, value):
         await run(['sysctl', f'{key}={value}'])

--- a/src/middlewared/middlewared/utils/metrics/arcstat.py
+++ b/src/middlewared/middlewared/utils/metrics/arcstat.py
@@ -1,5 +1,7 @@
 from types import MappingProxyType
 
+from truenas_pylibzfs.kstat import ArcStats, get_arcstats
+
 # We are essentially
 # copying the same logic in the upstream `arc_summary.py`
 # and "arcstat" script provided by ZFS but pulling out the
@@ -55,16 +57,16 @@ def do_round(dividend: int, divisor: int, to_decimal_place: int = 2) -> float:
     return round((dividend / divisor), to_decimal_place)
 
 
-def calculate_arc_demand_stats_impl(st: dict[str, int], intv: int) -> dict[str, int | float]:
+def calculate_arc_demand_stats_impl(st: ArcStats, intv: int) -> dict[str, int | float]:
     v: dict[str, int | float] = dict()
     v["dread"] = (
-        do_round((st["demand_data_hits"] + st["demand_metadata_hits"]), intv)
-        + do_round((st["demand_data_iohits"] + st["demand_metadata_iohits"]), intv)
-        + do_round((st["demand_data_misses"] + st["demand_metadata_misses"]), intv)
+        do_round((st.demand_data_hits + st.demand_metadata_hits), intv)
+        + do_round((st.demand_data_iohits + st.demand_metadata_iohits), intv)
+        + do_round((st.demand_data_misses + st.demand_metadata_misses), intv)
     )
-    v["ddhit"] = do_round(st["demand_data_hits"], intv)
-    v["ddioh"] = do_round(st["demand_data_iohits"], intv)
-    v["ddmis"] = do_round(st["demand_data_misses"], intv)
+    v["ddhit"] = do_round(st.demand_data_hits, intv)
+    v["ddioh"] = do_round(st.demand_data_iohits, intv)
+    v["ddmis"] = do_round(st.demand_data_misses, intv)
     v["ddread"] = v["ddhit"] + v["ddioh"] + v["ddmis"]
     v["ddh%"] = v["ddi%"] = v["ddm%"] = 0.0
     if v["ddread"] > 0:
@@ -72,9 +74,9 @@ def calculate_arc_demand_stats_impl(st: dict[str, int], intv: int) -> dict[str, 
         v["ddi%"] = do_round(int(100 * v["ddioh"]), int(v["ddread"]))
         v["ddm%"] = 100 - v["ddh%"] - v["ddi%"]
 
-    v["dmhit"] = do_round(st["demand_metadata_hits"], intv)
-    v["dmioh"] = do_round(st["demand_metadata_iohits"], intv)
-    v["dmmis"] = do_round(st["demand_metadata_misses"], intv)
+    v["dmhit"] = do_round(st.demand_metadata_hits, intv)
+    v["dmioh"] = do_round(st.demand_metadata_iohits, intv)
+    v["dmmis"] = do_round(st.demand_metadata_misses, intv)
     v["dmread"] = v["dmhit"] + v["dmioh"] + v["dmmis"]
     v["dmh%"] = v["dmi%"] = v["dmm%"] = 0.0
     if v["dmread"] > 0:
@@ -85,7 +87,7 @@ def calculate_arc_demand_stats_impl(st: dict[str, int], intv: int) -> dict[str, 
     return v
 
 
-def calculate_l2arc_stats_impl(st: dict[str, int], intv: int) -> dict[str, int | float]:
+def calculate_l2arc_stats_impl(st: ArcStats, intv: int) -> dict[str, int | float]:
     v = {
         "l2hits": 0,
         "l2miss": 0,
@@ -95,11 +97,11 @@ def calculate_l2arc_stats_impl(st: dict[str, int], intv: int) -> dict[str, int |
         "l2bytes": 0,
         "l2wbytes": 0,
     }
-    if st.get("l2_size"):
-        v["l2bytes"] = do_round(st["l2_read_bytes"], intv)
-        v["l2wbytes"] = do_round(st["l2_write_bytes"], intv)
-        v["l2hits"] = do_round(st["l2_hits"], intv)
-        v["l2miss"] = do_round(st["l2_misses"], intv)
+    if st.l2_size:
+        v["l2bytes"] = do_round(st.l2_read_bytes, intv)
+        v["l2wbytes"] = do_round(st.l2_write_bytes, intv)
+        v["l2hits"] = do_round(st.l2_hits, intv)
+        v["l2miss"] = do_round(st.l2_misses, intv)
         v["l2read"] = v["l2hits"] + v["l2miss"]
         v["l2hit%"] = v["l2miss%"] = 0.0
         if v["l2read"] > 0:
@@ -108,11 +110,11 @@ def calculate_l2arc_stats_impl(st: dict[str, int], intv: int) -> dict[str, int |
     return v
 
 
-def calculate_arc_stats_impl(st: dict[str, int], intv: int) -> dict[str, tuple[int | float, str]]:
+def calculate_arc_stats_impl(st: ArcStats, intv: int) -> dict[str, tuple[int | float, str]]:
     v: dict[str, int | float] = {
-        "free": st["memory_free_bytes"],
-        "avail": st["memory_available_bytes"],
-        "size": st["size"],
+        "free": st.memory_free_bytes,
+        "avail": st.memory_available_bytes,
+        "size": st.size,
     }
     v.update(calculate_arc_demand_stats_impl(st, intv))
     v.update(calculate_l2arc_stats_impl(st, intv))
@@ -120,17 +122,5 @@ def calculate_arc_stats_impl(st: dict[str, int], intv: int) -> dict[str, tuple[i
     return {vname: (val, ArcStatDescriptions[vname]) for vname, val in v.items()}
 
 
-def read_procfs_st() -> dict[str, int]:
-    rv = dict()
-    with open("/proc/spl/kstat/zfs/arcstats") as f:
-        for lineno, line in filter(lambda x: x[0] > 2, enumerate(f, start=1)):
-            try:
-                name, _, value = line.strip().split()
-                rv[name.strip()] = int(value)
-            except ValueError:
-                continue
-    return rv
-
-
 def get_arc_stats(intv: int = 1) -> dict[str, tuple[int | float, str]]:
-    return calculate_arc_stats_impl(read_procfs_st(), intv)
+    return calculate_arc_stats_impl(get_arcstats(), intv)

--- a/tests/api2/test_snmp_zfs_stats.py
+++ b/tests/api2/test_snmp_zfs_stats.py
@@ -1,0 +1,172 @@
+import re
+import subprocess
+import time
+
+import pytest
+
+from middlewared.test.integration.utils import call, host, ssh
+
+
+REMOTE_MIB_PATH = '/usr/local/share/snmp/mibs/TRUENAS-MIB.txt'
+
+# Expected OIDs and their SNMP types.
+# ARC subtree: 1.3.6.1.4.1.50536.1.3
+ARC_OIDS = {
+    'zfsArcSize': 'Gauge32',
+    'zfsArcMeta': 'Gauge32',
+    'zfsArcData': 'Gauge32',
+    'zfsArcHits': 'Gauge32',
+    'zfsArcMisses': 'Gauge32',
+    'zfsArcC': 'Gauge32',
+    'zfsArcMissPercent': 'STRING',
+    'zfsArcCacheHitRatio': 'STRING',
+    'zfsArcCacheMissRatio': 'STRING',
+}
+
+# L2ARC subtree: 1.3.6.1.4.1.50536.1.4
+L2ARC_OIDS = {
+    'zfsL2ArcHits': 'Counter32',
+    'zfsL2ArcMisses': 'Counter32',
+    'zfsL2ArcRead': 'Counter32',
+    'zfsL2ArcWrite': 'Counter32',
+    'zfsL2ArcSize': 'Gauge32',
+}
+
+# ZIL subtree: 1.3.6.1.4.1.50536.1.5
+ZIL_OIDS = {
+    'zfsZilstatOps1sec': 'Counter64',
+    'zfsZilstatOps5sec': 'Counter64',
+    'zfsZilstatOps10sec': 'Counter64',
+}
+
+# zpool table columns: 1.3.6.1.4.1.50536.1.1
+ZPOOL_COLUMNS = {
+    'zpoolIndex': 'INTEGER',
+    'zpoolName': 'STRING',
+    'zpoolHealth': 'STRING',
+    'zpoolReadOps': 'Counter64',
+    'zpoolWriteOps': 'Counter64',
+    'zpoolReadBytes': 'Counter64',
+    'zpoolWriteBytes': 'Counter64',
+    'zpoolReadOps1sec': 'Counter64',
+    'zpoolWriteOps1sec': 'Counter64',
+    'zpoolReadBytes1sec': 'Counter64',
+    'zpoolWriteBytes1sec': 'Counter64',
+}
+
+# zvol table columns: 1.3.6.1.4.1.50536.1.2
+ZVOL_COLUMNS = {
+    'zvolIndex': 'INTEGER',
+    'zvolDescr': 'STRING',
+    'zvolUsedBytes': 'Counter64',
+    'zvolAvailableBytes': 'Counter64',
+    'zvolReferencedBytes': 'Counter64',
+}
+
+# ARC OIDs that must be nonzero on any running system
+ARC_NONZERO = {'zfsArcSize', 'zfsArcC'}
+
+
+@pytest.fixture(scope='module')
+def snmpd_running():
+    call('service.control', 'START', 'snmp', job=True)
+    time.sleep(3)
+    yield
+
+
+@pytest.fixture(scope='module')
+def local_mib(tmp_path_factory):
+    """Fetch the TRUENAS-MIB from the remote host and write it to a local tempfile."""
+    content = ssh(f'cat {REMOTE_MIB_PATH}')
+    assert content, 'Failed to fetch TRUENAS-MIB from remote host'
+    path = tmp_path_factory.mktemp('mibs') / 'TRUENAS-MIB.txt'
+    path.write_text(content)
+    return str(path)
+
+
+def snmpwalk_raw(mib_path, oid):
+    """Walk an OID subtree from the test runner, return raw stdout."""
+    result = subprocess.run(
+        f'snmpwalk -v2c -c public -m {mib_path} {host().ip} {oid}',
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def parse_scalars(stdout):
+    """Parse snmpwalk output into {name: (type, value)} for scalar OIDs."""
+    parsed = {}
+    for line in stdout.splitlines():
+        # TRUENAS-MIB::zfsArcSize.0 = Gauge32: 12345
+        m = re.match(r'TRUENAS-MIB::(\w+)\.\d+\s+=\s+(\w+):\s+(.*)', line)
+        if m:
+            parsed[m.group(1)] = (m.group(2), m.group(3).strip(' "'))
+    return parsed
+
+
+def parse_table_rows(stdout):
+    """Parse snmpwalk table output into {row_index: {column_name: (type, value)}}."""
+    rows = {}
+    for line in stdout.splitlines():
+        # TRUENAS-MIB::zpoolName.1 = STRING: "boot-pool"
+        m = re.match(r'TRUENAS-MIB::(\w+)\.(\d+)\s+=\s+(\w+):\s+(.*)', line)
+        if m:
+            col_name, row_idx, snmp_type, value = m.group(1), m.group(2), m.group(3), m.group(4)
+            rows.setdefault(row_idx, {})[col_name] = (snmp_type, value.strip(' "'))
+    return rows
+
+
+def assert_scalar_shape(stats, expected_oids):
+    for name, expected_type in expected_oids.items():
+        assert name in stats, f'{name} missing from subtree walk'
+        actual_type, _ = stats[name]
+        assert actual_type == expected_type, (
+            f'{name}: expected type {expected_type}, got {actual_type}'
+        )
+
+
+def assert_table_row_shape(row, expected_columns, row_idx):
+    for col_name, expected_type in expected_columns.items():
+        assert col_name in row, f'{col_name} missing from table row {row_idx}'
+        actual_type, _ = row[col_name]
+        assert actual_type == expected_type, (
+            f'{col_name} row {row_idx}: expected type {expected_type}, got {actual_type}'
+        )
+
+
+def test_arc_oid_shape(snmpd_running, local_mib):
+    """All ARC OIDs are present with correct SNMP types."""
+    stats = parse_scalars(snmpwalk_raw(local_mib, '1.3.6.1.4.1.50536.1.3'))
+    assert_scalar_shape(stats, ARC_OIDS)
+
+    for name in ARC_NONZERO:
+        _, value = stats[name]
+        assert int(value) > 0, f'{name} should be nonzero on a running system'
+
+
+def test_l2arc_oid_shape(snmpd_running, local_mib):
+    """All L2ARC OIDs are present with correct SNMP types."""
+    stats = parse_scalars(snmpwalk_raw(local_mib, '1.3.6.1.4.1.50536.1.4'))
+    assert_scalar_shape(stats, L2ARC_OIDS)
+
+
+def test_zil_oid_shape(snmpd_running, local_mib):
+    """All ZIL OIDs are present with correct SNMP types."""
+    stats = parse_scalars(snmpwalk_raw(local_mib, '1.3.6.1.4.1.50536.1.5'))
+    assert_scalar_shape(stats, ZIL_OIDS)
+
+
+def test_zpool_table_shape(snmpd_running, local_mib):
+    """zpool table has at least one row (boot-pool) with all expected columns and types."""
+    rows = parse_table_rows(snmpwalk_raw(local_mib, '1.3.6.1.4.1.50536.1.1'))
+    assert rows, 'zpool table is empty — expected at least boot-pool'
+
+    for row_idx, row in rows.items():
+        assert_table_row_shape(row, ZPOOL_COLUMNS, row_idx)
+
+    # boot-pool should always be present
+    pool_names = {row['zpoolName'][1] for row in rows.values() if 'zpoolName' in row}
+    assert 'boot-pool' in pool_names


### PR DESCRIPTION
This comit replaces various custom parsers for zil and arcstat kstats with the standardized objects from truenas_pylibzfs.kstat.

The snmp-agent python script is also updated to not rely on the legacy py-libzfs module.

Original PR: https://github.com/truenas/middleware/pull/18717
