### PR TITLE
NAS-140808 / 26.0.0-BETA.2 / keep ip addr order when adding them (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/addresses.py
+++ b/src/middlewared/middlewared/plugins/interface/addresses.py
@@ -71,7 +71,12 @@ def configure_addresses_impl(
         for addr in get_link_addresses(sock, index=link_index)
         if addr.family != AddressFamily.LINK
     }
-    addrs_database = set()
+    # Order matters: when multiple IPv4s share a subnet, the kernel marks the
+    # FIRST added as primary and pins the subnet's connected-route src to it
+    # (which drives default-gateway source selection). Use a dict (insertion-
+    # ordered) as an ordered set so the add path below is deterministic --
+    # iterating a regular set does not guarantee order.
+    addrs_database: dict[AddressInfo, None] = {}
 
     # Check DHCP status
     status = dhcp_status(name)
@@ -81,7 +86,7 @@ def configure_addresses_impl(
     elif status.running and data["int_dhcp"]:
         lease = dhcp_leases(name)
         if lease and lease.ip_address and lease.subnet_mask:
-            addrs_database.add(
+            addrs_database.setdefault(
                 _alias_to_addr(
                     {
                         "address": lease.ip_address,
@@ -94,7 +99,7 @@ def configure_addresses_impl(
 
     # Add primary address from database
     if data[addr_key] and not data["int_dhcp"]:
-        addrs_database.add(
+        addrs_database.setdefault(
             _alias_to_addr(
                 {
                     "address": data[addr_key],
@@ -107,12 +112,12 @@ def configure_addresses_impl(
     vip = data.get("int_vip", "")
     if vip:
         netmask = "32" if data["int_version"] == 4 else "128"
-        addrs_database.add(_alias_to_addr({"address": vip, "netmask": netmask}))
+        addrs_database.setdefault(_alias_to_addr({"address": vip, "netmask": netmask}))
 
     # Add alias addresses
     alias_vips = []
     for alias in aliases:
-        addrs_database.add(
+        addrs_database.setdefault(
             _alias_to_addr(
                 {
                     "address": alias[alias_key],
@@ -124,7 +129,7 @@ def configure_addresses_impl(
             alias_vip = alias["alias_vip"]
             alias_vips.append(alias_vip)
             netmask = "32" if alias["alias_version"] == 4 else "128"
-            addrs_database.add(
+            addrs_database.setdefault(
                 _alias_to_addr({"address": alias_vip, "netmask": netmask})
             )
 
@@ -173,8 +178,12 @@ def configure_addresses_impl(
         "tunable.set_sysctl", f"net.ipv6.conf.{name}.autoconf", autoconf
     )
 
-    # Add addresses in database but not configured
-    for addr in addrs_database - addrs_configured:
+    # Add addresses in database but not configured. Iterate the dict in
+    # insertion order so int_address is added first and becomes the kernel
+    # primary for its subnet (see comment at the addrs_database declaration).
+    for addr in addrs_database:
+        if addr in addrs_configured:
+            continue
         address = addr.address
         if address == vip or address in alias_vips:
             continue


### PR DESCRIPTION
This is mostly a mechanical change. The `set()` used to collect desired addresses becomes an insertion-ordered dict (`dict[AddressInfo, None]`), and the add loop iterates the dict directly instead of `addrs_database - addrs_configured`. Call sites that did `addrs_database.add(addr)` now do `addrs_database.setdefault(addr)`. Remove loop is unchanged (`addr not in addrs_database` still works).

The resulting order in which `add_address()` is called:

  1. DHCP lease address (only when DHCP is running on the interface)
  2. `int_address` (the configured primary)
  3. VIP
  4. Aliases in DB order
  5. Alias-VIPs

Expectation change is that when an interface holds multiple IPv4 addresses on the same subnet, the kernel tags the first-added one as primary. With the old set iteration this primary was effectively random per process (set iteration order is not guaranteed), so it could shuffle across reboots. With this change the configured `int_address` is added first and stays primary deterministically.

Original PR: https://github.com/truenas/middleware/pull/18819
