### PR TITLE
NAS-140701 / 27.0.0-BETA.1 / fix incorrect developer comment

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -119,7 +119,8 @@ class IPMISELAlertSource(AlertSource):
     async def get_sensor_values(
         self,
     ) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...], tuple[tuple[str, str], ...]]:
-        # https://github.com/openbmc/ipmitool/blob/master/include/ipmitool/ipmi_sel.h#L297
+        # Sensor type / event strings come from FreeIPMI's `ipmi-sel`:
+        # https://git.savannah.gnu.org/cgit/freeipmi.git/tree/libfreeipmi/spec/ipmi-sensor-and-event-code-tables-spec.c
         sensor_types = (
             "Redundancy State",
             "Temperature",


### PR DESCRIPTION
Cf. 696fb90f1fead274e5c77e6ed12f0e3861464305 

Gist is that the comment here is incorrect since we don't use ipmitool.