### PR TITLE
NAS-140652 / 26.0.0-BETA.2 / fix nvme self-test error alert (buggy firmware) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/smart.py
+++ b/src/middlewared/middlewared/alert/source/smart.py
@@ -104,11 +104,17 @@ class SMARTAlertSource(ThreadedAlertSource):
         )
 
     def parse_nvme_smart_info(self, data: dict) -> SmartInfo:
-        latest_entry = data.get("nvme_self_test_log", {}).get(
-            "table", [{"self_test_result": {"value": -1}}]
-        )[-1]
+        # Per NVMe spec, self-test log entries are ordered newest-first, so
+        # index 0 is the most recent test. smartctl writes each kept entry at
+        # its hardware index, so the JSON table may be sparse (null gaps) when
+        # firmware leaves stale bytes in unused ring-buffer slots; skip nulls
+        # and take the first real entry rather than relying on position -1.
+        table = data.get("nvme_self_test_log", {}).get("table", [])
+        latest = next((e for e in table if e), None)
+        if latest is None:
+            return SmartInfo()
         return SmartInfo(
-            smart_testfail=latest_entry["self_test_result"]["value"] in (5, 6, 7),
+            smart_testfail=latest["self_test_result"]["value"] in (5, 6, 7),
         )
 
     def parse_smart_info(self, data: dict) -> SmartInfo:

--- a/tests/unit/test_smart_alert.py
+++ b/tests/unit/test_smart_alert.py
@@ -1,0 +1,129 @@
+import pytest
+
+from middlewared.alert.source.smart import SMARTAlertSource, SmartInfo
+
+
+# Real smartctl -x -jc output from NAS-140652 (serial redacted). Two passing
+# self-tests — this is the exact input that produced the transient false
+# "failed a SMART selftest" alert prior to the fix.
+REAL_NAS_140652 = {
+    "device": {"name": "/dev/nvme0n1", "type": "nvme", "protocol": "NVMe"},
+    "model_name": "TEAM TM8FP6256G",
+    "firmware_version": "VC2S038E",
+    "nvme_self_test_log": {
+        "current_self_test_operation": {
+            "value": 0,
+            "string": "No self-test in progress",
+        },
+        "table": [
+            {
+                "self_test_code": {"value": 1, "string": "Short"},
+                "self_test_result": {
+                    "value": 0,
+                    "string": "Completed without error",
+                },
+                "power_on_hours": 23575,
+            },
+            {
+                "self_test_code": {"value": 2, "string": "Extended"},
+                "self_test_result": {
+                    "value": 0,
+                    "string": "Completed without error",
+                },
+                "power_on_hours": 23335,
+            },
+        ],
+    },
+}
+
+
+def _entry(value: int) -> dict:
+    return {
+        "self_test_code": {"value": 1, "string": "Short"},
+        "self_test_result": {"value": value, "string": "x"},
+        "power_on_hours": 100,
+    }
+
+
+@pytest.mark.parametrize(
+    "data,expected_fail",
+    [
+        # Real data from NAS-140652 — two passes; must not alert.
+        (REAL_NAS_140652, False),
+        # Sparse trailing garbage scenario that triggered NAS-140652. smartctl
+        # emits entries at their hardware index, so a filtered-out middle slot
+        # leaves a JSON null. The old code took [-1] and grabbed the trailing
+        # garbage (value=5 = fatal error). The fix iterates past nulls and takes
+        # the actual newest entry at [0] (a passing test).
+        (
+            {"nvme_self_test_log": {"table": [_entry(0), _entry(0), None, _entry(5)]}},
+            False,
+        ),
+        # Same shape as above, but pinning the exact firmware-leak signature
+        # observed in the NAS-140652 raw `nvme self-test-log` dump: the
+        # trailing slot carries power_on_hours = 109951162777600
+        # (= 0x640000000000), which is uninitialized memory — proof the
+        # controller is not zeroing unused ring-buffer slots. If such a slot's
+        # op/result bytes ever align to a valid-looking failure code, smartctl
+        # keeps it and the old [-1] lookup would grab the garbage. Must not
+        # alert with the fix.
+        (
+            {
+                "nvme_self_test_log": {
+                    "table": [
+                        _entry(0),
+                        _entry(0),
+                        None,
+                        {
+                            "self_test_code": {"value": 1, "string": "Short"},
+                            "self_test_result": {"value": 5, "string": "x"},
+                            "power_on_hours": 109951162777600,
+                        },
+                    ]
+                }
+            },
+            False,
+        ),
+        # Genuine failures at index 0 — must still alert for all three NVMe
+        # failure codes (5 = fatal error, 6 = unknown failed segment,
+        # 7 = known failed segments).
+        ({"nvme_self_test_log": {"table": [_entry(5)]}}, True),
+        ({"nvme_self_test_log": {"table": [_entry(6)]}}, True),
+        ({"nvme_self_test_log": {"table": [_entry(7)]}}, True),
+        # Pass at [0] with an old failure behind it — failures age out; only the
+        # most recent test's result drives the alert.
+        ({"nvme_self_test_log": {"table": [_entry(0), _entry(5)]}}, False),
+        # NVMe abort codes (1-4, 8, 9) are not failures — must not alert.
+        ({"nvme_self_test_log": {"table": [_entry(1)]}}, False),
+        ({"nvme_self_test_log": {"table": [_entry(2)]}}, False),
+        ({"nvme_self_test_log": {"table": [_entry(8)]}}, False),
+        ({"nvme_self_test_log": {"table": [_entry(9)]}}, False),
+        # Reserved "entry not used" sentinel (0xF) — smartctl normally filters
+        # these, but if one slips through it must not alert.
+        ({"nvme_self_test_log": {"table": [_entry(0xF)]}}, False),
+        # Empty table — no exception (old code raised IndexError on table[-1]).
+        ({"nvme_self_test_log": {"table": []}}, False),
+        # Missing "table" key.
+        ({"nvme_self_test_log": {}}, False),
+        # Missing "nvme_self_test_log" key entirely.
+        ({}, False),
+        # Leading null followed by a real passing entry.
+        ({"nvme_self_test_log": {"table": [None, _entry(0)]}}, False),
+        # current_self_test_operation non-zero (test currently running) — the
+        # sibling field must not interfere with reading the table.
+        (
+            {
+                "nvme_self_test_log": {
+                    "current_self_test_operation": {"value": 1, "string": "Short"},
+                    "table": [_entry(0)],
+                }
+            },
+            False,
+        ),
+    ],
+)
+def test_parse_nvme_smart_info(data, expected_fail):
+    # parse_nvme_smart_info does not reference self; call it unbound.
+    info = SMARTAlertSource.parse_nvme_smart_info(None, data)
+    assert isinstance(info, SmartInfo)
+    assert info.smart_testfail is expected_fail


### PR DESCRIPTION
## Summary

Fix `parse_nvme_smart_info` in the SMART alert source to select the newest
NVMe self-test log entry and to tolerate sparse gaps in the table,
eliminating transient false `"failed a SMART selftest"` alerts that appear
and self-clear every 90 minutes (the alert's poll cadence).

## Root Cause

`parse_nvme_smart_info` used `table[-1]` while naming the variable
`latest_entry`, but `[-1]` is the *last* (oldest) element, not the newest.
Per the NVMe specification, the Device Self-Test Log (Log 0x06) stores
result entries in reverse chronological order — **index `0` is the most
recent test.** Using `[-1]` meant the alert was actually evaluating the
oldest visible entry, which is the opposite of the intent.

### Why the bug stays quiet on well-behaved drives

smartctl iterates all 20 hardware result slots and writes each *kept* entry
into `jref["table"][i]` at its **hardware index** (see
`smartmontools/nvmeprint.cpp`). An entry is skipped when
`op == 0 || result == 0xf`, i.e. the slot is marked "not used" per NVMe.
When the ring-buffer is well-formed, only an initial contiguous run of
slots is valid, so the emitted JSON is dense (`[e0, e1]`) and `[-1]` happens
to land on a real — passing — test. No alert, no visible bug.

### Why the bug fires on drives with lax ring-buffer hygiene

Some controller firmwares do not reliably zero out self-test log slots that
were never used. In that state the log exposes stale bytes in otherwise
"unused" slots. On the occasional read where such a slot's `Self test
code`/`Self test result` bytes happen to look valid *and* the result lands
in `{5, 6, 7}` (fatal error / failed segment codes), smartctl keeps the
slot — but at its hardware index, leaving earlier skipped slots as `null`
gaps in the JSON. The table becomes sparse, e.g.
`[e0, e1, null, garbage]`, and `table[-1]` grabs the trailing garbage. The
alert fires. On the next poll the firmware may return clean data, the
sparse garbage disappears, and the alert auto-clears — producing the
characteristic on/off oscillation at the
`IntervalSchedule(timedelta(minutes=90))` cadence.

### The broader logic issue

The real defect is not drive-specific. Two assumptions were baked into the
original code that do not hold in general:

1. **`[-1]` means "latest".** It does not for NVMe self-test logs; the spec
   orders them newest-first, so "latest" is `[0]`.
2. **The JSON `table` is dense.** It is not, because smartctl indexes by
   hardware position and the backing JSON library emits `null` for sparse
   gaps. Any code reading the `table` must treat it as potentially sparse.

Either assumption alone is a bug; together they turn random firmware
quirks in trailing log slots into spurious SMART failure alerts.

## Fix

- Read `table[0]` (first real entry) to obtain the actually-most-recent
  test result, matching the NVMe spec.
- Iterate past any falsy/`null` entries so a sparse table around
  firmware-induced gaps does not surface stale trailing slots.
- Fall back cleanly when no valid entry exists instead of relying on a
  default-list trick to paper over an empty/missing log.

## Tests

Added `tests/unit/test_smart_alert.py` with parametrized coverage of
`SMARTAlertSource.parse_nvme_smart_info`. The method never touches `self`,
so it's called unbound — no class instantiation or middleware plumbing.
Cases:

- **Real data from NAS-140652** (the verbatim smartctl dump with serial
  redacted) — regression anchor; must not alert.
- **Sparse trailing garbage** — `[entry, entry, null, {value: 5}]`; the
  exact shape that tripped the old `[-1]` lookup. Must not alert.
- **Genuine failures at `[0]`** — values `5`, `6`, `7` each individually
  covered; must alert.
- **Failure-aging** — pass at `[0]` with an old `{value: 5}` behind it;
  must not alert (only the newest test drives the decision).
- **NVMe abort codes** (`1`, `2`, `8`, `9`) — not failures; must not alert.
- **Reserved `0xF` sentinel** — smartctl normally filters it, but if one
  slips through it must not alert.
- **Empty `table`** — old code raised `IndexError` here; new code returns
  cleanly with no alert.
- **Missing `table` key** and **missing `nvme_self_test_log` key** — both
  return cleanly with no alert.
- **Leading `null` then real entry** — exercises the
  `next(e for e in table if e)` filter directly.
- **`current_self_test_operation` non-zero** (test currently running) —
  documents that the sibling field does not leak into the check.

Original PR: https://github.com/truenas/middleware/pull/18743
