### PR TITLE
NAS-140815 / 27.0.0-BETA.1 / Fix unpicklable custom exceptions across the codebase

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/version.py
+++ b/src/middlewared/middlewared/api/base/handler/version.py
@@ -18,14 +18,20 @@ class Direction(enum.StrEnum):
 class APIVersionDoesNotExistException(Exception):
     def __init__(self, version: str):
         self.version = version
-        super().__init__(f"API Version {self.version!r} does not exist")
+        super().__init__(version)
+
+    def __str__(self):
+        return f"API Version {self.version!r} does not exist"
 
 
 class APIVersionDoesNotContainModelException(Exception):
     def __init__(self, version: str, model_name: str):
         self.version = version
         self.model_name = model_name
-        super().__init__(f"API version {version!r} does not contain model {model_name!r}")
+        super().__init__(version, model_name)
+
+    def __str__(self):
+        return f"API version {self.version!r} does not contain model {self.model_name!r}"
 
 
 class APIVersion:

--- a/src/middlewared/middlewared/plugins/service_/services/dbus_router.py
+++ b/src/middlewared/middlewared/plugins/service_/services/dbus_router.py
@@ -24,7 +24,10 @@ class ServiceActionError(Exception):
         self.unit = unit
         self.action = action
         self.detail = detail
-        super().__init__(f"{unit} {action}: {detail}")
+        super().__init__(unit, action, detail)
+
+    def __str__(self):
+        return f"{self.unit} {self.action}: {self.detail}"
 
 
 logger = logging.getLogger(__name__)

--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -76,6 +76,7 @@ PASSDB_CTDB_CONFIG = ('passdb.tdb', PASSDB_CTDB_OPTIONS)
 class PassdbMustReinit(Exception):
     def __init__(self, reason):
         self.errmsg = reason
+        super().__init__(reason)
 
 
 class UserAccountControl(enum.IntFlag):

--- a/src/middlewared/middlewared/plugins/zfs/exceptions.py
+++ b/src/middlewared/middlewared/plugins/zfs/exceptions.py
@@ -14,19 +14,28 @@ __all__ = (
 class ZFSKeyAlreadyLoadedException(Exception):
     def __init__(self, path: str):
         self.message = f"{path!r} key is already loaded"
-        super().__init__(self.message)
+        super().__init__(path)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSNotEncryptedException(Exception):
     def __init__(self, path: str):
         self.message = f"{path!r} is not encrypted"
-        super().__init__(self.message)
+        super().__init__(path)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathAlreadyExistsException(Exception):
     def __init__(self, path: str):
         self.message = f"{path!r} already exists"
-        super().__init__(self.message)
+        super().__init__(path)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathHasClonesException(Exception):
@@ -34,13 +43,19 @@ class ZFSPathHasClonesException(Exception):
         self.path = path
         self.clones = clones
         self.message = f"{path!r} has the following clones: {','.join(clones)}"
-        super().__init__(self.message)
+        super().__init__(path, clones)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathHasHoldsException(Exception):
     def __init__(self, path: str, holds: Iterable[str]):
         self.message = f"{path!r} has the following holds: {','.join(holds)}"
-        super().__init__(self.message)
+        super().__init__(path, holds)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathInvalidException(Exception):
@@ -50,13 +65,19 @@ class ZFSPathInvalidException(Exception):
 class ZFSPathNotASnapshotException(Exception):
     def __init__(self, path: str):
         self.message = f"{path!r} must be a snapshot path (containing '@')"
-        super().__init__(self.message)
+        super().__init__(path)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathNotFoundException(Exception):
     def __init__(self, path: str):
         self.message = f"{path!r} not found"
-        super().__init__(self.message)
+        super().__init__(path)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathNotProvidedException(Exception):

--- a/src/middlewared/middlewared/plugins/zpool/exceptions.py
+++ b/src/middlewared/middlewared/plugins/zpool/exceptions.py
@@ -21,100 +21,148 @@ __all__ = (
 class ZpoolException(Exception):
     errno = errno.EFAULT
 
-    def __init__(self, message: str):
-        self.message = message
-        super().__init__(message)
-
 
 class ZpoolNotFoundException(ZpoolException):
     errno = errno.ENOENT
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r} not found")
+        self.message = f"{pool!r} not found"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolPoolUnhealthyException(ZpoolException):
     errno = errno.ENXIO
 
     def __init__(self, pool: str, health: str):
-        super().__init__(f"{pool!r}: pool is {health}")
+        self.message = f"{pool!r}: pool is {health}"
+        super().__init__(pool, health)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScanInvalidActionException(ZpoolException):
     errno = errno.EINVAL
 
     def __init__(self, action: str):
-        super().__init__(f"{action!r} is not a valid scan action (expected: start, pause, cancel)")
+        self.message = f"{action!r} is not a valid scan action (expected: start, pause, cancel)"
+        super().__init__(action)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScanInvalidTypeException(ZpoolException):
     errno = errno.EINVAL
 
     def __init__(self, scan_type: str):
-        super().__init__(f"{scan_type!r} is not a valid scan type (expected: scrub, errorscrub)")
+        self.message = f"{scan_type!r} is not a valid scan type (expected: scrub, errorscrub)"
+        super().__init__(scan_type)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScrubAlreadyRunningException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: scrub already in progress")
+        self.message = f"{pool!r}: scrub already in progress"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScrubPausedException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: scrub is paused")
+        self.message = f"{pool!r}: scrub is paused"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScrubPausedToCancelException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: scrub is paused and must be canceled before starting error scrub")
+        self.message = f"{pool!r}: scrub is paused and must be canceled before starting error scrub"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolErrorScrubAlreadyRunningException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: error scrub already in progress")
+        self.message = f"{pool!r}: error scrub already in progress"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolErrorScrubPausedException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: error scrub is paused")
+        self.message = f"{pool!r}: error scrub is paused"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolNotMasterNodeException(ZpoolException):
     errno = errno.ENXIO
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: scrub skipped because this node is not the active controller")
+        self.message = f"{pool!r}: scrub skipped because this node is not the active controller"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolScrubNotDueException(ZpoolException):
     errno = errno.EALREADY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: scrub not due yet")
+        self.message = f"{pool!r}: scrub not due yet"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolResiliverInProgressException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, pool: str):
-        super().__init__(f"{pool!r}: resilver in progress")
+        self.message = f"{pool!r}: resilver in progress"
+        super().__init__(pool)
+
+    def __str__(self):
+        return self.message
 
 
 class ZpoolTooManyScrubsException(ZpoolException):
     errno = errno.EBUSY
 
     def __init__(self, running: int):
-        super().__init__(
+        self.message = (
             f'{running} scrubs are already running. Running too many scrubs simultaneously '
             'will result in an unresponsive system. Refusing to start scrub.'
         )
+        super().__init__(running)
+
+    def __str__(self):
+        return self.message

--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -17,6 +17,7 @@ class CallError(CallException):
         self.errmsg = errmsg
         self.errno = errno
         self.extra = extra
+        super().__init__(errmsg, errno, extra)
 
     def __str__(self):
         errname = get_errname(self.errno)
@@ -33,6 +34,7 @@ class ValidationError(CallException):
         self.attribute = attribute
         self.errmsg = errmsg
         self.errno = errno
+        super().__init__(attribute, errmsg, errno)
 
     def __str__(self):
         errname = get_errname(self.errno)
@@ -118,6 +120,9 @@ class InstanceNotFound(ValidationError):
     """Raised when `get_instance` failed to locate specific object"""
     def __init__(self, errmsg: str) -> None:
         super().__init__(None, errmsg, errno.ENOENT)
+
+    def __reduce__(self):
+        return (type(self), (self.errmsg,))
 
 
 class MatchNotFound(IndexError):

--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -49,6 +49,7 @@ class DirectoryServiceHealthError(Exception):
     def __init__(self, fail_reason, errmsg):
         self.reason = self.reasons(fail_reason)
         self.errmsg = errmsg
+        super().__init__(fail_reason, errmsg)
 
     def __str__(self):
         return self.errmsg

--- a/src/middlewared/middlewared/utils/directoryservices/krb5_error.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_error.py
@@ -189,6 +189,7 @@ class KRB5Error(Exception):
         self.gss_minor_code = gss_minor
         self.errmsg = errmsg
         self.krb5_code = KRB5ErrCode(gss_minor & 0xFF)
+        super().__init__(gss_major, gss_minor, errmsg)
 
     def __str__(self) -> str:
         return f'[{self.krb5_code.name}] {self.errmsg}'

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -33,6 +33,7 @@ class UnexpectedFileChange(Exception):
         self.changes = changes
         self.path = path
         self.changes_str = ', '.join(FileChanges.dump(self.changes))
+        super().__init__(path, changes)
 
     def __str__(self) -> str:
         return f'{self.path}: unexpected change in the following file attributes: {self.changes_str}'

--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -28,6 +28,7 @@ class MsgSizeError(Exception):
         self.datalen = datalen
         self.errmsg = f'Message length [{self.datalen}] exceeded maximum size of {self.limit}'
         self.method_name = method_name or ''
+        super().__init__(limit, datalen, method_name)
         if limit is MsgSizeLimit.UNAUTHENTICATED:
             # This preserves legacy server behavior
             self.ws_close_code = WSCloseCode.INVALID_TEXT

--- a/src/middlewared/middlewared/utils/nss/nss_common.py
+++ b/src/middlewared/middlewared/utils/nss/nss_common.py
@@ -78,6 +78,7 @@ class NssError(Exception):
         self.nssop = nssop.value
         self.return_code = return_code
         self.mod_name = module.name
+        super().__init__(errno, nssop, return_code, module)
 
     def __str__(self) -> str:
         errmsg = f'NSS operation {self.nssop} failed with errno {self.errno}: {self.return_code}'

--- a/src/middlewared/middlewared/utils/service/call.py
+++ b/src/middlewared/middlewared/utils/service/call.py
@@ -16,7 +16,12 @@ __all__ = ["MethodNotFoundError", "ServiceCallMixin"]
 
 class MethodNotFoundError(CallError):
     def __init__(self, method_name: str, service: str):
+        self.method_name = method_name
+        self.service = service
         super().__init__(f'Method {method_name!r} not found in {service!r}', CallError.ENOMETHOD)
+
+    def __reduce__(self):
+        return (type(self), (self.method_name, self.service))
 
 
 class ServiceCallMixin:


### PR DESCRIPTION
## Problem

The truenas API client logs warnings like:

```
Error unpickling call exception: TypeError("APIVersionDoesNotContainModelException.init() missing 1 required positional argument: 'model_name'")
```

Python's pickle reconstructs exceptions as `ExcClass(*exc.args)`, where `exc.args` is whatever was passed to `Exception.__init__`. Two patterns broke this:

1. `super().__init__(f"formatted {message}")` — stores the formatted string as the sole arg, so unpickling calls e.g. `ZpoolPoolUnhealthyException("'pool' is DEGRADED")` which fails because `__init__` expects `(pool, health)`.
2. No `super().__init__()` call at all.

## Fix

For each exception, pass the raw constructor arguments to `super().__init__()` and move the human-readable message into `__str__`. For subclasses whose `__init__` signature cannot be expressed through the parent's (e.g. `InstanceNotFound` taking one arg where `ValidationError` takes three, `MethodNotFoundError` taking two args where `CallError` takes three), `__reduce__` is used to tell pickle exactly how to reconstruct the object.

`ZpoolException.__init__` was removed entirely — it is only used as a base class and its `__init__` was the obstacle preventing subclasses from calling `super().__init__()` cleanly with their own argument shapes.