### PR TITLE
NAS-140691 / 27.0.0-BETA.1 / Inherit `canmount` when migrating Incus containers (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -247,7 +247,7 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
 
             context.middleware.call_sync(
                 'pool.dataset.update_impl',
-                UpdateImplArgs(name=dataset['name'], iprops={'mountpoint'})
+                UpdateImplArgs(name=dataset['name'], iprops={'mountpoint', 'canmount'})
             )
             context.call_sync2(context.s.zfs.resource.mount, dataset['name'])
 


### PR DESCRIPTION
## Summary

Fixes a regression in the legacy Incus → container migration (`container.migrate`, first shipped in 26.0.0-BETA.1) that left migrated containers unable to start on every subsequent boot with:

```
libvirtError: internal error: guest failed to start: Failure in libvirt_lxc startup:
cannot find init path '/sbin/init' relative to container root: No such file or directory
```

## Root cause

Incus sets `canmount=noauto` locally on each container dataset so it can manage mounts itself. `container.migrate_specific_pool` inherited `mountpoint` and cleared `readonly` on the legacy datasets but did **not** touch `canmount`.

Migration appeared to succeed because it explicitly calls `zfs.resource.mount`, which works on a `canmount=noauto` dataset. On the next reboot, though, ZFS refused to auto-mount the dataset, so `container.start` handed an empty mountpoint directory to `libvirt_lxc`. `libvirt_lxc` created its usual bind-mount points (`/dev`, `/proc`, `/sys`, `/mnt`, `/.oldroot`) inside that empty directory, then failed when it could not `exec /sbin/init`.

## Fix

Extend the `iprops` set in `migrate_specific_pool` so each migrated container dataset inherits `canmount` alongside `mountpoint`. The parent `<pool>/.truenas_containers/containers` has `canmount` at default (`on`), so inheriting restores the child and ZFS auto-mounts it on subsequent boots.

## Scope

- **Fixes:** anyone who migrates legacy Incus containers on or after this change.
- **Does not fix in this PR:** users who already ran the broken migration on 26.0.0-BETA.1. Their container datasets still have `canmount=noauto (local)` on disk, and `maybe_migrate_legacy` will not re-run (`virt_global.pool` was cleared). Pending data on the size of that population, a one-shot `middlewared/migration/*.py` backfill may be added in a follow-up.

Affected BETA.1 users can unblock themselves manually, per container:

```
zfs set canmount=on <pool>/.truenas_containers/containers/<name>
zfs mount <pool>/.truenas_containers/containers/<name>
```

Original PR: https://github.com/truenas/middleware/pull/18779
