### PR TITLE
NAS-140792 / 26.0.0-BETA.2 / Fix attribute access on snapshot results in vm.clone

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -46,7 +46,7 @@ class VMService(Service):
         existing_snaps = await self.call2(self.s.zfs.resource.snapshot.query, ZFSResourceSnapshotQuery(
             paths=[zvol], properties=None,
         ))
-        existing_snap_names = {s['name'] for s in existing_snaps}
+        existing_snap_names = {s.name for s in existing_snaps}
 
         snapshot_name = name
         i = 0


### PR DESCRIPTION
## Problem

The output of `zfs.resource.snapshot.query` is an object, but it is incorrectly treated as a dictionary when checking for existing snapshots during VM cloning. This results in a `TypeError`.

## Solution

Handle the response as an object instead of a dictionary, ensuring correct access to its attributes and preventing the `TypeError`.
