### PR TITLE
NAS-140778 / 26.0.0-BETA.2 / Set `canmount=on` on migrated container datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -245,7 +245,11 @@ class ContainerService(Service):
 
                 self.middleware.call_sync(
                     "pool.dataset.update_impl",
-                    UpdateImplArgs(name=dataset["name"], iprops={"mountpoint", "canmount"})
+                    UpdateImplArgs(
+                        name=dataset["name"],
+                        zprops={"canmount": "on"},
+                        iprops={"mountpoint"},
+                    )
                 )
                 self.call_sync2(self.s.zfs.resource.mount, dataset["name"])
 


### PR DESCRIPTION
Corrects #18779 by explicitly setting `canmount=on` instead of trying to inherit. "canmount" is an uninheritable ZFS property.

Following this change, migrated container datasets will properly mount on boot. Fixes the regression introduced in 26-BETA.1.