### PR TITLE
NAS-140621 / 27.0.0-BETA.1 / Delete containers when pool is exported with cascade

### DIFF
--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -99,7 +99,11 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
         return containers_attached
 
     async def delete(self, attachments: list[dict[str, Any]]) -> None:
-        await self.toggle(attachments, False)
+        for attachment in attachments:
+            try:
+                await self.middleware.call2(self.s.container.delete, attachment['id'])
+            except Exception:
+                self.middleware.logger.warning('Unable to delete %r container', attachment['id'])
 
     async def toggle(self, attachments: list[dict[str, Any]], enabled: bool) -> None:
         await getattr(self, 'start' if enabled else 'stop')(attachments)


### PR DESCRIPTION
## Problem

During pool export with cascade=true, containers are not removed from the database via the
attachment delegate. As a result, container records persist even when cascade implies that all related attachments must be removed, leading to stale and inconsistent state.

## Solution

Updated container attachment delegate to make sure that when pool is being exported with config that related attachments are to be deleted, we actually delete them.