### PR TITLE
NAS-140496 / 26.0.0-BETA.2 / fix shell for alpine containers (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/nsenter.py
+++ b/src/middlewared/middlewared/plugins/container/nsenter.py
@@ -1,51 +1,28 @@
+from truenas_pylibvirt.nsexec import ALL_CAPABILITIES, build_argv_for_shell
+
 from middlewared.service import CallError, private, Service
 
-# Extracted from man capabilities(7)
-CAPABILITIES = frozenset([
-    "chown", "dac_override", "dac_read_search", "fowner", "fsetid", "kill", "setgid", "setuid", "setpcap",
-    "linux_immutable", "net_bind_service", "net_broadcast", "net_admin", "net_raw", "ipc_lock", "ipc_owner",
-    "sys_module", "sys_rawio", "sys_chroot", "sys_ptrace", "sys_pacct", "sys_admin", "sys_boot", "sys_nice",
-    "sys_resource", "sys_time", "sys_tty_config", "mknod", "lease", "audit_write", "audit_control", "setfcap",
-    "mac_override", "mac_admin", "syslog", "wake_alarm", "block_suspend", "audit_read", "perfmon", "bpf",
-    "checkpoint_restore",
-])
+
+# Re-exported under the legacy name so existing consumers
+# (`from .nsenter import CAPABILITIES`) keep working.
+CAPABILITIES = ALL_CAPABILITIES
 
 
 class ContainerService(Service):
     @private
     def nsenter(self, container):
         """
-        Produces `nsenter` command that can be used to execute commands inside the container.
+        Produces a command that can be used to execute commands inside the container.
         :param container: container as returned by `container.query`
         """
-        pid = container["status"]["pid"]
-        if pid is None:
+        if container["status"]["pid"] is None:
             raise CallError("Container is not running")
 
-        drop = []
-        match container["capabilities_policy"]:
-            case "DEFAULT":
-                # Standard capabilities disabled by libvirtd by default
-                drop = [
-                    f"cap_{name}"
-                    for name in ["sys_module", "sys_time", "mknod", "audit_control", "mac_admin"]
-                    if container["capabilities_state"].get(name) is not True
-                ]
-                drop += [f"cap_{name}" for name, enabled in container["capabilities_state"].items() if not enabled]
-            case "ALLOW":
-                drop = [f"cap_{name}" for name, enabled in container["capabilities_state"].items() if not enabled]
-            case "DENY":
-                drop = [f"cap_{name}" for name in CAPABILITIES if container["capabilities_state"].get(name) is not True]
-
-        caps = [f"cap_{name}" for name, enabled in container["capabilities_state"].items() if enabled]
-
-        capsh = []
-        if drop:
-            capsh.append(f"--drop={','.join(drop)}")
-        if caps:
-            capsh.append(f"--caps={','.join(caps)}+ep")
-
-        nsenter_cmd = ["/usr/bin/nsenter", "--target", f"{pid}", "--mount", "--uts", "--ipc", "--net", "--pid"]
-        if container["idmap"]:
-            nsenter_cmd.append("--user")
-        return nsenter_cmd + ["--", "capsh"] + capsh + ["--", "-c"]
+        return build_argv_for_shell(
+            uuid=container["uuid"],
+            uri=self.middleware.libvirt_domains_manager.containers_connection.uri,
+            capabilities_policy=container["capabilities_policy"],
+            capabilities_state=container["capabilities_state"],
+            has_idmap=bool(container["idmap"]),
+            shell_argv=["/bin/sh", "-c"],
+        )

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -15,6 +15,7 @@ from middlewared.test.integration.assets.pool import another_pool, pool
 from middlewared.test.integration.utils import call, host, ssh, websocket_url
 
 UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
+ALPINE_IMAGE_NAME = "alpine:edge:amd64:default"
 VIRSH = "virsh -c 'lxc:///system?socket=/run/truenas_libvirt/libvirt-sock'"
 # Capabilities necessary to launch a basic LXC container from linuxcontainers.org
 BASIC_CAPABILITIES = {
@@ -76,6 +77,14 @@ def ubuntu_image():
     version = [image["versions"][-1]["version"] for image in images if image["name"] == UBUNTU_IMAGE_NAME][0]
 
     yield {"name": UBUNTU_IMAGE_NAME, "version": version}
+
+
+@pytest.fixture(scope="module")
+def alpine_image():
+    images = call("container.image.query_registry")
+    version = [image["versions"][-1]["version"] for image in images if image["name"] == ALPINE_IMAGE_NAME][0]
+
+    yield {"name": ALPINE_IMAGE_NAME, "version": version}
 
 
 @contextlib.contextmanager
@@ -190,6 +199,36 @@ def test_container_stop_force_after_timeout(ubuntu_container):
     call("container.stop", container["id"], {"force_after_timeout": True}, job=True)
     container = call("container.get_instance", container["id"])
     assert container["status"]["state"] == "STOPPED"
+
+
+def test_container_shell_alpine(alpine_image):
+    # NAS-140496: Alpine images do not ship capsh, so the capsh wrapper
+    # produced by container.nsenter must run on the host before nsenter
+    # switches into the container's mount namespace. Since Alpine lacks
+    # capsh (the tool test_capabilities uses to validate Ubuntu), verify
+    # the security claim — capsh's bounding-set drop applied on the host
+    # survives execve + the nsenter namespace switch — by reading CapBnd
+    # from /proc/self/status in the final shell and decoding it on the
+    # host side.
+    with container(
+        alpine_image,
+        {"capabilities_state": {"lease": False}},
+        start=True,
+    ) as c:
+        assert "alpine" in ssh(nsenter(c, "cat /etc/os-release")).lower()
+
+        status = ssh(nsenter(c, "cat /proc/self/status"))
+        cap_bnd = re.search(r"^CapBnd:\s+([0-9a-fA-F]+)", status, re.MULTILINE).group(1)
+        # Alpine has no capsh; decode on the host.
+        # Output: "0x00000...=cap_chown,cap_dac_override,..."
+        decoded = ssh(f"/sbin/capsh --decode={cap_bnd}").strip()
+        caps = decoded.split("=", 1)[1].split(",")
+
+        # Explicitly dropped via capabilities_state -> must be absent.
+        assert "cap_lease" not in caps, f"CAP_LEASE survived drop: {decoded}"
+        # Not dropped by DEFAULT policy -> must still be present. Confirms
+        # we aren't over-dropping on the host-side capsh path.
+        assert "cap_chown" in caps, f"CAP_CHOWN unexpectedly missing: {decoded}"
 
 
 def test_container_shell(started_ubuntu_container):

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -312,7 +312,14 @@ def test_capabilities(ubuntu_image, configuration, has):
 
         def normalize(output):
             # `groups=0(root)` vs `groups=`
-            return re.sub("groups=(.*)", "", output)
+            output = re.sub("groups=(.*)", "", output)
+            # The nsexec entry path deliberately sets PR_SET_NO_NEW_PRIVS so
+            # setuid binaries inside the rootfs can't gain caps the entered
+            # shell doesn't already hold; the container init does not. This
+            # test is about capability equality, not securebits, so mask
+            # the differing flag.
+            output = re.sub(r"no-new-privs=\d", "no-new-privs=X", output)
+            return output
 
         # Ensure that the process launched with `nsenter` has the same capabilities as container init process
         assert normalize(ssh(nsenter(c, "capsh --print"))) == normalize(s)


### PR DESCRIPTION
Opening a shell from the UI into an Alpine-based container failed with:

```
nsenter: failed to execute capsh: No such file or directory
```

The UI then reconnected in a tight loop, occasionally taking the whole session offline. Debian/Ubuntu containers were unaffected.

### Root cause

`container.nsenter` built the command:

```
/usr/bin/nsenter --target PID --mount ... -- capsh [opts] -- -c <cmd>
```

`nsenter` switches into the container's mount namespace **before** exec'ing `capsh`, so `capsh` was looked up inside the container's filesystem. Alpine's base image does not ship `libcap` (which provides `capsh`), so the exec failed. Debian/Ubuntu happen to ship `libcap2-bin` by default, which masked the problem.

### Fix

Move `capsh` to run on the **host** (which always has `libcap2-bin`), then have it exec `nsenter`, which switches namespaces and runs `/bin/sh -c <cmd>` inside the container:

```
/sbin/capsh [opts] -- -c 'exec "$@"' _ \
  /usr/bin/nsenter --target PID --mount ... -- /bin/sh -c <cmd>
```

Capability bounding-set restrictions are per-task and survive both `execve` and the nsenter namespace switch, so the final shell inherits the same capability set it would have had under the previous in-container `capsh`.

### Test

Added `test_container_shell_alpine` and an `alpine_image` fixture (`alpine:edge:amd64:default`) in `tests/api2/test_container.py` — directly exercises the path that was broken. Existing Ubuntu coverage in `test_capabilities` continues to validate `capsh` semantics.

Original PR: https://github.com/truenas/middleware/pull/18789
