### PR TITLE
NAS-140757 / 26.0.0-BETA.2 / Detect missing docker root dataset in startup validation (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -126,7 +126,7 @@ def docker_dataset_update_props(props: dict) -> typing.Dict[str, str]:
 def missing_required_datasets(existing_datasets: set, docker_ds: str) -> set:
     diff = existing_datasets ^ set(docker_datasets(docker_ds))
     if fatal_diff := diff.intersection(
-        set(docker_ds) | {
+        {docker_ds} | {
             os.path.join(docker_ds, k) for k in (
                 'app_configs', 'app_mounts', 'docker', CATALOG_DATASET_NAME,
             )


### PR DESCRIPTION
This commit adds changes to fix a subtle issue where `missing_required_datasets` failed to detect when the root docker dataset itself was missing. The check constructed its fatal set using `set(docker_ds)`, which iterates the dataset path string character-by-character (e.g. `"tank/.ix-apps"` becomes `{'t','a','n','k','/','.','i','x','-','p','s'}`) rather than producing a single-element set containing the path. As a result, the root dataset was never included in the intersection check and a missing root docker dataset would silently pass validation instead of raising a `CallError` during docker startup. The fix replaces `set(docker_ds)` with `{docker_ds}` so the full dataset name participates in the fatal-set membership check as intended.

Original PR: https://github.com/truenas/middleware/pull/18787
