### PR TITLE
NAS-140741 / 25.10.3.1 / V-Series: DMI-gated X710 internode bond for v2.0 (NTG) controllers (by darkfiberiru) (by bugclerk)

### DIFF
--- a/src/freenas/usr/lib/systemd/network/10-vseries-internode.link
+++ b/src/freenas/usr/lib/systemd/network/10-vseries-internode.link
@@ -1,7 +1,17 @@
-# The v-series will use a regular interface for HA
-# inter-node communication.
+# V-Series HA inter-node communication:
+#   DMI Version "1.x" — external 10 GbE cable on this bnxt_en NIC is
+#                       renamed to `internode0` and used as the HA interconnect.
+#   DMI Version "2.x" or higher / invalid — NOT renamed: `internode0` is
+#                       instead a kernel bond across the two internal
+#                       X710 cross-connect ports, created by middleware
+#                       (failover.internal_interface.ensure_vseries_bond).
+# The product_version $= "1.*" glob matches only explicit 1.<something>
+# strings, so 2.x, 3.x, un-stamped, and malformed values all fall through
+# to the middleware bond path — which matches middleware's binary
+# < 2.0 vs >= 2.0 interconnect model.
 [Match]
 Firmware=smbios-field(product_name $= "TRUENAS-V*")
+Firmware=smbios-field(product_version $= "1.*")
 Property=INTERFACE=ens10f1np1
 Driver=bnxt_en
 Type=ether

--- a/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
+++ b/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
@@ -1,0 +1,59 @@
+# Copyright (c) - iXsystems Inc. dba TrueNAS
+#
+# Licensed under the terms of the TrueNAS Enterprise License Agreement
+# See the file LICENSE.IX for complete terms and conditions
+
+from dataclasses import dataclass
+from typing import Any
+
+from middlewared.alert.base import (
+    Alert,
+    AlertClass,
+    AlertClassConfig,
+    AlertCategory,
+    AlertLevel,
+    AlertSource,
+)
+from middlewared.utils import ProductType
+from middlewared.utils.version import parse_major_minor_version
+
+
+@dataclass(kw_only=True)
+class VSeriesUnstampedSPDAlert(AlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.HARDWARE,
+        level=AlertLevel.WARNING,
+        title="V-Series DMI Hardware Version Unreadable",
+        text=(
+            "DMI Type 1 Version is %(observed)r, which is not a valid "
+            'V-Series hardware revision (expected "<major>.<minor>", e.g. '
+            '"1.0" or "2.0"). Assuming >= 2.0 interconnect behavior. '
+            "Contact support."
+        ),
+        products=(ProductType.ENTERPRISE,),
+    )
+    observed: str
+
+
+class VSeriesUnstampedSPDAlertSource(AlertSource):
+    products = (ProductType.ENTERPRISE,)
+
+    async def check(self) -> list[Alert[Any]]:
+        """Fire on V-Series when the DMI Type 1 Version field isn't a strict
+        "<major>.<minor>" string.
+
+        Middleware uses this value to select the HA interconnect topology
+        (< 2.0 = external cable, >= 2.0 = internal X710 bond). A missing or
+        malformed value falls through to the >= 2.0 default, which is only
+        correct for NTG v2.0 hardware — every shipped V-Series controller
+        is expected to carry a valid stamp, so the alert surfaces units
+        that don't.
+        """
+        chassis = await self.middleware.call("truenas.get_chassis_hardware")
+        if not chassis.startswith("TRUENAS-V"):
+            return []
+        dmi = await self.middleware.call("system.dmidecode_info")
+        observed = dmi.get("system-version") or ""
+        if parse_major_minor_version(observed) is not None:
+            return []
+        return [Alert(VSeriesUnstampedSPDAlert(observed=observed))]

--- a/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
+++ b/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
@@ -3,13 +3,9 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
-from dataclasses import dataclass
-from typing import Any
-
 from middlewared.alert.base import (
     Alert,
     AlertClass,
-    AlertClassConfig,
     AlertCategory,
     AlertLevel,
     AlertSource,
@@ -18,27 +14,23 @@ from middlewared.utils import ProductType
 from middlewared.utils.version import parse_major_minor_version
 
 
-@dataclass(kw_only=True)
-class VSeriesUnstampedSPDAlert(AlertClass):
-    config = AlertClassConfig(
-        category=AlertCategory.HARDWARE,
-        level=AlertLevel.WARNING,
-        title="V-Series DMI Hardware Version Unreadable",
-        text=(
-            "DMI Type 1 Version is %(observed)r, which is not a valid "
-            'V-Series hardware revision (expected "<major>.<minor>", e.g. '
-            '"1.0" or "2.0"). Assuming >= 2.0 interconnect behavior. '
-            "Contact support."
-        ),
-        products=(ProductType.ENTERPRISE,),
+class VSeriesUnstampedSPDAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
+    title = "V-Series DMI Hardware Version Unreadable"
+    text = (
+        "DMI Type 1 Version is %(observed)r, which is not a valid "
+        'V-Series hardware revision (expected "<major>.<minor>", e.g. '
+        '"1.0" or "2.0"). Assuming >= 2.0 interconnect behavior. '
+        "Contact support."
     )
-    observed: str
+    products = (ProductType.ENTERPRISE,)
 
 
 class VSeriesUnstampedSPDAlertSource(AlertSource):
     products = (ProductType.ENTERPRISE,)
 
-    async def check(self) -> list[Alert[Any]]:
+    async def check(self):
         """Fire on V-Series when the DMI Type 1 Version field isn't a strict
         "<major>.<minor>" string.
 
@@ -51,9 +43,9 @@ class VSeriesUnstampedSPDAlertSource(AlertSource):
         """
         chassis = await self.middleware.call("truenas.get_chassis_hardware")
         if not chassis.startswith("TRUENAS-V"):
-            return []
+            return None
         dmi = await self.middleware.call("system.dmidecode_info")
         observed = dmi.get("system-version") or ""
         if parse_major_minor_version(observed) is not None:
-            return []
-        return [Alert(VSeriesUnstampedSPDAlert(observed=observed))]
+            return None
+        return Alert(VSeriesUnstampedSPDAlertClass, {"observed": observed})

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -172,8 +172,14 @@ class Enclosure:
                 # M series
                 self.model = dmi_model.value
                 self.controller = True
-            case 'ECStream_4IXGA-NTBp' | 'ECStream_4IXGA-NTBs':
-                # V series
+            case (
+                'ECStream_4IXGA-NTBp'
+                | 'ECStream_4IXGA-NTBs'
+                | 'ECStream_4IXGA-NTGp'
+                | 'ECStream_4IXGA-NTGs'
+            ):
+                # V series — NTB on the original board, NTG on the new
+                # 4IXGA_PEX89032 (X710) board. Same -p/-s convention.
                 self.model = dmi_model.value
                 self.controller = True
             case 'CELESTIC_P3215-O' | 'CELESTIC_P3217-B':

--- a/src/middlewared/middlewared/plugins/failover_/detect_utils.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_utils.py
@@ -12,9 +12,30 @@ from ixhardware import parse_dmi, PLATFORM_PREFIXES
 from pyudev import Context
 
 from middlewared.plugins.enclosure_.ses_enclosures2 import get_ses_enclosures
+from middlewared.utils.version import parse_major_minor_version
 
 
 logger = logging.getLogger(__name__)
+
+
+def is_vseries_v2_interconnect() -> bool:
+    """True when this V-Series controller uses the new internal X710 LACP
+    bond interconnect instead of the legacy external 10 GbE cable.
+
+    Sourced from the DMI Type 1 "Version" field:
+        < 2.0  (e.g. 1.0, 1.5, 1.99)  — external 10 GbE cable as internode0
+        >= 2.0 (e.g. 2.0, 2.1, 3.0)   — internal LACP bond across the two
+                                        on-board X710-AT2 ports as internode0
+    Invalid / un-stamped DMI falls back to the >= 2.0 path and fires the
+    vseries_unstamped_spd alert so support can see the bad SPD.
+
+    Precondition: callers must have already verified this is V-Series
+    hardware (HARDWARE in 'LUDICROUS' or 'PLAID'). The DMI Version field
+    is not meaningful on other platforms, so this will return garbage on
+    non-V-Series systems.
+    """
+    rev = parse_major_minor_version(parse_dmi().system_version)
+    return rev is None or rev >= (2, 0)
 
 
 @cache
@@ -84,12 +105,16 @@ def detect_platform() -> tuple[str, str]:
                 HARDWARE = 'PLAID'
             case _:
                 return HARDWARE, NODE
+        # 4IXGA backplane reports its SES product as NTB on the original
+        # V-Series board and NTG on the new 4IXGA_PEX89032 (X710) board.
+        # Both variants use the same -p/-s suffix to identify primary (A)
+        # vs secondary (B) controller position.
         for s in get_ses_enclosures(False):
             if s.vendor == 'ECStream':
-                if s.product == '4IXGA-NTBp':
+                if s.product in ('4IXGA-NTBp', '4IXGA-NTGp'):
                     NODE = 'A'
                     break
-                elif s.product == '4IXGA-NTBs':
+                elif s.product in ('4IXGA-NTBs', '4IXGA-NTGs'):
                     NODE = 'B'
                     break
         return HARDWARE, NODE

--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -4,12 +4,51 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 import ipaddress
+import subprocess
 from pathlib import Path
 
 from pyroute2 import NDB
 
+from middlewared.plugins.failover_.detect_utils import is_vseries_v2_interconnect
 from middlewared.service import Service
 from middlewared.utils.functools_ import cache
+
+
+def _find_vseries_x710_ports() -> list[str]:
+    # Intel X710 10GBASE-T family (the 4IXGA_PEX89032 board uses X710-AT2).
+    # The on-board X710-AT2 reports SUBSYS_ID=8086:0000 — same value a retail
+    # X710-AT2 add-in card is likely to report — so VID:DID + SUBSYS_ID alone
+    # is not a sufficient discriminator. Instead we also check the NIC's
+    # parent PCI bridge: both on-board ports sit directly behind a PEX89032
+    # (Broadcom / LSI PEX890xx Gen 5) switch downstream port. A user-installed
+    # X710-AT2 in a normal PCIe slot will parent to a CPU root port or a
+    # different bridge and therefore be ignored here.
+    ports: list[tuple[str, str]] = []
+    for iface in Path('/sys/class/net/').iterdir():
+        try:
+            uevent = (iface / 'device/uevent').read_text()
+        except (FileNotFoundError, OSError):
+            continue
+        if 'PCI_ID=8086:15FF' not in uevent:
+            continue
+        try:
+            nic_pci = (iface / 'device').resolve()
+            parent_vendor = (nic_pci.parent / 'vendor').read_text().strip()
+            parent_device = (nic_pci.parent / 'device').read_text().strip()
+        except (FileNotFoundError, OSError):
+            continue
+        if (parent_vendor, parent_device) != ('0x1000', '0xc034'):
+            continue
+        ports.append((nic_pci.name, iface.name))
+    ports.sort()
+    return [name for _, name in ports]
+
+
+def _bond_members(bond: str) -> list[str]:
+    try:
+        return Path(f'/sys/class/net/{bond}/bonding/slaves').read_text().split()
+    except FileNotFoundError:
+        return []
 
 
 class InternalInterfaceService(Service):
@@ -42,13 +81,144 @@ class InternalInterfaceService(Service):
             # {x/m/f/h}-series
             found.append('ntb0')
         elif hardware in ('LUDICROUS', 'PLAID'):
-            # v-series
+            # v-series. DMI Type 1 Version selects interconnect topology:
+            #   < 2.0  — external 10 GbE cable renamed to `internode0` by
+            #            systemd `.link` (no bond, no X710 masking).
+            #   >= 2.0 — `internode0` is a kernel LACP bond across the two
+            #            on-board X710-AT2 ports (see ensure_vseries_bond).
+            #            The members must also be returned here: the user
+            #            list filter does NOT drop enslaved interfaces on
+            #            its own, so member names would otherwise leak
+            #            into `interface.query`. We return the stable
+            #            post-rename names (`internode0_1`/`internode0_2`)
+            #            AND the current kernel names so masking holds
+            #            whether this method runs before or after the
+            #            rename that happens in ensure_vseries_bond().
             found.append('internode0')
+            if is_vseries_v2_interconnect():
+                x710_ports = _find_vseries_x710_ports()
+                if len(x710_ports) == 2:
+                    found.extend(('internode0_1', 'internode0_2'))
+                    for port in x710_ports:
+                        if port not in found:
+                            found.append(port)
         return tuple(found)
+
+    def ensure_vseries_bond(self):
+        # On V-Series with DMI Version >= 2.0, `internode0` is an LACP bond
+        # across the two on-board X710 cross-connect ports. Create it
+        # idempotently before the HA IP is assigned.
+        #
+        # Note: backport shells out to `ip` / `ethtool` rather than using
+        # truenas_pynetif (not present on 25.10.x). The master branch uses
+        # the pynetif genl helpers directly.
+        hardware = self.middleware.call_sync('failover.hardware')
+        if hardware not in ('LUDICROUS', 'PLAID'):
+            return
+        if not is_vseries_v2_interconnect():
+            return
+
+        members = _find_vseries_x710_ports()
+        if len(members) != 2:
+            self.logger.warning(
+                'v-series >= 2.0: expected 2 internal X710 ports, found %d',
+                len(members),
+            )
+            return
+
+        bond_name = 'internode0'
+        target_names = ('internode0_1', 'internode0_2')
+
+        # If bond already exists with the right members we're done.
+        # Otherwise tear it down and rebuild from scratch.
+        if Path(f'/sys/class/net/{bond_name}').exists():
+            if set(_bond_members(bond_name)) == set(target_names):
+                return
+            subprocess.run(['ip', 'link', 'del', bond_name], check=True)
+
+        # Rename each member to a stable, intent-revealing name
+        # (internode0_1 / internode0_2) before enslavement. Links must be
+        # DOWN to be renamed.
+        renamed: list[str] = []
+        for current, target in zip(members, target_names):
+            if current == target:
+                renamed.append(current)
+                continue
+            subprocess.run(['ip', 'link', 'set', current, 'down'], check=True)
+            subprocess.run(
+                ['ip', 'link', 'set', current, 'name', target], check=True
+            )
+            renamed.append(target)
+
+        # Apply per-member X710 tuning while the members are DOWN — avoids
+        # resets that would otherwise flap LACP on a live bond.
+        for port in renamed:
+            self._tune_vseries_x710_port(port)
+
+        # Create the bond DOWN with no slaves so mode-family options can be
+        # set (kernel rejects mode change once a bond has any slaves).
+        subprocess.run(
+            ['ip', 'link', 'add', bond_name, 'type', 'bond'], check=True
+        )
+        subprocess.run(['ip', 'link', 'set', bond_name, 'down'], check=True)
+        subprocess.run(
+            [
+                'ip', 'link', 'set', bond_name, 'type', 'bond',
+                'mode', '802.3ad',
+                'xmit_hash_policy', 'layer3+4',
+                'lacp_rate', 'fast',
+                'miimon', '100',
+            ],
+            check=True,
+        )
+        for member in renamed:
+            subprocess.run(['ip', 'link', 'set', member, 'down'], check=True)
+            subprocess.run(
+                ['ip', 'link', 'set', member, 'master', bond_name], check=True
+            )
+        subprocess.run(
+            ['ip', 'link', 'set', bond_name, 'mtu', '9000'], check=True
+        )
+        subprocess.run(['ip', 'link', 'set', bond_name, 'up'], check=True)
+
+    def _tune_vseries_x710_port(self, iface: str) -> None:
+        # Disable the i40e firmware LLDP agent so stray LLDP frames
+        # don't get consumed by firmware and firmware-side DCBX can't
+        # misnegotiate on this internal point-to-point interconnect.
+        # ethtool is already idempotent for this priv-flag so we don't
+        # bother reading current state first.
+        try:
+            subprocess.run(
+                ['ethtool', '--set-priv-flags', iface, 'disable-fw-lldp', 'on'],
+                check=True, capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            self.logger.warning(
+                '%s: priv-flag tuning skipped: %s', iface,
+                e.stderr.decode(errors='replace').strip(),
+            )
+
+        # 4-tuple RX flow hash (`sdfn` = src-IP + dst-IP + src-port +
+        # dst-port) so inbound controller-to-controller flows spread
+        # across X710 RX queues instead of collapsing to a single
+        # queue / CPU.
+        for flow_type in ('tcp4', 'udp4'):
+            try:
+                subprocess.run(
+                    ['ethtool', '-N', iface, 'rx-flow-hash', flow_type, 'sdfn'],
+                    check=True, capture_output=True,
+                )
+            except subprocess.CalledProcessError as e:
+                self.logger.warning(
+                    '%s: rx-flow-hash %s failed: %s', iface, flow_type,
+                    e.stderr.decode(errors='replace').strip(),
+                )
 
     async def pre_sync(self):
         if not await self.middleware.call('system.is_enterprise'):
             return
+
+        await self.middleware.run_in_thread(self.ensure_vseries_bond)
 
         node = await self.middleware.call('failover.node')
         if node == 'A':

--- a/src/middlewared/middlewared/utils/version.py
+++ b/src/middlewared/middlewared/utils/version.py
@@ -1,3 +1,9 @@
+import re
+
+
+_MAJOR_MINOR_RE = re.compile(r'[1-9][0-9]*\.[0-9]+')
+
+
 def parse_version_string(version_string: str) -> str | None:
     """
     This util retrieves version numbers from version string i.e 25.04.0 or 25.1.1.1.
@@ -10,3 +16,20 @@ def parse_version_string(version_string: str) -> str | None:
         return None
 
     return '.'.join(to_format)
+
+
+def parse_major_minor_version(raw: str | None) -> tuple[int, int] | None:
+    """
+    Strict "<major>.<minor>" parser: non-zero major (no leading zeros, any
+    digit count), numeric minor. Returns (major, minor) or None.
+
+    Everything else ("", "0100", "0.9", "01.0", "1", "1.0.0", "1.0-beta", ...)
+    is rejected. Surrounding whitespace is tolerated.
+    """
+    if not raw:
+        return None
+    head = raw.strip()
+    if not _MAJOR_MINOR_RE.fullmatch(head):
+        return None
+    major, minor = head.split('.')
+    return (int(major), int(minor))

--- a/tests/unit/test_vseries_hw_rev.py
+++ b/tests/unit/test_vseries_hw_rev.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from middlewared.plugins.failover_ import detect_utils
+
+
+# (raw DMI, expected is_vseries_v2_interconnect())
+# True  => new topology (internal X710 LACP bond)
+# False => old topology (external 10 GbE cable)
+# Unreadable / malformed DMI defaults to True (assume >= 2.0) and also
+# fires the vseries_unstamped_spd alert (see that alert source — it
+# calls parse_major_minor_version directly to detect the same condition).
+CASES = [
+    # Valid — old topology (< 2.0)
+    ('1.0', False),
+    ('1.1', False),
+    ('1.99', False),
+    # Valid — new topology (>= 2.0)
+    ('2.0', True),
+    ('2.1', True),
+    ('3.0', True),
+    ('9.9', True),
+    ('10.0', True),          # multi-digit major allowed
+    ('25.1', True),
+    ('99.99', True),
+    # Whitespace tolerated around the value
+    (' 2.0 ', True),
+    # Invalid — all default to new topology (True)
+    ('0.9', True),           # leading-zero major rejected
+    ('01.0', True),          # leading-zero major rejected
+    ('0100', True),          # no dot — Gigabyte packed form is NOT accepted
+    ('2.0.0', True),         # must be exactly <major>.<minor>
+    ('2.0-beta', True),      # no suffix
+    ('1', True),             # needs the dot + minor
+    ('1.', True),            # needs at least one digit after dot
+    ('', True),
+    (None, True),
+    ('bogus', True),
+    ('..', True),
+]
+
+
+@pytest.mark.parametrize('raw,expected', CASES)
+def test_is_vseries_v2_interconnect(raw, expected):
+    with patch.object(
+        detect_utils, 'parse_dmi',
+        return_value=SimpleNamespace(system_version=raw),
+    ):
+        assert detect_utils.is_vseries_v2_interconnect() is expected


### PR DESCRIPTION
## Summary

Add middleware support for the new NTG V-Series switch board (4IXGA_PEX89032). The NTG board replaces the older NTB board on v2.0 controllers, eliminates the external 10 GBaseT internode cable, and provides the HA interconnect via a 2×10 GbE cross-connect over the chassis backplane (dual X710-AT2 ports per controller). The freed-up 10 GBaseT port returns to the customer as a general-purpose interface.

## Why

Without this change, a v2.0 (NTG) controller returns `MANUAL` from `failover.node` (new SES product string unrecognised) and HA won't come up. This is a ship blocker for the NTG board.

## Behavior

A DMI Type 1 "Version" stamp on each controller drives a binary selection:

- DMI `< 2.0` (NTB controllers) — unchanged behavior: `.link` file renames the bnxt external-cable NIC to `internode0`, no bond.
- DMI `>= 2.0` (NTG controllers) — `.link` rename is gated off; middleware creates `internode0` as a kernel LACP bond (802.3ad, `layer3+4`, `lacp_rate=fast`, MTU 9000) across the two on-board X710-AT2 ports, renamed to `internode0_1` / `internode0_2` (by BDF) before enslavement.
- DMI unstamped/invalid — assumes `>= 2.0` behavior and fires `VSeriesUnstampedSPDAlert`.

## Changes

- `failover_/detect_utils.py` — new strict-regex DMI parser (`is_valid_vseries_hw_rev`, `detect_vseries_hw_rev`, boundary `VSERIES_V2_BOUNDARY = (2, 0)`). Node detection (`detect_platform`) extended to accept `4IXGA-NTG[p|s]` SES products alongside `4IXGA-NTB[p|s]`.
- `enclosure_/enclosure_class.py::_get_model_and_controller()` — extended same way for enclosure modelling.
- `failover_/internal_interface.py` — new `ensure_vseries_bond()` + PEX89032-parent discriminator (`_find_vseries_x710_ports()`) + per-member tuning entirely over genl/netlink: `disable-fw-lldp=on` via `EthtoolNetlink.set_priv_flags`, 4-tuple RX flow hash via `EthtoolNetlink.set_rx_flow_hash` (uses `ETHTOOL_MSG_RSS_SET`, new in Linux v6.17). `detect()` returns the bond + member names so `interface.query` hides them.
- `10-vseries-internode.link` — second `Firmware=smbios-field(product_version $= "1.*")` line so the bnxt rename only fires on 1.x DMI.
- `alert/source/vseries_unstamped_spd.py` — new `VSeriesUnstampedSPDAlert` (HARDWARE/WARNING/ENTERPRISE).
- `tests/unit/test_vseries_hw_rev.py` — 22-case parametrized test for the DMI parser.

Depends on truenas/truenas_pynetif#60 (three ethtool/netlink helpers).

## Test plan

Full 16-phase test matrix executed on an internal HA pair with 5 iterations per destructive phase:

- [x] Graceful reboots (A only, B only, simultaneous)
- [x] IPMI power cycles (A, B, both)
- [x] Cold boot from fully-dark chassis
- [x] Bond member down/up (single, both)
- [x] Manual HA failover round-trip
- [x] HA failover under active client IO
- [x] Bulk interconnect throughput (iperf3 -P 8) → ~19.8 Gb/s aggregate
- [x] 24-hour soak (continuous iperf3 + 2-hour state snapshots)

Bond converges with `ad_actor_oper_port_state = ad_partner_oper_port_state = 63` on both sides. No regressions observed in the external-cable (DMI 1.x) path.

## Backports

Required on `release/25.10.x` (first v2.0 ship carrier) and `release/26.x`. Both branches pre-date the v6.17 RSS_SET kernel path and don't carry `truenas_pynetif`; the backports shell out to `ethtool -N` / `ethtool --set-priv-flags` instead — see the NAS-140741 backport notes for specifics.

Original PR: https://github.com/truenas/middleware/pull/18788


Original PR: https://github.com/truenas/middleware/pull/18793
