### PR TITLE
NAS-140711 / 27.0.0-BETA.1 / Robustize helper to reset-failed

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/system.py
+++ b/src/middlewared/middlewared/test/integration/utils/system.py
@@ -20,8 +20,20 @@ def reset_systemd_svcs(svcs_to_reset):
     Input a space delimited string of systemd services to reset.
     Example usage:
         reset_systemd_svcs("nfs-idmapd nfs-mountd nfs-server rpcbind rpc-statd")
+
+    A unit that has never been started in this boot is not loaded by
+    systemd and cannot be reset; that specific case is treated as a
+    benign no-op so any other failure is still surfaced.
     """
-    ssh(f"systemctl reset-failed {svcs_to_reset}")
+    result = ssh(
+        f"systemctl reset-failed {svcs_to_reset}",
+        check=False,
+        complete_response=True,
+    )
+    if result["result"] or "not loaded" in result["output"]:
+        return
+
+    assert False, result["output"]
 
 
 def restart_systemd_svc(svc_to_restart: str, remote_node: bool = False):


### PR DESCRIPTION
This commit handles edge-case where maybe our CI is trying to reset a unit that is unloaded. This allows us to surface what may be a more useful error condition later on in tests.