### PR TITLE
NAS-140842 / 27.0.0-BETA.1 / Gather artifacts in runtest.py

### DIFF
--- a/src/middlewared/middlewared/test/integration/runner/artifacts.py
+++ b/src/middlewared/middlewared/test/integration/runner/artifacts.py
@@ -6,30 +6,29 @@ from .context import Context
 
 
 def get_artifacts(ctx: Context) -> None:
-    if ctx.verbose:
-        if ctx.ha:
-            get_folder("/var/log", f"{ctx.artifacts}/log_nodea", "root", "testing", ctx.ip)
-            get_folder("/var/log", f"{ctx.artifacts}/log_nodeb", "root", "testing", ctx.ip2)
-            get_cmd_result(
-                "midclt call core.get_jobs | jq .",
-                f"{ctx.artifacts}/core.get_jobs_nodea.json",
-                ctx.ip,
-            )
-            get_cmd_result(
-                "midclt call core.get_jobs | jq .",
-                f"{ctx.artifacts}/core.get_jobs_nodeb.json",
-                ctx.ip2,
-            )
-            get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg_nodea.json", ctx.ip)
-            get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg_nodeb.json", ctx.ip2)
-        else:
-            get_folder("/var/log", f"{ctx.artifacts}/log", "root", "testing", ctx.ip)
-            get_cmd_result(
-                "midclt call core.get_jobs | jq .",
-                f"{ctx.artifacts}/core.get_jobs.json",
-                ctx.ip,
-            )
-            get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg.json", ctx.ip)
+    if ctx.ha:
+        get_folder("/var/log", f"{ctx.artifacts}/log_nodea", "root", "testing", ctx.ip)
+        get_folder("/var/log", f"{ctx.artifacts}/log_nodeb", "root", "testing", ctx.ip2)
+        get_cmd_result(
+            "midclt call core.get_jobs | jq .",
+            f"{ctx.artifacts}/core.get_jobs_nodea.json",
+            ctx.ip,
+        )
+        get_cmd_result(
+            "midclt call core.get_jobs | jq .",
+            f"{ctx.artifacts}/core.get_jobs_nodeb.json",
+            ctx.ip2,
+        )
+        get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg_nodea.json", ctx.ip)
+        get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg_nodeb.json", ctx.ip2)
+    else:
+        get_folder("/var/log", f"{ctx.artifacts}/log", "root", "testing", ctx.ip)
+        get_cmd_result(
+            "midclt call core.get_jobs | jq .",
+            f"{ctx.artifacts}/core.get_jobs.json",
+            ctx.ip,
+        )
+        get_cmd_result("dmesg", f"{ctx.artifacts}/dmesg.json", ctx.ip)
 
 
 def get_folder(folder: str, destination: str, username: str, passwrd: str | None, host: str) -> dict[str, bool | str]:

--- a/src/middlewared/middlewared/test/integration/runner/run.py
+++ b/src/middlewared/middlewared/test/integration/runner/run.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 from .args import parse
+from .artifacts import get_artifacts
 from .config import write_config
 from .context import context_from_args
 from .env import set_env
@@ -24,5 +25,6 @@ def run(workdir: str) -> None:
     write_config(ctx)
     pytest_command = get_pytest_command(ctx)
     proc_returncode = subprocess.run(pytest_command).returncode
+    get_artifacts(ctx)
     if ctx.returncode:
         exit(proc_returncode)


### PR DESCRIPTION
Everything that can go wrong will go wrong. The only thing in `runtest.py` that was difficult to test and remained untested got lost in translation.