### PR TITLE
NAS-140807 / 26.0.0-BETA.2 / Fix update test

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/update.py
+++ b/src/middlewared/middlewared/api/v26_0_0/update.py
@@ -49,15 +49,6 @@ class UpdateUpdateResult(BaseModel):
     """The updated system update configuration."""
 
 
-class UpdateProfileChoicesArgs(BaseModel):
-    pass
-
-
-class UpdateProfileChoicesResult(BaseModel):
-    result: dict[str, UpdateProfileChoice]
-    """Object of available update profiles with their configuration details."""
-
-
 class UpdateProfileChoice(BaseModel):
     name: str
     """Profile name."""
@@ -67,6 +58,15 @@ class UpdateProfileChoice(BaseModel):
     """Profile description."""
     available: bool
     """Whether profile is available for selection."""
+
+
+class UpdateProfileChoicesArgs(BaseModel):
+    pass
+
+
+class UpdateProfileChoicesResult(BaseModel):
+    result: dict[str, UpdateProfileChoice]
+    """Object of available update profiles with their configuration details."""
 
 
 class UpdateStatusArgs(BaseModel):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -27,6 +27,7 @@ from .utils import MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH, sw_vers
 from .utils.audit import audit_username_from_session
 from .utils.debug import get_threads_stacks
 from .utils.limits import MsgSizeError, MsgSizeLimit, parse_message
+from .utils.mock import coerce_mock_result, get_mock_return_model
 from .utils.plugins import LoadPluginsMixin
 from .utils.prctl import set_cmdline, set_name
 from .utils.privilege import credential_has_full_admin
@@ -1492,13 +1493,16 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
                 raise ValueError(f'{name!r} is already mocked with {args!r}')
 
         serviceobj, methodobj = self.get_method(name)
+        mock_return_model = get_mock_return_model(serviceobj, methodobj)
 
         if inspect.iscoroutinefunction(mock):
             async def f(*args, **kwargs):
-                return await mock(serviceobj, *args, **kwargs)
+                result = await mock(serviceobj, *args, **kwargs)
+                return coerce_mock_result(result, mock_return_model)
         else:
             def f(*args, **kwargs):
-                return mock(serviceobj, *args, **kwargs)
+                result = mock(serviceobj, *args, **kwargs)
+                return coerce_mock_result(result, mock_return_model)
 
         if hasattr(methodobj, '_job'):
             f._job = methodobj._job

--- a/src/middlewared/middlewared/utils/mock.py
+++ b/src/middlewared/middlewared/utils/mock.py
@@ -1,0 +1,56 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from middlewared.api.base.handler.inspect import model_field_is_model, model_field_is_list_of_models
+
+MockReturnModel = tuple[Literal['model', 'list'], type[BaseModel]]
+
+
+def coerce_mock_result(result: Any, mock_return_model: MockReturnModel | None) -> Any:
+    """Convert dict mock results to Pydantic models for generic services."""
+    if mock_return_model is None:
+        return result
+
+    kind, entry_type = mock_return_model
+
+    if kind == 'model' and isinstance(result, dict):
+        return entry_type.model_construct(**result)
+
+    if kind == 'list' and isinstance(result, list):
+        return [
+            entry_type.model_construct(**item) if isinstance(item, dict) else item
+            for item in result
+        ]
+
+    return result
+
+
+def get_mock_return_model(serviceobj: Any, methodobj: Any) -> MockReturnModel | None:
+    """Get the Pydantic model for auto-wrapping mock return values.
+
+    Only applies to generic services (``_config.generic = True``) where
+    methods return Pydantic model instances at runtime.
+    """
+    config = getattr(serviceobj, '_config', None)
+    if not getattr(config, 'generic', False):
+        return None
+
+    if not hasattr(methodobj, 'new_style_returns'):
+        return None
+
+    try:
+        annotation = methodobj.new_style_returns.model_fields['result'].annotation
+    except (AttributeError, KeyError):
+        return None
+
+    if model := model_field_is_model(annotation):
+        return ('model', model)
+
+    if (
+        (model := model_field_is_list_of_models(annotation))
+        and isinstance(model, type) and issubclass(model, BaseModel)
+    ):
+        return ('list', model)
+
+    return None

--- a/src/middlewared/middlewared/utils/mock.py
+++ b/src/middlewared/middlewared/utils/mock.py
@@ -2,9 +2,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from middlewared.api.base.handler.inspect import model_field_is_model, model_field_is_list_of_models
+from middlewared.api.base.handler.inspect import (
+    model_field_is_model, model_field_is_list_of_models, model_field_is_dict_of_models,
+)
 
-MockReturnModel = tuple[Literal['model', 'list'], type[BaseModel]]
+MockReturnModel = tuple[Literal['model', 'list', 'dict'], type[BaseModel]]
 
 
 def coerce_mock_result(result: Any, mock_return_model: MockReturnModel | None) -> Any:
@@ -22,6 +24,12 @@ def coerce_mock_result(result: Any, mock_return_model: MockReturnModel | None) -
             entry_type.model_construct(**item) if isinstance(item, dict) else item
             for item in result
         ]
+
+    if kind == 'dict' and isinstance(result, dict):
+        return {
+            k: entry_type.model_construct(**v) if isinstance(v, dict) else v
+            for k, v in result.items()
+        }
 
     return result
 
@@ -52,5 +60,11 @@ def get_mock_return_model(serviceobj: Any, methodobj: Any) -> MockReturnModel | 
         and isinstance(model, type) and issubclass(model, BaseModel)
     ):
         return ('list', model)
+
+    if (
+        (model := model_field_is_dict_of_models(annotation))
+        and isinstance(model, type) and issubclass(model, BaseModel)
+    ):
+        return ('dict', model)
 
     return None


### PR DESCRIPTION
Backport https://github.com/truenas/middleware/pull/18457 and https://github.com/truenas/middleware/pull/18468/changes to 26 to fix `api2.test_update.test_update`

There are no changes in the production code paths. These changes are only related to mocking behavior in the integration tests.