### PR TITLE
NAS-140838 / 27.0.0-BETA.1 / simplify truenas-initrd script

### DIFF
--- a/src/freenas/etc/initramfs-tools/hooks/truenas_vfio
+++ b/src/freenas/etc/initramfs-tools/hooks/truenas_vfio
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copy the PCI passthrough slot list into the initrd so init-top can read it.
+# Runs at update-initramfs time. The source file is a flat newline-separated
+# list of PCI slots, written by middlewared. It lives under /data so it
+# survives BE upgrades (the installer rsyncs /data into the new BE).
+PREREQ=""
+prereqs() { echo "$PREREQ"; }
+case $1 in
+    prereqs) prereqs; exit 0 ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+config="/data/subsystems/initramfs/truenas_vfio_pci_ids"
+[ -r "$config" ] || exit 0
+
+copy_file config "$config" /etc/truenas_vfio_pci_ids

--- a/src/freenas/etc/initramfs-tools/modules
+++ b/src/freenas/etc/initramfs-tools/modules
@@ -1,0 +1,6 @@
+# Modules baked into the initrd. vfio* must be present so the init-top
+# bind script can attach isolated PCI devices before any host driver does.
+vfio
+vfio_iommu_type1
+vfio_virqfd
+vfio_pci

--- a/src/freenas/etc/initramfs-tools/scripts/init-top/truenas_bind_vfio
+++ b/src/freenas/etc/initramfs-tools/scripts/init-top/truenas_bind_vfio
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Runs in the very first phase of initramfs, before any host driver has
+# bound to the PCI devices. For every slot listed in the config, set the
+# driver_override to vfio-pci so the kernel attaches vfio-pci instead of
+# the host driver, then load vfio-pci to trigger binding.
+PREREQ=""
+prereqs() { echo "$PREREQ"; }
+case $1 in
+    prereqs) prereqs; exit 0 ;;
+esac
+
+config="/etc/truenas_vfio_pci_ids"
+[ -s "$config" ] || exit 0
+
+while read -r dev; do
+    [ -n "$dev" ] || continue
+    echo vfio-pci > "/sys/bus/pci/devices/$dev/driver_override" 2>/dev/null
+done < "$config"
+modprobe -i vfio-pci

--- a/src/freenas/etc/modprobe.d/kvm.conf
+++ b/src/freenas/etc/modprobe.d/kvm.conf
@@ -1,0 +1,1 @@
+options kvm ignore_msrs=1

--- a/src/freenas/etc/modprobe.d/nvidia.conf
+++ b/src/freenas/etc/modprobe.d/nvidia.conf
@@ -1,0 +1,3 @@
+softdep nouveau pre: vfio-pci
+softdep nvidia pre: vfio-pci
+softdep nvidia* pre: vfio-pci

--- a/src/freenas/etc/modules
+++ b/src/freenas/etc/modules
@@ -1,0 +1,7 @@
+# Loaded unconditionally so PCI passthrough works as soon as the user
+# isolates a device — no reboot needed for the modules themselves; the
+# bind script in the initrd handles claiming the PCI slot at boot time.
+vfio
+vfio_iommu_type1
+vfio_virqfd
+vfio_pci

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -1,3 +1,6 @@
+import os
+
+from truenas_os_pyutils.io import atomic_write
 from truenas_pylibvirt.utils.gpu import get_gpus
 
 from middlewared.alert.source.gpu_isolation import InvalidGpuPciIdsAlert
@@ -10,6 +13,14 @@ from middlewared.api.current import (
 )
 from middlewared.plugins.system.reboot import RebootReason
 from middlewared.service import Service, ValidationErrors, private
+
+
+# Flat newline-separated PCI slot list, one slot per line, sorted for stable
+# diffing. Lives under /data so it persists across BE upgrades (the installer
+# rsyncs /data into the new BE). The initramfs hook copies this file verbatim
+# into the initrd as /etc/truenas_vfio_pci_ids, where init-top/truenas_bind_vfio
+# reads it line-by-line.
+VFIO_PCI_IDS_PATH = '/data/subsystems/initramfs/truenas_vfio_pci_ids'
 
 
 class SystemAdvancedService(Service):
@@ -76,7 +87,51 @@ class SystemAdvancedService(Service):
             {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
             {'prefix': 'adv_'}
         )
-        await self.middleware.call('boot.update_initramfs')
+        changed = await self.middleware.call('system.advanced.write_vfio_pci_ids')
+        await self.middleware.call('boot.update_initramfs', {'force': changed})
+
+    @private
+    def write_vfio_pci_ids(self):
+        """
+        Materialize the flat list of PCI slots to bind to vfio-pci, expanding
+        each chosen GPU into the full set of PCI slots for its sibling functions
+        (video + audio + USB-C controller, etc.).
+
+        The initramfs-tools hook /etc/initramfs-tools/hooks/truenas_vfio copies
+        this file into the initrd at update-initramfs time;
+        init-top/truenas_bind_vfio reads it line-by-line and binds those slots
+        to vfio-pci before any host driver can claim them.
+
+        Returns True if the file changed (caller should force an initramfs rebuild).
+        """
+        igpi = self.middleware.call_sync('system.advanced.config').get('isolated_gpu_pci_ids') or []
+        # A "GPU" is actually a group of PCI functions sharing an IOMMU group
+        # (video + HDMI audio + sometimes a USB-C controller). All siblings
+        # must be bound to vfio-pci together — passthrough fails otherwise —
+        # so flatten gpu['devices'] into the slot list.
+        slots = []
+        for gpu in get_gpus():
+            if gpu['addr']['pci_slot'] in igpi:
+                for dev in gpu['devices']:
+                    slots.append(dev['pci_slot'])
+
+        # Sort so plain text equality is meaningful for change detection,
+        # regardless of get_gpus() / sysfs enumeration order.
+        new_content = ''.join(f'{s}\n' for s in sorted(slots))
+
+        try:
+            with open(VFIO_PCI_IDS_PATH) as f:
+                existing_content = f.read()
+        except FileNotFoundError:
+            existing_content = ''
+
+        if existing_content == new_content:
+            return False
+
+        os.makedirs(os.path.dirname(VFIO_PCI_IDS_PATH), exist_ok=True)
+        with atomic_write(VFIO_PCI_IDS_PATH, 'w') as f:
+            f.write(new_content)
+        return True
 
     @private
     async def validate_gpu_pci_ids(self, isolated_gpu_pci_ids, verrors, schema):
@@ -130,7 +185,11 @@ class SystemAdvancedService(Service):
             isolated_pci_ids = set(config.get('isolated_gpu_pci_ids', []))
 
             if not isolated_pci_ids:
-                # Nothing to validate
+                # Nothing to validate, but still reconcile the on-disk slot list
+                # in case it drifted from the database.
+                changed = await self.middleware.call('system.advanced.write_vfio_pci_ids')
+                if changed:
+                    await self.middleware.call('boot.update_initramfs', {'force': True})
                 await self.call2(self.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
                 return
 
@@ -155,7 +214,8 @@ class SystemAdvancedService(Service):
                     {'isolated_gpu_pci_ids': list(valid_pci_ids)},
                     {'prefix': 'adv_'}
                 )
-                await self.middleware.call('boot.update_initramfs')
+                changed = await self.middleware.call('system.advanced.write_vfio_pci_ids')
+                await self.middleware.call('boot.update_initramfs', {'force': changed})
 
                 self.logger.info(
                     'Removed invalid GPU PCI IDs from isolation configuration: %s',
@@ -177,7 +237,11 @@ class SystemAdvancedService(Service):
 
                 self.logger.info('Created alert and added reboot reason for invalid GPU PCI IDs')
             else:
-                # All isolated GPU PCI IDs are valid, ensure any previous alert is deleted
+                # All isolated GPU PCI IDs are valid; reconcile the on-disk
+                # slot list so it can't drift from the database.
+                changed = await self.middleware.call('system.advanced.write_vfio_pci_ids')
+                if changed:
+                    await self.middleware.call('boot.update_initramfs', {'force': True})
                 await self.call2(self.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
 
         except Exception as e:

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -14,7 +14,6 @@ from middlewared.api.current import (
 from middlewared.plugins.system.reboot import RebootReason
 from middlewared.service import Service, ValidationErrors, private
 
-
 # Flat newline-separated PCI slot list, one slot per line, sorted for stable
 # diffing. Lives under /data so it persists across BE upgrades (the installer
 # rsyncs /data into the new BE). The initramfs hook copies this file verbatim


### PR DESCRIPTION
## What

Move PCI passthrough (vfio) wiring out of `truenas-initrd.py` and into middlewared.

- `system.advanced.write_vfio_pci_ids` writes a flat newline-separated PCI slot list to `/data/subsystems/initramfs/truenas_vfio_pci_ids` on isolation changes and on boot validation.
- An initramfs-tools hook copies that file into the initrd at `/etc/truenas_vfio_pci_ids`; `init-top/truenas_bind_vfio` reads it and binds each slot to vfio-pci before any host driver can attach.
- The five files previously *generated* by the upgrade script (`/etc/modprobe.d/{kvm,nvidia}.conf`, `/etc/modules`, `/etc/initramfs-tools/modules`, and the init-top binder) now ship as static package files.

## Why

`truenas-initrd.py` runs under the *old* host's Python during a BE upgrade. Removing the GPU logic drops a DB query and the `truenas_pylibvirt.utils.gpu` import from that fragile cross-version path — the script's GPU responsibility is now zero.

## Notes

- The `/data` location survives BE upgrades via the installer's `/data` rsync.
- Flat text replaces JSON, so the initramfs hook no longer needs `python3`.
- `boot.update_initramfs` is force-rebuilt only when the slot list actually changed.