### PR TITLE
NAS-140689 / 27.0.0-BETA.1 / Fix container deletion during pool export by skipping dataset destroy

### DIFF
--- a/src/middlewared/middlewared/plugins/container/__init__.py
+++ b/src/middlewared/middlewared/plugins/container/__init__.py
@@ -121,6 +121,10 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
         return await self._svc_part.create_with_dataset(data)
 
     @private
+    def delete_container_from_db_and_libvirt(self, container: ContainerEntry) -> None:
+        self._svc_part.delete_container_from_db_and_libvirt(container)
+
+    @private
     def start_on_boot(self) -> None:
         start_on_boot(self.context)
 

--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -101,7 +101,10 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
     async def delete(self, attachments: list[dict[str, Any]]) -> None:
         for attachment in attachments:
             try:
-                await self.middleware.call2(self.s.container.delete, attachment['id'])
+                await self.middleware.call2(
+                    self.s.container.delete_container_from_db_and_libvirt,
+                    await self.middleware.call2(self.s.container.get_instance, attachment['id']),
+                )
             except Exception:
                 self.middleware.logger.warning('Unable to delete %r container', attachment['id'])
 

--- a/src/middlewared/middlewared/plugins/container/crud.py
+++ b/src/middlewared/middlewared/plugins/container/crud.py
@@ -250,6 +250,11 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
         container = self.get_instance__sync(id_)
         audit_callback(container.name)
 
+        self.delete_container_from_db_and_libvirt(container)
+        self.call_sync2(self.s.zfs.resource.destroy_impl, container.dataset)
+        self.middleware.call_sync('etc.generate', 'libvirt_guests')
+
+    def delete_container_from_db_and_libvirt(self, container: ContainerEntry) -> None:
         pylibvirt_container_obj = pylibvirt_container(self, container.model_dump(by_alias=True))
         try:
             self.middleware.libvirt_domains_manager.containers.delete(pylibvirt_container_obj)
@@ -259,9 +264,7 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
         for device in container.devices:
             self.middleware.call_sync('datastore.delete', 'container.device', device.id)
 
-        self.run_coroutine(self._delete(id_))
-        self.call_sync2(self.s.zfs.resource.destroy_impl, container.dataset)
-        self.middleware.call_sync('etc.generate', 'libvirt_guests')
+        self.run_coroutine(self._delete(container.id))
 
     async def validate(
         self, verrors: ValidationErrors, schema_name: str, data: ContainerDataT, old: ContainerEntry | None = None,


### PR DESCRIPTION
## Context

Changes were added to remove container entries from the database when a pool is being exported with cascade=true. However for master, this also ends up destroying the dataset on the pool along with container entry in the database. Changes have been made to only remove database entries.