### PR TITLE
NAS-140845 / 26.0.0-BETA.2 / Make `pool.is_upgraded` return `false` only if pool needs an upgrade (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -170,7 +170,7 @@ def api_method[**P, T](
     decorated method. NOTE: this is using a traditional threading.local() object and not a ContextVar so the
     method must be a non-coroutine based method/function.
 
-    `removed_in` specifies major TrueNAS version (in the format vXX.YY) which removes this API method.
+    `removed_in` specifies major TrueNAS version (in the format vXX) which removes this API method.
     """
     if list(returns.model_fields.keys()) != ["result"]:
         raise TypeError("`returns` model must only have one field called `result`")

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -129,18 +129,17 @@ class PoolService(Service):
         PoolIsUpgradedArgs,
         PoolIsUpgradedResult,
         pass_thread_local_storage=True,
-        roles=['POOL_READ']
+        roles=['POOL_READ'],
+        removed_in="v26",
     )
     def is_upgraded(self, tls, oid):
         """
-        Returns whether or not the pool of `id` is on the latest version
+        Returns whether the pool of `id` is on the latest version
         and with all feature flags enabled.
 
         Queries the database for the pool matching the given `id`, then
         checks each ZFS feature flag on the pool. Returns `true` only
         when every feature flag is in the ENABLED or ACTIVE state.
-        Returns `false` if the pool is not currently imported or if
-        the feature flags cannot be read for any reason.
 
         Raises a `ValidationError` if `id` does not match any pool in
         the database.
@@ -156,10 +155,8 @@ class PoolService(Service):
             )
 
         pname = pool[0]['vol_name']
-        try:
-            for feat, info in get_zpool_features_impl(tls.lzh, pname).items():
-                if info.state not in ('ENABLED', 'ACTIVE'):
-                    return False
-        except Exception:
-            return False
+        for feat, info in get_zpool_features_impl(tls.lzh, pname).items():
+            if info.state not in ('ENABLED', 'ACTIVE'):
+                return False
+
         return True

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -209,7 +209,10 @@ class PoolService(CRUDService):
     @private
     def pool_extend(self, pool, context):
         if context['extra'].get('is_upgraded'):
-            pool['is_upgraded'] = self.middleware.call_sync('pool.is_upgraded', pool['id'])
+            try:
+                pool['is_upgraded'] = self.middleware.call_sync('pool.is_upgraded', pool['id'])
+            except Exception:
+                pool['is_upgraded'] = False
 
         # WebUI expects the same data as in `boot.get_state`
         pool |= self.middleware.call_sync(


### PR DESCRIPTION
Making `pool.is_upgraded` return `false` for non-existing pools makes ZFS event handler create false `pool is not upgraded` alerts on pool removal. `test_outdated_pool_alert_removed_on_pool_delete` test fails.

`ZfsConfigSyncEvent` for removed pool arrives after `ZfsPoolDestroyEvent`. That provokes `pool.is_upgraded` call for the pool, which, with old logic, returns `false` (as the pool does not exist anymore) and a false alert is created.

The best fix performance-wise is to just pass the exception from `pool.is_upgraded`. There are no external callers for this API, and all the internal callers are now guarded with `try`/`except` block.

As there are no external callers, let's remove this method from public API in `27`.

Original PR: https://github.com/truenas/middleware/pull/18848
