### PR TITLE
NAS-140793 / 26.0.0-BETA.2 / Start licensed before middleware (by themylogin)

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -3,8 +3,8 @@ Description=TrueNAS Middleware
 DefaultDependencies=no
 
 Requires=ix-wait-on-disks.service
-Wants=dbus.socket
-After=dbus.socket libvirtd.service
+Wants=dbus.socket truenas-licensed.service
+After=dbus.socket libvirtd.service truenas-licensed.service
 Before=reboot.target shutdown.target halt.target
 Conflicts=reboot.target shutdown.target halt.target
 

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -352,12 +352,10 @@ class FailoverService(Service):
     async def ensure_remote_client(self):
         if self.CLIENT.remote_ip is not None:
             return
-        try:
-            self.CLIENT.remote_ip = await self.middleware.call('failover.remote_ip')
-            self.CLIENT.middleware = self.middleware
-            start_daemon_thread(name="fo_rem_client", target=self.CLIENT.run)
-        except CallError:
-            pass
+
+        self.CLIENT.remote_ip = await self.middleware.call('failover.remote_ip')
+        self.CLIENT.middleware = self.middleware
+        start_daemon_thread(name="fo_rem_client", target=self.CLIENT.run)
 
     @private
     def remote_connected(self):
@@ -378,4 +376,7 @@ class FailoverService(Service):
 
 async def setup(middleware):
     if await middleware.call('failover.licensed'):
-        await middleware.call('failover.ensure_remote_client')
+        try:
+            await middleware.call('failover.ensure_remote_client')
+        except Exception:
+            middleware.logger.error("Failed to determine remote heartbeat IP address", exc_info=True)


### PR DESCRIPTION
licensed must start before middleware so that `setup` functions could access the license and setup HA.

Additionally, log `ensure_remote_client` errors in `setup` (I missed them when debugging this). All its other callers already log its errors.

Original PR: https://github.com/truenas/middleware/pull/18806
