### PR TITLE
NAS-140765 / 26.0.0-BETA.2 / fix vseries alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
+++ b/src/middlewared/middlewared/alert/source/vseries_unstamped_spd.py
@@ -3,13 +3,9 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
-from dataclasses import dataclass
-from typing import Any
-
 from middlewared.alert.base import (
     Alert,
     AlertClass,
-    AlertClassConfig,
     AlertCategory,
     AlertLevel,
     AlertSource,
@@ -18,27 +14,23 @@ from middlewared.utils import ProductType
 from middlewared.utils.version import parse_major_minor_version
 
 
-@dataclass(kw_only=True)
-class VSeriesUnstampedSPDAlert(AlertClass):
-    config = AlertClassConfig(
-        category=AlertCategory.HARDWARE,
-        level=AlertLevel.WARNING,
-        title="V-Series DMI Hardware Version Unreadable",
-        text=(
-            "DMI Type 1 Version is %(observed)r, which is not a valid "
-            'V-Series hardware revision (expected "<major>.<minor>", e.g. '
-            '"1.0" or "2.0"). Assuming >= 2.0 interconnect behavior. '
-            "Contact support."
-        ),
-        products=(ProductType.ENTERPRISE,),
+class VSeriesUnstampedSPDAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
+    title = "V-Series DMI Hardware Version Unreadable"
+    text = (
+        "DMI Type 1 Version is %(observed)r, which is not a valid "
+        'V-Series hardware revision (expected "<major>.<minor>", e.g. '
+        '"1.0" or "2.0"). Assuming >= 2.0 interconnect behavior. '
+        "Contact support."
     )
-    observed: str
+    products = (ProductType.ENTERPRISE,)
 
 
 class VSeriesUnstampedSPDAlertSource(AlertSource):
     products = (ProductType.ENTERPRISE,)
 
-    async def check(self) -> list[Alert[Any]]:
+    async def check(self):
         """Fire on V-Series when the DMI Type 1 Version field isn't a strict
         "<major>.<minor>" string.
 
@@ -51,9 +43,9 @@ class VSeriesUnstampedSPDAlertSource(AlertSource):
         """
         chassis = await self.middleware.call("truenas.get_chassis_hardware")
         if not chassis.startswith("TRUENAS-V"):
-            return []
+            return None
         dmi = await self.middleware.call("system.dmidecode_info")
         observed = dmi.get("system-version") or ""
         if parse_major_minor_version(observed) is not None:
-            return []
-        return [Alert(VSeriesUnstampedSPDAlert(observed=observed))]
+            return None
+        return Alert(VSeriesUnstampedSPDAlertClass, {"observed": observed})


### PR DESCRIPTION
26 does not have type annotation changes to the alert system like 27 has.