### PR TITLE
NAS-140553 / 26.0.0-BETA.2 / Surface x-action-required compose extension on app.query (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/app.py
+++ b/src/middlewared/middlewared/api/v26_0_0/app.py
@@ -128,6 +128,8 @@ class AppEntry(BaseModel):
     """Information about the running containers, ports, and resources used by this application."""
     notes: LongString | None
     """User-provided notes or comments about this application instance."""
+    action_required: bool
+    """Whether this application requires user action (e.g., configuration migration or deprecation handling)."""
     portals: dict
     """Web portals and access points provided by the application (URLs, ports, etc.)."""
     version_details: dict | None = None

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/portals.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/portals.py
@@ -1,4 +1,6 @@
-from apps_validation.portals import IX_NOTES_KEY, IX_PORTAL_KEY, validate_portals_and_notes, ValidationErrors
+from apps_validation.portals import (
+    IX_ACTION_REQUIRED_KEY, IX_NOTES_KEY, IX_PORTAL_KEY, validate_portals_and_notes, ValidationErrors
+)
 
 from .lifecycle import get_rendered_template_config_of_app
 
@@ -17,12 +19,13 @@ def get_portals_and_app_notes(app_name: str, version: str) -> dict:
     rendered_config = get_rendered_template_config_of_app(app_name, version)
     portal_and_notes_config = {
         k: rendered_config[k]
-        for k in (IX_NOTES_KEY, IX_PORTAL_KEY)
+        for k in (IX_NOTES_KEY, IX_PORTAL_KEY, IX_ACTION_REQUIRED_KEY)
         if k in rendered_config
     }
     config = {
         'portals': {},
         'notes': None,
+        'action_required': False,
     }
     if portal_and_notes_config:
         try:
@@ -39,4 +42,5 @@ def get_portals_and_app_notes(app_name: str, version: str) -> dict:
     return {
         'portals': portals,
         'notes': portal_and_notes_config.get(IX_NOTES_KEY),
+        'action_required': bool(portal_and_notes_config.get(IX_ACTION_REQUIRED_KEY)),
     }

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -138,6 +138,7 @@ def list_apps(
             'state': state,
             'upgrade_available': upgrade_available,
             'latest_version': latest_version,
+            'action_required': False,
             'latest_app_version': latest_app_version,
             'image_updates_available': image_updates_available,
             **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
@@ -175,6 +176,7 @@ def list_apps(
                     'state': AppState.STOPPED.value,
                     'upgrade_available': upgrade_available,
                     'latest_version': latest_version,
+                    'action_required': False,
                     'latest_app_version': latest_app_version,
                     'image_updates_available': False,
                     **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}


### PR DESCRIPTION
This commit adds changes to expose `action_required` set by app dev which let's the user know that something needs to be done on the app side and he should check notes section.

Original PR: https://github.com/truenas/middleware/pull/18765
