### PR TITLE
NAS-138933 / 25.10.3.1 / Load auth_rpcgss at boot to fix Kerberos NFS after manual start (by ixhamza) (by bugclerk)

### DIFF
--- a/src/freenas/usr/lib/modules-load.d/truenas.conf
+++ b/src/freenas/usr/lib/modules-load.d/truenas.conf
@@ -2,3 +2,4 @@ ioatdma
 ntb_split
 ntb_netdev
 drivetemp
+auth_rpcgss


### PR DESCRIPTION
gssproxy writes 1 to `/proc/net/rpc/use-gss-proxy` once at startup. If the proc file doesn't exist yet (`auth_rpcgss` not loaded), it silently gives up. v0.9.2 [adds a 10-second retry timer for this case](https://github.com/gssapi/gssproxy/pull/85), but TrueNAS ships v0.9.1.

When NFS is started manually with auto-start disabled, `gssproxy` has already started and given up. The kernel's `use_gss_proxy` flag stays -1 and the first Kerberos client locks it to 0 (one-shot latch), breaking `RPCSEC_GSS` until reboot. Loading `auth_rpcgss` early ensures the proc file exists before gssproxy starts.

### Testing
Tested with NFS auto-start disabled and rebooting. Before fix, `use-gss-proxy` stayed -1 after manual NFS start and a raw `RPCSEC_GSS_INIT` request locked it to 0. After fix, `use-gss-proxy` is 1.

**_Note_**: tested without Kerberos infrastructure. Flag transition verified using a custom script that sends a raw `RPCSEC_GSS_INIT` RPC to trigger the kernel's `use_gss_proxy()` path.

[Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/2188/).

Original PR: https://github.com/truenas/middleware/pull/18549


Original PR: https://github.com/truenas/middleware/pull/18553
