### PR TITLE
NAS-140855 / 27.0.0-BETA.1 / Make container uuid required on ContainerEntry (by sonicaj) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -61,7 +61,7 @@ class ContainerStatus(BaseModel):
 class ContainerEntry(BaseModel):
     id: int
     """Container ID."""
-    uuid: UUIDv4String | None = None
+    uuid: UUIDv4String
     """Container UUID (for libvirt)."""
     name: NonEmptyString
     """Container name."""
@@ -126,6 +126,8 @@ class ContainerCreate(ContainerEntry):
     status: Excluded = excluded_field()
     devices: Excluded = excluded_field()
     default_network: Excluded = excluded_field()
+    uuid: UUIDv4String | None = None
+    """Container UUID (for libvirt). Auto-generated if not provided."""
     pool: str | None = None
     """Pool to use for this container. Leave it null to use container preferred pool instead."""
     image: "ContainerCreateImage"


### PR DESCRIPTION
This commit fixes a mypy strict-mode failure in container/nsenter.py where container.uuid was being passed to truenas_pylibvirt.nsexec.build_argv_for_shell which expects a non-Optional str, while ContainerEntry declared uuid as UUIDv4String | None. The optionality only ever made sense for the create input (the server backfills uuid.uuid4() during validate() if the caller omits it), but ContainerEntry doubles as the read/entry model returned by get_instance/query, where uuid is always populated -- the database column is NOT NULL, the validate() backfill runs on every create path, and there is no direct datastore.create that bypasses validate. This was confirmed against a live install where every container_container row has a non-null uuid.

The fix mirrors the existing override pattern already used in ContainerCreate for pool/image: tighten ContainerEntry.uuid to UUIDv4String (required) and override it as UUIDv4String | None = None on ContainerCreate so create callers can still omit it. The SQLAlchemy column declaration in container/crud.py is also updated with nullable=False to match the Alembic migration that has been enforcing NOT NULL since the table was created. No data migration is required.

Original PR: https://github.com/truenas/middleware/pull/18855


Original PR: https://github.com/truenas/middleware/pull/18865
