### PR TITLE
NAS-140673 / 25.10.3.1 / fix stale BMC alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -13,6 +13,13 @@ THRESHOLD_SENSOR_TYPES = (
 )
 
 
+def is_threshold_sensor_assertion_event(record):
+    return (
+        record["type"].startswith(THRESHOLD_SENSOR_TYPES)
+        and record["event_direction"] == "Assertion Event"
+    )
+
+
 def remove_deasserted_records(records):
     records = records.copy()
     assertions = defaultdict(lambda: defaultdict(set))
@@ -39,8 +46,7 @@ def remove_orphaned_assertions(records, sensor_states):
     return [
         r for r in records
         if not (
-            r["type"].startswith(THRESHOLD_SENSOR_TYPES)
-            and r["event_direction"] == "Assertion Event"
+            is_threshold_sensor_assertion_event(r)
             and sensor_states.get(r["name"]) == "Nominal"
         )
     ]
@@ -129,10 +135,7 @@ class IPMISELAlertSource(AlertSource):
 
         records = remove_deasserted_records(records)
 
-        if any(
-            r["type"].startswith(THRESHOLD_SENSOR_TYPES) and r["event_direction"] == "Assertion Event"
-            for r in records
-        ):
+        if any(is_threshold_sensor_assertion_event(r) for r in records):
             live_sensors = await self.middleware.call("ipmi.sensors.query")
             sensor_states = {s["name"]: s["state"] for s in live_sensors}
             records = remove_orphaned_assertions(records, sensor_states)

--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -14,7 +14,7 @@ THRESHOLD_SENSOR_TYPES = (
 
 
 def is_threshold_sensor_assertion_event(record):
-    return (
+    return bool(
         record["type"].startswith(THRESHOLD_SENSOR_TYPES)
         and record["event_direction"] == "Assertion Event"
     )

--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -5,6 +5,14 @@ from middlewared.alert.base import AlertClass, DismissableAlertClass, AlertCateg
 from middlewared.alert.schedule import IntervalSchedule
 
 
+THRESHOLD_SENSOR_TYPES = (
+    "Fan",
+    "Temperature",
+    "Voltage",
+    "Current",
+)
+
+
 def remove_deasserted_records(records):
     records = records.copy()
     assertions = defaultdict(lambda: defaultdict(set))
@@ -19,6 +27,23 @@ def remove_deasserted_records(records):
             event_assertions.clear()
 
     return list(filter(None, records))
+
+
+def remove_orphaned_assertions(records, sensor_states):
+    # A BMC that is powered off when a threshold sensor recovers will never
+    # log the matching deassertion, so `remove_deasserted_records` cannot
+    # clear the assertion. If the live sensor is currently reporting
+    # Nominal, the condition is resolved regardless of what the SEL says.
+    # Limited to threshold sensors because discrete-sensor "Nominal" does
+    # not imply past assertions are stale.
+    return [
+        r for r in records
+        if not (
+            r["type"].startswith(THRESHOLD_SENSOR_TYPES)
+            and r["event_direction"] == "Assertion Event"
+            and sensor_states.get(r["name"]) == "Nominal"
+        )
+    ]
 
 
 class IPMISELAlertClass(AlertClass, DismissableAlertClass):
@@ -103,6 +128,14 @@ class IPMISELAlertSource(AlertSource):
                     records.append(i)
 
         records = remove_deasserted_records(records)
+
+        if any(
+            r["type"].startswith(THRESHOLD_SENSOR_TYPES) and r["event_direction"] == "Assertion Event"
+            for r in records
+        ):
+            live_sensors = await self.middleware.call("ipmi.sensors.query")
+            sensor_states = {s["name"]: s["state"] for s in live_sensors}
+            records = remove_orphaned_assertions(records, sensor_states)
 
         alerts = []
         if records:

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_ipmi_sel.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_ipmi_sel.py
@@ -1,4 +1,7 @@
-from middlewared.alert.source.ipmi_sel import remove_deasserted_records
+from middlewared.alert.source.ipmi_sel import (
+    remove_deasserted_records,
+    remove_orphaned_assertions,
+)
 
 import pytest
 
@@ -27,3 +30,79 @@ import pytest
 ])
 def test_remove_deasserted_records(records, result):
     assert remove_deasserted_records(records) == [records[i] for i in result]
+
+
+FAN5_NONCRITICAL = {
+    "name": "SYS_FAN5",
+    "type": "Fan",
+    "event_direction": "Assertion Event",
+    "event": "Lower Non-critical - going low ; Sensor Reading = 0.00 RPM ; Threshold = 300.00 RPM",
+}
+FAN5_CRITICAL = {
+    "name": "SYS_FAN5",
+    "type": "Fan",
+    "event_direction": "Assertion Event",
+    "event": "Lower Critical - going low ; Sensor Reading = 0.00 RPM ; Threshold = 150.00 RPM",
+}
+CPU_TEMP_WARNING = {
+    "name": "CPU0_TEMP",
+    "type": "Temperature",
+    "event_direction": "Assertion Event",
+    "event": "Upper Non-critical - going high",
+}
+PSU_FAILURE = {
+    "name": "PS2 Status",
+    "type": "Power Supply",
+    "event_direction": "Assertion Event",
+    "event": "Power Supply Failure detected",
+}
+FAN_DEASSERT = {
+    "name": "SYS_FAN5",
+    "type": "Fan",
+    "event_direction": "Deassertion Event",
+    "event": "Lower Critical - going low",
+}
+
+
+@pytest.mark.parametrize("records,sensor_states,expected", [
+    # BMC missed the deassertion (controller was unplugged during fan
+    # replacement): fan is Nominal now, drop both stale assertions.
+    (
+        [FAN5_NONCRITICAL, FAN5_CRITICAL],
+        {"SYS_FAN5": "Nominal"},
+        [],
+    ),
+    # Fan is still in a bad state — keep the assertion.
+    (
+        [FAN5_NONCRITICAL],
+        {"SYS_FAN5": "Critical"},
+        [FAN5_NONCRITICAL],
+    ),
+    # Unknown sensor state — be conservative and keep the assertion.
+    (
+        [FAN5_NONCRITICAL],
+        {},
+        [FAN5_NONCRITICAL],
+    ),
+    # Non-threshold sensor (discrete PSU) in Nominal state must be kept;
+    # "Nominal" doesn't imply a past PSU failure assertion is stale.
+    (
+        [PSU_FAILURE],
+        {"PS2 Status": "Nominal"},
+        [PSU_FAILURE],
+    ),
+    # Deassertion records are left alone regardless of sensor state.
+    (
+        [FAN_DEASSERT],
+        {"SYS_FAN5": "Nominal"},
+        [FAN_DEASSERT],
+    ),
+    # Mixed: suppress the Nominal threshold assertion, keep others.
+    (
+        [FAN5_NONCRITICAL, CPU_TEMP_WARNING, PSU_FAILURE],
+        {"SYS_FAN5": "Nominal", "CPU0_TEMP": "Warning", "PS2 Status": "Nominal"},
+        [CPU_TEMP_WARNING, PSU_FAILURE],
+    ),
+])
+def test_remove_orphaned_assertions(records, sensor_states, expected):
+    assert remove_orphaned_assertions(records, sensor_states) == expected


### PR DESCRIPTION
## Summary

Suppress stale IPMI SEL assertion alerts for threshold sensors (Fan / Temperature / Voltage / Current) whose live sensor reading is currently `Nominal`.

## Problem

`remove_deasserted_records()` clears an assertion only when it can pair it with a matching `Deassertion Event` in the SEL. When a BMC is powered off while a sensor recovers (for example, a controller unplugged during a fan replacement on an HA pair), the BMC never observes the state transition back to OK and therefore never emits the deassertion. The assertion then remains in the SEL forever and the alert sticks around even after the hardware is healthy.

On an internal system, this manifested as two persistent `SYS_FAN5` alerts:

```
Assertion Event: Lower Non-critical - going low ; Threshold = 300.00 RPM
Assertion Event: Lower Critical     - going low ; Threshold = 150.00 RPM
```

while `ipmi-sensors` reported `SYS_FAN5 = 12000 RPM, 'OK'`.

## Fix

After the existing deassertion-pairing pass, query `ipmi.sensors` and drop any **threshold-sensor** assertion whose live state is `Nominal`.

- Only threshold sensors (`Fan`, `Temperature`, `Voltage`, `Current`) are affected — discrete sensors' `Nominal` state does not imply a past assertion is stale (e.g. a PSU presence assertion is cleared via its own deassertion path).
- The sensor query is skipped entirely when no threshold-assertion records remain after the deassertion pass, so a clean system pays no additional cost.
- `ipmi-sensors` is ~100 ms warm / ~360 ms cold per call, vs. the 5-minute schedule of the alert source — negligible overhead.

Original PR: https://github.com/truenas/middleware/pull/18753
