### PR TITLE
NAS-140671 / 26.0.0-BETA.2 / `sgdisk_explicit_alignment` improvements (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -29,6 +29,9 @@ def sgdisk_explicit_alignment(
     if disk_size_bytes % sector_size_bytes != 0:
         return None  # disk_size_bytes must be divisible by sector_size_bytes
 
+    if sector_size_bytes % 512 != 0:
+        return None  # sector_size_bytes must be divisible by 512
+
     if requested_partition_size % sector_size_bytes != 0:
         return None  # requested_partition_size must be divisible by sector_size_bytes
 
@@ -36,14 +39,17 @@ def sgdisk_explicit_alignment(
     requested_partition_sectors = requested_partition_size // sector_size_bytes
 
     # GPT partition-entry array size in sectors
+    mbr_size_bytes = 512
+    gpt_header_size_bytes = 512
     num_partition_entries = 128
     partition_entry_size_bytes = 128
     entry_array_bytes = num_partition_entries * partition_entry_size_bytes
-    entry_array_sectors = math.ceil(entry_array_bytes / sector_size_bytes)
+    gpt_size_bytes = mbr_size_bytes + gpt_header_size_bytes + entry_array_bytes
+    gpt_size_sectors = math.ceil(gpt_size_bytes / sector_size_bytes)
 
     # Standard GPT usable range
-    first_usable_sector = 2 + entry_array_sectors
-    last_usable_sector = total_sectors - entry_array_sectors - 2
+    first_usable_sector = gpt_size_sectors
+    last_usable_sector = total_sectors - gpt_size_sectors - 1
 
     latest_start_sector = last_usable_sector - requested_partition_sectors + 1
     if latest_start_sector < first_usable_sector:
@@ -63,7 +69,7 @@ def sgdisk_explicit_alignment(
     if best_alignment == default_alignment:
         return None
 
-    return best_alignment
+    return best_alignment * (sector_size_bytes // 512)
 
 
 class DiskService(Service):

--- a/src/middlewared/middlewared/pytest/unit/plugins/disk/test_format.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/disk/test_format.py
@@ -6,12 +6,14 @@ from middlewared.plugins.disk_.format import sgdisk_explicit_alignment
 @pytest.mark.parametrize("disk_size_bytes,sector_size_bytes,requested_partition_size,result", [
     # Legacy TrueNAS creates partitions that do not have any margins
     (6001175126016, 512, 6001175040000, 128),
-    # Replacing such a disk with a 4k-aligned disk requires smaller alignment
-    (6001175126016, 4096, 6001175040000, 16),
+    # 4k-aligned disk needs same alignment (as `-a` is expressed in 512 bytes logical sectors)
+    (6001175126016, 4096, 6001175040000, 128),
     # However, if we request a smaller partition, it would fit with default 1MB alignment perfectly
     (6001175126016, 4096, 6001174056960, None),
     # 1MB alignment is enough
     (6001175126016, 4096, 600117403648, None),
+    # Minimal alignment possible for a 4k disk
+    (1600321314816, 4096, 1600321273856, 8),
 ])
 def test_sgdisk_explicit_alignment(disk_size_bytes, sector_size_bytes, requested_partition_size, result):
     assert sgdisk_explicit_alignment(disk_size_bytes, sector_size_bytes, requested_partition_size) == result


### PR DESCRIPTION
* Initial GPT header calculation size was imprecise, resulting in overestimating the GPT size and giving less disk space for data
* Result should be multiplied by 8 for 4k disks as `sgdisk -a` accepts multiples of 2. This might have resulted in 4k disks having non-optimal alignment

Original PR: https://github.com/truenas/middleware/pull/18738
