### PR TITLE
NAS-140751 / 27.0.0-BETA.1 / Fix failing container integration test

### DIFF
--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -14,7 +14,7 @@ from truenas_api_client import ValidationErrors
 from middlewared.test.integration.assets.pool import another_pool, pool
 from middlewared.test.integration.utils import call, host, ssh, websocket_url
 
-UBUNTU_IMAGE_NAME = "ubuntu:plucky:amd64:default"
+UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
 VIRSH = "virsh -c 'lxc:///system?socket=/run/truenas_libvirt/libvirt-sock'"
 # Capabilities necessary to launch a basic LXC container from linuxcontainers.org
 BASIC_CAPABILITIES = {


### PR DESCRIPTION
 ## Problem
 
The test used `ubuntu:plucky:amd64:default` (Ubuntu 25.04 "Plucky Puffin"), which is no longer available.

## Solution
Changed to `ubuntu:noble:amd64:default` (Ubuntu 24.04 LTS). Noble is an LTS release so it should remain in the registry for a long time, avoiding this kind of breakage from short-lived interim releases.                                                                                                                                                                           
                                                                                                                                                                                              
      