### PR TITLE
NAS-140419 / 26.0.0-BETA.2 / Fix ATA Failed Selftest alert not raising

### DIFF
--- a/src/middlewared/middlewared/alert/source/smart.py
+++ b/src/middlewared/middlewared/alert/source/smart.py
@@ -68,7 +68,9 @@ class SMARTAlertSource(ThreadedAlertSource):
                 ec = attr["raw"]["value"]
 
         if ata_tests := data.get("ata_smart_self_test_log", {}).get("table", []):
-            test_failed = not ata_tests[-1]["status"]["passed"]
+            # NAS-140419: smartctl writes table[] newest-first (see ataPrintSmartSelfTestlog
+            # in smartmontools/ataprint.cpp), so [0] is the most recent test.
+            test_failed = not ata_tests[0]["status"]["passed"]
 
         return SmartInfo(
             uncorrected_errors=ue,


### PR DESCRIPTION
`parse_ata_smart_info` indexed `ata_smart_self_test_log.table[-1]` (the **oldest** retained entry) when checking the most recent ATA self-test. smartctl writes that JSON `table[]` newest-first (`smartmontools/ataprint.cpp:ataPrintSmartSelfTestlog`), so any drive with a historical "Completed without error" entry behind a recent failure evaluated `not True = False` and the `Hardware - Failed Selftest` alert was silently dropped. Switched to `[0]` (the newest), matching the NVMe parser in the same file.
