### PR TITLE
NAS-140095 / 26.0.0-BETA.2 / New `zpool.scrub` namespace (by creatorcary)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ async def do_create(self, app, data):
     pass
 ```
 
+**API Model Field Descriptions**:
+- Every field in API models (`Args`, `Result`, `Entry` classes) **must** have a description, either as a docstring or via `Field(description=...)`.
+- This is enforced by `test_api_docstrings` in the unit test suite.
+
 **API Versioning**:
 - Multiple API versions maintained in parallel (`src/middlewared/middlewared/api/v*/`)
 - Legacy methods wrapped with `LegacyAPIMethod`
@@ -314,5 +318,5 @@ self.logger.error('%s: %s', resource_identifier, description)
 
 - **Service Access**: Always call other services via `self.middleware.call('service.method', ...)`, never import and instantiate directly.
 - **Database Access**: Use the datastore service abstraction, not direct SQL queries.
-- **Error Handling**: Use `CallError` for general errors and `ValidationError` for input validation failures.
+- **Error Handling**: Use `CallError` for operational/runtime failures (system state, resource busy, I/O errors). Use `ValidationError` only when the **caller's input** is the problem (invalid argument value, nonexistent entity referenced by an argument, incompatible options). If the input is valid but the system can't perform the operation, that's a `CallError`, not a `ValidationError`.
 - **Logging**: Use `self.logger` in services for consistent logging (see Logging Guidelines above).

--- a/src/middlewared/middlewared/api/v26_0_0/__init__.py
+++ b/src/middlewared/middlewared/api/v26_0_0/__init__.py
@@ -126,3 +126,4 @@ from .webui_main_dashboard import *
 from .zfs_resource_crud import *
 from .zfs_resource_snapshot import *
 from .zpool_query import *
+from .zpool_scrub import *

--- a/src/middlewared/middlewared/api/v26_0_0/zpool_scrub.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zpool_scrub.py
@@ -1,0 +1,30 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel
+
+
+__all__ = [
+    "ZpoolScrubRun",
+    "ZpoolScrubRunArgs",
+    "ZpoolScrubRunResult",
+]
+
+
+class ZpoolScrubRun(BaseModel):
+    pool_name: str
+    """Name of the zpool."""
+    scan_type: Literal["SCRUB", "ERRORSCRUB"] = "SCRUB"
+    """SCRUB: full data integrity scan. ERRORSCRUB: targeted scan of blocks with known errors."""
+    action: Literal["START", "PAUSE", "CANCEL"] = "START"
+    """START: begin or resume. PAUSE: pause in-progress scan. CANCEL: stop entirely."""
+    threshold: int = 35
+    """Days before a scrub is due when the scrub should start."""
+
+
+class ZpoolScrubRunArgs(BaseModel):
+    data: ZpoolScrubRun
+    """Scrub run parameters."""
+
+
+class ZpoolScrubRunResult(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/plugins/pool_/dedup.py
+++ b/src/middlewared/middlewared/plugins/pool_/dedup.py
@@ -28,10 +28,10 @@ class PoolService(Service):
     @job(lock=lambda args: f'ddt_prefetch_{args[0]}')
     async def ddt_prefetch(self, job, pool_name):
         """
-        Prefetch DDT entries in pool `pool_name`.
+        Prefetch DDT entries in pool ``pool_name``.
 
-        .. deprecated::
-            Use `pool.prefetch` instead, which prefetches both DDT and BRT metadata.
+        .. versionremoved:: 26
+            Use ``pool.prefetch`` instead, which prefetches both DDT and BRT metadata.
         """
         return await self.middleware.call('zfs.resource.pool.prefetch', pool_name)
 

--- a/src/middlewared/middlewared/plugins/pool_/scrub.py
+++ b/src/middlewared/middlewared/plugins/pool_/scrub.py
@@ -1,25 +1,23 @@
-from datetime import datetime
-import asyncio
-import re
-import shlex
+from __future__ import annotations
+from typing import Literal, TYPE_CHECKING
 
 from middlewared.api import api_method, Event
 from middlewared.api.current import (
-    PoolScrubEntry, PoolScrubCreateArgs, PoolScrubCreateResult, PoolScrubUpdateArgs, PoolScrubUpdateResult,
-    PoolScrubDeleteArgs, PoolScrubDeleteResult, PoolScrubScrubArgs, PoolScrubScrubResult, PoolScrubRunArgs,
-    PoolScrubRunResult, PoolScanChangedEvent,
+    PoolScrubEntry, PoolScanChangedEvent,
+    PoolScrubCreateArgs, PoolScrubCreateResult,
+    PoolScrubUpdateArgs, PoolScrubUpdateResult,
+    PoolScrubDeleteArgs, PoolScrubDeleteResult,
+    PoolScrubScrubArgs, PoolScrubScrubResult,
+    PoolScrubRunArgs, PoolScrubRunResult,
 )
-from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
+from middlewared.plugins.zpool.exceptions import ZpoolException
+from middlewared.plugins.zpool.scrub_impl import scrub_pool
+from middlewared.service import CRUDService, job, private, CallError, ValidationErrors
+from middlewared.service.decorators import pass_thread_local_storage
 import middlewared.sqlalchemy as sa
-from middlewared.utils import run
 from middlewared.utils.cron import convert_db_format_to_schedule, convert_schedule_to_db_format
-
-
-RE_HISTORY_ZPOOL_SCRUB_CREATE = re.compile(r'^([0-9\.\:\-]{19})\s+(py-libzfs: )?zpool (scrub|create)', re.MULTILINE)
-
-
-class ScrubError(CallError):
-    pass
+if TYPE_CHECKING:
+    from middlewared.main import Job
 
 
 class PoolScrubModel(sa.Model):
@@ -193,6 +191,7 @@ class PoolScrubService(CRUDService):
         return response
 
     @api_method(PoolScrubScrubArgs, PoolScrubScrubResult, roles=['POOL_WRITE'])
+    @pass_thread_local_storage
     @job(
         description=lambda name, action="START": (
             f"Scrub of pool {name!r}" if action == "START"
@@ -200,84 +199,34 @@ class PoolScrubService(CRUDService):
         ),
         lock=lambda i: f'{i[0]}-{i[1] if len(i) >= 2 else "START"}' if i else '',
     )
-    async def scrub(self, job, name, action):
+    def scrub(self, job: Job, tls, name: str, action: Literal["START", "STOP", "PAUSE"]) -> None:
         """
-        Start/Stop/Pause a scrub on pool `name`.
+        Start, stop, or pause a scrub on pool ``name``.
+
+        START begins a regular scrub and blocks until it finishes, is paused,
+        or is canceled. STOP cancels an in-progress scrub. PAUSE pauses it.
+
+        .. deprecated:: 26.0.0
+            Use :doc:`zpool.scrub.run <api_methods_zpool.scrub.run>` instead.
         """
-        await self.middleware.call('zfs.pool.scrub_action', name, action)
+        scrub_action = "CANCEL" if action == "STOP" else action
 
-        if action == 'START':
-            while True:
-                scrub = await self.middleware.call('zfs.pool.scrub_state', name)
-
-                if scrub['pause']:
-                    job.set_progress(100, 'Scrub paused')
-                    break
-
-                if scrub['function'] != 'SCRUB':
-                    break
-
-                if scrub['state'] == 'FINISHED':
-                    job.set_progress(100, 'Scrub finished')
-                    break
-
-                if scrub['state'] == 'CANCELED':
-                    break
-
-                if scrub['state'] == 'SCANNING':
-                    job.set_progress(scrub['percentage'], 'Scrubbing')
-
-                await asyncio.sleep(1)
+        try:
+            zpool = tls.lzh.open_pool(name=name)
+            scrub_pool(tls.lzh, zpool, "SCRUB", scrub_action, progress_callback=job.set_progress)
+        except ZpoolException as e:
+            raise CallError(str(e), e.errno) from e
+        except Exception as e:
+            raise CallError(str(e)) from e
 
     @api_method(PoolScrubRunArgs, PoolScrubRunResult, roles=['POOL_WRITE'])
-    async def run(self, name, threshold):
+    def run(self, name: str, threshold: int) -> None:
         """
-        Initiate a scrub of a pool `name` if last scrub was performed more than `threshold` days before.
+        Initiate a scrub of pool ``name`` if the most recent scrub finished
+        more than ``threshold`` days ago. Does nothing if the scrub is not yet
+        due or if this node is not the active controller on an HA system.
+
+        .. deprecated:: 26.0.0
+            Use :doc:`zpool.scrub.run <api_methods_zpool.scrub.run>` instead.
         """
-        await self.middleware.call('alert.oneshot_delete', 'ScrubNotStarted', name)
-        await self.middleware.call('alert.oneshot_delete', 'ScrubStarted', name)
-        try:
-            started = await self.__run(name, threshold)
-        except ScrubError as e:
-            await self.middleware.call('alert.oneshot_create', 'ScrubNotStarted', {
-                'pool': name,
-                'text': e.errmsg,
-            })
-        else:
-            if started:
-                await self.middleware.call('alert.oneshot_create', 'ScrubStarted', name)
-
-    async def __run(self, name, threshold):
-        if name == await self.middleware.call('boot.pool_name'):
-            pool = (await self.middleware.call('zpool.query_impl', {'pool_names': [name], 'scan': True}))[0]
-        else:
-            if await self.middleware.call('failover.licensed'):
-                if await self.middleware.call('failover.status') == 'BACKUP':
-                    return
-
-            pool = await self.middleware.call('pool.query', [['name', '=', name]], {'get': True})
-            if pool['status'] == 'OFFLINE':
-                raise ScrubError(f'Pool {name} is offline, not running scrub')
-
-        if pool['scan'] and pool['scan']['state'] == 'SCANNING':
-            return False
-
-        last_scrubs = (await run(
-            'sh', '-c', f'zpool history {shlex.quote(name)} | grep -E "zpool (scrub|create|import)"',
-            encoding='utf-8',
-            errors='ignore',
-            check=False,
-        )).stdout
-        for match in reversed(list(RE_HISTORY_ZPOOL_SCRUB_CREATE.finditer(last_scrubs))):
-            last_scrub = datetime.strptime(match.group(1), '%Y-%m-%d.%H:%M:%S')
-            break
-        else:
-            self.logger.warning("Could not find last scrub of pool %r", name)
-            last_scrub = datetime.min
-
-        if (datetime.now() - last_scrub).total_seconds() < (threshold - 1) * 86400:
-            self.logger.debug('Pool %r last scrub %r', name, last_scrub)
-            return False
-
-        await self.middleware.call('pool.scrub.scrub', pool['name'])
-        return True
+        self.middleware.call_sync('zpool.scrub.run', {'pool_name': name, 'threshold': threshold})

--- a/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
@@ -1,10 +1,8 @@
 import errno
 import libzfs
-import subprocess
 import functools
 
 from middlewared.service import CallError, Service
-from middlewared.service_exception import ValidationError
 from .pool_utils import find_vdev, SEARCH_PATHS
 
 
@@ -112,47 +110,6 @@ class ZFSPoolService(Service):
         except libzfs.ZFSException as e:
             raise CallError(str(e), e.code)
 
-    def scrub_action(self, name: str, action: str = 'START'):
-        """Start/Stop/Pause a scrub on pool `name`."""
-        allowed_acts = ('START', 'STOP', 'PAUSE')
-        if action not in allowed_acts:
-            raise ValidationError('action', f'action must be one of {",".join(allowed_acts)}')
-
-        if action != 'PAUSE':
-            try:
-                with libzfs.ZFS() as zfs:
-                    pool = zfs.get(name)
-
-                    if action == 'START':
-                        running_scrubs = len([
-                            pool for pool in zfs.pools
-                            if pool.scrub.state == libzfs.ScanState.SCANNING
-                        ])
-                        if running_scrubs >= 10:
-                            raise CallError(
-                                f'{running_scrubs} scrubs are already running. Running too many scrubs simultaneously '
-                                'will result in an unresponsive system. Refusing to start scrub.'
-                            )
-
-                        pool.start_scrub()
-                    else:
-                        pool.stop_scrub()
-            except libzfs.ZFSException as e:
-                raise CallError(str(e), e.code)
-        else:
-            proc = subprocess.Popen(
-                f'zpool scrub -p {name}'.split(' '),
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            proc.communicate()
-
-            if proc.returncode != 0:
-                raise CallError('Unable to pause scrubbing')
-
-    def scrub_state(self, name):
-        with libzfs.ZFS() as zfs:
-            return zfs.get(name).scrub.asdict()
-
     def expand_state(self, name):
         with libzfs.ZFS() as zfs:
             return zfs.get(name).expand.asdict()
@@ -216,32 +173,3 @@ class ZFSPoolService(Service):
                 zfs.get(options['pool_name']).ddt_prune(percentage=options['percentage'], days=options['days'])
         except libzfs.ZFSException as e:
             raise CallError(str(e), e.code)
-
-    def find_not_online(self, pool: str):
-        pool = self.middleware.call_sync('zpool.query_impl', {'pool_names': [pool], 'topology': True})[0]
-
-        unavails = []
-        for nodes in pool['topology'].values():
-            for node in nodes:
-                unavails.extend(self.__find_not_online(node))
-        return unavails
-
-    def __find_not_online(self, node):
-        if len(node['children']) == 0 and node['state'] not in ('ONLINE', 'AVAIL'):
-            return [node]
-
-        unavails = []
-        for child in node['children']:
-            unavails.extend(self.__find_not_online(child))
-        return unavails
-
-    def get_vdev(self, name, vname):
-        try:
-            with libzfs.ZFS() as zfs:
-                pool = zfs.get(name)
-                vdev = find_vdev(pool, vname)
-                if not vdev:
-                    raise CallError(f'{vname} not found in {name}', errno.ENOENT)
-                return vdev.asdict()
-        except libzfs.ZFSException as e:
-            raise CallError(str(e))

--- a/src/middlewared/middlewared/plugins/zpool/exceptions.py
+++ b/src/middlewared/middlewared/plugins/zpool/exceptions.py
@@ -1,7 +1,120 @@
-__all__ = ("ZpoolNotFoundException",)
+import errno
+
+__all__ = (
+    "ZpoolException",
+    "ZpoolNotFoundException",
+    "ZpoolNotMasterNodeException",
+    "ZpoolPoolUnhealthyException",
+    "ZpoolScanInvalidActionException",
+    "ZpoolScanInvalidTypeException",
+    "ZpoolScrubAlreadyRunningException",
+    "ZpoolScrubPausedException",
+    "ZpoolScrubPausedToCancelException",
+    "ZpoolErrorScrubAlreadyRunningException",
+    "ZpoolErrorScrubPausedException",
+    "ZpoolScrubNotDueException",
+    "ZpoolResiliverInProgressException",
+    "ZpoolTooManyScrubsException",
+)
 
 
-class ZpoolNotFoundException(Exception):
+class ZpoolException(Exception):
+    errno = errno.EFAULT
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+class ZpoolNotFoundException(ZpoolException):
+    errno = errno.ENOENT
+
     def __init__(self, pool: str):
-        self.message = f"{pool!r} not found"
-        super().__init__(self.message)
+        super().__init__(f"{pool!r} not found")
+
+
+class ZpoolPoolUnhealthyException(ZpoolException):
+    errno = errno.ENXIO
+
+    def __init__(self, pool: str, health: str):
+        super().__init__(f"{pool!r}: pool is {health}")
+
+
+class ZpoolScanInvalidActionException(ZpoolException):
+    errno = errno.EINVAL
+
+    def __init__(self, action: str):
+        super().__init__(f"{action!r} is not a valid scan action (expected: start, pause, cancel)")
+
+
+class ZpoolScanInvalidTypeException(ZpoolException):
+    errno = errno.EINVAL
+
+    def __init__(self, scan_type: str):
+        super().__init__(f"{scan_type!r} is not a valid scan type (expected: scrub, errorscrub)")
+
+
+class ZpoolScrubAlreadyRunningException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: scrub already in progress")
+
+
+class ZpoolScrubPausedException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: scrub is paused")
+
+
+class ZpoolScrubPausedToCancelException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: scrub is paused and must be canceled before starting error scrub")
+
+
+class ZpoolErrorScrubAlreadyRunningException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: error scrub already in progress")
+
+
+class ZpoolErrorScrubPausedException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: error scrub is paused")
+
+
+class ZpoolNotMasterNodeException(ZpoolException):
+    errno = errno.ENXIO
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: scrub skipped because this node is not the active controller")
+
+
+class ZpoolScrubNotDueException(ZpoolException):
+    errno = errno.EALREADY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: scrub not due yet")
+
+
+class ZpoolResiliverInProgressException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, pool: str):
+        super().__init__(f"{pool!r}: resilver in progress")
+
+
+class ZpoolTooManyScrubsException(ZpoolException):
+    errno = errno.EBUSY
+
+    def __init__(self, running: int):
+        super().__init__(
+            f'{running} scrubs are already running. Running too many scrubs simultaneously '
+            'will result in an unresponsive system. Refusing to start scrub.'
+        )

--- a/src/middlewared/middlewared/plugins/zpool/get_zpool_features_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/get_zpool_features_impl.py
@@ -1,9 +1,9 @@
-import typing
+from truenas_pylibzfs import libzfs_types
 
 __all__ = ("get_zpool_features_impl",)
 
 
-def get_zpool_features_impl(lzh: typing.Any, pool_name: str) -> dict:
+def get_zpool_features_impl(lzh: libzfs_types.ZFS, pool_name: str) -> dict[str, libzfs_types.struct_zpool_feature]:
     """Return all feature flags and their states for a zpool.
 
     Opens the pool by name and retrieves the full set of known ZFS

--- a/src/middlewared/middlewared/plugins/zpool/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/query_impl.py
@@ -3,7 +3,7 @@ import typing
 
 from middlewared.utils import BOOT_POOL_NAME_VALID
 
-from truenas_pylibzfs import property_sets, ZFSException, ZFSError, ZPOOLProperty
+from truenas_pylibzfs import libzfs_types, property_sets, ZFSException, ZFSError, ZPOOLProperty
 
 from .exceptions import ZpoolNotFoundException
 from .get_zpool_features_impl import get_zpool_features_impl
@@ -68,7 +68,7 @@ def _format_topology(status_dict: dict) -> dict:
     return top
 
 
-def _format_scan(s: typing.Any) -> dict | None:
+def _format_scan(s: libzfs_types.struct_zpool_scrub | None) -> dict | None:
     """Transform a struct_zpool_scrub into a scan dict, or None.
 
     Args:
@@ -118,7 +118,7 @@ def _format_scan(s: typing.Any) -> dict | None:
     }
 
 
-def _format_expand(e: typing.Any) -> dict | None:
+def _format_expand(e: libzfs_types.struct_zpool_expand | None) -> dict | None:
     """Transform a struct_zpool_expand into an expansion dict, or None.
 
     Args:
@@ -157,7 +157,7 @@ def _format_expand(e: typing.Any) -> dict | None:
     }
 
 
-def _format_properties(props_struct: typing.Any, requested_names: list[str]) -> dict:
+def _format_properties(props_struct: libzfs_types.struct_zpool_property, requested_names: list[str]) -> dict:
     """Transform struct_zpool_property to a dict of property value dicts."""
     result = {}
     for name in requested_names:
@@ -171,7 +171,7 @@ def _format_properties(props_struct: typing.Any, requested_names: list[str]) -> 
     return result
 
 
-def _format_features(features_dict: dict) -> list[dict]:
+def _format_features(features_dict: dict[str, libzfs_types.struct_zpool_feature]) -> list[dict]:
     """Transform dict[str, struct_zpool_feature] to a list of feature dicts."""
     rv = list()
     for name, feat in features_dict.items():
@@ -186,7 +186,7 @@ def _format_features(features_dict: dict) -> list[dict]:
     return rv
 
 
-def _build_pool_dict(pool: typing.Any, lzh: typing.Any, data: dict) -> dict:
+def _build_pool_dict(pool: libzfs_types.ZFSPool, lzh: libzfs_types.ZFS, data: dict) -> dict:
     """Build a pool dict from pylibzfs pool object.
 
     Args:
@@ -265,7 +265,7 @@ def _get_zpools_cb(pool, state: list):
     return True
 
 
-def query_impl(lzh: typing.Any, data: dict) -> list[dict]:
+def query_impl(lzh: libzfs_types.ZFS, data: dict) -> list[dict]:
     """Query zpools status.
 
     Args:
@@ -289,7 +289,7 @@ def query_impl(lzh: typing.Any, data: dict) -> list[dict]:
         except ZFSException as e:
             if e.code == ZFSError.EZFS_NOENT:
                 if data.get("raise_on_noent", False):
-                    raise ZpoolNotFoundException(name)
+                    raise ZpoolNotFoundException(name) from e
                 else:
                     continue
             raise

--- a/src/middlewared/middlewared/plugins/zpool/scrub.py
+++ b/src/middlewared/middlewared/plugins/zpool/scrub.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from middlewared.api import api_method
+from middlewared.api.current import ZpoolScrubRun, ZpoolScrubRunArgs, ZpoolScrubRunResult
+from middlewared.service import Service, job
+from middlewared.service.decorators import pass_thread_local_storage
+from .scrub_impl import run_impl
+if TYPE_CHECKING:
+    from middlewared.job import Job
+
+
+class ZpoolScrubService(Service):
+    class Config:
+        namespace = "zpool.scrub"
+        cli_private = True
+
+    @api_method(ZpoolScrubRunArgs, ZpoolScrubRunResult, roles=["POOL_WRITE"], check_annotations=True)
+    @pass_thread_local_storage
+    @job()
+    def run(self, job: Job, tls, data: ZpoolScrubRun) -> None:
+        """Start, pause, or cancel a scrub on a ZFS pool.
+
+        When ``action`` is START, the pool is validated before the scrub begins:
+        the pool must be ONLINE or DEGRADED, must not have an active resilver,
+        and the most recent scrub must be older than ``threshold`` days. If any
+        of these checks fail the call returns silently (no error, no alert).
+        The job blocks until the scrub finishes, is paused, or is canceled.
+
+        PAUSE and CANCEL skip validation entirely and operate on the pool
+        directly.
+
+        At most 10 scrubs may run concurrently across all pools. Attempting to
+        start an 11th raises an error.
+
+        On a successful START a ``ScrubStarted`` alert is created. If the start
+        fails for a reason other than the threshold or HA checks, a
+        ``ScrubNotStarted`` alert is created instead.
+
+        .. versionadded:: 26.0.0
+        """
+        run_impl(self.context, tls.lzh, data, job.set_progress)

--- a/src/middlewared/middlewared/plugins/zpool/scrub_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/scrub_impl.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+import time
+from typing import Callable, Literal, TYPE_CHECKING
+
+from truenas_pylibzfs import ZFSError, ZFSException, ZPOOLProperty, libzfs_types
+
+from .exceptions import (
+    ZpoolErrorScrubAlreadyRunningException,
+    ZpoolErrorScrubPausedException,
+    ZpoolNotFoundException,
+    ZpoolNotMasterNodeException,
+    ZpoolScrubNotDueException,
+    ZpoolResiliverInProgressException,
+    ZpoolScanInvalidActionException,
+    ZpoolScanInvalidTypeException,
+    ZpoolScrubAlreadyRunningException,
+    ZpoolScrubPausedException,
+    ZpoolScrubPausedToCancelException,
+    ZpoolTooManyScrubsException,
+    ZpoolPoolUnhealthyException,
+)
+if TYPE_CHECKING:
+    from middlewared.api.current import ZpoolScrubRun
+    from middlewared.main import Middleware
+    from middlewared.service import ServiceContext
+
+__all__ = ("do_scan_action", "scrub_pool", "start_scrub", "wait_for_scrub")
+
+MAX_CONCURRENT_SCRUBS = 10
+
+ScrubProgressCallback = Callable[[float | None, str | None], None]
+
+
+def _count_running_scrubs(lzh: libzfs_types.ZFS) -> int:
+    """Count the number of pools with an active scan."""
+    count = [0]
+
+    def _cb(pool, state):
+        info = pool.scrub_info()
+        if info is not None and info.state == libzfs_types.ScanState.SCANNING:
+            state[0] += 1
+        return True
+
+    lzh.iter_pools(callback=_cb, state=count)
+    return count[0]
+
+
+def _get_scan_function(scan_type: Literal["SCRUB", "ERRORSCRUB"]) -> Literal[
+    libzfs_types.ScanFunction.SCRUB,
+    libzfs_types.ScanFunction.ERRORSCRUB,
+]:
+    """Resolve a scan type string to a ScanFunction enum.
+
+    Only SCRUB and ERRORSCRUB are allowed:
+      - SCRUB: full data integrity scan of the entire pool
+      - ERRORSCRUB: targeted scan of only blocks with known errors
+
+    RESILVER is excluded because it is initiated automatically by ZFS
+    when a replacement or re-attached vdev is detected.
+
+    Raises ZpoolScanInvalidTypeException if scan_type is not recognized."""
+    func = getattr(libzfs_types.ScanFunction, scan_type.upper(), None)
+    if func not in (
+        libzfs_types.ScanFunction.SCRUB,
+        libzfs_types.ScanFunction.ERRORSCRUB,
+    ):
+        raise ZpoolScanInvalidTypeException(scan_type)
+    return func
+
+
+def _get_scan_action(
+    func: libzfs_types.ScanFunction, action: Literal["START", "PAUSE", "CANCEL"]
+) -> tuple[libzfs_types.ScanFunction, libzfs_types.ScanScrubCmd]:
+    """Resolve an action string to the (ScanFunction, ScanScrubCmd) pair for zpool.scan().
+
+      - START: begin or resume the scan (func=<scan_type>, cmd=NORMAL)
+      - PAUSE: pause an in-progress scan (func=<scan_type>, cmd=PAUSE)
+      - CANCEL: cancel the scan entirely (func=NONE, cmd=NORMAL)
+
+    Raises ZpoolScanInvalidActionException if action is not recognized."""
+    match action.upper():
+        case "START":
+            return func, libzfs_types.ScanScrubCmd.NORMAL
+        case "PAUSE":
+            return func, libzfs_types.ScanScrubCmd.PAUSE
+        case "CANCEL":
+            return (
+                libzfs_types.ScanFunction.NONE,
+                libzfs_types.ScanScrubCmd.NORMAL,
+            )
+        case _:
+            raise ZpoolScanInvalidActionException(action)
+
+
+def _open_pool_handle(lzh: libzfs_types.ZFS, pool_name: str) -> libzfs_types.ZFSPool:
+    try:
+        return lzh.open_pool(name=pool_name)
+    except ZFSException as e:
+        if e.code == ZFSError.EZFS_NOENT:
+            raise ZpoolNotFoundException(pool_name) from e
+        raise
+
+
+def do_scan_action(
+    zpool: libzfs_types.ZFSPool, scan_type: Literal["SCRUB", "ERRORSCRUB"], action: Literal["START", "PAUSE", "CANCEL"]
+) -> None:
+    """Start, pause, or cancel a scan on a zpool.
+
+    scan_type: "SCRUB" for a full integrity scan, "ERRORSCRUB" for a targeted
+        scan of blocks with known errors only.
+    action: "START", "PAUSE", or "CANCEL".
+
+    A SCRUB and ERRORSCRUB cannot run concurrently. Starting an ERRORSCRUB
+    while a SCRUB is paused requires the paused SCRUB to be canceled first
+    (raised as ZpoolScrubPausedToCancelException). Similarly, a SCRUB cannot
+    be started while an ERRORSCRUB is running or paused.
+
+    Raises pool-specific exceptions for conflict states (see exceptions.py).
+    Unknown ZFSException errors are re-raised as-is."""
+    func = _get_scan_function(scan_type)
+    scan_func, scan_cmd = _get_scan_action(func, action)
+
+    try:
+        zpool.scan(func=scan_func, cmd=scan_cmd)
+    except ZFSException as e:
+        match e.code:
+            case ZFSError.EZFS_SCRUBBING:
+                raise ZpoolScrubAlreadyRunningException(zpool.name) from None
+            case ZFSError.EZFS_SCRUB_PAUSED:
+                raise ZpoolScrubPausedException(zpool.name) from None
+            case ZFSError.EZFS_SCRUB_PAUSED_TO_CANCEL:
+                raise ZpoolScrubPausedToCancelException(zpool.name) from None
+            case ZFSError.EZFS_ERRORSCRUBBING:
+                raise ZpoolErrorScrubAlreadyRunningException(zpool.name) from None
+            case ZFSError.EZFS_ERRORSCRUB_PAUSED:
+                raise ZpoolErrorScrubPausedException(zpool.name) from None
+            case ZFSError.EZFS_RESILVERING:
+                raise ZpoolResiliverInProgressException(zpool.name) from None
+        raise
+
+
+def validate_pool(
+    middleware: Middleware, lzh: libzfs_types.ZFS, pool_name: str, threshold: int
+) -> libzfs_types.ZFSPool:
+    """Validate that a pool exists, is healthy, and is due for a scrub.
+
+    Checks performed in order:
+      1. On HA systems, this node must be the active controller.
+      2. Non-boot pools must exist in the middleware datastore.
+      3. Pool health must be ONLINE or DEGRADED.
+      4. No resilver or scrub may already be in progress.
+      5. The last scrub (or pool create/import/scrub history entry) must
+         be older than ``threshold`` days.
+
+    Args:
+        middleware: Middleware instance for service calls.
+        lzh: Open libzfs handle.
+        pool_name: Name of the zpool.
+        threshold: Minimum age in days since the last scrub before a new
+            one is considered due.
+
+    Returns:
+        The opened ZFSPool handle.
+
+    Raises:
+        ZpoolNotMasterNodeException: This node is not the active HA controller.
+        ZpoolNotFoundException: Pool not in the datastore or ZFS.
+        ZpoolPoolUnhealthyException: Pool is FAULTED, OFFLINE, etc.
+        ZpoolResiliverInProgressException: A resilver is currently running.
+        ZpoolScrubAlreadyRunningException: A scrub is already in progress.
+        ZpoolScrubNotDueException: A recent scrub or pool event is within
+            the threshold window.
+    """
+    if pool_name != middleware.call_sync('boot.pool_name'):
+        if not middleware.call_sync('failover.is_single_master_node'):
+            raise ZpoolNotMasterNodeException(pool_name)
+
+        if not middleware.call_sync('datastore.query', 'storage.volume', [['vol_name', '=', pool_name]]):
+            raise ZpoolNotFoundException(pool_name)
+
+    # Open pool
+    zpool = _open_pool_handle(lzh, pool_name)
+
+    # Check pool health
+    health = zpool.get_properties(properties={ZPOOLProperty.HEALTH}).health.value
+    if health not in ("ONLINE", "DEGRADED"):
+        raise ZpoolPoolUnhealthyException(pool_name, health)
+
+    # Pre-check: reject if resilver is active or scrub already running
+    scan = zpool.scrub_info()
+    if scan is not None and scan.state == libzfs_types.ScanState.SCANNING:
+        if scan.func == libzfs_types.ScanFunction.RESILVER:
+            raise ZpoolResiliverInProgressException(pool_name)
+        if not scan.pass_scrub_pause:
+            raise ZpoolScrubAlreadyRunningException(pool_name)
+
+    # Threshold check via scan end_time
+    start_scrub = False
+    cutoff = int(time.time()) - (threshold - 1) * 86400
+
+    if (
+        scan
+        and scan.func == libzfs_types.ScanFunction.SCRUB
+        and scan.state == libzfs_types.ScanState.FINISHED
+    ):
+        if scan.end_time >= cutoff:
+            middleware.logger.trace('Pool %r last scrub ended %r', pool_name, scan.end_time)
+            raise ZpoolScrubNotDueException(pool_name)
+        start_scrub = True
+
+    # Slow path: check pool history for recent create/scrub/import
+    if not start_scrub:
+        for entry in zpool.iter_history(since=cutoff):
+            cmd = entry.get('history command', '')
+            if any(zpool_cmd in cmd for zpool_cmd in ('zpool create', 'zpool import', 'zpool scrub')):
+                middleware.logger.trace('Pool %r recent create/scrub within threshold window', pool_name)
+                break
+        else:
+            middleware.logger.warning('Could not find last scrub of pool %r', pool_name)
+            start_scrub = True
+
+    if not start_scrub:
+        raise ZpoolScrubNotDueException(pool_name)
+
+    return zpool
+
+
+def start_scrub(
+    lzh: libzfs_types.ZFS, zpool: libzfs_types.ZFSPool,
+    scan_type: Literal["SCRUB", "ERRORSCRUB"], action: Literal["START", "PAUSE", "CANCEL"],
+) -> None:
+    """Start, pause, or cancel a scan on a zpool.
+
+    For START, enforces a system-wide limit of MAX_CONCURRENT_SCRUBS
+    active scrubs before issuing the ZFS scan command.  Returns
+    immediately after the command succeeds — use ``wait_for_scrub``
+    to block until the scan finishes.
+
+    Raises:
+        ZpoolTooManyScrubsException: 10 or more scrubs already running.
+        ZpoolScrubAlreadyRunningException: A scrub is already active on
+            this pool.
+        ZpoolScrubPausedToCancelException: A paused scrub must be canceled
+            before starting an error scrub.
+    """
+    if action.upper() == "START":
+        running = _count_running_scrubs(lzh)
+        if running >= MAX_CONCURRENT_SCRUBS:
+            raise ZpoolTooManyScrubsException(running)
+
+    do_scan_action(zpool, scan_type, action)
+
+
+def wait_for_scrub(
+    zpool: libzfs_types.ZFSPool, scan_type: Literal["SCRUB", "ERRORSCRUB"],
+    *, progress_callback: ScrubProgressCallback | None = None,
+) -> None:
+    """Poll until a running scan finishes, is canceled, or is paused."""
+    expected_func = _get_scan_function(scan_type)
+    if scan_type.upper() == 'ERRORSCRUB':
+        prog_scan_type = 'Error scrub'
+    else:
+        prog_scan_type = 'Scrub'
+
+    while True:
+        scrub = zpool.scrub_info()
+        if scrub is None:
+            break
+
+        if scrub.func != expected_func:
+            break
+
+        match scrub.state:
+            case libzfs_types.ScanState.FINISHED:
+                if progress_callback:
+                    progress_callback(100, f'{prog_scan_type} finished')
+                break
+
+            case libzfs_types.ScanState.CANCELED:
+                break
+
+            case libzfs_types.ScanState.SCANNING:
+                if scrub.pass_scrub_pause:
+                    if progress_callback:
+                        progress_callback(100, f'{prog_scan_type} paused')
+                    break
+                if progress_callback and scrub.percentage is not None:
+                    progress_callback(scrub.percentage, f'{prog_scan_type} in progress')
+
+        time.sleep(1)
+
+
+def scrub_pool(
+    lzh: libzfs_types.ZFS, zpool: libzfs_types.ZFSPool,
+    scan_type: Literal["SCRUB", "ERRORSCRUB"], action: Literal["START", "PAUSE", "CANCEL"],
+    *, progress_callback: ScrubProgressCallback | None = None,
+) -> None:
+    """Start, pause, or cancel a scan on a zpool, blocking until done.
+
+    Convenience wrapper that calls ``start_scrub`` followed by
+    ``wait_for_scrub`` (for START actions only).
+    """
+    start_scrub(lzh, zpool, scan_type, action)
+    if action.upper() == "START":
+        wait_for_scrub(zpool, scan_type, progress_callback=progress_callback)
+
+
+def run_impl(
+    ctx: ServiceContext, lzh: libzfs_types.ZFS, data: ZpoolScrubRun,
+    progress_cb: ScrubProgressCallback | None = None
+) -> None:
+    """Execute a scrub run request with alert management.
+
+    For START: clears existing scrub alerts, validates the pool via
+    validate_pool(), starts the scrub, and creates a ScrubStarted or
+    ScrubNotStarted alert depending on the outcome. ScrubStarted is
+    created immediately after the scrub starts (before the polling
+    loop), matching the original pool.scrub.run fire-and-forget
+    behavior. Threshold, HA, resilver, and already-running failures
+    are swallowed silently (no error, no alert).
+
+    For PAUSE/CANCEL: opens the pool directly and performs the action,
+    skipping validation and alert management entirely.
+
+    Args:
+        ctx: Service context for middleware and alert calls.
+        lzh: Open libzfs handle.
+        data: Validated ZpoolScrubRun model with pool_name, scan_type,
+            action, and threshold.
+        progress_cb: Optional progress callback forwarded to scrub_pool().
+    """
+    if data.action != "START":
+        # PAUSE/CANCEL: skip threshold validation and alerts
+        zpool = _open_pool_handle(lzh, data.pool_name)
+        scrub_pool(lzh, zpool, data.scan_type, data.action)
+        return
+
+    for alert in ('ScrubNotStarted', 'ScrubStarted'):
+        ctx.middleware.call_sync('alert.oneshot_delete', alert, data.pool_name)
+
+    try:
+        pool = validate_pool(ctx.middleware, lzh, data.pool_name, data.threshold)
+        start_scrub(lzh, pool, data.scan_type, data.action)
+    except (
+        ZpoolNotMasterNodeException, ZpoolScrubNotDueException,
+        ZpoolResiliverInProgressException, ZpoolScrubAlreadyRunningException,
+    ):
+        # fail silently, no alert
+        return
+    except Exception as e:
+        ctx.middleware.call_sync('alert.oneshot_create', 'ScrubNotStarted', {
+            'pool': data.pool_name,
+            'text': str(e),
+        })
+        return
+
+    # Scrub started — create alert and wait for completion
+    ctx.middleware.call_sync('alert.oneshot_create', 'ScrubStarted', data.pool_name)
+    wait_for_scrub(pool, data.scan_type, progress_callback=progress_cb)

--- a/tests/api2/test_zpool_scrub.py
+++ b/tests/api2/test_zpool_scrub.py
@@ -1,0 +1,345 @@
+import time
+
+import pytest
+
+from truenas_api_client import ClientException
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call, ssh
+
+
+# ---------------------------------------------------------------------------
+# Topology helpers
+# ---------------------------------------------------------------------------
+
+_2_disk_mirror_topology = (2, lambda disks: {
+    "data": [{"type": "MIRROR", "disks": disks[0:2]}],
+})
+
+_3_disk_raidz1_topology = (3, lambda disks: {
+    "data": [{"type": "RAIDZ1", "disks": disks[0:3]}],
+})
+
+_3_disk_draid1_topology = (3, lambda disks: {
+    "data": [{
+        "type": "DRAID1",
+        "disks": disks[0:3],
+        "draid_data_disks": 1,
+        "draid_spare_disks": 0,
+    }],
+})
+
+_3_disk_mirror_with_spare_topology = (3, lambda disks: {
+    "data": [{"type": "MIRROR", "disks": disks[0:2]}],
+    "spares": disks[2:3],
+})
+
+_TOPOLOGY_FILL_MIB = 512
+_ACTION_FILL_MIB = 8192
+
+
+def _fill_pool(pool_name, size_mib=_ACTION_FILL_MIB):
+    """Write random data to the pool so scrubs take long enough to pause/cancel."""
+    ssh(f'dd if=/dev/urandom of=/mnt/{pool_name}/.scrub_fill '
+        f'bs=1M count={size_mib} conv=fdatasync 2>/dev/null',
+        timeout=300)
+
+
+def _get_scan(pool_name):
+    """Return the scan dict for a pool."""
+    return call("zpool.query", {
+        "pool_names": [pool_name], "scan": True,
+    })[0]["scan"]
+
+
+def _start_scrub_bg(pool_name: str) -> dict:
+    """Start a scrub in the background and wait until it is running.
+
+    The zpool.scrub.run job blocks until the scrub finishes, so calling
+    without job=True returns the job ID immediately while the scrub runs
+    in the background.
+    """
+    call("zpool.scrub.run", {"pool_name": pool_name, "action": "START", "threshold": 0})
+    for _ in range(30):
+        scan = _get_scan(pool_name)
+        if scan and scan["state"] == "SCANNING":
+            return scan
+        time.sleep(0.1)
+    pytest.fail("Scrub did not start")
+
+
+def _cancel_scrub(pool_name):
+    """Best-effort cancel of any running scrub on the pool."""
+    try:
+        call("zpool.scrub.run", {
+            "pool_name": pool_name,
+            "action": "CANCEL",
+        }, job=True)
+    except ClientException:
+        pass
+
+
+def _scrub_started_alerts(pool_name):
+    return [
+        a for a in call("alert.list")
+        if a["klass"] == "ScrubStarted" and a["args"] == pool_name
+    ]
+
+
+def _scrub_not_started_alerts(pool_name):
+    return [
+        a for a in call("alert.list")
+        if a["klass"] == "ScrubNotStarted" and a["args"]["pool"] == pool_name
+    ]
+
+
+def _poll_for_alert(finder, timeout=10):
+    """Poll until finder() returns a non-empty list, or fail."""
+    for _ in range(timeout):
+        alerts = finder()
+        if alerts:
+            return alerts
+        time.sleep(1)
+    pytest.fail("Expected alert was not created")
+
+
+# ---------------------------------------------------------------------------
+# Test: nonexistent pool
+# ---------------------------------------------------------------------------
+
+def test_nonexistent_pool():
+    """CANCEL on a nonexistent pool should raise an error.
+
+    START is not tested here because run_impl silently swallows errors
+    for START and creates a ScrubNotStarted alert instead of raising.
+    """
+    with pytest.raises(ClientException):
+        call("zpool.scrub.run", {
+            "pool_name": "nonexistent_pool_xyz",
+            "action": "CANCEL",
+        }, job=True)
+
+
+# ---------------------------------------------------------------------------
+# Parametrized topology tests — verify scrub works on each vdev layout.
+# Only start + error-scrub need topology coverage; action semantics
+# (pause, cancel) are topology-independent.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        _2_disk_mirror_topology,
+        _3_disk_raidz1_topology,
+        _3_disk_draid1_topology,
+        _3_disk_mirror_with_spare_topology,
+    ],
+    ids=["mirror", "raidz1", "draid1", "mirror+spare"],
+)
+def scrub_pool(request):
+    """Create one pool per topology, fill it, and share across all tests."""
+    with another_pool(topology=request.param) as p:
+        _fill_pool(p["name"], _TOPOLOGY_FILL_MIB)
+        yield p
+
+
+class TestZpoolScrubTopology:
+    """Verify scrub and error-scrub complete on each pool topology."""
+
+    def test_start(self, scrub_pool):
+        call("zpool.scrub.run", {
+            "pool_name": scrub_pool["name"],
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+        scan = _get_scan(scrub_pool["name"])
+        assert scan["function"] == "SCRUB"
+        assert scan["state"] == "FINISHED"
+
+    def test_error_scrub(self, scrub_pool):
+        """ERRORSCRUB completes without error (no blocks with known errors)."""
+        call("zpool.scrub.run", {
+            "pool_name": scrub_pool["name"],
+            "scan_type": "ERRORSCRUB",
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+
+# ---------------------------------------------------------------------------
+# Single shared pool for all remaining tests (action semantics, threshold,
+# validation-bypass, alerts, conflicts).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def shared_pool():
+    """One mirror pool shared by all non-topology tests."""
+    with another_pool(topology=_2_disk_mirror_topology) as p:
+        _fill_pool(p["name"])
+        yield p
+
+
+class TestZpoolScrubActions:
+    """Verify pause, resume, cancel, and conflict semantics.
+
+    Tests that need a running scrub use ``_start_scrub_bg`` which calls
+    without job=True (returns immediately) and polls until the scrub is
+    confirmed SCANNING.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _cancel_active_scrub(self, shared_pool):
+        yield
+        _cancel_scrub(shared_pool["name"])
+
+    def test_pause_and_resume(self, shared_pool):
+        name = shared_pool["name"]
+        start_time = _start_scrub_bg(name)["start_time"]
+
+        call("zpool.scrub.run", {"pool_name": name, "action": "PAUSE"}, job=True)
+
+        scan = _get_scan(name)
+        assert scan["state"] == "SCANNING"
+        assert scan["pause"] is not None
+
+        # Resume — the job blocks until the resumed scrub finishes.
+        call("zpool.scrub.run", {"pool_name": name, "action": "START", "threshold": 0}, job=True)
+
+        scan = _get_scan(name)
+        assert scan["function"] == "SCRUB"
+        assert scan["state"] == "FINISHED"
+        # start_time unchanged proves this was a resume, not a restart
+        assert scan["start_time"] == start_time
+
+    def test_cancel(self, shared_pool):
+        name = shared_pool["name"]
+        _start_scrub_bg(name)
+        call("zpool.scrub.run", {"pool_name": name, "action": "CANCEL"}, job=True)
+
+        scan = _get_scan(name)
+        assert scan["state"] == "CANCELED"
+
+    def test_duplicate_scrub_start(self, shared_pool):
+        """Starting a scrub while one is already running is silently ignored.
+
+        The original pool.scrub.run checked scan state and returned False when
+        a scrub was already running.  run_impl preserves this by treating
+        ZpoolScrubAlreadyRunningException as silently ignored.
+        """
+        name = shared_pool["name"]
+
+        start_time = _start_scrub_bg(name)["start_time"]
+        call("zpool.scrub.run", {"pool_name": name, "action": "START", "threshold": 0}, job=True)
+
+        scan = _get_scan(name)
+        assert scan["start_time"] == start_time, "A second scrub should not have started"
+
+    def test_errorscrub_while_scrub_paused(self, shared_pool):
+        """Starting an ERRORSCRUB while a regular scrub is paused creates a ScrubNotStarted alert."""
+        name = shared_pool["name"]
+
+        _start_scrub_bg(name)
+        call("zpool.scrub.run", {"pool_name": name, "action": "PAUSE"}, job=True)
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "scan_type": "ERRORSCRUB",
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+        _poll_for_alert(lambda: _scrub_not_started_alerts(name))
+
+
+class TestThreshold:
+    """Verify that threshold logic skips scrubs when one ran recently."""
+
+    def test_scrub_not_due_after_recent_scrub(self, shared_pool):
+        """A scrub that just finished should prevent another START within the threshold."""
+        name = shared_pool["name"]
+
+        # Use threshold=0 so the scrub actually runs on a fresh pool.
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+        scan = _get_scan(name)
+        assert scan["state"] == "FINISHED"
+        end_time_before = scan["end_time"]
+
+        # A second START with threshold=35 should be silently skipped
+        # (run_impl swallows ZpoolScrubNotDueException).
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "action": "START",
+            "threshold": 35,
+        }, job=True)
+
+        assert _get_scan(name)["end_time"] == end_time_before
+
+    def test_threshold_zero_always_scrubs(self, shared_pool):
+        """threshold=0 means the scrub is always due."""
+        name = shared_pool["name"]
+
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+        first_end = _get_scan(name)["end_time"]
+
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "action": "START",
+            "threshold": 0,
+        }, job=True)
+
+        second_end = _get_scan(name)["end_time"]
+        assert second_end >= first_end
+
+
+class TestPauseCancelBypassValidation:
+    """PAUSE and CANCEL must not go through threshold/health validation."""
+
+    @pytest.mark.parametrize("action", ["PAUSE", "CANCEL"])
+    def test_action_skips_threshold_check(self, shared_pool, action):
+        """PAUSE/CANCEL should succeed even if threshold would block a START."""
+        name = shared_pool["name"]
+
+        _start_scrub_bg(name)
+
+        # Act with a huge threshold — should NOT fail with "not due".
+        call("zpool.scrub.run", {
+            "pool_name": name,
+            "action": action,
+            "threshold": 9999,
+        }, job=True)
+
+        scan = _get_scan(name)
+        if action == "PAUSE":
+            assert scan["state"] == "SCANNING"
+            assert scan["pause"] is not None
+            _cancel_scrub(name)
+        else:
+            assert scan["state"] == "CANCELED"
+
+
+def test_start_creates_scrub_started_alert(self, shared_pool):
+    """A successful START should create a ScrubStarted alert.
+
+    The alert is created immediately when the scrub starts (before
+    it finishes), and the scrub_finished ZFS event deletes it when
+    the scrub completes.  We call without job=True so we can check
+    for the alert while the scrub is still running.
+    """
+    name = shared_pool["name"]
+
+    call("zpool.scrub.run", {
+        "pool_name": name,
+        "action": "START",
+        "threshold": 0,
+    })
+
+    _poll_for_alert(lambda: _scrub_started_alerts(name))

--- a/tests/api2/test_zpool_scrub.py
+++ b/tests/api2/test_zpool_scrub.py
@@ -88,7 +88,7 @@ def _scrub_started_alerts(pool_name):
 def _scrub_not_started_alerts(pool_name):
     return [
         a for a in call("alert.list")
-        if a["klass"] == "ScrubNotStarted" and a["args"]["pool"] == pool_name
+        if a["klass"] == "ScrubNotStarted" and a["key"] == pool_name
     ]
 
 
@@ -326,7 +326,7 @@ class TestPauseCancelBypassValidation:
             assert scan["state"] == "CANCELED"
 
 
-def test_start_creates_scrub_started_alert(self, shared_pool):
+def test_start_creates_scrub_started_alert(shared_pool):
     """A successful START should create a ScrubStarted alert.
 
     The alert is created immediately when the scrub starts (before


### PR DESCRIPTION
- Add new `zpool.scrub.run` endpoint backed by `truenas_pylibzfs` that replaces shell-based `zpool history` parsing and `py-libzfs` calls with native Python bindings
- Deprecate `pool.scrub.run` and `pool.scrub.scrub` (now thin wrappers that delegate to `zpool.scrub.run` / `scrub_impl`)
- Support ERRORSCRUB scan type and explicit PAUSE/CANCEL actions in the new endpoint
- Move scrub logic out of the async event loop into synchronous thread-based execution via `@pass_thread_local_storage`
- Delete `zfs.pool.scrub_action`, `zfs.pool.scrub_state`, `zfs.pool.find_not_online`, and `zfs.pool.get_vdev` (unused after migration)
- Improve error handling: pool health states beyond OFFLINE (FAULTED, REMOVED, UNAVAIL) now produce `ScrubNotStarted` alerts instead of propagating as unhandled exceptions; too-many-scrubs errors also produce alerts
- Add structured exception hierarchy in `zpool/exceptions.py` for all scrub failure modes
- Add integration tests covering start, pause, resume, cancel, error scrub, threshold enforcement, duplicate start, and alert creation/cleanup

Original PR: https://github.com/truenas/middleware/pull/18676
