### PR TITLE
NAS-140717 / 27.0.0-BETA.1 / Move VM NVRAM and TPM atomically with VM rename

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-import os
 import re
 import shlex
 import uuid
@@ -25,7 +24,7 @@ from .info import (
     MAXIMUM_SUPPORTED_VCPUS, supports_virtualization, vm_flags,
 )
 from .lifecycle import pylibvirt_vm
-from .utils import get_vm_nvram_file_name, SYSTEM_NVRAM_FOLDER_PATH
+from .utils import delete_vm_state, rename_vm_state, vm_state_missing_sources
 
 
 if TYPE_CHECKING:
@@ -160,27 +159,47 @@ class VMServicePart(CRUDServicePart[VMEntry]):
         await self.validate(verrors, 'vm_update', new, old=old)
         verrors.check()
 
-        entry = await self._update(id_, new.model_dump(exclude={'id', 'devices', 'display_available', 'status'}))
-
+        renamed = False
         if new.name != old.name:
             try:
-                old_path = os.path.join(
-                    SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(old.id, old.name)
+                await self.to_thread(rename_vm_state, old.id, old.name, new.id, new.name)
+            except FileExistsError as e:
+                raise CallError(
+                    f'Cannot rename VM {old.name!r} -> {new.name!r}: on-disk state already '
+                    'exists at the destination (likely stale NVRAM/TPM left over from a '
+                    'previously deleted VM). Name change aborted; VM configuration is unchanged.'
+                ) from e
+            except OSError as e:
+                raise CallError(
+                    f'Failed to rename VM state for {old.name!r} -> {new.name!r}: '
+                    f'{e.strerror or e} (errno={e.errno}). Name change aborted; '
+                    f'VM configuration is unchanged.'
+                ) from e
+            renamed = True
+
+            missing = await self.to_thread(
+                vm_state_missing_sources, new.id, new.name,
+                old.bootloader, old.trusted_platform_module,
+            )
+            if missing:
+                self.logger.warning(
+                    '%s: rename to %r proceeded with no prior on-disk state for %s; '
+                    'libvirt/swtpm will initialise fresh state on next start.',
+                    old.name, new.name, ', '.join(missing),
                 )
-                new_path = os.path.join(
-                    SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(new.id, new.name)
-                )
-                await self.middleware.run_in_thread(os.rename, old_path, new_path)
-            except FileNotFoundError:
-                if old.bootloader == new.bootloader == 'UEFI':
-                    # So we only want to raise an error if bootloader is UEFI because for BIOS
-                    # nvram file will not exist and it is fine. If bootloader is changed from
-                    # BIOS to UEFI, even then we will not have it and it is fine so we don't want
-                    # to raise an error in that case.
-                    raise CallError(
-                        f'VM name has been updated but nvram file for {old.name} does not exist '
-                        f'which can result in {new.name} VM not booting properly.'
+
+        try:
+            entry = await self._update(id_, new.model_dump(exclude={'id', 'devices', 'display_available', 'status'}))
+        except Exception:
+            if renamed:
+                try:
+                    await self.to_thread(rename_vm_state, new.id, new.name, old.id, old.name)
+                except Exception:
+                    self.logger.error(
+                        '%s: state-file rollback failed after DB update failure',
+                        old.name, exc_info=True,
                     )
+            raise
 
         if old.shutdown_timeout != new.shutdown_timeout:
             await self.middleware.call('etc.generate', 'libvirt_guests')
@@ -223,6 +242,12 @@ class VMServicePart(CRUDServicePart[VMEntry]):
             self.call_sync2(self.s.vm.device.delete, device.id, VMDeviceDeleteOptions(force=False))
 
         self.run_coroutine(self._delete(id_))
+        try:
+            delete_vm_state(vm.id, vm.name)
+        except Exception:
+            self.logger.error(
+                '%s: failed to remove on-disk VM state (nvram/tpm)', vm.name, exc_info=True,
+            )
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
     async def validate(

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-import os
 import re
 import shlex
 import uuid
@@ -25,7 +24,7 @@ from .info import (
     MAXIMUM_SUPPORTED_VCPUS, supports_virtualization, vm_flags,
 )
 from .lifecycle import pylibvirt_vm
-from .utils import get_vm_nvram_file_name, SYSTEM_NVRAM_FOLDER_PATH
+from .utils import delete_vm_state, rename_vm_state, vm_state_missing_sources
 
 
 if TYPE_CHECKING:
@@ -160,27 +159,41 @@ class VMServicePart(CRUDServicePart[VMEntry]):
         await self.validate(verrors, 'vm_update', new, old=old)
         verrors.check()
 
-        entry = await self._update(id_, new.model_dump(exclude={'id', 'devices', 'display_available', 'status'}))
-
+        renamed = False
         if new.name != old.name:
             try:
-                old_path = os.path.join(
-                    SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(old.id, old.name)
+                await self.to_thread(rename_vm_state, old.id, old.name, new.id, new.name)
+            except OSError as e:
+                raise CallError(
+                    f'Failed to rename VM state for {old.name!r} -> {new.name!r}: '
+                    f'{e.strerror or e} (errno={e.errno}). Name change aborted; '
+                    f'VM configuration is unchanged.'
+                ) from e
+            renamed = True
+
+            missing = await self.to_thread(
+                vm_state_missing_sources, new.id, new.name,
+                old.bootloader, old.trusted_platform_module,
+            )
+            if missing:
+                self.logger.warning(
+                    '%s: rename to %r proceeded with no prior on-disk state for %s; '
+                    'libvirt/swtpm will initialise fresh state on next start.',
+                    old.name, new.name, ', '.join(missing),
                 )
-                new_path = os.path.join(
-                    SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(new.id, new.name)
-                )
-                await self.middleware.run_in_thread(os.rename, old_path, new_path)
-            except FileNotFoundError:
-                if old.bootloader == new.bootloader == 'UEFI':
-                    # So we only want to raise an error if bootloader is UEFI because for BIOS
-                    # nvram file will not exist and it is fine. If bootloader is changed from
-                    # BIOS to UEFI, even then we will not have it and it is fine so we don't want
-                    # to raise an error in that case.
-                    raise CallError(
-                        f'VM name has been updated but nvram file for {old.name} does not exist '
-                        f'which can result in {new.name} VM not booting properly.'
+
+        try:
+            entry = await self._update(id_, new.model_dump(exclude={'id', 'devices', 'display_available', 'status'}))
+        except Exception:
+            if renamed:
+                try:
+                    await self.to_thread(rename_vm_state, new.id, new.name, old.id, old.name)
+                except Exception:
+                    self.logger.error(
+                        '%s: state-file rollback failed after DB update failure',
+                        old.name, exc_info=True,
                     )
+            raise
 
         if old.shutdown_timeout != new.shutdown_timeout:
             await self.middleware.call('etc.generate', 'libvirt_guests')
@@ -223,6 +236,12 @@ class VMServicePart(CRUDServicePart[VMEntry]):
             self.call_sync2(self.s.vm.device.delete, device.id, VMDeviceDeleteOptions(force=False))
 
         self.run_coroutine(self._delete(id_))
+        try:
+            delete_vm_state(vm.id, vm.name)
+        except Exception:
+            self.logger.error(
+                '%s: failed to remove on-disk VM state (nvram/tpm)', vm.name, exc_info=True,
+            )
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
     async def validate(

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -1,3 +1,10 @@
+import contextlib
+import os
+import shutil
+
+import truenas_os
+
+
 SYSTEM_TPM_FOLDER_PATH = '/var/db/system/vm/tpm'
 SYSTEM_NVRAM_FOLDER_PATH = '/var/db/system/vm/nvram'
 LIBVIRT_QEMU_UID = 986
@@ -10,3 +17,115 @@ def get_vm_tpm_state_dir_name(id_: int, name: str) -> str:
 
 def get_vm_nvram_file_name(id_: int, name: str) -> str:
     return f'{id_}_{name}_VARS.fd'
+
+
+def vm_nvram_path(id_: int, name: str) -> str:
+    return os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(id_, name))
+
+
+def vm_tpm_path(id_: int, name: str) -> str:
+    return os.path.join(SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name(id_, name))
+
+
+def _open_state_parent(path: str) -> int:
+    # RESOLVE_NO_SYMLINKS guards against an attacker dropping a symlink inside
+    # /var/db/system/vm/{nvram,tpm} between our checks and the actual rename.
+    # O_PATH is enough: the fd is only used as an anchor for *at() syscalls.
+    assert path in (SYSTEM_NVRAM_FOLDER_PATH, SYSTEM_TPM_FOLDER_PATH), path
+    return truenas_os.openat2(
+        path,
+        os.O_PATH | os.O_DIRECTORY,
+        resolve=truenas_os.RESOLVE_NO_SYMLINKS,
+    )
+
+
+def rename_vm_state(old_id: int, old_name: str, new_id: int, new_name: str) -> None:
+    """Rename NVRAM file and TPM state directory for a VM.
+
+    renameat2 is atomic on the same filesystem and preserves the inode, so
+    ownership/mode/xattrs survive the rename (NVRAM stays libvirt-qemu, the
+    per-VM TPM dir stays tss-owned with its .lock and tpm2-00.permall).
+
+    Missing sources are silently skipped — a VM that has never booted has no
+    on-disk state and libvirt/swtpm will initialise both on first start.
+
+    AT_RENAME_NOREPLACE ensures we fail loudly if the destination already
+    exists (e.g. stale state from a previously deleted VM).
+
+    All-or-nothing: if NVRAM renames but TPM then raises, the NVRAM rename
+    is reverted before the original exception propagates.
+    """
+    nvram_fd = _open_state_parent(SYSTEM_NVRAM_FOLDER_PATH)
+    try:
+        tpm_fd = _open_state_parent(SYSTEM_TPM_FOLDER_PATH)
+        try:
+            items = [
+                (
+                    nvram_fd,
+                    get_vm_nvram_file_name(old_id, old_name),
+                    get_vm_nvram_file_name(new_id, new_name),
+                ),
+                (
+                    tpm_fd,
+                    get_vm_tpm_state_dir_name(old_id, old_name),
+                    get_vm_tpm_state_dir_name(new_id, new_name),
+                ),
+            ]
+            performed: list[tuple[int, str, str]] = []
+            try:
+                for parent_fd, src, dst in items:
+                    try:
+                        truenas_os.renameat2(
+                            src,
+                            dst,
+                            src_dir_fd=parent_fd,
+                            dst_dir_fd=parent_fd,
+                            flags=truenas_os.AT_RENAME_NOREPLACE,
+                        )
+                    except FileNotFoundError:
+                        continue
+                    performed.append((parent_fd, src, dst))
+            except Exception:
+                for parent_fd, src, dst in reversed(performed):
+                    with contextlib.suppress(OSError):
+                        truenas_os.renameat2(
+                            dst,
+                            src,
+                            src_dir_fd=parent_fd,
+                            dst_dir_fd=parent_fd,
+                            flags=truenas_os.AT_RENAME_NOREPLACE,
+                        )
+                raise
+        finally:
+            os.close(tpm_fd)
+    finally:
+        os.close(nvram_fd)
+
+
+def delete_vm_state(id_: int, name: str) -> None:
+    """Remove NVRAM file and TPM state dir for a VM. Best-effort and idempotent."""
+    nvram_fd = _open_state_parent(SYSTEM_NVRAM_FOLDER_PATH)
+    try:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(get_vm_nvram_file_name(id_, name), dir_fd=nvram_fd)
+    finally:
+        os.close(nvram_fd)
+
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(vm_tpm_path(id_, name))
+
+
+def vm_state_missing_sources(
+    id_: int, name: str, bootloader: str, tpm: bool
+) -> list[str]:
+    """Return which on-disk artefacts were expected but not present.
+
+    Used after a successful rename to log a warning for never-booted VMs so
+    operators know libvirt/swtpm will initialise fresh state on next start.
+    """
+    missing: list[str] = []
+    if bootloader == 'UEFI' and not os.path.exists(vm_nvram_path(id_, name)):
+        missing.append('NVRAM')
+    if tpm and not os.path.exists(vm_tpm_path(id_, name)):
+        missing.append('TPM')
+    return missing

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -1,3 +1,10 @@
+import contextlib
+import os
+import shutil
+
+import truenas_os
+
+
 SYSTEM_TPM_FOLDER_PATH = '/var/db/system/vm/tpm'
 SYSTEM_NVRAM_FOLDER_PATH = '/var/db/system/vm/nvram'
 LIBVIRT_QEMU_UID = 986
@@ -10,3 +17,106 @@ def get_vm_tpm_state_dir_name(id_: int, name: str) -> str:
 
 def get_vm_nvram_file_name(id_: int, name: str) -> str:
     return f'{id_}_{name}_VARS.fd'
+
+
+def vm_nvram_path(id_: int, name: str) -> str:
+    return os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(id_, name))
+
+
+def vm_tpm_path(id_: int, name: str) -> str:
+    return os.path.join(SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name(id_, name))
+
+
+def _open_state_parent(path: str) -> int:
+    # RESOLVE_NO_SYMLINKS guards against an attacker dropping a symlink inside
+    # /var/db/system/vm/{nvram,tpm} between our checks and the actual rename.
+    # O_PATH is enough: the fd is only used as an anchor for *at() syscalls.
+    return truenas_os.openat2(
+        path,
+        os.O_PATH | os.O_DIRECTORY,
+        resolve=truenas_os.RESOLVE_NO_SYMLINKS,
+    )
+
+
+def rename_vm_state(old_id: int, old_name: str, new_id: int, new_name: str) -> None:
+    """Rename NVRAM file and TPM state directory for a VM.
+
+    renameat2 is atomic on the same filesystem and preserves the inode, so
+    ownership/mode/xattrs survive the rename (NVRAM stays libvirt-qemu, the
+    per-VM TPM dir stays tss-owned with its .lock and tpm2-00.permall).
+
+    Missing sources are silently skipped — a VM that has never booted has no
+    on-disk state and libvirt/swtpm will initialise both on first start.
+
+    AT_RENAME_NOREPLACE ensures we fail loudly if the destination already
+    exists (e.g. stale state from a previously deleted VM).
+
+    All-or-nothing: if NVRAM renames but TPM then raises, the NVRAM rename
+    is reverted before the original exception propagates.
+    """
+    nvram_fd = _open_state_parent(SYSTEM_NVRAM_FOLDER_PATH)
+    try:
+        tpm_fd = _open_state_parent(SYSTEM_TPM_FOLDER_PATH)
+        try:
+            items = [
+                (nvram_fd,
+                 get_vm_nvram_file_name(old_id, old_name),
+                 get_vm_nvram_file_name(new_id, new_name)),
+                (tpm_fd,
+                 get_vm_tpm_state_dir_name(old_id, old_name),
+                 get_vm_tpm_state_dir_name(new_id, new_name)),
+            ]
+            performed: list[tuple[int, str, str]] = []
+            try:
+                for parent_fd, src, dst in items:
+                    try:
+                        truenas_os.renameat2(
+                            src, dst,
+                            src_dir_fd=parent_fd,
+                            dst_dir_fd=parent_fd,
+                            flags=truenas_os.AT_RENAME_NOREPLACE,
+                        )
+                    except FileNotFoundError:
+                        continue
+                    performed.append((parent_fd, src, dst))
+            except Exception:
+                for parent_fd, src, dst in reversed(performed):
+                    with contextlib.suppress(OSError):
+                        truenas_os.renameat2(
+                            dst, src,
+                            src_dir_fd=parent_fd,
+                            dst_dir_fd=parent_fd,
+                            flags=truenas_os.AT_RENAME_NOREPLACE,
+                        )
+                raise
+        finally:
+            os.close(tpm_fd)
+    finally:
+        os.close(nvram_fd)
+
+
+def delete_vm_state(id_: int, name: str) -> None:
+    """Remove NVRAM file and TPM state dir for a VM. Best-effort and idempotent."""
+    nvram_fd = _open_state_parent(SYSTEM_NVRAM_FOLDER_PATH)
+    try:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(get_vm_nvram_file_name(id_, name), dir_fd=nvram_fd)
+    finally:
+        os.close(nvram_fd)
+
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(vm_tpm_path(id_, name))
+
+
+def vm_state_missing_sources(id_: int, name: str, bootloader: str, tpm: bool) -> list[str]:
+    """Return which on-disk artefacts were expected but not present.
+
+    Used after a successful rename to log a warning for never-booted VMs so
+    operators know libvirt/swtpm will initialise fresh state on next start.
+    """
+    missing: list[str] = []
+    if bootloader == 'UEFI' and not os.path.exists(vm_nvram_path(id_, name)):
+        missing.append('NVRAM')
+    if tpm and not os.path.exists(vm_tpm_path(id_, name)):
+        missing.append('TPM')
+    return missing

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_state_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_state_utils.py
@@ -1,0 +1,175 @@
+import errno
+import os
+
+import pytest
+
+from middlewared.plugins.vm import utils as vm_utils
+from middlewared.plugins.vm.utils import (
+    delete_vm_state,
+    get_vm_nvram_file_name,
+    get_vm_tpm_state_dir_name,
+    rename_vm_state,
+    vm_nvram_path,
+    vm_state_missing_sources,
+    vm_tpm_path,
+)
+
+
+@pytest.fixture
+def state_dirs(tmp_path, monkeypatch):
+    nvram = tmp_path / 'nvram'
+    tpm = tmp_path / 'tpm'
+    nvram.mkdir()
+    tpm.mkdir()
+    monkeypatch.setattr(vm_utils, 'SYSTEM_NVRAM_FOLDER_PATH', str(nvram))
+    monkeypatch.setattr(vm_utils, 'SYSTEM_TPM_FOLDER_PATH', str(tpm))
+    return nvram, tpm
+
+
+def _make_nvram(nvram_dir, id_: int, name: str, data: bytes = b'vars') -> str:
+    path = os.path.join(str(nvram_dir), get_vm_nvram_file_name(id_, name))
+    with open(path, 'wb') as f:
+        f.write(data)
+    return path
+
+
+def _make_tpm(tpm_dir, id_: int, name: str) -> str:
+    path = os.path.join(str(tpm_dir), get_vm_tpm_state_dir_name(id_, name))
+    os.mkdir(path)
+    with open(os.path.join(path, 'tpm2-00.permall'), 'wb') as f:
+        f.write(b'tpmstate')
+    with open(os.path.join(path, '.lock'), 'wb') as f:
+        f.write(b'')
+    return path
+
+
+def test_rename_vm_state_moves_both_artefacts(state_dirs):
+    nvram, tpm = state_dirs
+    old_nvram = _make_nvram(nvram, 1, 'foo')
+    old_tpm = _make_tpm(tpm, 1, 'foo')
+    old_nvram_ino = os.stat(old_nvram).st_ino
+    old_tpm_ino = os.stat(old_tpm).st_ino
+
+    rename_vm_state(1, 'foo', 1, 'bar')
+
+    new_nvram = vm_nvram_path(1, 'bar')
+    new_tpm = vm_tpm_path(1, 'bar')
+    assert not os.path.exists(old_nvram)
+    assert not os.path.exists(old_tpm)
+    assert os.path.exists(new_nvram)
+    assert os.path.isdir(new_tpm)
+    # Inode preserved → metadata (ownership, mode, xattrs) survived the rename.
+    assert os.stat(new_nvram).st_ino == old_nvram_ino
+    assert os.stat(new_tpm).st_ino == old_tpm_ino
+    # TPM dir contents moved with the directory.
+    assert os.path.exists(os.path.join(new_tpm, 'tpm2-00.permall'))
+    assert os.path.exists(os.path.join(new_tpm, '.lock'))
+
+
+def test_rename_vm_state_missing_both_is_noop(state_dirs):
+    # Never-booted VM: neither artefact exists. Should not raise.
+    rename_vm_state(2, 'foo', 2, 'bar')
+    nvram, tpm = state_dirs
+    assert os.listdir(str(nvram)) == []
+    assert os.listdir(str(tpm)) == []
+
+
+def test_rename_vm_state_missing_tpm_only(state_dirs):
+    nvram, _ = state_dirs
+    _make_nvram(nvram, 3, 'foo')
+    rename_vm_state(3, 'foo', 3, 'bar')
+    assert os.path.exists(vm_nvram_path(3, 'bar'))
+
+
+def test_rename_vm_state_missing_nvram_only(state_dirs):
+    _, tpm = state_dirs
+    _make_tpm(tpm, 4, 'foo')
+    rename_vm_state(4, 'foo', 4, 'bar')
+    assert os.path.isdir(vm_tpm_path(4, 'bar'))
+
+
+def test_rename_vm_state_stale_destination_fails_without_moving(state_dirs):
+    nvram, _ = state_dirs
+    _make_nvram(nvram, 5, 'foo', b'src')
+    _make_nvram(nvram, 5, 'bar', b'stale')  # pre-existing — must not be clobbered
+    with pytest.raises(FileExistsError):
+        rename_vm_state(5, 'foo', 5, 'bar')
+    # Both files still present, contents untouched.
+    with open(vm_nvram_path(5, 'foo'), 'rb') as f:
+        assert f.read() == b'src'
+    with open(vm_nvram_path(5, 'bar'), 'rb') as f:
+        assert f.read() == b'stale'
+
+
+def test_rename_vm_state_rolls_back_nvram_when_tpm_fails(state_dirs, monkeypatch):
+    nvram, tpm = state_dirs
+    _make_nvram(nvram, 6, 'foo')
+    _make_tpm(tpm, 6, 'foo')
+    # Pre-create a stale TPM destination so AT_RENAME_NOREPLACE fails on TPM.
+    _make_tpm(tpm, 6, 'bar')
+
+    with pytest.raises(FileExistsError):
+        rename_vm_state(6, 'foo', 6, 'bar')
+
+    # NVRAM should be back under the old name; TPM original still at old name.
+    assert os.path.exists(vm_nvram_path(6, 'foo'))
+    assert not os.path.exists(vm_nvram_path(6, 'bar'))
+    assert os.path.isdir(vm_tpm_path(6, 'foo'))
+
+
+def test_delete_vm_state_removes_both(state_dirs):
+    nvram, tpm = state_dirs
+    _make_nvram(nvram, 7, 'foo')
+    _make_tpm(tpm, 7, 'foo')
+    delete_vm_state(7, 'foo')
+    assert not os.path.exists(vm_nvram_path(7, 'foo'))
+    assert not os.path.exists(vm_tpm_path(7, 'foo'))
+
+
+def test_delete_vm_state_missing_both_is_noop(state_dirs):
+    # Never-booted VM — neither artefact exists. Must not raise.
+    delete_vm_state(8, 'foo')
+
+
+def test_delete_vm_state_nvram_only(state_dirs):
+    nvram, _ = state_dirs
+    _make_nvram(nvram, 9, 'foo')
+    delete_vm_state(9, 'foo')
+    assert not os.path.exists(vm_nvram_path(9, 'foo'))
+
+
+def test_delete_vm_state_tpm_only(state_dirs):
+    _, tpm = state_dirs
+    _make_tpm(tpm, 10, 'foo')
+    delete_vm_state(10, 'foo')
+    assert not os.path.exists(vm_tpm_path(10, 'foo'))
+
+
+def test_vm_state_missing_sources_reports_gaps(state_dirs):
+    nvram, tpm = state_dirs
+    _make_nvram(nvram, 11, 'uefi_only')
+    _make_tpm(tpm, 12, 'tpm_only')
+
+    assert vm_state_missing_sources(11, 'uefi_only', 'UEFI', tpm=True) == ['TPM']
+    assert vm_state_missing_sources(12, 'tpm_only', 'UEFI', tpm=True) == ['NVRAM']
+    assert vm_state_missing_sources(13, 'neither', 'UEFI', tpm=True) == ['NVRAM', 'TPM']
+    # BIOS bootloader → NVRAM is never expected.
+    assert vm_state_missing_sources(13, 'neither', 'BIOS', tpm=False) == []
+
+
+def test_rename_rejects_symlink_parent(tmp_path, monkeypatch):
+    # The real system dataset has no symlinks in the path; this test proves
+    # that if a symlink is injected at the parent dir, RESOLVE_NO_SYMLINKS
+    # blocks the rename entirely.
+    real_nvram = tmp_path / 'real_nvram'
+    real_tpm = tmp_path / 'real_tpm'
+    real_nvram.mkdir()
+    real_tpm.mkdir()
+    link_nvram = tmp_path / 'link_nvram'
+    link_nvram.symlink_to(real_nvram)
+    monkeypatch.setattr(vm_utils, 'SYSTEM_NVRAM_FOLDER_PATH', str(link_nvram))
+    monkeypatch.setattr(vm_utils, 'SYSTEM_TPM_FOLDER_PATH', str(real_tpm))
+
+    with pytest.raises(OSError) as ei:
+        rename_vm_state(14, 'foo', 14, 'bar')
+    assert ei.value.errno == errno.ELOOP


### PR DESCRIPTION
## Problem

Two bugs in the VM lifecycle leave on-disk state out of sync with the VM record:

1. **Rename loses TPM state and can desync the DB.** `do_update` only renamed the NVRAM file; the TPM state directory (`/var/db/system/vm/tpm/{id}_{name}_tpm_state/`) was never touched. After rename, pylibvirt generates XML pointing libvirt/swtpm at the new name, the old-named TPM dir is orphaned, and swtpm silently initialises fresh empty state — Windows 11's TPM appears reset, BitLocker keys and measured-boot state are lost. On top of that, the DB update ran *before* the filesystem rename, so any I/O failure left the DB at the new name while the files stayed at the old one. The `CallError` raised on a missing NVRAM was also misleading — libvirt recreates NVRAM from its `template=` attribute on first start.

2. **Delete leaks state.** `do_delete` removed the libvirt domain, devices, and DB row but never touched the NVRAM file or TPM state directory, so those artefacts accumulated in the system dataset indefinitely after their VMs were gone.

## Solution

Centralise the filesystem handling and run it all-or-nothing so the DB and the on-disk state cannot disagree:

- New `rename_vm_state` / `delete_vm_state` / `vm_state_missing_sources` helpers in `plugins/vm/utils.py`. Rename uses `truenas_os.renameat2` under `openat2(RESOLVE_NO_SYMLINKS)` parent FDs with `AT_RENAME_NOREPLACE` — atomic, symlink-safe, refuses to clobber stale destinations, and preserves inode metadata (NVRAM keeps libvirt-qemu ownership, TPM dir keeps tss ownership and its `.lock` + `tpm2-00.permall` contents). Missing sources are silently skipped so never-booted VMs rename cleanly; a WARNING log line announces the no-state case so operators see it. If the NVRAM rename succeeds and the TPM rename then fails, the NVRAM step is rolled back before the exception propagates.
- `do_update` reorders to **filesystem first, then DB**. A filesystem failure now aborts the rename before the DB changes and returns a clear `CallError` naming the path + errno. If the DB update itself fails, the filesystem rename is reverted symmetrically via `rename_vm_state(new…, old…)`. Blocking Python calls moved from `self.middleware.run_in_thread(...)` to the typed `self.to_thread(...)` on `ServiceContext`.
- `do_delete` now invokes `delete_vm_state` after the DB row is gone, best-effort with error logging, so VM deletion no longer leaks NVRAM / TPM artefacts.
- Unit tests under `pytest/unit/plugins/vm/test_state_utils.py` cover happy path, missing-source no-op, stale-destination `EEXIST`, partial-failure rollback, and symlink rejection. Live-VM smoke test confirmed inode + ownership + mode survive the rename and that delete cleans both artefacts.


Has been tested with a live windows 11 VM as well to ensure TPM/nvram changes are good.