### PR TITLE
NAS-140692 / 27.0.0-BETA.1 / remove LANG field in webshell app

### DIFF
--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -105,7 +105,6 @@ class ShellWorkerThread(threading.Thread):
             env = {
                 "TERM": "xterm",
                 "HOME": homedir,
-                "LANG": "en_US.UTF-8",
                 "PATH": "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/root/bin",
                 "LC_ALL": "C.UTF-8",
             }


### PR DESCRIPTION
## Summary

Remove the hardcoded `LANG=en_US.UTF-8` from the web shell's exec environment
so opening the web-based shell no longer prints bash locale warnings. This is
an 8-year-old FreeNAS-era bug introduced in commit 45850b2871 (2017-06-28)
that survived the SCALE migration to Debian unexamined.

## Symptom

On every web shell session start, bash emits:

```
-bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
-bash: warning: setlocale: LC_COLLATE: cannot change locale (en_US.UTF-8): No such file or directory
```

Logging in as the same user via SSH does **not** produce these warnings.

## Root Cause

`src/middlewared/middlewared/apps/webshell_app.py` builds a fixed `env` dict
and hands it to `os.execve()` when spawning the user's shell:

```python
env = {
    "TERM": "xterm",
    "HOME": homedir,
    "LANG": "en_US.UTF-8",
    "PATH": "...",
    "LC_ALL": "C.UTF-8",
}
```

`en_US.UTF-8` is not a generated locale on TrueNAS SCALE — `locale -a` lists
only `C`, `C.UTF-8`, and `POSIX`. When bash starts it calls `setlocale()` per
category; the per-category lookup against `LANG` fails for `LC_CTYPE` and
`LC_COLLATE` and prints a warning before `LC_ALL=C.UTF-8` takes final effect.

SSH is silent because sshd/PAM does not set `LANG` at all, so bash falls back
to `LC_ALL` cleanly with no per-category miss.

### Why this line existed

`git blame` traces the line to commit 45850b2871 (2017-06-28, FreeNAS era)
which spawned `/usr/local/bin/bash` — the FreeBSD path. On FreeBSD
`en_US.UTF-8` was generated by default, so the value was correct at the time.
The line survived the SCALE migration to Debian unchanged and unexamined.

## Fix

Drop the `LANG` entry. `LC_ALL=C.UTF-8` already covers every category and is
a locale that is guaranteed to exist on the appliance, so no installation of
`en_US.UTF-8` is required.

```python
env = {
    "TERM": "xterm",
    "HOME": homedir,
    "PATH": "...",
    "LC_ALL": "C.UTF-8",
}
```