### PR TITLE
NAS-140701 / 26.0.0-BETA.2 / fix incorrect developer comment (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -81,7 +81,8 @@ class IPMISELAlertSource(AlertSource):
     dismissed_datetime_kv_key = "alert:ipmi_sel:dismissed_datetime"
 
     async def get_sensor_values(self):
-        # https://github.com/openbmc/ipmitool/blob/master/include/ipmitool/ipmi_sel.h#L297
+        # Sensor type / event strings come from FreeIPMI's `ipmi-sel`:
+        # https://git.savannah.gnu.org/cgit/freeipmi.git/tree/libfreeipmi/spec/ipmi-sensor-and-event-code-tables-spec.c
         sensor_types = (
             "Redundancy State",
             "Temperature",


### PR DESCRIPTION
Cf. 696fb90f1fead274e5c77e6ed12f0e3861464305 

Gist is that the comment here is incorrect since we don't use ipmitool.

Original PR: https://github.com/truenas/middleware/pull/18758
