### PR TITLE
NAS-140663 / 26.0.0-BETA.2 / avahi: forcibly disable wide-area lookups (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -41,7 +41,7 @@ allow-interfaces=${", ".join([x["name"] for x in allow_interfaces])}
 disallow-other-stacks=yes
 
 [wide-area]
-enable-wide-area=yes
+enable-wide-area=no
 
 [publish]
 publish-hinfo=no


### PR DESCRIPTION
This commit alters the default configuration for avahi so that wide-area lookups are forcibly disabled. This only impacts avahi-browse behavior, which is not used on truenas for any purposes, but has historically been a security concern in the avahi codebase.

Original PR: https://github.com/truenas/middleware/pull/18735
