### PR TITLE
NAS-140697 / 26.0.0-BETA.2 / Switch to using api_client authentication helpers (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -575,8 +575,11 @@ class KeychainCredentialService(CRUDService):
                 try:
                     c.login_with_password(data["admin_username"], data["password"],
                                           otp_token=data["otp_token"] or None)
-                except ValueError:
-                    raise CallError("Invalid username or password")
+                except ValueError as e:
+                    # login_with_password raises ValueError with a descriptive message for:
+                    # invalid credentials, OTP required / invalid OTP, expired account,
+                    # account lacks API access, or HA redirect to active controller.
+                    raise CallError(str(e))
             else:
                 raise CallError("You should specify either remote system password or temporary authentication token")
 

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -572,10 +572,10 @@ class KeychainCredentialService(CRUDService):
                 if not c.call("auth.login_with_token", data["token"]):
                     raise CallError("Invalid token")
             elif data["password"]:
-                args = [data["admin_username"], data["password"]]
-                if data["otp_token"]:
-                    args.append(data["otp_token"])
-                if not c.call("auth.login", *args):
+                try:
+                    c.login_with_password(data["admin_username"], data["password"],
+                                          otp_token=data["otp_token"] or None)
+                except ValueError:
                     raise CallError("Invalid username or password")
             else:
                 raise CallError("You should specify either remote system password or temporary authentication token")

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -124,12 +124,7 @@ class TrueNAS_Server:
         uri = host_websocket_uri(addr)
         cl = Client(uri, private_methods=True, py_exceptions=True, log_py_exceptions=True, verify_ssl=False)
         try:
-            resp = cl.call('auth.login_ex', {
-                'mechanism': 'PASSWORD_PLAIN',
-                'username': 'root',
-                'password': password()
-            })
-            assert resp['response_type'] == 'SUCCESS'
+            cl.login_with_password('root', password())
         except Exception:
             cl.close()
             raise
@@ -176,13 +171,8 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
         with Client(uri, private_methods=True, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions,
                     verify_ssl=False) as c:
             if auth is not None:
-                auth_req = {
-                    "mechanism": "PASSWORD_PLAIN",
-                    "username": auth[0],
-                    "password": auth[1]
-                }
                 try:
-                    resp = c.call("auth.login_ex", auth_req)
+                    c.login_with_password(auth[0], auth[1])
                 except CallError as e:
                     if e.errno == errno.EBUSY and e.errmsg == 'Rate Limit Exceeded':
                         # our "roles" tests (specifically common_checks() function)
@@ -192,19 +182,19 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
                         # this is easiest path forward to not cause a bunch of roles
                         # related tests to trip on our rate limiting functionality
                         truenas_server.client.call("rate.limit.cache_clear")
-                        resp = c.call("auth.login_ex", auth_req)
+                        c.login_with_password(auth[0], auth[1])
                     else:
                         raise
                 except ClientException as e:
                     if e.errno == errno.EBUSY and e.error == 'Rate Limit Exceeded':
                         # Same as above, but for clients with `py_exceptions=False`
                         truenas_server.client.call("rate.limit.cache_clear")
-                        resp = c.call("auth.login_ex", auth_req)
+                        c.login_with_password(auth[0], auth[1])
                     else:
                         raise
-
-                if auth_required:
-                    assert resp['response_type'] == 'SUCCESS'
+                except ValueError:
+                    if auth_required:
+                        raise
             yield c
     except socket.timeout:
         fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')


### PR DESCRIPTION
This commit switches the keychain plugin and our integration tests to using the login_with_password API client helper function to perform truenas version agnostic authentication to remote truenas servers.

Original PR: https://github.com/truenas/middleware/pull/18756
