### PR TITLE
NAS-140747 / 26.0.0-BETA.2 / add datasetTable to snmp (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 import threading
 import time
-import contextlib
-import os
 
 import truenas_pylibzfs
 from truenas_pylibzfs import kstat
@@ -214,6 +212,18 @@ zvol_table = agent.Table(
     ],
 )
 
+dataset_table = agent.Table(
+    oidstr="TRUENAS-MIB::datasetTable",
+    indexes=[agent.Integer32()],
+    columns=[
+        (1, agent.Integer32()),
+        (2, agent.DisplayString()),
+        (3, agent.Counter64()),
+        (4, agent.Counter64()),
+        (5, agent.Counter64()),
+    ],
+)
+
 hdd_temp_table = agent.Table(
     oidstr="TRUENAS-MIB::hddTempTable",
     indexes=[
@@ -340,56 +350,68 @@ def fill_in_zvol_snmp_row_info(idx, name, props):
     row.setRowCell(5, agent.Counter64(props.referenced.value))
 
 
+def fill_in_dataset_snmp_row_info(idx, name, props):
+    row = dataset_table.addRow([agent.Integer32(idx)])
+    row.setRowCell(1, agent.Integer32(idx))
+    row.setRowCell(2, agent.DisplayString(name))
+    row.setRowCell(3, agent.Counter64(props.used.value))
+    row.setRowCell(4, agent.Counter64(props.available.value))
+    row.setRowCell(5, agent.Counter64(props.referenced.value))
+
+
+def collect_dataset_info(hdl, state):
+    try:
+        props = hdl.get_properties(properties=state["zfs_props"])
+    except truenas_pylibzfs.ZFSException:
+        pass
+    else:
+        state["dataset_idx"] += 1
+        fill_in_dataset_snmp_row_info(state["dataset_idx"], hdl.name, props)
+        if hdl.type == truenas_pylibzfs.ZFSType.ZFS_TYPE_VOLUME:
+            state["zvol_idx"] += 1
+            fill_in_zvol_snmp_row_info(state["zvol_idx"], hdl.name, props)
+
+    hdl.iter_filesystems(callback=collect_dataset_info, state=state)
+    return True
+
+
+def collect_zfs_info(pool, state):
+    state["pool_idx"] += 1
+    idx = state["pool_idx"]
+    name = pool.name
+
+    health = pool.get_properties(
+        properties={truenas_pylibzfs.ZPOOLProperty.HEALTH}
+    ).health.value
+    pool_status = pool.status(get_stats=True)
+    io_overall, io_1s = gather_zpool_iostat_info(state["prev_zpool_info"], name, pool_status)
+    fill_in_zpool_snmp_row_info(idx, name, health, io_overall, io_1s)
+    # be sure and update our zpool io data so next time it's called
+    # we calculate the 1sec values properly
+    state["prev_zpool_info"].update(io_overall)
+
+    collect_dataset_info(pool.root_dataset(), state)
+    return True
+
+
 def report_zfs_info(prev_zpool_info):
     zpool_table.clear()
     zvol_table.clear()
+    dataset_table.clear()
 
     lz = truenas_pylibzfs.open_handle()
-
-    # zpool related information
-    pools = []
-
-    def collect_pool(pool, state):
-        state.append(pool)
-        return True
-
-    lz.iter_pools(callback=collect_pool, state=pools)
-
-    for idx, pool in enumerate(pools, start=1):
-        name = pool.name
-        health = pool.get_properties(
-            properties={truenas_pylibzfs.ZPOOLProperty.HEALTH}
-        ).health.value
-        pool_status = pool.status(get_stats=True)
-        io_overall, io_1s = gather_zpool_iostat_info(prev_zpool_info, name, pool_status)
-        fill_in_zpool_snmp_row_info(idx, name, health, io_overall, io_1s)
-        # be sure and update our zpool io data so next time it's called
-        # we calculate the 1sec values properly
-        prev_zpool_info.update(io_overall)
-
-    zvol_props = {
-        truenas_pylibzfs.ZFSProperty.USED,
-        truenas_pylibzfs.ZFSProperty.AVAILABLE,
-        truenas_pylibzfs.ZFSProperty.REFERENCED,
+    state = {
+        "prev_zpool_info": prev_zpool_info,
+        "pool_idx": 0,
+        "zvol_idx": 0,
+        "dataset_idx": 0,
+        "zfs_props": {
+            truenas_pylibzfs.ZFSProperty.USED,
+            truenas_pylibzfs.ZFSProperty.AVAILABLE,
+            truenas_pylibzfs.ZFSProperty.REFERENCED,
+        },
     }
-    for idx, zvol_name in enumerate(get_list_of_zvols(), start=1):
-        try:
-            rsrc = lz.open_resource(name=zvol_name)
-            props = rsrc.get_properties(properties=zvol_props)
-            fill_in_zvol_snmp_row_info(idx, zvol_name, props)
-        except truenas_pylibzfs.ZFSException:
-            continue
-
-
-def get_list_of_zvols():
-    zvols = set()
-    root_dir = '/dev/zvol/'
-    with contextlib.suppress(FileNotFoundError):  # no zvols
-        for dir_path, unused_dirs, files in os.walk(root_dir):
-            for file in filter(lambda x: '@' not in x, files):
-                zvols.add(os.path.join(dir_path, file).removeprefix(root_dir).replace('+', ' '))
-
-    return list(zvols)
+    lz.iter_pools(callback=collect_zfs_info, state=state)
 
 
 if __name__ == "__main__":

--- a/src/freenas/usr/local/share/snmp/mibs/TRUENAS-MIB.txt
+++ b/src/freenas/usr/local/share/snmp/mibs/TRUENAS-MIB.txt
@@ -7,7 +7,7 @@ IMPORTS
     TEXTUAL-CONVENTION, DisplayString         FROM SNMPv2-TC;
 
 trueNas MODULE-IDENTITY
-    LAST-UPDATED "202602111800Z"
+    LAST-UPDATED "202604211800Z"
     ORGANIZATION "www.truenas.com"
     CONTACT-INFO
         "postal:   541 Division Street
@@ -16,6 +16,9 @@ trueNas MODULE-IDENTITY
          email:    support@TrueNAS.com"
     DESCRIPTION
         "TrueNAS Specific MIBs"
+    REVISION     "202604211800Z"
+    DESCRIPTION
+        "Added datasetTable covering both ZFS filesystems and zvols."
     REVISION     "202602111800Z"
     DESCRIPTION
         ""
@@ -46,6 +49,7 @@ zvol    OBJECT IDENTIFIER ::= { zfs 2 }
 arc     OBJECT IDENTIFIER ::= { zfs 3 }
 l2arc   OBJECT IDENTIFIER ::= { zfs 4 }
 zil     OBJECT IDENTIFIER ::= { zfs 5 }
+dataset OBJECT IDENTIFIER ::= { zfs 6 }
 
 zpoolTable OBJECT-TYPE
     SYNTAX     SEQUENCE OF ZpoolEntry
@@ -238,6 +242,71 @@ zvolReferencedBytes OBJECT-TYPE
     DESCRIPTION
         "The zfs referenced property value"
     ::= { zvolEntry 5 }
+
+datasetTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF DatasetEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "Table of ZFS datasets, covering both filesystems and zvols."
+    ::= { dataset 1 }
+
+datasetEntry OBJECT-TYPE
+    SYNTAX     DatasetEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        ""
+    INDEX { datasetIndex }
+    ::= { datasetTable 1 }
+
+DatasetEntry ::= SEQUENCE {
+        datasetIndex                 Integer32,
+        datasetDescr                 DisplayString,
+        datasetUsedBytes             Counter64,
+        datasetAvailableBytes        Counter64,
+        datasetReferencedBytes       Counter64
+    }
+
+datasetIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        ""
+    ::= { datasetEntry 1 }
+
+datasetDescr OBJECT-TYPE
+    SYNTAX     DisplayString
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The name of the dataset (filesystem or zvol)"
+    ::= { datasetEntry 2 }
+
+datasetUsedBytes OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The zfs used property value"
+    ::= { datasetEntry 3 }
+
+datasetAvailableBytes OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The zfs available property value"
+    ::= { datasetEntry 4 }
+
+datasetReferencedBytes OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The zfs referenced property value"
+    ::= { datasetEntry 5 }
 
 zfsArcSize OBJECT-TYPE
     SYNTAX Gauge32


### PR DESCRIPTION
## Summary

Restore SNMP visibility of ZFS filesystems alongside zvols. Since the Linux port landed in 2022, `snmp-agent.py` only enumerated zvols (via an `os.walk('/dev/zvol/')` scan) and silently stopped reporting filesystem datasets entirely. A customer monitoring their array with Zabbix hit this regression — their dataset usage metrics had gone missing — and the issue was escalated internally to engineering.

This PR rewrites the dataset collection path to use the new `truenas_pylibzfs` bindings and exposes the full dataset tree through a new `datasetTable` MIB entry, while leaving the existing `zvolTable` contract intact for consumers that already depend on it.

## Change

**`snmp-agent.py`** — refactored around `truenas_pylibzfs`:

- `collect_zfs_info(pool, state)` is the callback passed to `lz.iter_pools(...)`. All per-pool work (zpool row: name, health, iostat totals + 1s deltas, `prev_zpool_info` maintenance) happens inside the callback rather than building an intermediate list and looping.
- `collect_dataset_info(hdl, state)` is a recursive callback passed to `hdl.iter_filesystems(...)`, seeded with `pool.root_dataset()`. `zfs_iter_filesystems_v2` returns both `ZFS_TYPE_FILESYSTEM` and `ZFS_TYPE_VOLUME` handles, so the single walk enumerates the full dataset tree — filesystems and zvols together — without needing a separate `/dev/zvol/` scan.
- The legacy `get_list_of_zvols()` helper and its `os` / `contextlib` imports are removed.
- Shared state (`pool_idx`, `zvol_idx`, `dataset_idx`, cached `zfs_props` set) is carried in a dict passed through the callbacks, so indices are assigned in a stable, deterministic order.

**`TRUENAS-MIB.txt`** — adds a new OID branch:

- `dataset OBJECT IDENTIFIER ::= { zfs 6 }` (i.e. `.1.3.6.1.4.1.50536.1.6`).
- `datasetTable` with the same five columns as `zvolTable` (`datasetIndex`, `datasetDescr`, `datasetUsedBytes`, `datasetAvailableBytes`, `datasetReferencedBytes`). Description explicitly notes the table covers both filesystems and zvols.
- `LAST-UPDATED` bumped and a new `REVISION` line added.
- `zvolTable` is **unchanged**; existing Zabbix/Nagios/etc. configs that poll `.1.3.6.1.4.1.50536.1.2` keep working exactly as before.

Populating logic in the agent:

- Every dataset and zvol is written to `datasetTable`.
- Only ZFS volumes are additionally written to `zvolTable`, preserving its historical zvol-only semantics.

## Testing

Verified on an internal development system (two-pool layout: `boot-pool` and `zz`). Test zvols were created under `zz` to exercise both tables, then destroyed afterward.

### `zpoolTable` — unchanged behavior, both pools reported

```
TRUENAS-MIB::zpoolIndex.1 = INTEGER: 1
TRUENAS-MIB::zpoolIndex.2 = INTEGER: 2
TRUENAS-MIB::zpoolName.1 = STRING: boot-pool
TRUENAS-MIB::zpoolName.2 = STRING: zz
TRUENAS-MIB::zpoolHealth.1 = STRING: ONLINE
TRUENAS-MIB::zpoolHealth.2 = STRING: ONLINE
TRUENAS-MIB::zpoolReadOps.1 = Counter64: 1260589
TRUENAS-MIB::zpoolWriteOps.1 = Counter64: 7927826
TRUENAS-MIB::zpoolReadBytes.1 = Counter64: 105717800960
TRUENAS-MIB::zpoolWriteBytes.1 = Counter64: 104973684736
```

### `zvolTable` — zvols only, matches pre-change semantics

Before creating any zvols:

```
TRUENAS-MIB::zvolTable = No Such Object available on this agent at this OID
```

After `zfs create -V 100M -s zz/testvol1` and `zz/testvol2`:

```
TRUENAS-MIB::zvolIndex.1 = INTEGER: 1
TRUENAS-MIB::zvolIndex.2 = INTEGER: 2
TRUENAS-MIB::zvolDescr.1 = STRING: zz/testvol2
TRUENAS-MIB::zvolDescr.2 = STRING: zz/testvol1
TRUENAS-MIB::zvolUsedBytes.1 = Counter64: 57344
TRUENAS-MIB::zvolUsedBytes.2 = Counter64: 57344
TRUENAS-MIB::zvolAvailableBytes.1 = Counter64: 23850783070640
TRUENAS-MIB::zvolAvailableBytes.2 = Counter64: 23850783070640
TRUENAS-MIB::zvolReferencedBytes.1 = Counter64: 57344
TRUENAS-MIB::zvolReferencedBytes.2 = Counter64: 57344
```

### `datasetTable` — filesystems **and** zvols visible

345 rows covering both pool trees. Excerpt showing the boundary where the `zz` pool tree ends and the two test zvols appear interleaved with filesystems:

```
TRUENAS-MIB::datasetDescr.334 = STRING: zz
TRUENAS-MIB::datasetDescr.335 = STRING: zz/.system
TRUENAS-MIB::datasetDescr.336 = STRING: zz/.system/samba4
TRUENAS-MIB::datasetDescr.337 = STRING: zz/.system/cores
TRUENAS-MIB::datasetDescr.338 = STRING: zz/.system/webshare
TRUENAS-MIB::datasetDescr.339 = STRING: zz/.system/configs-ae32c386e13840b2bf9c0083275e7941
TRUENAS-MIB::datasetDescr.340 = STRING: zz/.system/vm
TRUENAS-MIB::datasetDescr.341 = STRING: zz/.system/nfs
TRUENAS-MIB::datasetDescr.342 = STRING: zz/.system/truesearch
TRUENAS-MIB::datasetDescr.343 = STRING: zz/.system/netdata-ae32c386e13840b2bf9c0083275e7941
TRUENAS-MIB::datasetDescr.344 = STRING: zz/testvol2
TRUENAS-MIB::datasetDescr.345 = STRING: zz/testvol1
```

Original PR: https://github.com/truenas/middleware/pull/18776
