### PR TITLE
NAS-140621 / 26.0.0-BETA.2 / Delete containers when pool is exported with cascade (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -88,7 +88,14 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
         return containers_attached
 
     async def delete(self, attachments):
-        await self.toggle(attachments, False)
+        for attachment in attachments:
+            try:
+                container = await self.middleware.call('container.get_instance', attachment['id'])
+                await self.middleware.call('container.delete_container_from_db_and_libvirt', container)
+            except Exception:
+                self.middleware.logger.warning('Unable to delete %r container', attachment['id'])
+        else:
+            await self.middleware.call('etc.generate', 'libvirt_guests')
 
     async def toggle(self, attachments, enabled):
         return await getattr(self, 'start' if enabled else 'stop')(attachments)

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -351,7 +351,12 @@ class ContainerService(CRUDService):
         """
         container = self.middleware.call_sync("container.get_instance", id_)
         audit_callback(container['name'])
+        self.delete_container_from_db_and_libvirt(container)
+        self.call_sync2(self.s.zfs.resource.destroy_impl, container['dataset'])
+        self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
+    @private
+    def delete_container_from_db_and_libvirt(self, container):
         pylibvirt_container = self.middleware.call_sync("container.pylibvirt_container", container)
         try:
             self.middleware.libvirt_domains_manager.containers.delete(pylibvirt_container)
@@ -361,9 +366,7 @@ class ContainerService(CRUDService):
         for device in container['devices']:
             self.middleware.call_sync('datastore.delete', 'container.device', device['id'])
 
-        self.middleware.call_sync('datastore.delete', 'container.container', id_)
-        self.call_sync2(self.s.zfs.resource.destroy_impl, container['dataset'])
-        self.middleware.call_sync('etc.generate', 'libvirt_guests')
+        self.middleware.call_sync('datastore.delete', 'container.container', container['id'])
 
     @api_method(ContainerPoolChoicesArgs, ContainerPoolChoicesResult, roles=['CONTAINER_READ'])
     async def pool_choices(self):


### PR DESCRIPTION
## Problem

During pool export with cascade=true, containers are not removed from the database via the
attachment delegate. As a result, container records persist even when cascade implies that all related attachments must be removed, leading to stale and inconsistent state.

## Solution

Updated container attachment delegate to make sure that when pool is being exported with config that related attachments are to be deleted, we actually delete them.

Original PR: https://github.com/truenas/middleware/pull/18745
