### PR TITLE
NAS-140831 / 26.0.0-BETA.2 / Fix iSCSI service startup when LIO and SCST modes are mixed (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/lio.py
+++ b/src/middlewared/middlewared/etc_files/lio.py
@@ -1,5 +1,8 @@
-from middlewared.utils.lio.config import write_lio_config
+from middlewared.utils.lio.config import teardown_lio_config, write_lio_config
 
 
 def render(service, middleware, render_ctx):
+    if not middleware.call_sync('iscsi.global.lio_enabled'):
+        teardown_lio_config()
+        return
     write_lio_config(render_ctx)

--- a/src/middlewared/middlewared/etc_files/systemd.py
+++ b/src/middlewared/middlewared/etc_files/systemd.py
@@ -11,6 +11,7 @@ async def render(service, middleware):
             services_enabled[unit] = service["enable"]
 
     licensed = await middleware.call('failover.licensed')
+    lio_enabled = await middleware.call('iscsi.global.lio_enabled')
 
     for unit, enable in services_enabled.items():
         state = await system_dbus.get_unit_file_state(unit)
@@ -21,7 +22,7 @@ async def render(service, middleware):
             continue
 
         is_enabled = state == "enabled"
-        if unit == "scst" and licensed:
+        if unit == "scst" and (licensed or lio_enabled):
             enable = False
 
         if enable != is_enabled:

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -211,6 +211,10 @@ class ISCSIGlobalService(SystemServiceService):
 
         await self._update_service(old, new, options={'ha_propagate': False})
 
+        if old['mode'] != new['mode']:
+            # Re-evaluate scst.service enabled/disabled state for the new mode
+            await self.middleware.call('etc.generate', 'rc')
+
         if old['direct_config'] != new['direct_config']:
             await self.middleware.call('etc.generate', 'scst_direct')
             if licensed:


### PR DESCRIPTION
Issues
- When SCST mode is selected, `etc_files/lio.py` was unconditionally calling `write_lio_config()` at the POOL_IMPORT checkpoint, causing LIO kernel modules to be loaded on every boot regardless of the configured mode.
- In non-HA deployments, `scst.service` is started by systemd independently of the middleware, so switching to LIO mode left SCST attempting to start on the next boot.

Fixes
- Guard the LIO render function: `write_lio_config` is skipped when LIO is not enabled, and any existing LIO configfs state is actively torn down if the mode has been switched away from LIO.

- Extend the existing HA logic in `systemd.py` to also force `scst.service` disabled when LIO is enabled, and regenerates the rc group on mode change so the enable/disable takes effect immediately without a reboot.


Original PR: https://github.com/truenas/middleware/pull/18835
