### PR TITLE
NAS-140662 / 27.0.0-BETA.1 / Remove py-libzfs from integration test

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/mock_binary.py
+++ b/src/middlewared/middlewared/test/integration/utils/mock_binary.py
@@ -35,10 +35,13 @@ class BinaryMock:
 
 
 def set_usr_readonly(value, ip=None):
-    cmd = 'python3 -c "import libzfs;'
-    cmd += r'hdl = libzfs.ZFS().get_dataset_by_path(\"/usr\");'
-    cmd += r'hdl.update_properties({\"readonly\": {\"value\": '
-    cmd += f'\\"{value}\\"' + '}});"'
+    cmd = 'python3 -c "'
+    cmd += 'from truenas_os_pyutils.mount import statmount;'
+    cmd += 'import truenas_pylibzfs;'
+    cmd += r'ds_name = statmount(path=\"/usr\", as_dict=False).sb_source;'
+    cmd += r'hdl = truenas_pylibzfs.open_handle();'
+    cmd += r'hdl.open_resource(name=ds_name).set_properties(properties={truenas_pylibzfs.ZFSProperty.READONLY: '
+    cmd += f'\\"{value}\\"' + '});"'
     ssh(cmd, ip=ip)
 
 


### PR DESCRIPTION
This commit removes the legacy libzfs module from some of our testing framework.