### PR TITLE
NAS-140801 / 27.0.0-BETA.1 / Show downloaded size when image content-length is missing

### DIFF
--- a/src/middlewared/middlewared/plugins/container/query_pull_images.py
+++ b/src/middlewared/middlewared/plugins/container/query_pull_images.py
@@ -101,7 +101,7 @@ def pull(context: ServiceContext, job: Job, pool: str, image: dict[str, typing.A
                                 f'Downloading image: {downloaded_size_mb:.1f}MB / {total_size_mb:.1f}MB'
                             )
                         else:
-                            job.set_progress(40, f'Downloading image: {total_size_mb:.1f}MB')
+                            job.set_progress(40, f'Downloading image: {downloaded_size_mb:.1f}MB')
 
                 # Extract tarball to mountpoint
                 job.set_progress(80, 'Extracting image files...')


### PR DESCRIPTION
##  Problem                                                                                                                                                                                     
                                                                                                                                                                                              
  When pulling a container image from the registry, if the server's HTTP response does not include a content-length header (or returns 0), the download progress message always displays      
  "Downloading image: 0.0MB" regardless of how much data has actually been downloaded. This is because the code was using total_size_mb (which is 0.0 when content-length is absent) instead  
  of downloaded_size_mb.                                                                                                                                                                      
                                                                                                                                                                                            
##  Solution

  Use downloaded_size_mb in the progress message so users see the actual amount downloaded so far (e.g., "Downloading image: 12.5MB") instead of a static "0.0MB".                            
  