### PR TITLE
NAS-140745 / 27.0.0-BETA.1 / remove USB boot logic in truenas-initrd.py

### DIFF
--- a/src/freenas/usr/local/bin/truenas-initrd.py
+++ b/src/freenas/usr/local/bin/truenas-initrd.py
@@ -14,63 +14,14 @@ import subprocess
 import sys
 import textwrap
 
-import pyudev
-
-
 logger = logging.getLogger(__name__)
 
 
-def _iter_leaf_vdevs(vdevs):
-    for v in vdevs:
-        if v.children:
-            yield from _iter_leaf_vdevs(v.children)
-        elif v.vdev_type == 'disk':
-            yield v
-
-
-def _append_pool_name(pool, state):
-    state.append(pool.name)
-    return True
-
-
 def update_zfs_default(root, readonly_rootfs):
-    pool_names = []
-    lzh = truenas_pylibzfs.open_handle()
-    lzh.iter_pools(callback=_append_pool_name, state=pool_names)
-
-    for i in ['freenas-boot', 'boot-pool']:
-        if i in pool_names:
-            boot_pool = i
-            break
-    else:
-        raise CallError(f'Failed to locate valid boot pool. Pools located were: {", ".join(pool_names)}')
-
-    # follow_links=False so the vdev path stays in the form stored in
-    # the pool nvlist (e.g. /dev/disk/by-partuuid/...) to match the
-    # udev-keyed mapping built below, rather than realpath()-resolved.
-    status = lzh.open_pool(name=boot_pool).status(
-        get_stats=False, follow_links=False, full_path=True,
-    )
-    disks = [v.name.replace('/dev/', '') for v in _iter_leaf_vdevs(status.storage_vdevs)]
-
-    mapping = {}
-    for dev in filter(
-        lambda d: not d.sys_name.startswith("sr") and d.get("DEVTYPE") in ("disk", "partition"),
-        pyudev.Context().list_devices(subsystem="block")
-    ):
-        if dev.get("DEVTYPE") == "disk":
-            mapping[dev.sys_name] = dev.get("ID_BUS")
-        elif dev.get("ID_PART_ENTRY_UUID"):
-            parent = dev.find_parent("block")
-            mapping[dev.sys_name] = parent.get("ID_BUS")
-            mapping[os.path.join("disk/by-partuuid", dev.get("ID_PART_ENTRY_UUID"))] = parent.get("ID_BUS")
-
-    has_usb = False
-    for dev in disks:
-        if mapping.get(dev) == "usb":
-            has_usb = True
-            break
-
+    # Older versions wrote ZFS_INITRD_POST_MODPROBE_SLEEP=15 here when the boot pool was on
+    # USB, to let USB enumeration finish before zpool import. USB boot is no longer supported,
+    # so this function only strips the line from upgraded installs; can be removed once
+    # versions that wrote it are past EOL.
     zfs_config_path = os.path.join(root, "etc/default/zfs")
     with open(zfs_config_path) as f:
         original_config = f.read()
@@ -78,8 +29,6 @@ def update_zfs_default(root, readonly_rootfs):
 
     zfs_var_name = "ZFS_INITRD_POST_MODPROBE_SLEEP"
     lines = [line for line in lines if not line.startswith(f"{zfs_var_name}=")]
-    if has_usb:
-        lines.append(f"{zfs_var_name}=15")
 
     new_config = "\n".join(lines) + "\n"
     if new_config != original_config:
@@ -237,11 +186,9 @@ if __name__ == "__main__":
 
     # BEGIN LAZY IMPORTS
     # ------------------
-    import truenas_pylibzfs
     from truenas_pylibvirt.utils.gpu import get_gpus
     from truenas_os_pyutils.io import atomic_write
 
-    from middlewared.service_exception import CallError
     from middlewared.utils.db import FREENAS_DATABASE, query_config_table, query_table
     from middlewared.utils.rootfs import ReadonlyRootfsManager
     # ------------------


### PR DESCRIPTION
## Summary

Remove the USB boot-pool detection and `ZFS_INITRD_POST_MODPROBE_SLEEP=15` workaround from `truenas-initrd.py`. The code was added five years ago during SCALE alpha to address a single user's boot failure and has sat untouched since, despite USB boot no longer being a supported configuration on TrueNAS.

## History

The workaround was introduced in commit [ead10f29e5](https://github.com/truenas/middleware/commit/ead10f29e58fc185062c1abb2418a53cecf4a216) (2021-01-20) to address [NAS-108931](https://ixsystems.atlassian.net/browse/NAS-108931) — *"TrueNAS SCALE fails to boot from USB"* — reported against SCALE-20.12-ALPHA. The reporter's USB boot disk was not enumerated by the kernel in time for `zpool import boot-pool`, so the import failed and the system dropped to a rescue shell. The mitigation: if any boot-pool vdev was on a USB bus, inject `ZFS_INITRD_POST_MODPROBE_SLEEP=15` into `/etc/default/zfs` so initramfs would pause 15 seconds after loading the ZFS module before attempting the import.

## Why this is safe to remove

- **USB boot is not a supported configuration on TrueNAS** and has not been for many years. Users still running USB-backed boot pools are doing so against public documentation.
- **Our enterprise product line does not ship with USB-based boot devices.** There is zero enterprise exposure from removing this code path.
- **The kernel, udev, and ZFS initramfs logic have all changed dramatically since January 2021.** The specific enumeration race the workaround targets may not even manifest on current kernels in the same form; if it does, the proper fix lives in the initramfs/udev layer, not a hardcoded 15-second sleep driven by product-side config.
- **The original reporter never confirmed the workaround actually fixed their problem.** NAS-108931 was closed without user acknowledgement that the 15-second sleep resolved the boot failure, so we have been carrying a workaround whose efficacy against the original report was never validated.

## Change

`update_zfs_default()` is reduced to a cleanup-only function: it strips any `ZFS_INITRD_POST_MODPROBE_SLEEP=` line from `/etc/default/zfs`, so installs upgraded from a version that wrote the line are transparently cleaned up. A developer-facing comment records the history and flags the function as safe to delete once versions that wrote the line are past EOL.

With the USB detection gone, the following are also removed from `truenas-initrd.py`:

- Top-level `import pyudev`
- The `_iter_leaf_vdevs` and `_append_pool_name` helpers (only used to walk boot-pool vdevs for the USB check)
- Lazy imports of `truenas_pylibzfs` and `CallError`