### PR TITLE
NAS-140266 / 27.0.0-BETA.1 / Fix spurious attr_model write causing namespace export failure

### DIFF
--- a/src/middlewared/middlewared/plugins/nvmet/subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/subsys.py
@@ -235,11 +235,11 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
             system_product = dmiinfo.get('system-product-name', '')
 
         if vendor:
-            return (system_product or vendor)[:MAX_MODEL_LEN]
+            return (system_product or vendor)[:MAX_MODEL_LEN].strip()
         else:
             if system_product.lower().startswith('truenas'):
-                return system_product[:MAX_MODEL_LEN]
-            return f'TrueNAS {system_product}'[:MAX_MODEL_LEN]
+                return system_product[:MAX_MODEL_LEN].strip()
+            return f'TrueNAS {system_product}'[:MAX_MODEL_LEN].strip()
 
     @private
     @cache

--- a/src/middlewared/middlewared/utils/nvmet/kernel.py
+++ b/src/middlewared/middlewared/utils/nvmet/kernel.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from contextlib import contextmanager
+import logging
 import os
 import pathlib
 import subprocess
@@ -28,6 +29,8 @@ from .render_common import (
     port_subsys_index,
     subsys_ana,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class NvmetConfig:
@@ -111,7 +114,11 @@ class NvmetConfig:
             p = pathlib.Path(path, k)
             curval = p.read_text().strip()
             if not self.values_match(curval, v):
-                p.write_text(f'{v}\n')
+                try:
+                    p.write_text(f'{v}\n')
+                except OSError:
+                    logger.exception('Failed to update %s: current=%r new=%r', p, curval, v)
+                    raise
 
 
 class NvmetHostConfig(NvmetConfig):


### PR DESCRIPTION
Issue
- When `system-product-name` is absent from DMI, `model()` returns `"TrueNAS "` with a trailing space. On each reload after initial setup, `update_attrs()` reads the kernel's current `attr_model` value with `.strip()`, which strips that space, causing a spurious mismatch.  The kernel rejects the unnecessary write with `EINVAL` because `attr_model` is immutable once assigned — blocking the entire `write_config()` call and preventing new namespaces from being exported.

Fixes
- Strip trailing whitespace from the subsystem model string so it round-trips correctly through the kernel configfs read/write cycle.
- Add path and value context to configfs write failure logs to aid future diagnosis.
