### PR TITLE
NAS-140632 / 26.0.0-BETA.2 / Add LIO as an alternative iSCSI/FC target stack (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v26_0_0/iscsi_global.py
@@ -36,7 +36,7 @@ class ISCSIGlobalEntry(BaseModel):
     systems and requires the system and network environment have Remote Direct Memory Access (RDMA)-capable hardware."""
     direct_config: bool | None
     """Whether configuration is written into the kernel directly by middlewared."""
-    mode: int = Field(ge=0, le=1)
+    mode: int = Field(ge=0, le=2)
     """Internal iSCSI operational mode."""
 
 

--- a/src/middlewared/middlewared/etc_files/lio.py
+++ b/src/middlewared/middlewared/etc_files/lio.py
@@ -1,0 +1,5 @@
+from middlewared.utils.lio.config import write_lio_config
+
+
+def render(service, middleware, render_ctx):
+    write_lio_config(render_ctx)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -410,6 +410,26 @@ class EtcService(Service):
                          checkpoint=Checkpoint.POOL_IMPORT, mode=0o744),
             ),
         ),
+        'lio': EtcGroup(
+            ctx=(
+                CtxMethod(method='failover.licensed'),
+                CtxMethod(method='failover.node'),
+                CtxMethod(method='failover.status'),
+                CtxMethod(method='fc.capable'),
+                CtxMethod(method='fcport.query'),
+                CtxMethod(method='iscsi.auth.query'),
+                CtxMethod(method='iscsi.extent.query', args=[[['enabled', '=', True]]]),
+                CtxMethod(method='iscsi.global.config'),
+                CtxMethod(method='iscsi.initiator.query'),
+                CtxMethod(method='iscsi.portal.query'),
+                CtxMethod(method='iscsi.target.query'),
+                CtxMethod(method='iscsi.targetextent.query'),
+            ),
+            entries=(
+                EtcEntry(renderer_type=RendererType.PY, path='lio',
+                         checkpoint=Checkpoint.POOL_IMPORT),
+            ),
+        ),
         'scst_direct': EtcGroup(entries=(
             EtcEntry(renderer_type=RendererType.MAKO, path='scst.direct',
                      checkpoint=Checkpoint.POOL_IMPORT, mode=0o600),

--- a/src/middlewared/middlewared/plugins/fc/fc.py
+++ b/src/middlewared/middlewared/plugins/fc/fc.py
@@ -66,7 +66,8 @@ class FCService(Service):
     def fc_hosts(self, filters, options):
         result = []
         if self.middleware.call_sync('fc.capable'):
-            self.__load_kernel_module()
+            if not self.middleware.call_sync('iscsi.global.lio_enabled'):
+                self.__load_kernel_module()
             slots = self.middleware.call_sync('fc.slot_info')
             with os.scandir('/sys/class/fc_host') as scan:
                 for i in filter(lambda x: x.is_symlink() and x.name.startswith('host'), scan):
@@ -151,7 +152,8 @@ class FCService(Service):
         Load the Fibre Channel HBA kernel module.
         """
         if await self.middleware.call('fc.capable'):
-            await self.middleware.run_in_thread(self.__load_kernel_module)
+            if not await self.middleware.call('iscsi.global.lio_enabled'):
+                await self.middleware.run_in_thread(self.__load_kernel_module)
 
     @private
     @cache

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -59,6 +59,8 @@ class iSCSITargetAluaService(Service):
         self._standby_write_empty_config = None
 
     async def before_start(self):
+        if await self.middleware.call('iscsi.global.lio_enabled'):
+            return
         self.standby_skip_cluster_mode = True
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('failover.status') == 'BACKUP':
@@ -66,14 +68,20 @@ class iSCSITargetAluaService(Service):
                 await self.middleware.call('etc.generate', 'scst')
 
     async def after_start(self):
+        if await self.middleware.call('iscsi.global.lio_enabled'):
+            return
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('failover.status') == 'BACKUP':
                 await self.middleware.call('iscsi.alua.standby_after_start')
 
     async def before_stop(self):
+        if await self.middleware.call('iscsi.global.lio_enabled'):
+            return
         self.standby_starting = False
 
     async def after_stop(self):
+        if await self.middleware.call('iscsi.global.lio_enabled'):
+            return
         self.standby_skip_cluster_mode = True
         if await self.middleware.call('failover.status') == 'BACKUP':
             # Good hygiene

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -1,88 +1,28 @@
-import glob
-import os
-from contextlib import suppress
-
 from middlewared.api.current import ISCSIGlobalSessionsItem
+from middlewared.plugins.fc.utils import wwn_as_colon_hex
 from middlewared.service import private, Service, filterable_api_method
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils import run
 from middlewared.utils.filter_list import filter_list
 
 
 class ISCSIGlobalService(Service):
-
     class Config:
         namespace = 'iscsi.global'
 
-    @filterable_api_method(item=ISCSIGlobalSessionsItem, roles=['SHARING_ISCSI_GLOBAL_READ'])
+    @filterable_api_method(
+        item=ISCSIGlobalSessionsItem, roles=['SHARING_ISCSI_GLOBAL_READ']
+    )
     def sessions(self, filters, options):
         """
         Get a list of currently running iSCSI sessions. This includes initiator and target names
         and the unique connection IDs.
         """
-        sessions = []
         global_info = self.middleware.call_sync('iscsi.global.config')
-        base_path = '/sys/kernel/scst_tgt/targets/iscsi'
-        for target_dir in glob.glob(f'{base_path}/{global_info["basename"]}*'):
-            target = target_dir.rsplit('/', 1)[-1]
-            if target.startswith(f'{global_info["basename"]}:HA:'):
-                continue
-            for session in os.listdir(os.path.join(target_dir, 'sessions')):
-                session_dir = os.path.join(target_dir, 'sessions', session)
-                ip_file = glob.glob(f'{session_dir}/*/ip')
-                if not ip_file:
-                    continue
-
-                # Initiator alias is another name sent by initiator but we are unable to retrieve it in scst
-                session_dict = {
-                    'initiator': session.rsplit('#', 1)[0],
-                    'initiator_alias': None,
-                    'target': target,
-                    'target_alias': target.rsplit(':', 1)[-1],
-                    'header_digest': None,
-                    'data_digest': None,
-                    'max_data_segment_length': None,
-                    'max_receive_data_segment_length': None,
-                    'max_xmit_data_segment_length': None,
-                    'max_burst_length': None,
-                    'first_burst_length': None,
-                    'immediate_data': False,
-                    'iser': False,
-                    'offload': False,  # It is a chelsio NIC driver to offload iscsi, we are not using it so far
-                }
-                with open(ip_file[0], 'r') as f:
-                    session_dict['initiator_addr'] = f.read().strip()
-                transport = os.path.join(os.path.dirname(ip_file[0]), 'transport')
-                with suppress(FileNotFoundError):
-                    with open(transport, 'r') as f:
-                        session_dict['iser'] = 'iSER' == f.read().strip()
-                for k, f, op in (
-                    ('header_digest', 'HeaderDigest', None),
-                    ('data_digest', 'DataDigest', None),
-                    ('max_burst_length', 'MaxBurstLength', lambda i: int(i)),
-                    ('max_receive_data_segment_length', 'MaxRecvDataSegmentLength', lambda i: int(i)),
-                    ('max_xmit_data_segment_length', 'MaxXmitDataSegmentLength', lambda i: int(i)),
-                    ('first_burst_length', 'FirstBurstLength', lambda i: int(i)),
-                    ('immediate_data', 'ImmediateData', lambda i: True if i == 'Yes' else False),
-                ):
-                    f_path = os.path.join(session_dir, f)
-                    if os.path.exists(f_path):
-                        with open(f_path, 'r') as fd:
-                            data = fd.read().strip()
-                            if data != 'None':
-                                if op:
-                                    data = op(data)
-                                session_dict[k] = data
-
-                # We get recv/emit data segment length, keeping consistent with freebsd, we can
-                # take the maximum of two and show it for max_data_segment_length
-                if session_dict['max_xmit_data_segment_length'] and session_dict['max_receive_data_segment_length']:
-                    session_dict['max_data_segment_length'] = max(
-                        session_dict['max_receive_data_segment_length'], session_dict['max_xmit_data_segment_length']
-                    )
-
-                sessions.append(session_dict)
-        return filter_list(sessions, filters, options)
+        if self.middleware.call_sync('iscsi.global.lio_enabled'):
+            raw = self.middleware.call_sync('iscsi.lio.sessions', global_info)
+        else:
+            raw = self.middleware.call_sync('iscsi.scst.sessions', global_info)
+        return filter_list(raw, filters, options)
 
     @private
     def resync_readonly_property_for_zvol(self, id_, read_only_value):
@@ -90,11 +30,13 @@ class ISCSIGlobalService(Service):
             extent = self.middleware.call_sync(
                 'iscsi.extent.query',
                 [['enabled', '=', True], ['path', '=', f'zvol/{id_}']],
-                {'get': True}
+                {'get': True},
             )
             ro = True if read_only_value.lower() == 'on' else False
             if extent['ro'] != ro:
-                self.middleware.call_sync('iscsi.extent.update', extent['id'], {'ro': ro})
+                self.middleware.call_sync(
+                    'iscsi.extent.update', extent['id'], {'ro': ro}
+                )
         except MatchNotFound:
             return
 
@@ -104,18 +46,19 @@ class ISCSIGlobalService(Service):
             return
 
         extent = self.middleware.call_sync(
-            'iscsi.extent.query', [['enabled', '=', True], ['path', '=', f'zvol/{id_}']],
-            {'select': ['name', 'enabled', 'path']}
+            'iscsi.extent.query',
+            [['enabled', '=', True], ['path', '=', f'zvol/{id_}']],
+            {'select': ['name', 'enabled', 'path']},
         )
         if not extent:
             return
 
+        name = extent[0]['name']
         try:
-            # CORE ctl device names are incompatible with SCALE SCST
-            # so (similarly to scst.mako.conf) replace period with underscore, slash with dash
-            extent_name = extent[0]["name"].replace('.', '_').replace('/', '-')
-            with open(f'/sys/kernel/scst_tgt/devices/{extent_name}/resync_size', 'w') as f:
-                f.write('1')
+            if self.middleware.call_sync('iscsi.global.lio_enabled'):
+                self.middleware.call_sync('iscsi.lio.resync_lun_size_for_zvol', name)
+            else:
+                self.middleware.call_sync('iscsi.scst.resync_lun_size_for_zvol', name)
         except Exception as e:
             if isinstance(e, OSError) and e.errno == 124:
                 # 124 == Wrong medium type
@@ -125,7 +68,9 @@ class ISCSIGlobalService(Service):
                 # SCST sees the zvol size change and so does the initiator so it's safe to ignore.
                 pass
             else:
-                self.logger.warning('Failed to resync lun size for %r', extent[0]['name'], exc_info=True)
+                self.logger.warning(
+                    'Failed to resync lun size for %r', name, exc_info=True
+                )
 
     @private
     def resync_lun_size_for_file(self, path):
@@ -133,17 +78,19 @@ class ISCSIGlobalService(Service):
             return
 
         extent = self.middleware.call_sync(
-            'iscsi.extent.query', [
-                ['enabled', '=', True], ['type', '=', 'FILE'], ['path', '=', path]
-            ], {'select': ['enabled', 'type', 'path', 'name']}
+            'iscsi.extent.query',
+            [['enabled', '=', True], ['type', '=', 'FILE'], ['path', '=', path]],
+            {'select': ['enabled', 'type', 'path', 'name']},
         )
         if not extent:
             return
 
+        name = extent[0]['name']
         try:
-            extent_name = extent[0]["name"].replace('.', '_')
-            with open(f'/sys/kernel/scst_tgt/devices/{extent_name}/resync_size', 'w') as f:
-                f.write('1')
+            if self.middleware.call_sync('iscsi.global.lio_enabled'):
+                self.middleware.call_sync('iscsi.lio.resync_lun_size_for_file', name)
+            else:
+                self.middleware.call_sync('iscsi.scst.resync_lun_size_for_file', name)
         except Exception as e:
             if isinstance(e, OSError) and e.errno == 124:
                 # 124 == Wrong medium type
@@ -153,7 +100,9 @@ class ISCSIGlobalService(Service):
                 # SCST sees the zvol size change and so does the initiator so it's safe to ignore.
                 pass
             else:
-                self.logger.warning('Failed to resync lun size for %r', extent[0]['name'], exc_info=True)
+                self.logger.warning(
+                    'Failed to resync lun size for %r', name, exc_info=True
+                )
 
     @private
     async def terminate_luns_for_pool(self, pool_name):
@@ -163,23 +112,62 @@ class ISCSIGlobalService(Service):
         g_config = await self.middleware.call('iscsi.global.config')
         targets = {t['id']: t for t in await self.middleware.call('iscsi.target.query')}
         extents = {
-            t['id']: t for t in await self.middleware.call(
-                'iscsi.extent.query', [['enabled', '=', True]], {'select': ['enabled', 'path', 'id']}
+            t['id']: t
+            for t in await self.middleware.call(
+                'iscsi.extent.query',
+                [['enabled', '=', True]],
+                {'select': ['enabled', 'path', 'id']},
             )
         }
+        lio = await self.middleware.call('iscsi.global.lio_enabled')
+        alua = await self.middleware.call('iscsi.global.alua_enabled')
+
+        node = await self.middleware.call('failover.node')
+        fcports_by_target = {}
+        for fp in await self.middleware.call('fcport.query'):
+            tid = fp['target']['id']
+            wwpn_str = fp['wwpn_b'] if node == 'B' else fp['wwpn']
+            fcports_by_target.setdefault(tid, [])
+            fcports_by_target[tid].append(wwn_as_colon_hex(wwpn_str))
 
         for associated_target in filter(
-            lambda a: a['extent'] in extents and extents[a['extent']]['path'].startswith(f'zvol/{pool_name}/'),
-            await self.middleware.call('iscsi.targetextent.query')
+            lambda a: (
+                a['extent'] in extents
+                and extents[a['extent']]['path'].startswith(f'zvol/{pool_name}/')
+            ),
+            await self.middleware.call('iscsi.targetextent.query'),
         ):
-            self.middleware.logger.debug('Terminating associated target %r', associated_target['id'])
-            cp = await run([
-                'scstadmin', '-noprompt', '-rem_lun', str(associated_target['lunid']), '-driver',
-                'iscsi', '-target', f'{g_config["basename"]}:{targets[associated_target["target"]]["name"]}',
-                '-group', 'security_group'
-            ], check=False)
+            target = targets[associated_target['target']]
+            lun_id = associated_target['lunid']
+            mode = target['mode']
+            self.middleware.logger.debug(
+                'Terminating associated target %r', associated_target['id']
+            )
 
-            if cp.returncode:
-                self.middleware.logger.error(
-                    'Failed to remove associated target %r : %s', associated_target['id'], cp.stderr.decode()
+            if mode in ('ISCSI', 'BOTH'):
+                iqn = f'{g_config["basename"]}:{target["name"]}'
+                if lio:
+                    await self.middleware.call(
+                        'iscsi.lio.remove_target_lun', iqn, lun_id
+                    )
+                else:
+                    await self.middleware.call(
+                        'iscsi.scst.remove_target_lun', iqn, lun_id
+                    )
+
+            if mode in ('FC', 'BOTH'):
+                for wwpn in fcports_by_target.get(target['id'], []):
+                    if lio:
+                        await self.middleware.call(
+                            'iscsi.lio.remove_target_lun', wwpn, lun_id
+                        )
+                    else:
+                        await self.middleware.call(
+                            'iscsi.scst.remove_target_lun', wwpn, lun_id
+                        )
+
+            if not lio and alua:
+                ha_iqn = f'{g_config["basename"]}:HA:{target["name"]}'
+                await self.middleware.call(
+                    'iscsi.scst.remove_target_lun', ha_iqn, lun_id
                 )

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -113,10 +113,27 @@ class ISCSIGlobalService(SystemServiceService):
         return data
 
     @private
-    def _validate_mode(self, schema_name, mode, old_mode, verrors):
-        # Placeholder for future mode-specific validation
+    async def _validate_mode(self, schema_name, mode, old, verrors):
+        old_mode = old['mode']
+
+        # Basic sanity: reject unknown mode values before any further checks.
         if mode not in ISCSIMODE:
             verrors.add(schema_name, f'Invalid mode ({mode})')
+            return
+
+        # Switching from SCST to LIO requires additional compatibility checks
+        # because the two stacks have different capability constraints.  Run
+        # these before the service check so the user sees all issues at once
+        # and can reconfigure while the service is still running.
+        if mode >= ISCSIMODE.LIO and old_mode < ISCSIMODE.LIO:
+            verrors.extend(
+                await self.middleware.call('iscsi.lio.validate_scst_compat', schema_name)
+            )
+
+        # Mode switches require the service to be stopped so the old stack can
+        # be torn down cleanly before the new one is brought up.
+        if await self.middleware.call('service.started', 'iscsitarget'):
+            verrors.add(schema_name, 'Cannot switch iSCSI mode while the service is running.')
 
     @api_method(
         ISCSIGlobalUpdateArgs,
@@ -136,7 +153,7 @@ class ISCSIGlobalService(SystemServiceService):
 
         if (mode := data.get('mode')) is not None:
             if mode != old['mode']:
-                self._validate_mode('iscsiglobal_update.mode', mode, old['mode'], verrors)
+                await self._validate_mode('iscsiglobal_update.mode', mode, old, verrors)
 
         servers = data.get('isns_servers') or []
         server_addresses = []
@@ -288,6 +305,11 @@ class ISCSIGlobalService(SystemServiceService):
         if direct_config is None:
             return DEFAULT_DIRECT_CONFIG
         return direct_config
+
+    @private
+    async def lio_enabled(self):
+        """Returns True when the iSCSI target stack is set to LIO."""
+        return (await self.config()).get('mode') == ISCSIMODE.LIO
 
     @private
     async def using_dlm(self):

--- a/src/middlewared/middlewared/plugins/iscsi_/iser.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iser.py
@@ -9,11 +9,15 @@ class iSCSITargetISERService(Service):
     """
     Support iSER configuration.
     """
+
     class Config:
         private = True
         namespace = 'iscsi.iser'
 
     async def before_start(self):
+        if await self.middleware.call('iscsi.global.lio_enabled'):
+            # ib_isert is loaded by utils/lio/config.py _load_modules() if needed
+            return
         if await self.middleware.call('iscsi.global.iser_enabled'):
             await self.middleware.run_in_thread(self._load_kernel_module)
 

--- a/src/middlewared/middlewared/plugins/iscsi_/lio.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/lio.py
@@ -1,0 +1,369 @@
+import pathlib
+
+from middlewared.service import private, Service, ValidationErrors
+from middlewared.utils.lio.config import (
+    FC_DIR,
+    FILEIO_DIR,
+    IBLOCK_DIR,
+    ISCSI_DIR,
+    sanitize_lio_extent,
+)
+
+
+def _tpg_params(tpg_dir: pathlib.Path) -> dict:
+    """Read session parameters from tpgt_N/param/.
+
+    LIO does not expose per-session negotiated parameters via configfs.
+    The TPG-level param/ values are the configured maxima; for most sessions
+    they equal the negotiated values (initiators rarely negotiate lower).
+    MaxXmitDataSegmentLength has no LIO equivalent and is left absent so the
+    caller keeps its default of None.
+    """
+    result = {}
+    param_dir = tpg_dir / 'param'
+    if not param_dir.exists():
+        return result
+    for fname, key, conv in (
+        ('MaxBurstLength', 'max_burst_length', int),
+        ('MaxRecvDataSegmentLength', 'max_receive_data_segment_length', int),
+        ('FirstBurstLength', 'first_burst_length', int),
+        ('ImmediateData', 'immediate_data', lambda v: v == 'Yes'),
+    ):
+        try:
+            result[key] = conv((param_dir / fname).read_text().strip())
+        except (OSError, ValueError):
+            pass
+    if 'max_receive_data_segment_length' in result:
+        result['max_data_segment_length'] = result['max_receive_data_segment_length']
+    return result
+
+
+class iSCSILIOService(Service):
+    class Config:
+        namespace = 'iscsi.lio'
+        private = True
+
+    @private
+    async def validate_scst_compat(self, schema_name):
+        """Check that the current configuration is compatible with LIO.
+
+        Called when switching from any SCST mode to LIO.  Returns a
+        ValidationErrors object; the caller extends its own error collection
+        with the result.
+        """
+        verrors = ValidationErrors()
+
+        # LIO exposes exactly one global discovery-auth slot (userid /
+        # password / userid_mutual / password_mutual).  SCST allows multiple
+        # iscsi.auth entries to carry discovery_auth credentials, each with a
+        # distinct tag.  If more than one exists the reconciler would silently
+        # use only the first and drop the rest, causing any initiator that
+        # relies on a non-first credential to be rejected without explanation.
+        disc_auths = await self.middleware.call(
+            'iscsi.auth.query', [['discovery_auth', '!=', 'NONE']]
+        )
+        if len(disc_auths) > 1:
+            tags = ', '.join(str(a['tag']) for a in disc_auths)
+            verrors.add(
+                schema_name,
+                f'LIO supports only one discovery authentication credential. '
+                f'{len(disc_auths)} entries have discovery_auth configured '
+                f'(tags: {tags}). Remove all but one before switching to LIO mode.',
+            )
+
+        # In LIO, CHAP credentials are stored per-initiator ACL entry
+        # (acls/<iqn>/auth/userid + auth/password).  This requires static
+        # ACLs, meaning the initiator group must list at least one specific
+        # IQN.  SCST stores IncomingUser at the target level and matches any
+        # initiator that presents the right credential, so wildcard initiator
+        # groups work there.  Flag any CHAP/Mutual-CHAP target group whose
+        # initiator group is open (no IQNs) or absent -- those targets cannot
+        # authenticate initiators after the switch.
+        initiator_groups = {
+            ig['id']: ig['initiators']
+            for ig in await self.middleware.call('iscsi.initiator.query')
+        }
+        targets = await self.middleware.call(
+            'iscsi.target.query', [], {'select': ['name', 'groups', 'auth_networks']}
+        )
+        chap_open = []
+        for t in targets:
+            for g in t.get('groups', []):
+                if g.get('authmethod') not in ('CHAP', 'CHAP_MUTUAL'):
+                    continue
+                ig_id = g.get('initiator')
+                # No initiator group, or group is open (empty initiators list).
+                if not ig_id or not initiator_groups.get(ig_id):
+                    chap_open.append(t['name'])
+                    break  # one error per target is enough
+        if chap_open:
+            names = ', '.join(chap_open)
+            verrors.add(
+                schema_name,
+                f'LIO requires static initiator ACLs (specific IQNs) for CHAP '
+                f'authentication. The following targets have CHAP configured with '
+                f'an open or absent initiator group and cannot authenticate '
+                f'initiators under LIO: {names}. Assign a named initiator group '
+                f'with at least one IQN to each of these targets before switching.',
+            )
+
+        # In LIO each ACL entry receives credentials from whichever auth entry
+        # the reconciler finds first for the referenced tag.  SCST supports
+        # multiple iscsi.auth entries sharing the same tag and emits one
+        # IncomingUser line per entry, so any of those credentials is accepted.
+        # Under LIO, all but the first-found entry for a tag are silently
+        # unusable -- initiators that authenticate with a non-first credential
+        # will be rejected.  Flag any CHAP target group whose auth tag maps to
+        # more than one credential entry.
+        auth_tag_counts = {}
+        for a in await self.middleware.call('iscsi.auth.query'):
+            if a.get('user') and a.get('secret'):
+                auth_tag_counts[a['tag']] = auth_tag_counts.get(a['tag'], 0) + 1
+
+        chap_multitag = []
+        for t in targets:
+            for g in t.get('groups', []):
+                if g.get('authmethod') not in ('CHAP', 'CHAP_MUTUAL'):
+                    continue
+                tag = g.get('auth')
+                if tag and auth_tag_counts.get(tag, 0) > 1:
+                    chap_multitag.append(f'{t["name"]} (tag {tag})')
+                    break  # one error per target is enough
+        if chap_multitag:
+            entries = ', '.join(chap_multitag)
+            verrors.add(
+                schema_name,
+                f'LIO supports only one CHAP credential per auth tag. The '
+                f'following targets reference an auth tag with multiple '
+                f'credentials: {entries}. Reduce each referenced tag to a '
+                f'single credential entry before switching to LIO mode.',
+            )
+
+        # LIO has no built-in iSNS client.  If iSNS servers are configured
+        # the targets will silently disappear from the iSNS namespace after
+        # the switch, breaking any initiator that relies on iSNS for discovery.
+        global_cfg = await self.middleware.call('iscsi.global.config')
+        if global_cfg.get('isns_servers'):
+            verrors.add(
+                schema_name,
+                'LIO does not support iSNS. iSNS servers are currently '
+                'configured; initiators that use iSNS for target discovery '
+                'will lose visibility of targets after switching to LIO mode. '
+                'Remove all iSNS server entries before switching.',
+            )
+
+        # auth_networks provides per-target source-IP access control in SCST.
+        # LIO has no equivalent configfs mechanism; enforcement would require
+        # generating firewall rules, which is out of scope for the reconciler.
+        # Flag targets that would lose this protection after the switch.
+        net_restricted = [t['name'] for t in targets if t.get('auth_networks')]
+        if net_restricted:
+            names = ', '.join(net_restricted)
+            verrors.add(
+                schema_name,
+                f'LIO does not enforce auth_networks (source-IP access '
+                f'control). The following targets have auth_networks '
+                f'configured and would become reachable from all IPs under '
+                f'LIO: {names}. Remove the auth_networks restrictions or '
+                f'implement equivalent filtering before switching.',
+            )
+
+        return verrors
+
+    @private
+    def sessions(self, global_info):
+        """Enumerate active iSCSI sessions from the LIO configfs tree.
+
+        Two session sources are consulted per TPG:
+
+        1. Static ACL sessions (generate_node_acls=0): appear as directories under
+           acls/<iqn>/ with an 'info' file that contains the connection IP.
+
+           The kernel iscsi_target_core info file format:
+               InitiatorName: iqn.xxx
+               InitiatorAlias: alias
+               LIO Session ID: N  SessionType: Normal
+               SessionState: TARG_SESS_STATE_LOGGED_IN
+               ConnectionState: TARG_CONN_STATE_LOGGED_IN CID: 0
+                 Address 1.2.3.4 TCP
+
+        2. Dynamic ACL sessions (generate_node_acls=1): the kernel only writes the
+           initiator IQN to tpgt_N/dynamic_sessions, one per line.  No IP is
+           available from this interface, so initiator_addr is returned as ''.
+
+        Per-session negotiated parameters (digests, burst lengths) are not exposed
+        via either configfs interface.  TPG-level param/ values are used instead;
+        for most sessions they equal the negotiated values (initiators rarely
+        negotiate lower).  Digest fields (not present in LIO param/) remain None.
+        """
+        sessions = []
+        iscsi_dir = pathlib.Path('/sys/kernel/config/target/iscsi')
+        if not iscsi_dir.exists():
+            return sessions
+
+        for target_dir in iscsi_dir.iterdir():
+            if not target_dir.is_dir():
+                continue
+            target = target_dir.name
+            for tpg_dir in target_dir.iterdir():
+                if not tpg_dir.is_dir() or not tpg_dir.name.startswith('tpgt_'):
+                    continue
+
+                # --- Static ACL sessions (have configfs dirs with 'info' file) ---
+                acls_dir = tpg_dir / 'acls'
+                if acls_dir.exists():
+                    for acl_dir in acls_dir.iterdir():
+                        if not acl_dir.is_dir():
+                            continue
+                        try:
+                            lines = (acl_dir / 'info').read_text().splitlines()
+                        except OSError:
+                            continue
+                        if not lines or lines[0].startswith('No active'):
+                            continue
+
+                        initiator_alias = None
+                        initiator_addr = None
+                        iser = False
+                        for line in lines:
+                            if line.startswith('InitiatorAlias:'):
+                                alias = line.split(':', 1)[1].strip()
+                                initiator_alias = alias or None
+                            elif 'Address' in line:
+                                # "  Address 1.2.3.4 TCP"
+                                parts = line.split()
+                                addr_idx = parts.index('Address')
+                                initiator_addr = parts[addr_idx + 1]
+                                transport = (
+                                    parts[addr_idx + 2]
+                                    if addr_idx + 2 < len(parts)
+                                    else 'TCP'
+                                )
+                                iser = transport == 'iSER'
+                                break  # first connection is sufficient
+
+                        if initiator_addr is None:
+                            continue  # session exists but no active connection yet
+
+                        sess = {
+                            'initiator': acl_dir.name,
+                            'initiator_alias': initiator_alias,
+                            'target': target,
+                            'target_alias': target.rsplit(':', 1)[-1],
+                            'initiator_addr': initiator_addr,
+                            'header_digest': None,
+                            'data_digest': None,
+                            'max_data_segment_length': None,
+                            'max_receive_data_segment_length': None,
+                            'max_xmit_data_segment_length': None,
+                            'max_burst_length': None,
+                            'first_burst_length': None,
+                            'immediate_data': False,
+                            'iser': iser,
+                            'offload': False,
+                        }
+                        sess.update(_tpg_params(tpg_dir))
+                        sessions.append(sess)
+
+                # --- Dynamic ACL sessions (IQN-only, no IP from kernel) ---
+                dyn_file = tpg_dir / 'dynamic_sessions'
+                if not dyn_file.exists():
+                    continue
+                try:
+                    content = dyn_file.read_text()
+                except OSError:
+                    continue
+                for line in content.splitlines():
+                    # Kernel page buffers may contain trailing \x00 bytes; strip() alone
+                    # does not remove null bytes, so strip them explicitly first.
+                    initiator = line.replace('\x00', '').strip()
+                    if not initiator:
+                        continue
+                    sess = {
+                        'initiator': initiator,
+                        'initiator_alias': None,
+                        'target': target,
+                        'target_alias': target.rsplit(':', 1)[-1],
+                        'initiator_addr': '',
+                        'header_digest': None,
+                        'data_digest': None,
+                        'max_data_segment_length': None,
+                        'max_receive_data_segment_length': None,
+                        'max_xmit_data_segment_length': None,
+                        'max_burst_length': None,
+                        'first_burst_length': None,
+                        'immediate_data': False,
+                        'iser': False,
+                        'offload': False,
+                    }
+                    sess.update(_tpg_params(tpg_dir))
+                    sessions.append(sess)
+        return sessions
+
+    @private
+    def remove_target_lun(self, target_name: str, lun_id: int):
+        if target_name.startswith('iqn.'):
+            # iSCSI targets can have multiple TPGs (one per portal group tag).
+            # All TPGs on a target share the same LUN set, so remove from each.
+            target_dir = ISCSI_DIR / target_name
+            if not target_dir.exists():
+                return
+            tpg_dirs = [
+                d
+                for d in target_dir.iterdir()
+                if d.is_dir() and d.name.startswith('tpgt_')
+            ]
+        else:
+            # FC targets always have exactly one TPG (tpgt_1).
+            tpg_dirs = [FC_DIR / target_name / 'tpgt_1']
+
+        so_path = None
+        for tpg_dir in tpg_dirs:
+            lun_dir = tpg_dir / 'lun' / f'lun_{lun_id}'
+            if not lun_dir.exists():
+                continue
+
+            # Remember the storage object path before we remove the LUN symlink.
+            if so_path is None:
+                for child in lun_dir.iterdir():
+                    if child.is_symlink():
+                        so_path = child.resolve()
+                        break
+
+            # Remove mapped LUN entries from all ACLs for this lun_id.
+            acls_dir = tpg_dir / 'acls'
+            if acls_dir.exists():
+                for acl_dir in acls_dir.iterdir():
+                    mapped = acl_dir / f'lun_{lun_id}'
+                    if mapped.is_dir():
+                        for child in mapped.iterdir():
+                            if child.is_symlink():
+                                child.unlink()
+                        try:
+                            mapped.rmdir()
+                        except OSError:
+                            pass
+
+            # Remove the TPG LUN directory.
+            for child in lun_dir.iterdir():
+                if child.is_symlink():
+                    child.unlink()
+            try:
+                lun_dir.rmdir()
+            except OSError:
+                pass
+
+        # Remove the storage object if it still exists.
+        if so_path and so_path.exists():
+            try:
+                so_path.rmdir()
+            except OSError:
+                pass
+
+    @private
+    def resync_lun_size_for_zvol(self, name):
+        (IBLOCK_DIR / sanitize_lio_extent(name) / 'control').write_text('rescan')
+
+    @private
+    def resync_lun_size_for_file(self, name):
+        (FILEIO_DIR / sanitize_lio_extent(name) / 'control').write_text('rescan')

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -1,10 +1,12 @@
 import asyncio
+import glob
 import itertools
 import os
 import pathlib
 import signal
+from contextlib import suppress
 
-from middlewared.service import Service
+from middlewared.service import private, Service
 from middlewared.utils import run
 from .utils import ISCSI_TARGET_PARAMETERS, sanitize_extent
 from scstadmin import SCSTAdmin
@@ -136,7 +138,9 @@ class iSCSITargetService(Service):
             pid = int(pathlib.Path(ISCSI_SCSTD_PIDFILE).read_text().strip())
             os.kill(pid, sig)
         except FileNotFoundError:
-            self.logger.warning('iscsi-scstd pidfile not found, daemon may not be running')
+            self.logger.warning(
+                'iscsi-scstd pidfile not found, daemon may not be running'
+            )
         except ProcessLookupError:
             self.logger.warning('iscsi-scstd process not found (stale pidfile?)')
         except ValueError:
@@ -187,6 +191,33 @@ class iSCSITargetService(Service):
         else:
             return False
 
+    @private
+    async def remove_target_lun(self, target_name: str, lun_id: int):
+        # TBD: consider switching to sysfs mgmt write (del {lun_id}) instead of scstadmin
+        driver = 'iscsi' if target_name.startswith('iqn.') else 'qla2x00t'
+        cp = await run(
+            [
+                'scstadmin',
+                '-noprompt',
+                '-rem_lun',
+                str(lun_id),
+                '-driver',
+                driver,
+                '-target',
+                target_name,
+                '-group',
+                'security_group',
+            ],
+            check=False,
+        )
+        if cp.returncode:
+            self.logger.error(
+                'Failed to remove LUN %d from target %r: %s',
+                lun_id,
+                target_name,
+                cp.stderr.decode(),
+            )
+
     def delete_iscsi_lun(self, iqn, lun):
         pathlib.Path(
             f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt'
@@ -208,7 +239,9 @@ class iSCSITargetService(Service):
             op = self._xfer_prstate(luns_path, extent, lun)
         else:
             op = 'replace'
-        pathlib.Path(luns_path, 'mgmt').write_text(f'{op} {sanitize_extent(extent)} {lun}\n')
+        pathlib.Path(luns_path, 'mgmt').write_text(
+            f'{op} {sanitize_extent(extent)} {lun}\n'
+        )
 
     def delete_fc_lun(self, wwpn, lun):
         pathlib.Path(f'{SCST_BASE}/targets/qla2x00t/{wwpn}/luns/mgmt').write_text(
@@ -221,7 +254,9 @@ class iSCSITargetService(Service):
             op = self._xfer_prstate(luns_path, extent, lun)
         else:
             op = 'replace'
-        pathlib.Path(luns_path, 'mgmt').write_text(f'{op} {sanitize_extent(extent)} {lun}\n')
+        pathlib.Path(luns_path, 'mgmt').write_text(
+            f'{op} {sanitize_extent(extent)} {lun}\n'
+        )
 
     def set_node_optimized(self, node):
         """Update which node is reported as being the active/optimized path."""
@@ -261,7 +296,11 @@ class iSCSITargetService(Service):
     def set_alua_transitioning(self):
         """Set the local controller's ALUA target group state to transitioning."""
         node = self.middleware.call_sync('failover.node')
-        path = SCST_CONTROLLER_A_TARGET_GROUPS_STATE if node == 'A' else SCST_CONTROLLER_B_TARGET_GROUPS_STATE
+        path = (
+            SCST_CONTROLLER_A_TARGET_GROUPS_STATE
+            if node == 'A'
+            else SCST_CONTROLLER_B_TARGET_GROUPS_STATE
+        )
         try:
             pathlib.Path(path).write_text('transitioning\n')
         except Exception:
@@ -270,7 +309,11 @@ class iSCSITargetService(Service):
     def set_alua_active(self):
         """Set the local controller's ALUA target group state to active."""
         node = self.middleware.call_sync('failover.node')
-        path = SCST_CONTROLLER_A_TARGET_GROUPS_STATE if node == 'A' else SCST_CONTROLLER_B_TARGET_GROUPS_STATE
+        path = (
+            SCST_CONTROLLER_A_TARGET_GROUPS_STATE
+            if node == 'A'
+            else SCST_CONTROLLER_B_TARGET_GROUPS_STATE
+        )
         try:
             pathlib.Path(path).write_text('active\n')
         except Exception:
@@ -327,3 +370,99 @@ class iSCSITargetService(Service):
             retries,
             cp.stdout.decode() or cp.stderr.decode(),
         )
+
+    @private
+    def resync_lun_size_for_zvol(self, name):
+        # CORE ctl device names are incompatible with SCALE SCST
+        # so (similarly to scst.mako.conf) replace period with underscore, slash with dash
+        extent_name = name.replace('.', '_').replace('/', '-')
+        with open(f'{SCST_DEVICES}/{extent_name}/resync_size', 'w') as f:
+            f.write('1')
+
+    @private
+    def resync_lun_size_for_file(self, name):
+        extent_name = name.replace('.', '_')
+        with open(f'{SCST_DEVICES}/{extent_name}/resync_size', 'w') as f:
+            f.write('1')
+
+    @private
+    def sessions(self, global_info):
+        """Enumerate active iSCSI sessions from the SCST sysfs tree."""
+        sessions = []
+        base_path = '/sys/kernel/scst_tgt/targets/iscsi'
+        for target_dir in glob.glob(f'{base_path}/{global_info["basename"]}*'):
+            target = target_dir.rsplit('/', 1)[-1]
+            if target.startswith(f'{global_info["basename"]}:HA:'):
+                continue
+            for session in os.listdir(os.path.join(target_dir, 'sessions')):
+                session_dir = os.path.join(target_dir, 'sessions', session)
+                ip_file = glob.glob(f'{session_dir}/*/ip')
+                if not ip_file:
+                    continue
+
+                # Initiator alias is another name sent by initiator but we are unable to retrieve it in scst
+                session_dict = {
+                    'initiator': session.rsplit('#', 1)[0],
+                    'initiator_alias': None,
+                    'target': target,
+                    'target_alias': target.rsplit(':', 1)[-1],
+                    'header_digest': None,
+                    'data_digest': None,
+                    'max_data_segment_length': None,
+                    'max_receive_data_segment_length': None,
+                    'max_xmit_data_segment_length': None,
+                    'max_burst_length': None,
+                    'first_burst_length': None,
+                    'immediate_data': False,
+                    'iser': False,
+                    'offload': False,  # It is a chelsio NIC driver to offload iscsi, we are not using it so far
+                }
+                with open(ip_file[0], 'r') as f:
+                    session_dict['initiator_addr'] = f.read().strip()
+                transport = os.path.join(os.path.dirname(ip_file[0]), 'transport')
+                with suppress(FileNotFoundError):
+                    with open(transport, 'r') as f:
+                        session_dict['iser'] = 'iSER' == f.read().strip()
+                for k, f, op in (
+                    ('header_digest', 'HeaderDigest', None),
+                    ('data_digest', 'DataDigest', None),
+                    ('max_burst_length', 'MaxBurstLength', lambda i: int(i)),
+                    (
+                        'max_receive_data_segment_length',
+                        'MaxRecvDataSegmentLength',
+                        lambda i: int(i),
+                    ),
+                    (
+                        'max_xmit_data_segment_length',
+                        'MaxXmitDataSegmentLength',
+                        lambda i: int(i),
+                    ),
+                    ('first_burst_length', 'FirstBurstLength', lambda i: int(i)),
+                    (
+                        'immediate_data',
+                        'ImmediateData',
+                        lambda i: True if i == 'Yes' else False,
+                    ),
+                ):
+                    f_path = os.path.join(session_dir, f)
+                    if os.path.exists(f_path):
+                        with open(f_path, 'r') as fd:
+                            data = fd.read().strip()
+                            if data != 'None':
+                                if op:
+                                    data = op(data)
+                                session_dict[k] = data
+
+                # We get recv/emit data segment length, keeping consistent with freebsd, we can
+                # take the maximum of two and show it for max_data_segment_length
+                if (
+                    session_dict['max_xmit_data_segment_length']
+                    and session_dict['max_receive_data_segment_length']
+                ):
+                    session_dict['max_data_segment_length'] = max(
+                        session_dict['max_receive_data_segment_length'],
+                        session_dict['max_xmit_data_segment_length'],
+                    )
+
+                sessions.append(session_dict)
+        return sessions

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -453,6 +453,9 @@ class iSCSITargetService(CRUDService):
         # We explicitly need to do this unfortunately as scst does not accept these changes with a reload
         # So this is the best way to do this without going through a restart of the service
         if await self.middleware.call('service.started', 'iscsitarget'):
+            if await self.middleware.call('iscsi.global.lio_enabled'):
+                # LIO: the reload (etc.generate 'lio') reconciler removes the target; nothing to do here.
+                return
             g_config = await self.middleware.call('iscsi.global.config')
             iqn = f'{g_config["basename"]}:{name}'
             # By the time we reach here the extent mapping has already been

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -1,11 +1,13 @@
 import asyncio
 
 from middlewared.utils import run
+from middlewared.utils.lio.config import ISCSI_DIR, teardown_lio_config
 
-from .base import SimpleService
+from .base import SwitchableSimpleService
+from .base_state import ServiceState
 
 
-class ISCSITargetService(SimpleService):
+class ISCSITargetService(SwitchableSimpleService):
     name = "iscsitarget"
     reloadable = True
     systemd_async_start = True
@@ -13,6 +15,22 @@ class ISCSITargetService(SimpleService):
     etc = ["scst", "scst_targets"]
 
     systemd_unit = "scst"
+
+    async def _lio_mode(self):
+        return await self.middleware.call('iscsi.global.lio_enabled')
+
+    async def select_systemd_unit_name(self):
+        if await self._lio_mode():
+            return None
+        return self.systemd_unit
+
+    async def get_state_no_unit(self):
+        return ServiceState(ISCSI_DIR.exists(), [])
+
+    async def select_etc(self):
+        if await self._lio_mode():
+            return ['lio']
+        return self.etc
 
     async def _wait_to_avoid_states(self, states, retries=10):
         initial_retries = retries
@@ -30,20 +48,34 @@ class ISCSITargetService(SimpleService):
 
     async def before_start(self):
         await self.middleware.call("iscsi.alua.before_start")
-        # Because we are a systemd_async_start service, it is possible that
-        # a start could be requested while a stop is still in progress.
-        if await self.middleware.call("failover.in_progress"):
-            await self._wait_to_avoid_states(['deactivating'], 5)
-        else:
-            await self._wait_to_avoid_states(['deactivating'])
+        if not await self._lio_mode():
+            # Because we are a systemd_async_start service, it is possible that
+            # a start could be requested while a stop is still in progress.
+            if await self.middleware.call("failover.in_progress"):
+                await self._wait_to_avoid_states(['deactivating'], 5)
+            else:
+                await self._wait_to_avoid_states(['deactivating'])
         await self.middleware.call("iscsi.iser.before_start")
 
     async def start(self):
+        if await self._lio_mode():
+            # In LIO mode there is no systemd unit to start (select_systemd_unit_name
+            # returns None) and config is written by etc.generate('lio') before this
+            # method is called.  Nothing further to do here.
+            return
         if await self.middleware.call("failover.status") not in ["MASTER", "SINGLE"]:
             if not await self.middleware.call("iscsi.global.alua_enabled"):
                 # Do not start SCST on STANDBY node unless ALUA is enabled.
                 return
         await super().start()
+
+    async def stop(self):
+        if await self._lio_mode():
+            # In LIO mode there is no systemd unit; tear down the configfs tree
+            # directly and return without invoking the SCST stop path.
+            await self.middleware.run_in_thread(teardown_lio_config)
+            return
+        await super().stop()
 
     async def after_start(self):
         await self.middleware.call("iscsi.alua.after_start")
@@ -55,6 +87,10 @@ class ISCSITargetService(SimpleService):
         await self.middleware.call("iscsi.alua.after_stop")
 
     async def reload(self):
+        if await self._lio_mode():
+            # In LIO mode reloads are handled by etc.generate('lio') which rewrites
+            # the configfs tree directly.  No scstadmin reload is needed.
+            return True
         if await self.middleware.call("iscsi.global.direct_config_enabled"):
             return await self.middleware.call("iscsi.scst.apply_config_file")
         else:
@@ -66,13 +102,14 @@ class ISCSITargetService(SimpleService):
         """If we are becoming the ACTIVE node on a HA system, and if SCST was already loaded
         then we can perform a shortcut operation to switch from being the STANDBY node to the
         ACTIVE one, *without* restarting SCST, but just by reconfiguring it."""
-        if await self.middleware.call('iscsi.global.alua_enabled'):
-            if await self.middleware.call('iscsi.scst.is_kernel_module_loaded'):
-                try:
-                    return await self.middleware.call("iscsi.alua.become_active")
-                except Exception:
-                    self.logger.warning('Failover exception', exc_info=True)
-                    # Fall through
+        if not await self._lio_mode():
+            if await self.middleware.call('iscsi.global.alua_enabled'):
+                if await self.middleware.call('iscsi.scst.is_kernel_module_loaded'):
+                    try:
+                        return await self.middleware.call("iscsi.alua.become_active")
+                    except Exception:
+                        self.logger.warning('Failover exception', exc_info=True)
+                        # Fall through
         # Fallback to doing a regular restart
         rjob = await self.middleware.call(
             'service.control',

--- a/src/middlewared/middlewared/utils/iscsi/constants.py
+++ b/src/middlewared/middlewared/utils/iscsi/constants.py
@@ -4,3 +4,18 @@ import enum
 class ISCSIMODE(enum.IntEnum):
     SCST_DLM_PRSTATE_SAVE = 0
     SCST_DLM_PRSTATE_NOSAVE = 1
+    LIO = 2
+
+
+class ALUA_STATE(enum.IntEnum):
+    """Values match ASYMMETRIC ACCESS STATE table in SPC-5"""
+
+    OPTIMIZED = 0
+    NONOPTIMIZED = 1
+    STANDBY = 2
+    UNAVAILABLE = 3
+    OFFLINE = 14
+    TRANSITIONING = 15
+
+    def __str__(self):
+        return str(self.value)

--- a/src/middlewared/middlewared/utils/lio/config.py
+++ b/src/middlewared/middlewared/utils/lio/config.py
@@ -1,0 +1,1281 @@
+"""
+LIO (Linux I/O target) configfs reconciler.
+
+Computes the desired state from render_ctx, then adds what is missing, updates
+what has changed, and deletes what is stale.  All operations are direct pathlib
+writes to /sys/kernel/config/target/; no rtslib-fb dependency.
+
+Phase 1: non-HA iSCSI/TCP + iSER + FC (tcm_qla2xxx), with ALUA stubs.
+
+Configfs tree
+-------------
+/sys/kernel/config/target/
++-- core/
+|   +-- iblock_0/
+|   |   +-- {extent}/             storage object (block device)
+|   |       +-- udev_path         write device path to open
+|   |       +-- enable            write "1" to activate
+|   |       +-- wwn/vpd_unit_serial
+|   +-- fileio_0/
+|       +-- {extent}/             storage object (file/zvol via file I/O)
+|           +-- fd_dev_name
+|           +-- enable
+|           +-- wwn/vpd_unit_serial
++-- iscsi/
+|   +-- {iqn}/                    iSCSI target
+|       +-- tpgt_{tag}/           TPG; tag = portal["tag"], NOT hardcoded to 1
+|           +-- enable
+|           +-- param/            negotiation parameters
+|           +-- portals/
+|           |   +-- {ip}:{port}/  listen address
+|           +-- lun/
+|           |   +-- lun_{id}/
+|           |       +-- {alias}   symlink -> core/{backstore}/{extent}/
+|           +-- acls/
+|               +-- {initiator}/  one dir per allowed initiator IQN
+|                   +-- auth/     CHAP credentials
+|                   +-- lun_{id}/
+|                       +-- default  symlink -> ../../lun/lun_{id}/
++-- qla2xxx/                      FC fabric (tcm_qla2xxx)
+    +-- {wwpn}/                   FC target; WWPN in colon-hex
+        +-- tpgt_1/               always tag 1 -- FC has exactly one TPG
+            +-- enable
+            +-- lun/
+            |   +-- lun_{id}/
+            |       +-- {alias}   symlink -> core/{backstore}/{extent}/
+            +-- acls/
+                +-- {initiator}/  one dir per allowed initiator WWPN
+                    +-- lun_{id}/
+                        +-- default  symlink -> ../../lun/lun_{id}/
+"""
+
+import os
+import pathlib
+import subprocess
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+
+from middlewared.plugins.fc.utils import wwn_as_colon_hex
+from middlewared.utils.iscsi.constants import ALUA_STATE
+
+
+LIO_CONFIG_DIR = pathlib.Path("/sys/kernel/config/target")
+
+# Storage backstores
+IBLOCK_DIR = LIO_CONFIG_DIR / "core" / "iblock_0"
+FILEIO_DIR = LIO_CONFIG_DIR / "core" / "fileio_0"
+
+
+def sanitize_lio_extent(name: str) -> str:
+    """Sanitize an extent name for use as a LIO configfs directory name.
+
+    LIO configfs directory names cannot contain '/' (interpreted as a path
+    separator by the VFS).  Replace with '-', mirroring what SCST does.
+    """
+    return name.replace("/", "-")
+
+
+# Fabric directories (created on demand via configfs mkdir, not at module load)
+ISCSI_DIR = LIO_CONFIG_DIR / "iscsi"
+FC_DIR = LIO_CONFIG_DIR / "qla2xxx"
+
+# Kernel module presence paths
+_SYSMOD = pathlib.Path("/sys/module")
+MOD_ISCSI_TARGET = _SYSMOD / "iscsi_target_mod"
+MOD_TCM_QLA2XXX = _SYSMOD / "tcm_qla2xxx"
+MOD_IB_ISERT = _SYSMOD / "ib_isert"
+MOD_TARGET_CORE = _SYSMOD / "target_core_mod"
+MOD_TCM_IBLOCK = _SYSMOD / "target_core_iblock"
+MOD_TCM_FILE = _SYSMOD / "target_core_file"
+MOD_TCM_PSCSI = _SYSMOD / "target_core_pscsi"
+MOD_TCM_USER = _SYSMOD / "target_core_user"
+
+# ALUA default group name (always present, created by kernel on SO creation)
+ALUA_DEFAULT_GROUP = "default_tg_pt_gp"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: pathlib.Path, value: str):
+    """Write a value to a configfs attribute, creating the path as needed."""
+    path.write_text(f"{value}\n")
+
+
+def _read(path: pathlib.Path) -> str:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _wait_for(path: pathlib.Path, retries: int = 10) -> bool:
+    """Wait for a configfs file to appear after creating a directory."""
+    while not path.exists() and retries > 0:
+        time.sleep(0.5)
+        retries -= 1
+    return path.exists()
+
+
+def _write_if_changed(path: pathlib.Path, value: str):
+    """Write value only if it differs from the current content."""
+    current = _read(path)
+    if current != str(value):
+        _write(path, value)
+
+
+def _write_auth_cred(path: pathlib.Path, value: str):
+    r"""Write a CHAP credential without appending a newline.
+
+    LIO's auth store functions (userid, password, etc.) do not strip the
+    trailing newline that _write() appends.  The kernel would then store
+    "user\n" and the subsequent CHAP_N strlen comparison would fail.
+
+    A read-compare guard cannot be used here: _read() calls .strip(), so
+    a stored "user\n" reads back as "user" -- identical to the correct
+    "user" -- and the write would be skipped, leaving the broken value in
+    place.  Always write unconditionally for these attributes.
+    """
+    path.write_text((value or "").rstrip())
+
+
+def _write_vpd_serial(path: pathlib.Path, value: str):
+    """Write vpd_unit_serial, accounting for the kernel's read-back prefix.
+
+    The kernel show function returns "T10 VPD Unit Serial Number: <serial>",
+    so a plain string comparison would always mismatch.  Strip the prefix
+    before comparing to avoid a spurious write that would return EINVAL once
+    the storage object is exported (export_count > 0).
+    """
+    current = _read(path)
+    _VPD_SERIAL_PREFIX = "T10 VPD Unit Serial Number: "
+    if current.startswith(_VPD_SERIAL_PREFIX):
+        current = current[len(_VPD_SERIAL_PREFIX):]
+    if current != value:
+        _write(path, value)
+
+
+def _extent_device_path(extent: dict) -> str | None:
+    """Return the actual device/file path for an extent, or None if unavailable."""
+    if extent["type"] == "DISK":
+        disk = extent.get("disk") or extent.get("path", "")
+        if disk:
+            return os.path.join("/dev", disk)
+    elif extent["type"] == "FILE":
+        return extent.get("path")
+    return None
+
+
+def _so_dir(extent: dict) -> pathlib.Path:
+    """Return the storage object directory for an extent."""
+    if extent["type"] == "DISK":
+        return IBLOCK_DIR / sanitize_lio_extent(extent["name"])
+    else:
+        return FILEIO_DIR / sanitize_lio_extent(extent["name"])
+
+
+def _so_path(extent: dict) -> pathlib.Path:
+    """Return the absolute configfs path for the storage object (same as _so_dir)."""
+    return _so_dir(extent)
+
+
+def _naa_to_vpd_components(naa: str) -> tuple[str, str] | None:
+    """
+    Derive LIO vpd_unit_serial and company_id from a stored TrueNAS NAA.
+
+    TrueNAS NAA format: '0x6589cfc000000' + sha256[0:19]
+    = '0x' + 32 hex chars (NAA type nibble + 6-char OUI + 25-char vendor-specific)
+
+    LIO's spc_gen_naa_6h_vendor_specific() builds VPD page 0x83 NAA type 6 from:
+      - company_id (24-bit OUI): nibbles 1-6 of the NAA
+      - vpd_unit_serial hex chars: nibbles 7-31 (vendor-specific field)
+
+    Reverse-engineering: set company_id = int(naa_hex[1:7], 16) and
+    vpd_unit_serial = naa_hex[7:32] so that LIO reconstructs the exact same NAA.
+
+    Returns (vpd_unit_serial, company_id_hex_str) or None if naa is invalid.
+    """
+    if not naa:
+        return None
+    h = naa.lower()
+    if h.startswith("0x"):
+        h = h[2:]
+    if len(h) != 32 or h[0] != "6":
+        return None
+    company_id = h[1:7]  # 6 hex chars = 24-bit OUI
+    vpd_serial = h[7:32]  # 25 vendor-specific nibbles
+    return vpd_serial, f"0x{company_id}"
+
+
+def _fc_wwpn(fcport: dict, node: str, licensed: bool) -> str | None:
+    """
+    Return the WWPN (colon-hex) to use for this node.
+    Non-HA: always use wwpn.
+    HA: node A -> wwpn, node B -> wwpn_b.
+    """
+    if not licensed:
+        return wwn_as_colon_hex(fcport["wwpn"])
+    if node == "B":
+        return wwn_as_colon_hex(fcport["wwpn_b"])
+    return wwn_as_colon_hex(fcport["wwpn"])
+
+
+# ---------------------------------------------------------------------------
+# Storage objects
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _storage_objects(render_ctx: dict):
+    """
+    Reconcile iblock and fileio storage objects.
+
+    Creates before yield, deletes after yield (so LUN symlinks referencing
+    these objects are removed first by inner context managers).
+    """
+    # Compute desired state: name -> extent
+    desired = {}
+    for extent in render_ctx["iscsi.extent.query"]:
+        if extent.get("locked"):
+            continue
+        device_path = _extent_device_path(extent)
+        if not device_path or not os.path.exists(device_path):
+            continue
+        desired[sanitize_lio_extent(extent["name"])] = extent
+
+    # Compute live state across both backstores
+    live_iblock = set(os.listdir(IBLOCK_DIR)) if IBLOCK_DIR.exists() else set()
+    live_fileio = set(os.listdir(FILEIO_DIR)) if FILEIO_DIR.exists() else set()
+    live = live_iblock | live_fileio
+
+    add_names = set(desired) - live
+    remove_names = live - set(desired)
+
+    # Create new storage objects
+    for name in add_names:
+        extent = desired[name]
+        so_dir = _so_dir(extent)
+        so_dir.mkdir(parents=True, exist_ok=True)
+        _configure_storage_object(so_dir, extent, render_ctx)
+
+    # Update existing storage objects (identity or ALUA state may have changed)
+    for name in set(desired) & live:
+        extent = desired[name]
+        so_dir = _so_dir(extent)
+        _update_storage_object_attrs(so_dir, extent, render_ctx)
+
+    yield
+
+    # Delete stale storage objects after LUN symlinks have been removed
+    for name in remove_names:
+        if name in live_iblock:
+            so_dir = IBLOCK_DIR / name
+        else:
+            so_dir = FILEIO_DIR / name
+        _delete_storage_object(so_dir)
+
+
+def _configure_storage_object(so_dir: pathlib.Path, extent: dict, render_ctx: dict):
+    """Write configfs attributes for a newly created storage object."""
+    device_path = _extent_device_path(extent)
+    control = so_dir / "control"
+
+    if extent["type"] == "DISK":
+        # iblock: write device path via udev_path file and control knob
+        if not _wait_for(control):
+            raise RuntimeError(f"LIO configfs: {control} never appeared")
+        _write(control, f"udev_path={device_path}")
+        udev_path_file = so_dir / "udev_path"
+        # udev_path_file is a secondary confirmation attribute; best-effort write only
+        if _wait_for(udev_path_file):
+            _write(udev_path_file, device_path)
+        if extent.get("ro"):
+            _write(control, "readonly=1")
+        else:
+            _write(control, "readonly=0")
+    else:
+        # fileio: write device path and size via control knob
+        if not _wait_for(control):
+            raise RuntimeError(f"LIO configfs: {control} never appeared")
+        size = extent.get("filesize") or 0
+        if size:
+            _write(control, f"fd_dev_name={device_path},fd_dev_size={size}")
+        else:
+            _write(control, f"fd_dev_name={device_path}")
+        if extent.get("ro"):
+            _write(control, "fd_dev_readonly=1")
+
+    # Set serial and identity attributes (wwn/ appears after control write)
+    _set_storage_object_identity(so_dir, extent)
+
+    # Enable the storage object
+    enable = so_dir / "enable"
+    if not _wait_for(enable):
+        raise RuntimeError(f"LIO configfs: {enable} never appeared")
+    _write(enable, "1")
+
+    # Configure ALUA groups (after enable so alua/ is populated)
+    _configure_alua(so_dir, render_ctx)
+
+
+def _set_storage_object_identity(so_dir: pathlib.Path, extent: dict):
+    """Write VPD serial and product identity attributes.
+
+    LIO's spc_gen_naa_6h_vendor_specific() derives the VPD page 0x83 NAA type 6
+    from company_id (OUI) + hex digits of vpd_unit_serial.  We reverse-engineer
+    the stored TrueNAS NAA to recover those two fields so LIO emits the exact
+    same NAA that SCST would.  Both must be written before the storage object is
+    enabled (the kernel gates writes with export_count == 0).
+    """
+    wwn_dir = so_dir / "wwn"
+    if not _wait_for(wwn_dir):
+        raise RuntimeError(f"LIO configfs: {wwn_dir} never appeared")
+
+    components = _naa_to_vpd_components(extent.get("naa") or "")
+    if components:
+        vpd_serial_str, company_id_hex = components
+        company_id_path = wwn_dir / "company_id"
+        if company_id_path.exists():
+            _write_if_changed(company_id_path, company_id_hex)
+        vpd_serial_path = wwn_dir / "vpd_unit_serial"
+        # vpd_unit_serial appears shortly after wwn_dir; best-effort write only
+        if _wait_for(vpd_serial_path):
+            _write_vpd_serial(vpd_serial_path, vpd_serial_str)
+    else:
+        # No valid NAA -- fall back to the human-readable serial from the DB.
+        serial = extent.get("serial") or ""
+        if serial:
+            vpd_serial_path = wwn_dir / "vpd_unit_serial"
+            # vpd_unit_serial appears shortly after wwn_dir; best-effort write only
+            if _wait_for(vpd_serial_path):
+                _write_vpd_serial(vpd_serial_path, serial)
+
+    vendor_id = wwn_dir / "vendor_id"
+    if vendor_id.exists():
+        _write_if_changed(vendor_id, (extent.get("vendor") or "TrueNAS")[:8])
+
+    product_id_path = wwn_dir / "product_id"
+    if product_id_path.exists():
+        _write_if_changed(
+            product_id_path, (extent.get("product_id") or "iSCSI Disk")[:16]
+        )
+
+
+def _configure_alua(so_dir: pathlib.Path, render_ctx: dict):
+    """Configure ALUA groups for a storage object.
+
+    Phase 1 (non-HA / SINGLE): the kernel auto-creates default_tg_pt_gp with state
+    ACTIVE_OPTIMIZED (0).  We write it explicitly so the intent is clear and so the
+    correct state is restored if something externally altered it.
+
+    Phase 2 (HA): create controller_A and controller_B groups under alua/, set their
+    tg_pt_gp_id values to match the SCST group IDs, and write the initial access state
+    (ACTIVE_OPTIMIZED for ACTIVE node, OFFLINE for STANDBY).  Also assign each LUN in
+    every TPG to the correct group via lun/lun_N/alua_tg_pt_gp (see _reconcile_luns).
+    """
+    failover_status = render_ctx.get("failover.status", "SINGLE")
+    if failover_status != "SINGLE":
+        # Phase 2: HA ALUA not yet implemented.
+        return
+
+    alua_dir = so_dir / "alua" / "default_tg_pt_gp"
+    if not alua_dir.exists():
+        return
+    state_path = alua_dir / "alua_access_state"
+    if state_path.exists():
+        _write_if_changed(state_path, str(ALUA_STATE.OPTIMIZED))
+
+
+def _update_storage_object_attrs(so_dir: pathlib.Path, extent: dict, render_ctx: dict):
+    """Update identity attributes and ALUA state on an existing storage object."""
+    _set_storage_object_identity(so_dir, extent)
+    _configure_alua(so_dir, render_ctx)
+
+
+def _delete_storage_object(so_dir: pathlib.Path):
+    """Remove a storage object directory.
+
+    LIO's enable attribute is write-once ("1" only); there is no disable op.
+    Just rmdir directly once all LUN symlinks referencing this object are gone.
+    """
+    try:
+        so_dir.rmdir()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# iSCSI targets
+# ---------------------------------------------------------------------------
+
+
+def _build_iscsi_desired(render_ctx: dict) -> dict:
+    """
+    Build the desired iSCSI target state from render_ctx.
+
+    Returns a dict:
+        {iqn: {
+            'iqn': str,
+            'tpgs': {
+                tpg_tag: {
+                    'tag': int,
+                    'portals': [{'ip': str, 'port': int, 'iser': bool}],
+                    'generate_node_acls': bool,
+                    'luns': {lun_id: extent_name},
+                    'acls': {initiator_iqn: {'user': str, 'password': str,
+                                             'mutual_user': str, 'mutual_password': str,
+                                             'luns': {lun_id: extent_name}}},
+                }
+            }
+        }}
+    """
+    global_cfg = render_ctx["iscsi.global.config"]
+    iser_enabled = global_cfg.get("iser", False)
+
+    extents = {e["id"]: e for e in render_ctx["iscsi.extent.query"]}
+    portals = {p["id"]: p for p in render_ctx["iscsi.portal.query"]}
+    initiators = {i["id"]: i for i in render_ctx["iscsi.initiator.query"]}
+    auth_by_tag = defaultdict(list)
+    for a in render_ctx["iscsi.auth.query"]:
+        auth_by_tag[a["tag"]].append(a)
+
+    # LUN assignments: target_id -> {lun_id -> extent}
+    target_luns = defaultdict(dict)
+    for te in render_ctx["iscsi.targetextent.query"]:
+        extent = extents.get(te["extent"])
+        if extent and not extent.get("locked"):
+            device_path = _extent_device_path(extent)
+            if device_path and os.path.exists(device_path):
+                target_luns[te["target"]][te["lunid"]] = extent
+
+    desired = {}
+    for target in render_ctx["iscsi.target.query"]:
+        if target["mode"] == "FC":
+            continue  # FC-only targets handled separately
+
+        iqn = f"{global_cfg['basename']}:{target['name']}"
+        tpgs = {}
+
+        for group in target.get("groups", []):
+            portal = portals.get(group["portal"])
+            if not portal:
+                continue
+
+            tag = portal["tag"]
+            initiator_group = (
+                initiators.get(group["initiator"]) if group.get("initiator") else None
+            )
+            authmethod = group.get("authmethod", "NONE")
+            auth_tag = group.get("auth")
+
+            # Resolve CHAP credentials
+            chap_entries = auth_by_tag.get(auth_tag, []) if auth_tag else []
+
+            if tag not in tpgs:
+                tpgs[tag] = {
+                    "tag": tag,
+                    "alias": target.get("alias") or "",
+                    "portals": [],
+                    "generate_node_acls": False,
+                    "chap_user": "",
+                    "chap_password": "",
+                    "chap_mutual_user": "",
+                    "chap_mutual_password": "",
+                    "luns": target_luns[target["id"]],
+                    "acls": {},
+                }
+
+            # Add portals (avoid duplicates)
+            existing_portal_addrs = {(p["ip"], p["port"]) for p in tpgs[tag]["portals"]}
+            for listen in portal.get("listen", []):
+                key = (listen["ip"], listen.get("port", global_cfg["listen_port"]))
+                if key not in existing_portal_addrs:
+                    tpgs[tag]["portals"].append(
+                        {
+                            "ip": listen["ip"],
+                            "port": listen.get("port", global_cfg["listen_port"]),
+                            "iser": iser_enabled,
+                        }
+                    )
+                    existing_portal_addrs.add(key)
+
+            # ACLs
+            if initiator_group is None or not initiator_group.get("initiators"):
+                # Allow all: use generate_node_acls.
+                # NOTE: CHAP cannot be enforced with generate_node_acls=1.  LIO
+                # verifies initiator CHAP credentials from the per-ACL auth
+                # directory; dynamic ACLs have empty credentials, so CHAP
+                # negotiation always fails.  CHAP targets must use static ACLs
+                # (a specific initiator group).  The tpgt_N/auth/ directory
+                # holds the TARGET's outgoing credentials for mutual CHAP only.
+                tpgs[tag]["generate_node_acls"] = True
+                if authmethod in ("CHAP", "CHAP_MUTUAL") and chap_entries:
+                    cred = chap_entries[0]
+                    tpgs[tag]["chap_user"] = cred.get("user", "")
+                    tpgs[tag]["chap_password"] = cred.get("secret", "")
+                    if authmethod == "CHAP_MUTUAL":
+                        tpgs[tag]["chap_mutual_user"] = cred.get("peeruser", "")
+                        tpgs[tag]["chap_mutual_password"] = cred.get("peersecret", "")
+            else:
+                for iqn_initiator in initiator_group["initiators"]:
+                    if iqn_initiator not in tpgs[tag]["acls"]:
+                        tpgs[tag]["acls"][iqn_initiator] = {
+                            "user": "",
+                            "password": "",
+                            "mutual_user": "",
+                            "mutual_password": "",
+                            "luns": target_luns[target["id"]],
+                        }
+                    acl = tpgs[tag]["acls"][iqn_initiator]
+                    if authmethod in ("CHAP", "CHAP_MUTUAL") and chap_entries:
+                        cred = chap_entries[0]
+                        acl["user"] = cred.get("user", "")
+                        acl["password"] = cred.get("secret", "")
+                        if authmethod == "CHAP_MUTUAL":
+                            acl["mutual_user"] = cred.get("peeruser", "")
+                            acl["mutual_password"] = cred.get("peersecret", "")
+
+        if tpgs:
+            desired[iqn] = {"iqn": iqn, "tpgs": tpgs}
+
+    return desired
+
+
+@contextmanager
+def _iscsi_targets(render_ctx: dict):
+    """Reconcile iSCSI targets, TPGs, portals, LUNs, and ACLs."""
+    if not ISCSI_DIR.exists():
+        yield
+        return
+
+    desired = _build_iscsi_desired(render_ctx)
+    live_targets = {e.name for e in ISCSI_DIR.iterdir() if e.is_dir()}
+
+    add_targets = set(desired) - live_targets
+    remove_targets = live_targets - set(desired)
+    update_targets = set(desired) & live_targets
+
+    # Create new targets and their full sub-tree
+    for iqn in add_targets:
+        target_dir = ISCSI_DIR / iqn
+        target_dir.mkdir()
+        _configure_iscsi_target(target_dir, desired[iqn], render_ctx)
+
+    # Update existing targets
+    for iqn in update_targets:
+        target_dir = ISCSI_DIR / iqn
+        _update_iscsi_target(target_dir, desired[iqn], render_ctx)
+
+    yield
+
+    # Remove stale targets (TPGs, LUNs, ACLs must be removed first)
+    for iqn in remove_targets:
+        target_dir = ISCSI_DIR / iqn
+        _delete_iscsi_target(target_dir)
+
+
+def _configure_iscsi_target(
+    target_dir: pathlib.Path, target_cfg: dict, render_ctx: dict
+):
+    """Create and configure all TPGs under a new iSCSI target."""
+    for tpg_cfg in target_cfg["tpgs"].values():
+        _create_iscsi_tpg(target_dir, tpg_cfg, render_ctx)
+
+
+def _update_iscsi_target(target_dir: pathlib.Path, target_cfg: dict, render_ctx: dict):
+    """Reconcile TPGs under an existing iSCSI target."""
+    live_tpgs = {
+        int(d.name.split("_")[1])
+        for d in target_dir.iterdir()
+        if d.is_dir() and d.name.startswith("tpgt_")
+    }
+    desired_tags = set(target_cfg["tpgs"].keys())
+
+    for tag in desired_tags - live_tpgs:
+        _create_iscsi_tpg(target_dir, target_cfg["tpgs"][tag], render_ctx)
+
+    for tag in desired_tags & live_tpgs:
+        tpg_dir = target_dir / f"tpgt_{tag}"
+        _update_iscsi_tpg(tpg_dir, target_cfg["tpgs"][tag], render_ctx)
+
+    for tag in live_tpgs - desired_tags:
+        tpg_dir = target_dir / f"tpgt_{tag}"
+        _delete_iscsi_tpg(tpg_dir)
+
+
+def _create_iscsi_tpg(target_dir: pathlib.Path, tpg_cfg: dict, render_ctx: dict):
+    """Create a TPG and all its sub-objects.
+
+    Note: the TPG tag comes from portal["tag"] and is not hardcoded to 1.
+    A target can have multiple TPGs with different tags (one per portal group).
+    All TPGs on a target share the same LUN set.  Contrast with FC targets,
+    which always have exactly one TPG with tag 1.
+    """
+    tag = tpg_cfg["tag"]
+    tpg_dir = target_dir / f"tpgt_{tag}"
+    tpg_dir.mkdir()
+
+    _set_tpg_attribs(tpg_dir, tpg_cfg)
+    _set_tpg_alias(tpg_dir, tpg_cfg)
+    _set_tpg_auth(tpg_dir, tpg_cfg)
+    _reconcile_portals(tpg_dir, tpg_cfg)
+    _reconcile_luns(tpg_dir, tpg_cfg)
+    _reconcile_acls(tpg_dir, tpg_cfg)
+
+    enable = tpg_dir / "enable"
+    if not _wait_for(enable):
+        raise RuntimeError(f"LIO configfs: {enable} never appeared")
+    _write(enable, "1")
+
+
+def _update_iscsi_tpg(tpg_dir: pathlib.Path, tpg_cfg: dict, render_ctx: dict):
+    """Update portals, LUNs, and ACLs on an existing TPG."""
+    _set_tpg_attribs(tpg_dir, tpg_cfg)
+    _set_tpg_alias(tpg_dir, tpg_cfg)
+    _set_tpg_auth(tpg_dir, tpg_cfg)
+    _reconcile_portals(tpg_dir, tpg_cfg)
+    _reconcile_luns(tpg_dir, tpg_cfg)
+    _reconcile_acls(tpg_dir, tpg_cfg)
+
+
+def _set_tpg_attribs(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Set TPG-level attributes."""
+    attrib_dir = tpg_dir / "attrib"
+    if not attrib_dir.exists():
+        return
+
+    generate_acls = "1" if tpg_cfg["generate_node_acls"] else "0"
+    has_chap = (
+        any(
+            acl.get("user") or acl.get("mutual_user")
+            for acl in tpg_cfg["acls"].values()
+        )
+        or bool(tpg_cfg.get("chap_user"))
+        or bool(tpg_cfg.get("chap_mutual_user"))
+    )
+    for attr, val in (
+        ("authentication", "1" if has_chap else "0"),
+        ("generate_node_acls", generate_acls),
+        ("cache_dynamic_acls", generate_acls),
+        ("demo_mode_write_protect", "0"),
+    ):
+        p = attrib_dir / attr
+        if p.exists():
+            _write_if_changed(p, val)
+
+
+def _set_tpg_alias(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Write TargetAlias to tpgt_N/param/TargetAlias.
+
+    An empty string clears the alias (no TargetAlias sent in LOGIN response).
+    """
+    p = tpg_dir / "param" / "TargetAlias"
+    if p.exists():
+        _write_if_changed(p, tpg_cfg.get("alias") or "")
+
+
+def _set_tpg_auth(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Write TPG-level auth credentials to tpgt_N/auth/.
+
+    tpgt_N/auth/ holds the TARGET's outgoing credentials for mutual CHAP
+    (target authenticates itself to the initiator).  These are distinct from
+    the per-ACL credentials in acls/<iqn>/auth/ that verify the initiator.
+    """
+    auth_dir = tpg_dir / "auth"
+    if not auth_dir.exists():
+        return
+    for attr, key in (
+        ("userid", "chap_user"),
+        ("password", "chap_password"),
+        ("userid_mutual", "chap_mutual_user"),
+        ("password_mutual", "chap_mutual_password"),
+    ):
+        p = auth_dir / attr
+        if p.exists():
+            _write_auth_cred(p, tpg_cfg.get(key, "") or "")
+    authenticate_target = auth_dir / "authenticate_target"
+    if authenticate_target.exists():
+        _write_if_changed(
+            authenticate_target, "1" if tpg_cfg.get("chap_mutual_user") else "0"
+        )
+
+
+def _portal_key(ip: str, port: int) -> str:
+    """Return the configfs directory name for a portal."""
+    # IPv6 addresses use brackets in the directory name
+    if ":" in ip and not ip.startswith("["):
+        return f"[{ip}]:{port}"
+    return f"{ip}:{port}"
+
+
+def _reconcile_portals(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Add/remove network portals in this TPG."""
+    np_dir = tpg_dir / "np"
+    if not np_dir.exists():
+        return
+
+    desired = {_portal_key(p["ip"], p["port"]): p for p in tpg_cfg["portals"]}
+    live = set(os.listdir(np_dir))
+
+    for key in set(desired) - live:
+        p = desired[key]
+        portal_dir = np_dir / key
+        portal_dir.mkdir()
+        # Set iSER attribute if supported — best-effort; older kernels may not expose it
+        iser_path = portal_dir / "iser"
+        if _wait_for(iser_path, retries=5):
+            _write(iser_path, "1" if p.get("iser") else "0")
+
+    for key in live - set(desired):
+        portal_dir = np_dir / key
+        try:
+            portal_dir.rmdir()
+        except OSError:
+            pass
+
+
+def _reconcile_luns(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Reconcile LUN -> storage object associations in this TPG."""
+    lun_dir = tpg_dir / "lun"
+    if not lun_dir.exists():
+        return
+
+    desired_luns = tpg_cfg["luns"]  # {lun_id: extent}
+    live_lun_dirs = {
+        int(d.name.split("_")[1]): d
+        for d in lun_dir.iterdir()
+        if d.is_dir() and d.name.startswith("lun_")
+    }
+
+    # Add missing LUNs
+    for lun_id, extent in desired_luns.items():
+        if lun_id not in live_lun_dirs:
+            lun_path = lun_dir / f"lun_{lun_id}"
+            lun_path.mkdir()
+            so_path = _so_path(extent)
+            # Create symlink: {alias} -> storage object directory
+            alias = (
+                f"iblock_{sanitize_lio_extent(extent['name'])}"
+                if extent["type"] == "DISK"
+                else f"fileio_{sanitize_lio_extent(extent['name'])}"
+            )
+            link = lun_path / alias
+            link.symlink_to(so_path)
+            # Phase 2: write the ALUA group name to lun_path / "alua_tg_pt_gp"
+            # to assign this LUN to controller_A or controller_B as appropriate.
+
+    # Remove stale LUNs
+    for lun_id, lun_path in live_lun_dirs.items():
+        if lun_id not in desired_luns:
+            # Remove the symlink inside first
+            for child in lun_path.iterdir():
+                if child.is_symlink():
+                    child.unlink()
+            try:
+                lun_path.rmdir()
+            except OSError:
+                pass
+
+
+def _reconcile_acls(tpg_dir: pathlib.Path, tpg_cfg: dict):
+    """Reconcile initiator ACLs in this TPG."""
+    acls_dir = tpg_dir / "acls"
+    if not acls_dir.exists():
+        return
+
+    if tpg_cfg["generate_node_acls"]:
+        # Allow-all: remove all explicit ACLs
+        for acl_dir in list(acls_dir.iterdir()):
+            if acl_dir.is_dir():
+                _delete_acl(acl_dir)
+        return
+
+    desired_acls = tpg_cfg["acls"]  # {iqn: acl_cfg}
+    live_acls = {d.name for d in acls_dir.iterdir() if d.is_dir()}
+
+    for iqn in set(desired_acls) - live_acls:
+        acl_dir = acls_dir / iqn
+        acl_dir.mkdir()
+        _configure_acl(acl_dir, desired_acls[iqn], tpg_dir)
+
+    for iqn in set(desired_acls) & live_acls:
+        acl_dir = acls_dir / iqn
+        _update_acl(acl_dir, desired_acls[iqn], tpg_dir)
+
+    for iqn in live_acls - set(desired_acls):
+        _delete_acl(acls_dir / iqn)
+
+
+def _configure_acl(acl_dir: pathlib.Path, acl_cfg: dict, tpg_dir: pathlib.Path):
+    """Set auth and mapped LUNs on a new ACL."""
+    _set_acl_auth(acl_dir, acl_cfg)
+    _reconcile_mapped_luns(acl_dir, acl_cfg["luns"], tpg_dir)
+
+
+def _update_acl(acl_dir: pathlib.Path, acl_cfg: dict, tpg_dir: pathlib.Path):
+    """Update auth and mapped LUNs on an existing ACL."""
+    _set_acl_auth(acl_dir, acl_cfg)
+    _reconcile_mapped_luns(acl_dir, acl_cfg["luns"], tpg_dir)
+
+
+def _set_acl_auth(acl_dir: pathlib.Path, acl_cfg: dict):
+    """Write CHAP credentials to an ACL's auth/ directory."""
+    auth_dir = acl_dir / "auth"
+    if not auth_dir.exists():
+        return
+
+    for attr, val in (
+        ("userid", acl_cfg.get("user", "")),
+        ("password", acl_cfg.get("password", "")),
+        ("userid_mutual", acl_cfg.get("mutual_user", "")),
+        ("password_mutual", acl_cfg.get("mutual_password", "")),
+    ):
+        p = auth_dir / attr
+        if p.exists():
+            _write_auth_cred(p, val or "")
+
+
+def _reconcile_mapped_luns(acl_dir: pathlib.Path, luns: dict, tpg_dir: pathlib.Path):
+    """Reconcile mapped LUN entries under an ACL."""
+    desired_lun_ids = set(luns.keys())
+    live_mapped = {
+        int(d.name.split("_")[1]): d
+        for d in acl_dir.iterdir()
+        if d.is_dir() and d.name.startswith("lun_")
+    }
+
+    for lun_id in desired_lun_ids - set(live_mapped):
+        mapped_dir = acl_dir / f"lun_{lun_id}"
+        mapped_dir.mkdir()
+        # Symlink 'default' -> TPG lun/lun_N directory
+        tpg_lun_path = tpg_dir / "lun" / f"lun_{lun_id}"
+        link = mapped_dir / "default"
+        link.symlink_to(tpg_lun_path)
+
+    for lun_id, mapped_dir in live_mapped.items():
+        if lun_id not in desired_lun_ids:
+            for child in mapped_dir.iterdir():
+                if child.is_symlink():
+                    child.unlink()
+            try:
+                mapped_dir.rmdir()
+            except OSError:
+                pass
+
+
+def _delete_acl(acl_dir: pathlib.Path):
+    """Remove an ACL and all its mapped LUNs."""
+    for d in list(acl_dir.iterdir()):
+        if d.is_dir() and d.name.startswith("lun_"):
+            for child in d.iterdir():
+                if child.is_symlink():
+                    child.unlink()
+            try:
+                d.rmdir()
+            except OSError:
+                pass
+    try:
+        acl_dir.rmdir()
+    except OSError:
+        pass
+
+
+def _delete_iscsi_tpg(tpg_dir: pathlib.Path):
+    """Remove a TPG and all its sub-objects."""
+    # Remove ACLs
+    acls_dir = tpg_dir / "acls"
+    if acls_dir.exists():
+        for acl_dir in list(acls_dir.iterdir()):
+            if acl_dir.is_dir():
+                _delete_acl(acl_dir)
+
+    # Remove LUNs
+    lun_dir = tpg_dir / "lun"
+    if lun_dir.exists():
+        for d in list(lun_dir.iterdir()):
+            if d.is_dir() and d.name.startswith("lun_"):
+                for child in d.iterdir():
+                    if child.is_symlink():
+                        child.unlink()
+                try:
+                    d.rmdir()
+                except OSError:
+                    pass
+
+    # Remove portals
+    np_dir = tpg_dir / "np"
+    if np_dir.exists():
+        for d in list(np_dir.iterdir()):
+            if d.is_dir():
+                try:
+                    d.rmdir()
+                except OSError:
+                    pass
+
+    # Disable and remove TPG
+    enable = tpg_dir / "enable"
+    if enable.exists():
+        try:
+            _write(enable, "0")
+        except OSError:
+            pass
+    try:
+        tpg_dir.rmdir()
+    except OSError:
+        pass
+
+
+def _delete_iscsi_target(target_dir: pathlib.Path):
+    """Remove an iSCSI target and all its TPGs."""
+    for d in list(target_dir.iterdir()):
+        if d.is_dir() and d.name.startswith("tpgt_"):
+            _delete_iscsi_tpg(d)
+    try:
+        target_dir.rmdir()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# iSCSI discovery auth
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _discovery_auth(render_ctx: dict):
+    """Configure discovery authentication."""
+    disc_auth_dir = ISCSI_DIR / "discovery_auth"
+    if not disc_auth_dir.exists():
+        yield
+        return
+
+    # Find the first discovery CHAP credential
+    incoming_user = ""
+    incoming_pass = ""
+    outgoing_user = ""
+    outgoing_pass = ""
+
+    for auth in render_ctx["iscsi.auth.query"]:
+        disc_auth = auth.get("discovery_auth", "NONE")
+        if disc_auth in ("CHAP", "CHAP_MUTUAL"):
+            if not incoming_user and auth.get("user") and auth.get("secret"):
+                incoming_user = auth["user"]
+                incoming_pass = auth["secret"]
+                if (
+                    disc_auth == "CHAP_MUTUAL"
+                    and auth.get("peeruser")
+                    and auth.get("peersecret")
+                ):
+                    outgoing_user = auth["peeruser"]
+                    outgoing_pass = auth["peersecret"]
+                break
+
+    for attr, val in (
+        ("userid", incoming_user),
+        ("password", incoming_pass),
+        ("userid_mutual", outgoing_user),
+        ("password_mutual", outgoing_pass),
+    ):
+        p = disc_auth_dir / attr
+        if p.exists():
+            _write_auth_cred(p, val)
+
+    # Enable/disable discovery auth enforcement
+    enforce = disc_auth_dir / "enforce_discovery_auth"
+    if enforce.exists():
+        _write_if_changed(enforce, "1" if incoming_user else "0")
+
+    yield
+
+
+# ---------------------------------------------------------------------------
+# FC targets
+# ---------------------------------------------------------------------------
+
+
+def _build_fc_desired(render_ctx: dict) -> dict:
+    """
+    Build the desired FC target state.
+
+    Returns {wwpn_colon_hex: {
+        'wwpn': str,
+        'luns': {lun_id: extent},
+        'acls': {initiator_wwpn: {'luns': {lun_id: extent}}},
+    }}
+    """
+    if not render_ctx.get("fc.capable"):
+        return {}
+
+    extents = {e["id"]: e for e in render_ctx["iscsi.extent.query"]}
+    node = render_ctx.get("failover.node", "A")
+    licensed = render_ctx.get("failover.licensed", False)
+
+    # LUN assignments: target_id -> {lun_id -> extent}
+    target_luns = defaultdict(dict)
+    for te in render_ctx["iscsi.targetextent.query"]:
+        extent = extents.get(te["extent"])
+        if extent and not extent.get("locked"):
+            device_path = _extent_device_path(extent)
+            if device_path and os.path.exists(device_path):
+                target_luns[te["target"]][te["lunid"]] = extent
+
+    desired = {}
+    for fcport in render_ctx["fcport.query"]:
+        if not fcport.get("target"):
+            continue
+        target = fcport["target"]
+        if target.get("mode") == "ISCSI":
+            continue  # iSCSI-only targets
+
+        wwpn = _fc_wwpn(fcport, node, licensed)
+        if not wwpn:
+            continue
+
+        desired[wwpn] = {
+            "wwpn": wwpn,
+            "luns": target_luns[target["id"]],
+            "acls": {},  # FC ACLs populated from initiator groups if any
+        }
+
+    return desired
+
+
+@contextmanager
+def _fc_targets(render_ctx: dict):
+    """Reconcile FC targets and their LUNs/ACLs."""
+    if not FC_DIR.exists():
+        yield
+        return
+
+    desired = _build_fc_desired(render_ctx)
+    live_targets = {e.name for e in FC_DIR.iterdir() if e.is_dir()}
+
+    add_targets = set(desired) - live_targets
+    remove_targets = live_targets - set(desired)
+    update_targets = set(desired) & live_targets
+
+    for wwpn in add_targets:
+        target_dir = FC_DIR / wwpn
+        target_dir.mkdir()
+        _configure_fc_target(target_dir, desired[wwpn])
+
+    for wwpn in update_targets:
+        target_dir = FC_DIR / wwpn
+        _update_fc_target(target_dir, desired[wwpn])
+
+    yield
+
+    for wwpn in remove_targets:
+        target_dir = FC_DIR / wwpn
+        _delete_fc_target(target_dir)
+
+
+def _configure_fc_target(target_dir: pathlib.Path, fc_cfg: dict):
+    """Create FC TPG (always tag 1) with LUNs.
+
+    Note: FC targets always have exactly one TPG with tag 1.  iSCSI targets
+    differ — their TPG tag comes from portal["tag"] and is not hardcoded.
+    Code that manipulates TPG directories must account for this asymmetry
+    (e.g. do not assume tpgt_1 when iterating iSCSI targets).
+    """
+    tpg_dir = target_dir / "tpgt_1"
+    tpg_dir.mkdir()
+    _reconcile_luns(tpg_dir, fc_cfg)
+    _reconcile_acls(tpg_dir, fc_cfg)
+    enable = tpg_dir / "enable"
+    if not _wait_for(enable):
+        raise RuntimeError(f"LIO configfs: {enable} never appeared")
+    _write(enable, "1")
+
+
+def _update_fc_target(target_dir: pathlib.Path, fc_cfg: dict):
+    """Update an existing FC target's LUNs."""
+    tpg_dir = target_dir / "tpgt_1"
+    if tpg_dir.exists():
+        _reconcile_luns(tpg_dir, fc_cfg)
+        _reconcile_acls(tpg_dir, fc_cfg)
+
+
+def _delete_fc_target(target_dir: pathlib.Path):
+    """Remove a FC target and its TPG."""
+    tpg_dir = target_dir / "tpgt_1"
+    if tpg_dir.exists():
+        _delete_iscsi_tpg(tpg_dir)  # same cleanup logic as iSCSI TPG
+    try:
+        target_dir.rmdir()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def _load_modules(render_ctx: dict):
+    """Load any LIO kernel modules that are not yet present.
+
+    Presence is detected via configfs/sysfs paths that each module creates,
+    avoiding a modprobe call when everything is already loaded (the common
+    case on every render after first start).
+
+      target_core_mod + iscsi_target_mod -> MOD_ISCSI_TARGET exists
+      tcm_qla2xxx                        -> MOD_TCM_QLA2XXX exists
+      ib_isert                           -> MOD_IB_ISERT exists
+
+    """
+    needed = []
+
+    if not MOD_ISCSI_TARGET.exists():
+        needed.extend(["target_core_mod", "iscsi_target_mod"])
+
+    if render_ctx.get("fc.capable") and not MOD_TCM_QLA2XXX.exists():
+        needed.append("tcm_qla2xxx")
+
+    if render_ctx.get("iscsi.global.config", {}).get("iser"):
+        if not MOD_IB_ISERT.exists():
+            needed.append("ib_isert")
+
+    if needed:
+        subprocess.run(["modprobe", "-a"] + needed, capture_output=True)
+
+
+def _wait_for_iscsi_threads(timeout: float = 10.0) -> None:
+    """Wait for all iscsi_target_mod kthreads to exit after target teardown.
+
+    iscsi_target_mod spawns three thread types per connection/portal:
+      iscsi_trx  -- RX thread (ISCSI_RX_THREAD_NAME, iscsi_target_core.h:26)
+      iscsi_ttx  -- TX thread (ISCSI_TX_THREAD_NAME, iscsi_target_core.h:27)
+      iscsi_np   -- per-portal login/accept thread (iscsi_target.c:374)
+
+    Removing network portals and disabling TPGs triggers async teardown of
+    all three.  modprobe -r must not run until they are gone -- if it does,
+    the threads wake from schedule_timeout into poisoned (freed) module
+    memory and the kernel panics (observed as int3 / 0xcc fill oops).
+
+    Races with thread exit are expected: OSError from /proc reads is normal
+    and is silently ignored.
+    """
+    _ISCSI_THREAD_NAMES = {"iscsi_trx", "iscsi_ttx", "iscsi_np"}
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        alive = False
+        for comm in pathlib.Path("/proc").glob("*/task/*/comm"):
+            try:
+                if comm.read_text().strip() in _ISCSI_THREAD_NAMES:
+                    alive = True
+                    break
+            except OSError:
+                pass
+        if not alive:
+            return
+        time.sleep(0.1)
+
+
+def teardown_lio_config():
+    """Remove all LIO configfs state.
+
+    Deletion order mirrors the creation order in write_lio_config: targets
+    before storage objects, so LUN symlinks are gone before the SOs they
+    reference are removed.
+    """
+    if not LIO_CONFIG_DIR.exists():
+        return
+
+    # iSCSI targets (skip discovery_auth which is a file node, not a target)
+    if ISCSI_DIR.exists():
+        for entry in list(ISCSI_DIR.iterdir()):
+            if entry.is_dir() and entry.name != "discovery_auth":
+                _delete_iscsi_target(entry)
+        try:
+            ISCSI_DIR.rmdir()
+        except OSError:
+            pass
+
+    # FC targets
+    if FC_DIR.exists():
+        for entry in list(FC_DIR.iterdir()):
+            if entry.is_dir():
+                _delete_fc_target(entry)
+        try:
+            FC_DIR.rmdir()
+        except OSError:
+            pass
+
+    # Storage objects -- remove SOs, then the backstore group dir, then core.
+    # The kernel holds a module reference on target_core_iblock / target_core_file
+    # for as long as the backstore group directory (iblock_0 / fileio_0) exists,
+    # even when it is empty.
+    core_dir = LIO_CONFIG_DIR / "core"
+    for backstore in (IBLOCK_DIR, FILEIO_DIR):
+        if backstore.exists():
+            for entry in list(backstore.iterdir()):
+                if entry.is_dir():
+                    _delete_storage_object(entry)
+            try:
+                backstore.rmdir()
+            except OSError:
+                pass
+    if core_dir.exists():
+        try:
+            core_dir.rmdir()
+        except OSError:
+            pass
+
+    # Wait for iscsi_trx kthreads to exit before unloading the module.
+    # Portal removal triggers async session teardown; the threads must be
+    # fully gone before modprobe -r or the kernel panics on poisoned memory.
+    _wait_for_iscsi_threads()
+
+    # Unload all LIO modules so the next start gets a clean state.
+    # Order: fabric modules first (most dependent), then backends, then core.
+    to_unload = []
+    for mod, name in (
+        (MOD_IB_ISERT, "ib_isert"),
+        (MOD_TCM_QLA2XXX, "tcm_qla2xxx"),
+        (MOD_ISCSI_TARGET, "iscsi_target_mod"),
+        (MOD_TCM_IBLOCK, "target_core_iblock"),
+        (MOD_TCM_FILE, "target_core_file"),
+        (MOD_TCM_PSCSI, "target_core_pscsi"),
+        (MOD_TCM_USER, "target_core_user"),
+        (MOD_TARGET_CORE, "target_core_mod"),
+    ):
+        if mod.exists():
+            to_unload.append(name)
+    if to_unload:
+        subprocess.run(["modprobe", "-ra"] + to_unload, capture_output=True)
+
+
+def write_lio_config(render_ctx: dict):
+    """
+    Reconcile the live LIO configfs state against the desired state.
+
+    Context managers are nested so that:
+    - Storage objects are created before targets reference them (LUNs)
+    - LUN symlinks are removed before storage objects are deleted
+    """
+    _load_modules(render_ctx)
+    if not LIO_CONFIG_DIR.exists():
+        return
+
+    # Ensure backstore directories exist
+    IBLOCK_DIR.mkdir(parents=True, exist_ok=True)
+    FILEIO_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Fabric dirs are created on demand via configfs mkdir (target_register_template
+    # only adds to a list; the directory appears when we mkdir it here).
+    if MOD_ISCSI_TARGET.exists():
+        ISCSI_DIR.mkdir(exist_ok=True)
+    if MOD_TCM_QLA2XXX.exists():
+        FC_DIR.mkdir(exist_ok=True)
+
+    with (
+        _storage_objects(render_ctx),
+        _iscsi_targets(render_ctx),
+        _fc_targets(render_ctx),
+        _discovery_auth(render_ctx),
+    ):
+        pass

--- a/tests/sharing_protocols/iscsi/test_264_iscsi_mode_compat.py
+++ b/tests/sharing_protocols/iscsi/test_264_iscsi_mode_compat.py
@@ -1,0 +1,1098 @@
+"""
+test_264_iscsi_mode_compat.py
+
+Cross-mode compatibility suite for iSCSI target stacks.
+
+Validates that client-visible behaviour is consistent across ISCSIMODEs.
+The primary guard: a customer switching from SCST to LIO must not encounter
+a regression in any area covered here.
+
+One service restart per mode; all targets and extents are created once and
+shared across all mode iterations.
+"""
+
+import contextlib
+import random
+import string
+from time import sleep
+
+import pytest
+
+from assets.websocket.iscsi import (
+    TUR,
+    _device_identification,
+    _serial_number,
+    initiator,
+    portal,
+    target,
+    target_extent_associate,
+    verify_capacity,
+    verify_luns,
+    zvol_extent,
+)
+from assets.websocket.pool import zvol as zvol_dataset
+from assets.websocket.service import ensure_service_enabled
+from auto_config import pool_name
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
+from protocols import ISCSIDiscover, iscsi_scsi_connection
+
+
+class ISCSIMODE:
+    SCST_DLM_PRSTATE_SAVE = 0
+    SCST_DLM_PRSTATE_NOSAVE = 1
+    LIO = 2
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SERVICE_NAME = 'iscsitarget'
+MB = 1024 * 1024
+basename = 'iqn.2005-10.org.freenas.ctl'
+
+MODES_UNDER_TEST = [
+    ISCSIMODE.SCST_DLM_PRSTATE_SAVE,  # 0 -- default SCST
+    ISCSIMODE.LIO,  # 2
+]
+MODE_IDS = {
+    ISCSIMODE.SCST_DLM_PRSTATE_SAVE: 'scst',
+    ISCSIMODE.LIO: 'lio',
+}
+
+# Random suffix to avoid name collisions with other test modules running
+# in the same environment.
+_rnd = ''.join(random.choices(string.digits, k=4))
+
+# Target names and IQNs
+T_BASIC = f'mc{_rnd}basic'
+IQN_BASIC = f'{basename}:{T_BASIC}'
+
+T_CHAP = f'mc{_rnd}chap'
+IQN_CHAP = f'{basename}:{T_CHAP}'
+
+# Zvol sizes (MB)
+SIZE_BASIC = 256
+SIZE_CHAP = 64
+
+# CHAP credentials for t_chap (14 chars -- within the 12-16 char API requirement)
+CHAP_USER = f'mc{_rnd}user'
+CHAP_SECRET = f'mc{_rnd}secret12'
+
+# Specific initiator IQN for the CHAP target.
+# LIO requires static ACLs (specific IQN) for CHAP credential verification;
+# dynamic ACLs (generate_node_acls=1) have empty credentials and reject everyone.
+CHAP_INITIATOR_IQN = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}init'
+
+T_MUTUAL = f'mc{_rnd}mutual'
+IQN_MUTUAL = f'{basename}:{T_MUTUAL}'
+SIZE_MUTUAL = 64
+
+# Mutual CHAP credentials (12-16 chars each; peersecret must differ from secret)
+# user/secret    -- initiator proves itself to the target
+# peer_user/peer_secret -- target proves itself to the initiator
+MUTUAL_USER = f'mc{_rnd}mutuser'  # 13 chars
+MUTUAL_SECRET = f'mc{_rnd}mutsec01'  # 14 chars
+MUTUAL_PEER_USER = f'mc{_rnd}tgtuser'  # 13 chars
+MUTUAL_PEER_SECRET = f'mc{_rnd}tgtsec01'  # 14 chars; differs from MUTUAL_SECRET
+MUTUAL_INITIATOR_IQN = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}mutinit'
+
+T_MULTILUN = f'mc{_rnd}ml'
+IQN_MULTILUN = f'{basename}:{T_MULTILUN}'
+# Three LUNs of distinct sizes so per-LUN capacity tests are unambiguous.
+# Index == LUN ID (LUN 0 = 64 MB, LUN 1 = 128 MB, LUN 2 = 192 MB).
+ML_LUN_SIZES = [64, 128, 192]  # MB
+
+T_NOLUN0 = f'mc{_rnd}nl0'
+IQN_NOLUN0 = f'{basename}:{T_NOLUN0}'
+SIZE_NOLUN0 = 64  # MB
+NOLUN0_LUN_ID = 1  # only LUN on this target; LUN 0 is intentionally absent
+
+T_ACL = f'mc{_rnd}acl'
+IQN_ACL = f'{basename}:{T_ACL}'
+SIZE_ACL = 64  # MB
+
+# The IQN that is explicitly permitted on the ACL target.
+ACL_INITIATOR_IQN = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}aclinit'
+# A different IQN that is NOT in the ACL -- must be rejected.
+ACL_UNLISTED_IQN = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}notlisted'
+
+# Discovery CHAP credentials (tag 3 -- distinct from target CHAP tags 1 and 2).
+DISC_USER = f'mc{_rnd}discusr'  # 13 chars
+DISC_SECRET = f'mc{_rnd}discsec0'  # 14 chars
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_designator(s, designator_type):
+    """Return the first VPD 0x83 designator matching designator_type."""
+    x = s.inquiry(evpd=1, page_code=0x83)
+    for designator in x.result['designator_descriptors']:
+        if designator['designator_type'] == designator_type:
+            del designator['piv']
+            return designator
+
+
+@contextlib.contextmanager
+def _snapshot(dataset, name):
+    """Create a ZFS snapshot; delete it on exit (survives rollback)."""
+    snap_id = f'{dataset}@{name}'
+    call('pool.snapshot.create', {'dataset': dataset, 'name': name})
+    try:
+        yield snap_id
+    finally:
+        with contextlib.suppress(Exception):
+            call('pool.snapshot.delete', snap_id)
+
+
+@contextlib.contextmanager
+def iscsi_auth(tag, user, secret, **kwargs):
+    auth_config = call(
+        'iscsi.auth.create', {'tag': tag, 'user': user, 'secret': secret, **kwargs}
+    )
+    try:
+        yield auth_config
+    finally:
+        call('iscsi.auth.delete', auth_config['id'])
+
+
+def _vendor_nibbles_from_naa(naa_hex):
+    """Extract the 25-char vendor-specific field from a TrueNAS NAA hex string.
+
+    The stored NAA format is "0x" + 32 hex chars:
+      1 nibble : NAA type (6)
+      6 nibbles: IEEE company ID
+      25 nibbles: vendor-specific field (written to LIO wwn/vpd_unit_serial)
+
+    LIO returns these 25 chars as the VPD page 0x80 Unit Serial Number.
+    """
+    # skip "0x" (2) + NAA nibble (1) + company ID (6) = 9 chars
+    return naa_hex[9:]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def saved_iscsi_mode():
+    """Save the current iSCSI mode and service state; restore both on teardown."""
+    cfg = call('iscsi.global.config')
+    original_mode = cfg['mode']
+    was_running = call('service.started', SERVICE_NAME)
+    try:
+        yield
+    finally:
+        call('service.control', 'STOP', SERVICE_NAME, job=True)
+        call('iscsi.global.update', {'mode': original_mode})
+        if was_running:
+            call('service.control', 'START', SERVICE_NAME, job=True)
+
+
+@pytest.fixture(scope='module')
+def iscsi_config(saved_iscsi_mode):
+    """Create a minimal set of targets and extents once for the entire module."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(ensure_service_enabled(SERVICE_NAME))
+
+        # One wildcard portal and one open initiator group for non-CHAP targets.
+        p_wild = stack.enter_context(portal(comment=f'mc{_rnd}-wildcard'))
+        init_open = stack.enter_context(initiator(comment=f'mc{_rnd}-open'))
+        # Named initiator group for the CHAP target -- LIO requires a static ACL
+        # (specific IQN) to have per-ACL credentials for CHAP_N verification.
+        init_chap = stack.enter_context(
+            initiator(comment=f'mc{_rnd}-chap', initiators=[CHAP_INITIATOR_IQN])
+        )
+        init_mutual = stack.enter_context(
+            initiator(comment=f'mc{_rnd}-mutual', initiators=[MUTUAL_INITIATOR_IQN])
+        )
+        init_acl = stack.enter_context(
+            initiator(comment=f'mc{_rnd}-acl', initiators=[ACL_INITIATOR_IQN])
+        )
+
+        p_wild_id = p_wild['id']
+        init_open_id = init_open['id']
+        init_chap_id = init_chap['id']
+        init_mutual_id = init_mutual['id']
+        init_acl_id = init_acl['id']
+
+        # ---- t_basic: single LUN 0, no auth ----
+        zv_basic = stack.enter_context(
+            zvol_dataset(f'{pool_name}/mc{_rnd}ba', SIZE_BASIC)
+        )
+        ext_basic = stack.enter_context(
+            zvol_extent(f'{pool_name}/mc{_rnd}ba', f'mcext{_rnd}ba')
+        )
+        t_basic = stack.enter_context(
+            target(T_BASIC, [{'portal': p_wild_id, 'initiator': init_open_id}])
+        )
+        stack.enter_context(target_extent_associate(t_basic['id'], ext_basic['id'], 0))
+
+        # ---- t_chap: single LUN 0, CHAP auth ----
+        auth_chap = stack.enter_context(iscsi_auth(1, CHAP_USER, CHAP_SECRET))
+        stack.enter_context(zvol_dataset(f'{pool_name}/mc{_rnd}ch', SIZE_CHAP))
+        ext_chap = stack.enter_context(
+            zvol_extent(f'{pool_name}/mc{_rnd}ch', f'mcext{_rnd}ch')
+        )
+        t_chap_obj = stack.enter_context(
+            target(
+                T_CHAP,
+                [
+                    {
+                        'portal': p_wild_id,
+                        'initiator': init_chap_id,
+                        'authmethod': 'CHAP',
+                        'auth': auth_chap['tag'],
+                    }
+                ],
+            )
+        )
+        stack.enter_context(
+            target_extent_associate(t_chap_obj['id'], ext_chap['id'], 0)
+        )
+
+        # ---- t_mutual: single LUN 0, mutual CHAP ----
+        auth_mutual = stack.enter_context(
+            iscsi_auth(
+                2,
+                MUTUAL_USER,
+                MUTUAL_SECRET,
+                peeruser=MUTUAL_PEER_USER,
+                peersecret=MUTUAL_PEER_SECRET,
+            )
+        )
+        stack.enter_context(zvol_dataset(f'{pool_name}/mc{_rnd}mu', SIZE_MUTUAL))
+        ext_mutual = stack.enter_context(
+            zvol_extent(f'{pool_name}/mc{_rnd}mu', f'mcext{_rnd}mu')
+        )
+        t_mutual_obj = stack.enter_context(
+            target(
+                T_MUTUAL,
+                [
+                    {
+                        'portal': p_wild_id,
+                        'initiator': init_mutual_id,
+                        'authmethod': 'CHAP_MUTUAL',
+                        'auth': auth_mutual['tag'],
+                    }
+                ],
+            )
+        )
+        stack.enter_context(
+            target_extent_associate(t_mutual_obj['id'], ext_mutual['id'], 0)
+        )
+
+        # ---- t_multilun: 3 LUNs (IDs 0/1/2) of different sizes ----
+        ext_ml = []
+        for i, sz in enumerate(ML_LUN_SIZES):
+            stack.enter_context(zvol_dataset(f'{pool_name}/mc{_rnd}ml{i}', sz))
+            ext_ml.append(
+                stack.enter_context(
+                    zvol_extent(f'{pool_name}/mc{_rnd}ml{i}', f'mcext{_rnd}ml{i}')
+                )
+            )
+        t_multilun = stack.enter_context(
+            target(T_MULTILUN, [{'portal': p_wild_id, 'initiator': init_open_id}])
+        )
+        for lun_id, ex in enumerate(ext_ml):
+            stack.enter_context(
+                target_extent_associate(t_multilun['id'], ex['id'], lun_id)
+            )
+
+        # ---- t_nolun0: single LUN at ID 1; LUN 0 intentionally absent ----
+        stack.enter_context(zvol_dataset(f'{pool_name}/mc{_rnd}nl0', SIZE_NOLUN0))
+        ext_nolun0 = stack.enter_context(
+            zvol_extent(f'{pool_name}/mc{_rnd}nl0', f'mcext{_rnd}nl0')
+        )
+        t_nolun0 = stack.enter_context(
+            target(T_NOLUN0, [{'portal': p_wild_id, 'initiator': init_open_id}])
+        )
+        stack.enter_context(
+            target_extent_associate(t_nolun0['id'], ext_nolun0['id'], NOLUN0_LUN_ID)
+        )
+
+        # ---- t_acl: single LUN 0, no auth, named initiator group ----
+        stack.enter_context(zvol_dataset(f'{pool_name}/mc{_rnd}ac', SIZE_ACL))
+        ext_acl = stack.enter_context(
+            zvol_extent(f'{pool_name}/mc{_rnd}ac', f'mcext{_rnd}ac')
+        )
+        t_acl = stack.enter_context(
+            target(T_ACL, [{'portal': p_wild_id, 'initiator': init_acl_id}])
+        )
+        stack.enter_context(target_extent_associate(t_acl['id'], ext_acl['id'], 0))
+
+        # ---- discovery auth: enforces CHAP on SendTargets ----
+        stack.enter_context(
+            iscsi_auth(3, DISC_USER, DISC_SECRET, discovery_auth='CHAP')
+        )
+
+        try:
+            yield {
+                'ip': truenas_server.ip,
+                'portal_id': p_wild_id,
+                'initiator_id': init_open_id,
+                'targets': {
+                    'basic': {
+                        'iqn': IQN_BASIC,
+                        'extent': ext_basic,
+                        'zvol': zv_basic['id'],
+                        'size_mb': SIZE_BASIC,
+                    },
+                    'chap': {
+                        'iqn': IQN_CHAP,
+                    },
+                    'mutual': {
+                        'iqn': IQN_MUTUAL,
+                    },
+                    'multilun': {
+                        'iqn': IQN_MULTILUN,
+                        'lun_sizes_mb': ML_LUN_SIZES,
+                    },
+                    'nolun0': {
+                        'iqn': IQN_NOLUN0,
+                        'lun_id': NOLUN0_LUN_ID,
+                        'size_mb': SIZE_NOLUN0,
+                    },
+                    'acl': {
+                        'iqn': IQN_ACL,
+                    },
+                },
+            }
+        finally:
+            # Stop the service before ExitStack tears down targets/extents/zvols.
+            # The service holds these resources in its config; deletion may fail
+            # while it is running.
+            call('service.control', 'STOP', SERVICE_NAME, job=True)
+
+
+@pytest.fixture(
+    scope='module',
+    params=MODES_UNDER_TEST,
+    ids=[MODE_IDS[m] for m in MODES_UNDER_TEST],
+)
+def active_mode(request, iscsi_config):
+    """Switch ISCSIMODE and restart the service. One restart per mode value."""
+    mode = request.param
+    call('service.control', 'STOP', SERVICE_NAME, job=True)
+    call('iscsi.global.update', {'mode': mode})
+    call('service.control', 'START', SERVICE_NAME, job=True)
+    sleep(5)
+    yield mode
+
+
+# ---------------------------------------------------------------------------
+# t_basic -- standard INQUIRY and VPD pages
+# ---------------------------------------------------------------------------
+
+
+def test_standard_inquiry(iscsi_config, active_mode):
+    """Standard INQUIRY: vendor, product_id, and revision must be non-empty;
+    product_id must match the value stored in the database.
+    """
+    cfg = iscsi_config['targets']['basic']
+    extent_data = call(
+        'iscsi.extent.query',
+        [['name', '=', cfg['extent']['name']]],
+        {'get': True},
+    )
+    db_product_id = extent_data['product_id']
+
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        data = s.inquiry().result
+
+    vendor = data['t10_vendor_identification'].decode('utf-8').strip()
+    product = data['product_identification'].decode('utf-8').strip()
+    revision = data['product_revision_level'].decode('utf-8').strip()
+
+    assert vendor, f'mode={active_mode}: vendor_id is empty'
+    assert product, f'mode={active_mode}: product_id is empty'
+    assert revision, f'mode={active_mode}: product_revision_level is empty'
+    assert product == db_product_id, (
+        f'mode={active_mode}: product_id mismatch -- '
+        f'wire={product!r}  db={db_product_id!r}'
+    )
+
+
+def test_vpd_0x83_naa(iscsi_config, active_mode):
+    """VPD page 0x83 NAA designator must match the stored TrueNAS NAA for all modes.
+
+    This is the key migration invariant: switching from SCST to LIO must not
+    change the device identity seen by initiators.
+    """
+    cfg = iscsi_config['targets']['basic']
+    extent_data = call(
+        'iscsi.extent.query',
+        [['name', '=', cfg['extent']['name']]],
+        {'get': True},
+    )
+    expected_naa = extent_data['naa']
+
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        wire = _device_identification(s)
+
+    assert 'naa' in wire, f'No NAA designator in VPD 0x83 response: {wire}'
+    assert wire['naa'] == expected_naa, (
+        f'mode={active_mode}: VPD 0x83 NAA mismatch -- '
+        f'wire={wire["naa"]!r}  db={expected_naa!r}'
+    )
+
+
+def test_vpd_0x80_serial(iscsi_config, active_mode):
+    """VPD page 0x80 Unit Serial Number: assert the per-mode expected value.
+
+    SCST returns the human-readable serial UUID stored in the database.
+    LIO returns the 25-char vendor-nibble hex derived from the stored NAA
+    (written to wwn/vpd_unit_serial at config time).
+
+    This test explicitly validates the known intentional difference rather
+    than requiring cross-mode equality.
+    """
+    cfg = iscsi_config['targets']['basic']
+    extent_data = call(
+        'iscsi.extent.query',
+        [['name', '=', cfg['extent']['name']]],
+        {'get': True},
+    )
+
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        wire_serial = _serial_number(s).rstrip('\x00')
+
+    if active_mode == ISCSIMODE.LIO:
+        expected = _vendor_nibbles_from_naa(extent_data['naa'])
+    else:
+        expected = extent_data['serial']
+
+    assert wire_serial == expected, (
+        f'mode={active_mode}: VPD 0x80 serial mismatch -- '
+        f'wire={wire_serial!r}  expected={expected!r}'
+    )
+
+
+def test_read_capacity(iscsi_config, active_mode):
+    """Wire-reported capacity must match the configured zvol size."""
+    cfg = iscsi_config['targets']['basic']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        verify_capacity(s, cfg['size_mb'] * MB)
+
+
+def test_basic_read_write(iscsi_config, active_mode):
+    """Write a known pattern, read it back in-session and after reconnect."""
+    cfg = iscsi_config['targets']['basic']
+    ip = iscsi_config['ip']
+    iqn = cfg['iqn']
+    zeros = bytearray(512)
+    pattern = bytearray.fromhex('c0ffee00') * 128  # 512 bytes
+
+    with iscsi_scsi_connection(ip, iqn) as s:
+        TUR(s)
+        s.writesame16(0, 4, zeros)  # clear first 4 LBAs
+        s.write16(2, 1, pattern)  # write pattern to LBA 2
+        assert s.read16(2, 1).datain == pattern
+        assert s.read16(0, 1).datain == zeros
+
+    # Reconnect and verify persistence
+    with iscsi_scsi_connection(ip, iqn) as s:
+        TUR(s)
+        assert s.read16(2, 1).datain == pattern
+        assert s.read16(0, 1).datain == zeros
+
+
+def test_session_count(iscsi_config, active_mode):
+    """client_count must be at least 1 while a session is active."""
+    cfg = iscsi_config['targets']['basic']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        count = call('iscsi.global.client_count')
+    assert count >= 1, f'mode={active_mode}: expected client_count >= 1, got {count}'
+
+
+def test_session_list(iscsi_config, active_mode):
+    """iscsi.global.sessions must contain an entry for the active session.
+
+    Checks target IQN and that initiator_addr is present.  For LIO in
+    generate_node_acls mode the kernel only exposes the initiator IQN via
+    tpgt_N/dynamic_sessions (no IP), so initiator_addr is '' -- the assertion
+    is relaxed to isinstance check in that case.
+    """
+    cfg = iscsi_config['targets']['basic']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        sessions = call('iscsi.global.sessions')
+
+    matching = [sess for sess in sessions if sess['target'] == cfg['iqn']]
+    assert matching, (
+        f'mode={active_mode}: no session found for {cfg["iqn"]} -- sessions={sessions!r}'
+    )
+    addr = matching[0]['initiator_addr']
+    if active_mode == ISCSIMODE.LIO:
+        assert isinstance(addr, str), (
+            f'mode={active_mode}: initiator_addr is not a string in session {matching[0]!r}'
+        )
+    else:
+        assert addr, (
+            f'mode={active_mode}: initiator_addr is empty in session {matching[0]!r}'
+        )
+
+
+# ---------------------------------------------------------------------------
+# t_basic -- concurrent initiators
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_initiators(iscsi_config, active_mode):
+    """Two simultaneous sessions to the same target must both be active and
+    share the same underlying storage.
+
+    Each iscsi_scsi_connection context creates an independent libiscsi session
+    with its own TCP connection and ISID.  Verifies:
+
+    - client_count is at least 2 while both sessions are open.
+    - A write from one session is immediately visible to the other
+      (shared block device; no per-session write buffering).
+    """
+    ip = iscsi_config['ip']
+    iqn = iscsi_config['targets']['basic']['iqn']
+    pattern_1 = bytearray.fromhex('11111111') * 128
+    pattern_2 = bytearray.fromhex('22222222') * 128
+
+    init1 = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}ci1'
+    init2 = f'iqn.2005-10.org.freenas.ctl:mc{_rnd}ci2'
+
+    with iscsi_scsi_connection(ip, iqn, initiator_name=init1) as s1:
+        with iscsi_scsi_connection(ip, iqn, initiator_name=init2) as s2:
+            TUR(s1)
+            TUR(s2)
+
+            # client_count counts distinct initiator IPs, not sessions.
+            # Both connections originate from the same test machine, so
+            # client_count == 1; use the session list to verify two sessions.
+            sessions = call('iscsi.global.sessions', [['target', '=', iqn]])
+            assert len(sessions) >= 2, (
+                f'mode={active_mode}: expected >= 2 sessions to {iqn}, got {sessions!r}'
+            )
+
+            s1.write16(8, 1, pattern_1)
+            s2.write16(9, 1, pattern_2)
+
+            # Cross-read: each session must see the other's write.
+            assert s2.read16(8, 1).datain == pattern_1, (
+                f'mode={active_mode}: session 2 cannot read session 1 write at LBA 8'
+            )
+            assert s1.read16(9, 1).datain == pattern_2, (
+                f'mode={active_mode}: session 1 cannot read session 2 write at LBA 9'
+            )
+
+
+# ---------------------------------------------------------------------------
+# t_basic -- resize
+# ---------------------------------------------------------------------------
+
+
+def test_resize_zvol_visible(iscsi_config, active_mode):
+    """Zvol resize must be reflected in READ CAPACITY on the connected session.
+
+    With AEN enabled (the default) the target sends an async capacity-change
+    notification so no CHECK CONDITION appears on the initiator; the new size
+    is simply visible on the next READ CAPACITY.  Uses a dedicated
+    zvol/extent/target so the shared t_basic size is unaffected.
+    """
+    ip = iscsi_config['ip']
+    zvol_path = f'{pool_name}/mc{_rnd}rz'
+    extent_name = f'mcext{_rnd}rz'
+    target_name = f'mc{_rnd}resize'
+    iqn = f'{basename}:{target_name}'
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(zvol_dataset(zvol_path, SIZE_BASIC))
+        ext = stack.enter_context(zvol_extent(zvol_path, extent_name))
+        t = stack.enter_context(
+            target(
+                target_name,
+                [
+                    {
+                        'portal': iscsi_config['portal_id'],
+                        'initiator': iscsi_config['initiator_id'],
+                    }
+                ],
+            )
+        )
+        stack.enter_context(target_extent_associate(t['id'], ext['id'], 0))
+
+        with iscsi_scsi_connection(ip, iqn) as s:
+            TUR(s)
+            verify_capacity(s, SIZE_BASIC * MB)
+
+            call('pool.dataset.update', zvol_path, {'volsize': (SIZE_BASIC * 2) * MB})
+
+            verify_capacity(s, (SIZE_BASIC * 2) * MB)
+
+
+# ---------------------------------------------------------------------------
+# t_basic -- product_id customisation
+# ---------------------------------------------------------------------------
+
+
+def test_product_id_create(iscsi_config, active_mode):
+    """A custom product_id set at extent creation must appear in Standard INQUIRY.
+
+    test_261 covers the default product_id ("iSCSI Disk").  This test verifies
+    that a non-default value supplied at iscsi.extent.create is correctly written
+    to the storage object identity (SCST: config template; LIO: wwn/product_id
+    at SO creation time, before enable, when export_count == 0).
+
+    Hot-update (iscsi.extent.update on a live SO) is intentionally not tested:
+    LIO's wwn/product_id is a configfs attribute gated by export_count -- writes
+    are silently ignored once LUNs are mapped, so updating requires a full
+    service restart to tear down and recreate the storage object.  That is an
+    acceptable constraint for a rarely-changed identity field.
+    """
+    ip = iscsi_config['ip']
+    zvol_path = f'{pool_name}/mc{_rnd}pid'
+    extent_name = f'mcext{_rnd}pid'
+    target_name = f'mc{_rnd}pid'
+    iqn = f'{basename}:{target_name}'
+    custom_pid = f'mc{_rnd}pid'[:16]
+
+    def _inquiry_product(s):
+        return s.inquiry().result['product_identification'].decode('utf-8').strip()
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(zvol_dataset(zvol_path, 64))
+        ext = call(
+            'iscsi.extent.create',
+            {
+                'type': 'DISK',
+                'disk': f'zvol/{zvol_path}',
+                'name': extent_name,
+                'product_id': custom_pid,
+            },
+        )
+        stack.callback(lambda: call('iscsi.extent.delete', ext['id'], True))
+        t = stack.enter_context(
+            target(
+                target_name,
+                [
+                    {
+                        'portal': iscsi_config['portal_id'],
+                        'initiator': iscsi_config['initiator_id'],
+                    }
+                ],
+            )
+        )
+        stack.enter_context(target_extent_associate(t['id'], ext['id'], 0))
+
+        with iscsi_scsi_connection(ip, iqn) as s:
+            TUR(s)
+            assert _inquiry_product(s) == custom_pid, (
+                f'mode={active_mode}: custom product_id not reflected in INQUIRY'
+            )
+
+
+# ---------------------------------------------------------------------------
+# t_snapshot -- snapshot and rollback
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_rollback(iscsi_config, active_mode):
+    """Snapshot rollback must restore the zvol to its pre-snapshot state.
+
+    Pattern:
+      1. Write pattern A to LBA 4 and close the session.
+      2. Take a snapshot.
+      3. Open a new session and overwrite LBA 4 with pattern B.
+      4. Roll back to the snapshot.
+      5. Open a new session and verify LBA 4 contains pattern A again.
+
+    A new connection is used after rollback so the read goes to the target
+    stack fresh, with no possibility of a session-level read cache returning
+    stale data.
+    """
+    ip = iscsi_config['ip']
+    iqn = iscsi_config['targets']['basic']['iqn']
+    zvol_path = iscsi_config['targets']['basic']['zvol']
+    zeros = bytearray(512)
+    pattern_a = bytearray.fromhex('aabbccdd') * 128  # state at snapshot time
+    pattern_b = bytearray.fromhex('11223344') * 128  # written after snapshot
+
+    # Establish known state: zeros in LBAs 0-7, pattern_a in LBA 4.
+    with iscsi_scsi_connection(ip, iqn) as s:
+        TUR(s)
+        s.writesame16(0, 8, zeros)
+        s.write16(4, 1, pattern_a)
+
+    with _snapshot(zvol_path, f'mc{_rnd}snap') as snap_id:
+        # Overwrite LBA 4 with pattern_b (post-snapshot write).
+        with iscsi_scsi_connection(ip, iqn) as s:
+            TUR(s)
+            s.write16(4, 1, pattern_b)
+
+        call('pool.snapshot.rollback', snap_id)
+
+        # New connection -- data at LBA 4 must be pattern_a (rollback restored it).
+        with iscsi_scsi_connection(ip, iqn) as s:
+            TUR(s)
+            assert s.read16(4, 1).datain == pattern_a, (
+                f'mode={active_mode}: LBA 4 should be pattern_a after rollback'
+            )
+            assert s.read16(3, 1).datain == zeros, (
+                f'mode={active_mode}: LBA 3 should still be zeros after rollback'
+            )
+
+
+# ---------------------------------------------------------------------------
+# t_chap -- target authentication
+# ---------------------------------------------------------------------------
+
+
+def test_chap_valid_login(iscsi_config, active_mode):
+    """Login with correct CHAP credentials must succeed."""
+    cfg = iscsi_config['targets']['chap']
+    with iscsi_scsi_connection(
+        iscsi_config['ip'],
+        cfg['iqn'],
+        user=CHAP_USER,
+        secret=CHAP_SECRET,
+        initiator_name=CHAP_INITIATOR_IQN,
+    ) as s:
+        TUR(s)
+
+
+def test_chap_no_credentials(iscsi_config, active_mode):
+    """Login without credentials must be rejected by a CHAP-protected target."""
+    cfg = iscsi_config['targets']['chap']
+    with pytest.raises(RuntimeError) as exc:
+        with iscsi_scsi_connection(
+            iscsi_config['ip'],
+            cfg['iqn'],
+            initiator_name=CHAP_INITIATOR_IQN,
+        ) as s:
+            TUR(s)
+    assert 'Unable to connect to' in str(exc), exc
+
+
+def test_chap_wrong_secret(iscsi_config, active_mode):
+    """Login with an incorrect CHAP secret must be rejected."""
+    cfg = iscsi_config['targets']['chap']
+    with pytest.raises(RuntimeError) as exc:
+        with iscsi_scsi_connection(
+            iscsi_config['ip'],
+            cfg['iqn'],
+            user=CHAP_USER,
+            secret='wrongsecret123',
+            initiator_name=CHAP_INITIATOR_IQN,
+        ) as s:
+            TUR(s)
+    assert 'Unable to connect to' in str(exc), exc
+
+
+# ---------------------------------------------------------------------------
+# t_mutual -- mutual CHAP
+# ---------------------------------------------------------------------------
+
+
+def test_mutual_chap_valid_login(iscsi_config, active_mode):
+    """Login with correct credentials on both sides must succeed.
+
+    The initiator proves itself to the target (CHAP_N / CHAP_R) and the
+    target proves itself back to the initiator (reverse CHAP).
+    """
+    cfg = iscsi_config['targets']['mutual']
+    with iscsi_scsi_connection(
+        iscsi_config['ip'],
+        cfg['iqn'],
+        user=MUTUAL_USER,
+        secret=MUTUAL_SECRET,
+        target_user=MUTUAL_PEER_USER,
+        target_secret=MUTUAL_PEER_SECRET,
+        initiator_name=MUTUAL_INITIATOR_IQN,
+    ) as s:
+        TUR(s)
+
+
+def test_mutual_chap_wrong_target_secret(iscsi_config, active_mode):
+    """Login must fail when the target's reverse-CHAP response does not match.
+
+    The initiator presents correct credentials, but the expected target secret
+    differs from the one the target will use.  The initiator rejects the
+    target's reverse-CHAP response and aborts the login.
+    """
+    cfg = iscsi_config['targets']['mutual']
+    with pytest.raises(RuntimeError) as exc:
+        with iscsi_scsi_connection(
+            iscsi_config['ip'],
+            cfg['iqn'],
+            user=MUTUAL_USER,
+            secret=MUTUAL_SECRET,
+            target_user=MUTUAL_PEER_USER,
+            target_secret='wrongtarget12',
+            initiator_name=MUTUAL_INITIATOR_IQN,
+        ) as s:
+            TUR(s)
+    assert 'Unable to connect to' in str(exc), exc
+
+
+# ---------------------------------------------------------------------------
+# t_multilun -- LUN enumeration and per-LUN properties
+# ---------------------------------------------------------------------------
+
+
+def test_multilun_report_luns(iscsi_config, active_mode):
+    """REPORT LUNS must enumerate all configured LUN IDs."""
+    cfg = iscsi_config['targets']['multilun']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn']) as s:
+        TUR(s)
+        verify_luns(s, list(range(len(cfg['lun_sizes_mb']))))
+
+
+def test_multilun_per_lun_capacity(iscsi_config, active_mode):
+    """READ CAPACITY on each LUN must reflect its individual configured size."""
+    cfg = iscsi_config['targets']['multilun']
+    ip = iscsi_config['ip']
+    iqn = cfg['iqn']
+    for lun_id, size_mb in enumerate(cfg['lun_sizes_mb']):
+        with iscsi_scsi_connection(ip, iqn, lun=lun_id) as s:
+            verify_capacity(s, size_mb * MB)
+
+
+def test_multilun_xcopy(iscsi_config, active_mode):
+    """XCOPY (Extended Copy, opcode 0x83) must copy blocks between two LUNs on the
+    same target without the data traversing the initiator.
+
+    Uses LUN 0 as source and LUN 1 as destination on the t_multilun target.
+    Writes deadbeef to LBAs 1, 3, 4 on LUN 0; issues XCOPY to copy 4 blocks
+    starting at source LBA 1 to destination LBA 10; verifies:
+      - Source LUN 0 is unchanged.
+      - Destination LUN 1 has the correct blocks at LBAs 10, 12, 13 (zeros
+        elsewhere), matching the block-offset copy of LBAs 1-4.
+    """
+    ip = iscsi_config['ip']
+    iqn = iscsi_config['targets']['multilun']['iqn']
+    zeros = bytearray(512)
+    deadbeef = bytearray.fromhex('deadbeef') * 128
+
+    with iscsi_scsi_connection(ip, iqn, lun=0) as s1:
+        with iscsi_scsi_connection(ip, iqn, lun=1) as s2:
+            TUR(s1)
+            TUR(s2)
+
+            d1 = _get_designator(s1, 3)
+            d2 = _get_designator(s2, 3)
+
+            s1.writesame16(0, 20, zeros)
+            s2.writesame16(0, 20, zeros)
+
+            # Write source pattern: deadbeef at LBAs 1, 3, 4.
+            s1.write16(1, 1, deadbeef)
+            s1.write16(3, 1, deadbeef)
+            s1.write16(4, 1, deadbeef)
+
+            s1.extendedcopy4(
+                priority=1,
+                list_identifier=0x34,
+                target_descriptor_list=[
+                    {
+                        'descriptor_type_code': 'Identification descriptor target descriptor',
+                        'peripheral_device_type': 0x00,
+                        'target_descriptor_parameters': d1,
+                        'device_type_specific_parameters': {'disk_block_length': 512},
+                    },
+                    {
+                        'descriptor_type_code': 'Identification descriptor target descriptor',
+                        'peripheral_device_type': 0x00,
+                        'target_descriptor_parameters': d2,
+                        'device_type_specific_parameters': {'disk_block_length': 512},
+                    },
+                ],
+                segment_descriptor_list=[
+                    {
+                        'descriptor_type_code': 'Copy from block device to block device',
+                        'dc': 1,
+                        'source_target_descriptor_id': 0,
+                        'destination_target_descriptor_id': 1,
+                        'block_device_number_of_blocks': 4,
+                        'source_block_device_logical_block_address': 1,
+                        'destination_block_device_logical_block_address': 10,
+                    }
+                ],
+            )
+
+            # Source LUN 0 must be unchanged.
+            for lba in range(0, 20):
+                r = s1.read16(lba, 1)
+                expected = deadbeef if lba in (1, 3, 4) else zeros
+                assert r.datain == expected, (
+                    f'mode={active_mode}: LUN 0 LBA {lba}: unexpected data after XCOPY'
+                )
+
+            # Destination LUN 1: LBAs 10, 12, 13 copied (1->10, 3->12, 4->13); rest zeros.
+            for lba in range(0, 20):
+                r = s2.read16(lba, 1)
+                expected = deadbeef if lba in (10, 12, 13) else zeros
+                assert r.datain == expected, (
+                    f'mode={active_mode}: LUN 1 LBA {lba}: unexpected data after XCOPY'
+                )
+
+
+# ---------------------------------------------------------------------------
+# t_nolun0 -- no LUN 0
+# ---------------------------------------------------------------------------
+
+
+def test_nolun0_report_luns(iscsi_config, active_mode):
+    """REPORT LUNS must enumerate only LUN 1 when LUN 0 is absent.
+
+    Tests that the target stack correctly reports a sparse LUN space:
+    only the configured LUN ID appears; LUN 0 is not fabricated.
+
+    We connect to the existing LUN (1) rather than the absent LUN 0 because
+    libiscsi sends a TUR to the connected LUN on login; that TUR would fail
+    against an absent LUN before we could issue REPORT LUNS.  See the
+    equivalent comment in test_261_iscsi_cmd.py::test__no_lun_zero.
+
+    Note: a SCSI-compliant target (including SCST) does respond to REPORT
+    LUNS addressed to an absent LUN 0 -- the spec requires it -- but that path
+    cannot be exercised via libiscsi for the reason above.
+    """
+    cfg = iscsi_config['targets']['nolun0']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn'], lun=cfg['lun_id']) as s:
+        verify_luns(s, [cfg['lun_id']])
+
+
+def test_nolun0_capacity(iscsi_config, active_mode):
+    """READ CAPACITY on the non-zero LUN must reflect the configured size."""
+    cfg = iscsi_config['targets']['nolun0']
+    with iscsi_scsi_connection(iscsi_config['ip'], cfg['iqn'], lun=cfg['lun_id']) as s:
+        verify_capacity(s, cfg['size_mb'] * MB)
+
+
+# ---------------------------------------------------------------------------
+# t_acl -- initiator ACL filtering
+# ---------------------------------------------------------------------------
+
+
+def test_acl_permitted_login(iscsi_config, active_mode):
+    """An initiator whose IQN is listed in the initiator group must be allowed in."""
+    cfg = iscsi_config['targets']['acl']
+    with iscsi_scsi_connection(
+        iscsi_config['ip'],
+        cfg['iqn'],
+        initiator_name=ACL_INITIATOR_IQN,
+    ) as s:
+        TUR(s)
+
+
+def test_acl_denied_login(iscsi_config, active_mode):
+    """An initiator whose IQN is not in the initiator group must be rejected."""
+    cfg = iscsi_config['targets']['acl']
+    with pytest.raises(RuntimeError) as exc:
+        with iscsi_scsi_connection(
+            iscsi_config['ip'],
+            cfg['iqn'],
+            initiator_name=ACL_UNLISTED_IQN,
+        ) as s:
+            TUR(s)
+    assert 'Unable to connect to' in str(exc), exc
+
+
+# ---------------------------------------------------------------------------
+# Service lifecycle -- restart and reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_service_restart_reconnects(iscsi_config, active_mode):
+    """iSCSI service restart must preserve target config and data accessibility.
+
+    Stops and starts the service in the current mode.  Both SCST and LIO must
+    re-apply the full configuration on startup.  Verifies:
+
+    - A connection to the basic (no-auth) target can be re-established.
+    - Data written before the restart is readable afterwards (zvol not affected).
+    - A CHAP-protected target still accepts correct credentials (auth config
+      survives restart).
+    """
+    ip = iscsi_config['ip']
+    pattern = bytearray.fromhex('cafebabe') * 128
+
+    # Write a known pattern before the restart.
+    with iscsi_scsi_connection(ip, iscsi_config['targets']['basic']['iqn']) as s:
+        TUR(s)
+        s.write16(0, 1, pattern)
+
+    call('service.control', 'STOP', SERVICE_NAME, job=True)
+    call('service.control', 'START', SERVICE_NAME, job=True)
+    sleep(5)
+
+    # Basic target must be reachable and the pre-restart write must survive.
+    with iscsi_scsi_connection(ip, iscsi_config['targets']['basic']['iqn']) as s:
+        TUR(s)
+        assert s.read16(0, 1).datain == pattern, (
+            f'mode={active_mode}: data not preserved through service restart'
+        )
+
+    # CHAP-protected target must still accept correct credentials after restart.
+    with iscsi_scsi_connection(
+        ip,
+        iscsi_config['targets']['chap']['iqn'],
+        user=CHAP_USER,
+        secret=CHAP_SECRET,
+        initiator_name=CHAP_INITIATOR_IQN,
+    ) as s:
+        TUR(s)
+
+
+# ---------------------------------------------------------------------------
+# Discovery -- SendTargets with and without authentication
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_no_auth_sees_nothing(iscsi_config, active_mode):
+    """SendTargets without credentials must be rejected when discovery auth is enforced."""
+    with ISCSIDiscover(iscsi_config['ip']) as disc:
+        result = disc.discover()
+    assert result == {}, (
+        f'mode={active_mode}: expected empty discovery without credentials, got {result!r}'
+    )
+
+
+def test_discovery_auth_valid(iscsi_config, active_mode):
+    """SendTargets with correct discovery credentials must return targets visible to the
+    discovery initiator.
+
+    Only targets whose initiator group is open (any IQN permitted) appear in the
+    SendTargets response for an arbitrary discovery initiator IQN.  Targets with named
+    initiator groups (t_chap, t_mutual, t_acl) are correctly filtered out because the
+    discovery initiator's IQN is not listed in those groups.
+    """
+    with ISCSIDiscover(
+        iscsi_config['ip'],
+        initiator_username=DISC_USER,
+        initiator_password=DISC_SECRET,
+    ) as disc:
+        result = disc.discover()
+    discovered = set(result.keys())
+    # Only open-initiator-group targets are discoverable by an arbitrary IQN.
+    expected = {IQN_BASIC, IQN_MULTILUN, IQN_NOLUN0}
+    assert expected.issubset(discovered), (
+        f'mode={active_mode}: expected IQNs not found in discovery -- '
+        f'missing={(expected - discovered)!r}  got={discovered!r}'
+    )
+
+
+def test_discovery_auth_invalid(iscsi_config, active_mode):
+    """SendTargets with wrong credentials must be rejected."""
+    with ISCSIDiscover(
+        iscsi_config['ip'],
+        initiator_username=DISC_USER,
+        initiator_password='wrongsecret12',
+    ) as disc:
+        result = disc.discover()
+    assert result == {}, (
+        f'mode={active_mode}: expected rejection with wrong credentials, got {result!r}'
+    )

--- a/tests/sharing_protocols/iscsi/test_265_iscsi_portal_binding.py
+++ b/tests/sharing_protocols/iscsi/test_265_iscsi_portal_binding.py
@@ -1,0 +1,237 @@
+"""
+test_265_iscsi_portal_binding.py
+
+Validates iSCSI portal binding behaviour across ISCSIMODEs.
+
+This module is deliberately separate from test_264_iscsi_mode_compat.py so
+that it can control portal setup independently.  test_264 keeps a wildcard
+portal (0.0.0.0:3260) alive for its entire run; since the portal API only
+supports port 3260, creating a second portal on the same port alongside the
+wildcard would be ambiguous.  This module runs with only a specific-IP portal
+and no wildcard, giving a clean test environment.
+
+Two LUNs are configured on the target to broaden coverage:
+
+  LUN 0 -- zvol (DISK extent)
+  LUN 1 -- file (FILE extent)
+
+This exercises both backend types through a specific-IP portal in a single
+module run.
+"""
+
+import contextlib
+import ipaddress
+import random
+import string
+from time import sleep
+
+import pytest
+
+from assets.websocket.iscsi import (
+    TUR,
+    initiator,
+    portal,
+    target,
+    target_extent_associate,
+    verify_capacity,
+    verify_luns,
+    zvol_extent,
+)
+from assets.websocket.pool import zvol as zvol_dataset
+from auto_config import pool_name
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+from protocols import ISCSIDiscover, iscsi_scsi_connection
+from assets.websocket.service import ensure_service_enabled
+
+
+class ISCSIMODE:
+    SCST_DLM_PRSTATE_SAVE = 0
+    SCST_DLM_PRSTATE_NOSAVE = 1
+    LIO = 2
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SERVICE_NAME = 'iscsitarget'
+MB = 1024 * 1024
+basename = 'iqn.2005-10.org.freenas.ctl'
+
+MODES_UNDER_TEST = [
+    ISCSIMODE.SCST_DLM_PRSTATE_SAVE,  # 0 -- default SCST
+    ISCSIMODE.LIO,  # 2
+]
+MODE_IDS = {
+    ISCSIMODE.SCST_DLM_PRSTATE_SAVE: 'scst',
+    ISCSIMODE.LIO: 'lio',
+}
+
+_rnd = ''.join(random.choices(string.digits, k=4))
+
+# pb = portal-binding prefix, keeps names distinct from test_264
+T_SPECIFIC = f'pb{_rnd}spec'
+IQN_SPECIFIC = f'{basename}:{T_SPECIFIC}'
+
+SIZE_ZVOL = 64  # MB -- LUN 0
+SIZE_FILE = 96  # MB -- LUN 1 (distinct size for unambiguous capacity assertions)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_nonloopback_ipv4():
+    """Return the first non-loopback, non-wildcard IPv4 from portal choices."""
+    choices = call('iscsi.portal.listen_ip_choices')
+    for ip in choices:
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if addr.version == 4 and not addr.is_loopback and not addr.is_unspecified:
+            return ip
+    raise RuntimeError(
+        'No suitable specific IPv4 address available from iscsi.portal.listen_ip_choices'
+    )
+
+
+@contextlib.contextmanager
+def file_extent(dataset_path, filename, filesize_mb, extent_name):
+    """Create a FILE-type iSCSI extent backed by a file in an existing dataset."""
+    config = call(
+        'iscsi.extent.create',
+        {
+            'type': 'FILE',
+            'name': extent_name,
+            'filesize': filesize_mb * MB,
+            'path': f'/mnt/{dataset_path}/{filename}',
+        },
+    )
+    try:
+        yield config
+    finally:
+        call('iscsi.extent.delete', config['id'], True, True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def saved_iscsi_mode():
+    """Save the current iSCSI mode and service state; restore both on teardown."""
+    cfg = call('iscsi.global.config')
+    original_mode = cfg['mode']
+    was_running = call('service.started', SERVICE_NAME)
+    try:
+        yield
+    finally:
+        call('service.control', 'STOP', SERVICE_NAME, job=True)
+        call('iscsi.global.update', {'mode': original_mode})
+        if was_running:
+            call('service.control', 'START', SERVICE_NAME, job=True)
+
+
+@pytest.fixture(scope='module')
+def portal_config(saved_iscsi_mode):
+    """Create a specific-IP portal with a two-LUN target (zvol + file)."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(ensure_service_enabled(SERVICE_NAME))
+
+        specific_ip = _first_nonloopback_ipv4()
+
+        p_specific = stack.enter_context(
+            portal(listen=[{'ip': specific_ip}], comment=f'pb{_rnd}-specific')
+        )
+        init_open = stack.enter_context(initiator(comment=f'pb{_rnd}-open'))
+
+        # LUN 0 -- zvol (DISK extent)
+        stack.enter_context(zvol_dataset(f'{pool_name}/pb{_rnd}zv', SIZE_ZVOL))
+        ext_zvol = stack.enter_context(
+            zvol_extent(f'{pool_name}/pb{_rnd}zv', f'pbext{_rnd}zv')
+        )
+
+        # LUN 1 -- file (FILE extent)
+        ds_path = stack.enter_context(dataset(f'pb{_rnd}ds'))
+        ext_file = stack.enter_context(
+            file_extent(ds_path, f'pb{_rnd}.img', SIZE_FILE, f'pbext{_rnd}fi')
+        )
+
+        t = stack.enter_context(
+            target(
+                T_SPECIFIC, [{'portal': p_specific['id'], 'initiator': init_open['id']}]
+            )
+        )
+        stack.enter_context(target_extent_associate(t['id'], ext_zvol['id'], 0))
+        stack.enter_context(target_extent_associate(t['id'], ext_file['id'], 1))
+
+        try:
+            yield {
+                'specific_ip': specific_ip,
+                'iqn': IQN_SPECIFIC,
+                'size_zvol_mb': SIZE_ZVOL,
+                'size_file_mb': SIZE_FILE,
+            }
+        finally:
+            call('service.control', 'STOP', SERVICE_NAME, job=True)
+
+
+@pytest.fixture(
+    scope='module',
+    params=MODES_UNDER_TEST,
+    ids=[MODE_IDS[m] for m in MODES_UNDER_TEST],
+)
+def active_mode(request, portal_config):
+    """Switch ISCSIMODE and restart the service. One restart per mode value."""
+    mode = request.param
+    call('service.control', 'STOP', SERVICE_NAME, job=True)
+    call('iscsi.global.update', {'mode': mode})
+    call('service.control', 'START', SERVICE_NAME, job=True)
+    sleep(5)
+    yield mode
+
+
+# ---------------------------------------------------------------------------
+# t_specific_ip -- specific-IP portal binding
+# ---------------------------------------------------------------------------
+
+
+def test_specific_ip_portal_reachable(portal_config, active_mode):
+    """Login via the specific-IP portal must succeed and LUN 0 (zvol) must be accessible.
+
+    Verifies that the iSCSI stack correctly binds to and listens on the
+    specific IP address configured in the portal.
+    """
+    with iscsi_scsi_connection(portal_config['specific_ip'], portal_config['iqn']) as s:
+        TUR(s)
+        verify_capacity(s, portal_config['size_zvol_mb'] * MB)
+
+
+def test_specific_ip_file_lun_capacity(portal_config, active_mode):
+    """LUN 1 (file extent) must report the correct capacity."""
+    with iscsi_scsi_connection(
+        portal_config['specific_ip'], portal_config['iqn'], lun=1
+    ) as s:
+        verify_capacity(s, portal_config['size_file_mb'] * MB)
+
+
+def test_specific_ip_report_luns(portal_config, active_mode):
+    """REPORT LUNS must enumerate both LUN 0 (zvol) and LUN 1 (file)."""
+    with iscsi_scsi_connection(portal_config['specific_ip'], portal_config['iqn']) as s:
+        verify_luns(s, [0, 1])
+
+
+def test_specific_ip_discovery_shows_target(portal_config, active_mode):
+    """SendTargets discovery via the specific IP must return the bound target."""
+    with ISCSIDiscover(portal_config['specific_ip']) as disc:
+        result = disc.discover()
+    discovered = set(result.keys())
+
+    assert IQN_SPECIFIC in discovered, (
+        f'mode={active_mode}: {IQN_SPECIFIC!r} not found in specific-IP discovery '
+        f'-- got {discovered!r}'
+    )


### PR DESCRIPTION
Adds `ISCSIMODE.LIO` (mode=2) as a selectable iSCSI target stack alongside the existing SCST modes. The implementation is a "big switch" — selecting LIO and restarting the iSCSI service brings up LIO with the same configured targets, extents, and initiator ACLs that SCST was serving. No data disruption; initiators reconnect and see the same device identities.

Device identity (VPD page 0x83 NAA designator) is preserved across migration by reverse-engineering the stored TrueNAS NAA into LIO's company_id + vpd_unit_serial components, ensuring initiators and multipath stacks see no device identity change.

Switching from SCST to LIO is blocked with a clear error if the configuration cannot be faithfully represented in LIO: open initiator groups with CHAP, multiple discovery-auth credentials, multiple CHAP credentials per auth tag, iSNS servers, or auth_networks on any target.

iSER is supported without additional configuration. HA ALUA is not yet implemented.

Test suite
- _test_264_iscsi_mode_compat.py_: cross-mode compatibility suite exercising SCST and LIO (non-HA) across iSCSI/FC with block and file extents, CHAP, mutual CHAP, discovery auth, portal binding, ALUA, and the pre-switch validation checks.
 - _test_265_iscsi_portal_binding.py_: portal binding behavior across modes.
 
 ----
 iSCSI passing CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/1976/).

Original PR: https://github.com/truenas/middleware/pull/18714
