### PR TITLE
NAS-140778 / 27.0.0-BETA.1 / Set `canmount=on` on migrated container datasets (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -247,7 +247,11 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
 
             context.middleware.call_sync(
                 'pool.dataset.update_impl',
-                UpdateImplArgs(name=dataset['name'], iprops={'mountpoint', 'canmount'})
+                UpdateImplArgs(
+                    name=dataset['name'],
+                    zprops={'canmount': 'on'},
+                    iprops={'mountpoint'},
+                )
             )
             context.call_sync2(context.s.zfs.resource.mount, dataset['name'])
 


### PR DESCRIPTION
Corrects #18779 by explicitly setting `canmount=on` instead of trying to inherit. "canmount" is an uninheritable ZFS property.

Following this change, migrated container datasets will properly mount on boot. Fixes the regression introduced in 26-BETA.1.

Original PR: https://github.com/truenas/middleware/pull/18798
