### PR TITLE
NAS-140867 / 27.0.0-BETA.1 / Fix removed methods handling

### DIFF
--- a/src/middlewared/middlewared/api/base/server/method.py
+++ b/src/middlewared/middlewared/api/base/server/method.py
@@ -21,6 +21,7 @@ class Method:
         self.middleware = middleware
         self.name = name
         self.serviceobj, self.methodobj = self.middleware.get_method(self.name)
+        self._private: bool | None = None
 
     async def accepts_model(self):
         """
@@ -36,7 +37,19 @@ class Method:
 
     @property
     def private(self):
+        if self._private is not None:
+            return self._private
+
         return getattr(self.methodobj, "_private", False) or self.serviceobj._config.private
+
+    @private.setter
+    def private(self, private: bool) -> None:
+        """
+        Override the private attribute of the method.
+        :param private: new private value
+        :return:
+        """
+        self._private = private
 
     async def call(self, app: "RpcWebSocketApp", id_: Any, params: list):
         """

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -389,12 +389,14 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
 
     def _create_api(self, version: str, method_factory: typing.Callable[[Middleware, str], Method]) -> API:
         methods = []
-        for method_name, method in self._get_methods():
-            if removed_in := getattr(method, "_removed_in", None):
-                if version >= removed_in:
-                    continue
+        for method_name, methodobj in self._get_methods():
+            method = method_factory(self, method_name)
 
-            methods.append(method_factory(self, method_name))
+            if removed_in := getattr(methodobj, "_removed_in", None):
+                if version >= removed_in:
+                    method.private = True
+
+            methods.append(method)
 
         events = []
 


### PR DESCRIPTION
Currently, methods that have `removed_in` set are removed from corresponding API completely, so we can't call them from our integration tests. That's not the desired behavior, because we just might have plans to make them private.