### PR TITLE
NAS-140874 / 27.0.0-BETA.1 / write zfs tunables to persistent storage

### DIFF
--- a/src/freenas/etc/initramfs-tools/hooks/truenas_zfs_modprobe
+++ b/src/freenas/etc/initramfs-tools/hooks/truenas_zfs_modprobe
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Bake the zfs modprobe options written by middlewared into the initrd so they
+# apply when zfs loads to import the boot pool. The source file lives under
+# /data (which survives BE upgrades via the installer's /data rsync).
+PREREQ=""
+prereqs() { echo "$PREREQ"; }
+case $1 in
+    prereqs) prereqs; exit 0 ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+config="/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
+# Nothing to do unless there's at least one option to apply.
+[ -s "$config" ] || exit 0
+
+copy_file config "$config" /etc/modprobe.d/zfs.conf

--- a/src/middlewared/middlewared/plugins/tunable/__init__.py
+++ b/src/middlewared/middlewared/plugins/tunable/__init__.py
@@ -20,7 +20,7 @@ from middlewared.api.current import (
 from middlewared.service import GenericCRUDService, job, private
 
 from .crud import TunableServicePart
-from .utils import TUNABLE_TYPES, handle_tunable_change, set_sysctl, set_zfs_parameter
+from .utils import TUNABLE_TYPES, handle_tunable_change, set_sysctl, set_zfs_parameter, write_zfs_modprobe
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -77,6 +77,10 @@ class TunableService(GenericCRUDService[TunableEntry]):
     @private
     def set_zfs_parameter(self, name: str, value: str) -> None:
         set_zfs_parameter(self.middleware, name, value)
+
+    @private
+    def write_zfs_modprobe(self) -> bool:
+        return write_zfs_modprobe(self.middleware)
 
     @private
     async def handle_tunable_change(self, tunable: dict[str, Any]) -> None:

--- a/src/middlewared/middlewared/plugins/tunable/utils.py
+++ b/src/middlewared/middlewared/plugins/tunable/utils.py
@@ -105,10 +105,11 @@ def write_zfs_modprobe(middleware: Middleware) -> bool:
     Returns True if the file changed (caller should force an initramfs rebuild).
     """
     options = []
-    for tunable in middleware.call_sync(
-        'tunable.query', [['type', '=', 'ZFS'], ['enabled', '=', True]]
+    for tunable in middleware.call_sync2(
+        middleware.services.tunable.query,
+        [['type', '=', 'ZFS'], ['enabled', '=', True]],
     ):
-        options.append(f'{tunable["var"]}={tunable["value"]}')
+        options.append(f'{tunable.var}={tunable.value}')
 
     # Sort so plain text equality is meaningful for change detection,
     # regardless of tunable.query / sysfs enumeration order.

--- a/src/middlewared/middlewared/plugins/tunable/utils.py
+++ b/src/middlewared/middlewared/plugins/tunable/utils.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import subprocess
 from typing import TYPE_CHECKING, Any
+
+from truenas_os_pyutils.io import atomic_write
 
 from middlewared.service_exception import CallError
 from middlewared.utils import run
@@ -14,6 +17,11 @@ if TYPE_CHECKING:
 
 
 TUNABLE_TYPES: list[str] = ['SYSCTL', 'UDEV', 'ZFS']
+
+# Lives under /data so it persists across BE upgrades (the installer rsyncs
+# /data into the new BE). The initramfs hook copies this file into the initrd
+# as /etc/modprobe.d/zfs.conf so options apply when zfs loads in the initramfs.
+ZFS_MODPROBE_PATH = '/data/subsystems/initramfs/truenas_zfs_modprobe.conf'
 
 _SYSCTLS: set[str] = set()
 
@@ -86,26 +94,67 @@ async def generate_sysctl(middleware: Middleware, ha_propagate: bool = False) ->
         await middleware.call('failover.call_remote', 'etc.generate', ['sysctl'])
 
 
+def write_zfs_modprobe(middleware: Middleware) -> bool:
+    """
+    Materialize the zfs modprobe options from the enabled ZFS tunables to a
+    stable path under /data. The initramfs-tools hook
+    /etc/initramfs-tools/hooks/truenas_zfs_modprobe copies this file into the
+    initrd as /etc/modprobe.d/zfs.conf so the options apply when zfs loads
+    inside the initramfs (boot pool import).
+
+    Returns True if the file changed (caller should force an initramfs rebuild).
+    """
+    options = []
+    for tunable in middleware.call_sync(
+        'tunable.query', [['type', '=', 'ZFS'], ['enabled', '=', True]]
+    ):
+        options.append(f'{tunable["var"]}={tunable["value"]}')
+
+    # Sort so plain text equality is meaningful for change detection,
+    # regardless of tunable.query / sysfs enumeration order.
+    new_content = f'options zfs {" ".join(sorted(options))}\n' if options else ''
+
+    try:
+        with open(ZFS_MODPROBE_PATH) as f:
+            existing_content = f.read()
+    except FileNotFoundError:
+        existing_content = ''
+
+    if existing_content == new_content:
+        return False
+
+    os.makedirs(os.path.dirname(ZFS_MODPROBE_PATH), exist_ok=True)
+    with atomic_write(ZFS_MODPROBE_PATH, 'w') as f:
+        f.write(new_content)
+    return True
+
+
 async def update_initramfs(middleware: Middleware, ha_propagate: bool = False) -> None:
-    if ha_propagate:
-        tasks = [
-            middleware.create_task(middleware.call('boot.update_initramfs')),
-            middleware.call('failover.call_remote', 'boot.update_initramfs', [], {
-                'timeout': 300,
-            })
-        ]
+    if not ha_propagate:
+        changed = await middleware.call('tunable.write_zfs_modprobe')
+        await middleware.call('boot.update_initramfs', {'force': changed})
+        return
 
-        errors = []
-        for i, result in enumerate(await asyncio.gather(*tasks, return_exceptions=True)):
-            if isinstance(result, Exception):
-                if i == 0:
-                    error = 'Failed to update initramfs on local node: '
-                else:
-                    error = 'Failed to update initramfs on remote node node: '
+    # Phase 1: write the modprobe config on both nodes. Must finish on both
+    # before phase 2 — boot.update_initramfs runs the initramfs hook that
+    # reads the file we just wrote.
+    local_changed, remote_changed = await asyncio.gather(
+        middleware.call('tunable.write_zfs_modprobe'),
+        middleware.call('failover.call_remote', 'tunable.write_zfs_modprobe'),
+    )
 
-                errors.append(error + str(result))
-
-        if errors:
-            raise CallError('\n'.join(errors))
-    else:
-        await middleware.call('boot.update_initramfs')
+    # Phase 2: rebuild the initramfs on both nodes concurrently.
+    results = await asyncio.gather(
+        middleware.call('boot.update_initramfs', {'force': local_changed}),
+        middleware.call(
+            'failover.call_remote', 'boot.update_initramfs',
+            [{'force': remote_changed}], {'timeout': 300},
+        ),
+        return_exceptions=True,
+    )
+    errors = []
+    for node, result in zip(('local', 'remote'), results):
+        if isinstance(result, Exception):
+            errors.append(f'Failed to update initramfs on {node} node: {result}')
+    if errors:
+        raise CallError('\n'.join(errors))

--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -16,6 +16,25 @@ ZFS = "zil_nocacheflush"
 ZFS_DEFAULT_VALUE = "0"
 ZFS_NEW_VALUE = "1"
 
+ZFS_MODPROBE_PATH = "/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
+
+UPDATE_INITRAMFS_BINARY = "/usr/sbin/update-initramfs"
+UPDATE_INITRAMFS_RUN_COUNT_PATH = "/tmp/mock-update-initramfs-run-count"
+UPDATE_INITRAMFS_MOCK_CODE = textwrap.dedent("""\
+    import os
+
+    path = "/tmp/mock-update-initramfs-run-count"
+    if os.path.exists(path):
+        run_count = int(open(path).read().strip())
+    else:
+        run_count = 0
+
+    run_count += 1
+
+    with open(path, "w") as f:
+        f.write(f"{run_count}\\n")
+""")
+
 
 def assert_ssh_both_nodes(command, output, **kwargs):
     ips = [None]
@@ -24,6 +43,38 @@ def assert_ssh_both_nodes(command, output, **kwargs):
 
     for ip in ips:
         assert ssh(command, ip=ip, **kwargs) == output
+
+
+@contextlib.contextmanager
+def mock_update_initramfs():
+    """
+    Replace `update-initramfs` with a counter-incrementing Python mock on
+    both nodes for the duration of the block, and reset the counter on
+    entry so callers can assert absolute values via
+    `assert_update_initramfs_run_count`.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock_binary(
+            UPDATE_INITRAMFS_BINARY, code=UPDATE_INITRAMFS_MOCK_CODE, exitcode=0,
+        ))
+        if ha:
+            stack.enter_context(mock_binary(
+                UPDATE_INITRAMFS_BINARY, code=UPDATE_INITRAMFS_MOCK_CODE,
+                exitcode=0, remote=True,
+            ))
+        assert_ssh_both_nodes(
+            f"rm -f {UPDATE_INITRAMFS_RUN_COUNT_PATH} && echo ok", "ok\n",
+        )
+        yield
+
+
+def assert_update_initramfs_run_count(value):
+    # `|| echo 0` so the assertion works before the mock has been invoked
+    # (i.e., the counter file doesn't exist yet).
+    assert_ssh_both_nodes(
+        f"cat {UPDATE_INITRAMFS_RUN_COUNT_PATH} 2>/dev/null || echo 0",
+        f"{value}\n",
+    )
 
 
 def test_create_invalid_sysctl():
@@ -131,42 +182,14 @@ def test_udev_lifecycle():
 
 
 def test_zfs_lifecycle():
-    binary = "/usr/sbin/update-initramfs"
-    code = textwrap.dedent("""\
-        import os
-
-        path = "/tmp/mock-update-initramfs-run-count"
-        if os.path.exists(path):
-            run_count = int(open(path).read().strip())
-        else:
-            run_count = 0
-
-        run_count += 1
-
-        with open(path, "w") as f:
-            f.write(f"{run_count}\\n")
-    """)
-    exitcode = 0
-
-    with contextlib.ExitStack() as stack:
-        stack.enter_context(mock_binary(binary, code=code, exitcode=exitcode))
-        if ha:
-            stack.enter_context(
-                mock_binary(binary, code=code, exitcode=exitcode, remote=True)
-            )
-
-        zfs_modprobe_path = "/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
-
+    with mock_update_initramfs():
         def assert_default_value():
-            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
+            assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", "", check=False)
             assert_ssh_both_nodes(f"cat /sys/module/zfs/parameters/{ZFS}", f"{ZFS_DEFAULT_VALUE}\n")
 
         def assert_new_value():
-            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", f"options zfs {ZFS}={ZFS_NEW_VALUE}\n", check=False)
+            assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", f"options zfs {ZFS}={ZFS_NEW_VALUE}\n", check=False)
             assert_ssh_both_nodes(f"cat /sys/module/zfs/parameters/{ZFS}", f"{ZFS_NEW_VALUE}\n")
-
-        def assert_update_initramfs_run_count(value):
-            assert_ssh_both_nodes("cat /tmp/mock-update-initramfs-run-count", f"{value}\n")
 
         assert_default_value()
 
@@ -211,41 +234,7 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
     skipped the write_zfs_modprobe content comparison) would silently
     rebuild the initrd on every tunable update.
     """
-    binary = "/usr/sbin/update-initramfs"
-    code = textwrap.dedent("""\
-        import os
-
-        path = "/tmp/mock-update-initramfs-run-count"
-        if os.path.exists(path):
-            run_count = int(open(path).read().strip())
-        else:
-            run_count = 0
-
-        run_count += 1
-
-        with open(path, "w") as f:
-            f.write(f"{run_count}\\n")
-    """)
-
-    zfs_modprobe_path = "/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
-    counter_path = "/tmp/mock-update-initramfs-run-count"
-
-    with contextlib.ExitStack() as stack:
-        stack.enter_context(mock_binary(binary, code=code, exitcode=0))
-        if ha:
-            stack.enter_context(
-                mock_binary(binary, code=code, exitcode=0, remote=True)
-            )
-
-        # Reset counter so we can assert absolute values.
-        assert_ssh_both_nodes(f"rm -f {counter_path} && echo ok", "ok\n")
-
-        def assert_run_count(value):
-            assert_ssh_both_nodes(
-                f"cat {counter_path} 2>/dev/null || echo 0",
-                f"{value}\n", check=False,
-            )
-
+    with mock_update_initramfs():
         # Disabled ZFS tunable: do_create's ZFS branch is gated on `enabled`,
         # so update_initramfs is not called and the modprobe file is untouched.
         tunable = call("tunable.create", {
@@ -255,8 +244,8 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
             "enabled": False,
         }, job=True)
         try:
-            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
-            assert_run_count(0)
+            assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", "", check=False)
+            assert_update_initramfs_run_count(0)
 
             # Real DB-level mutation (old != new at field level, so do_update
             # does not short-circuit). update_initramfs runs, but
@@ -268,8 +257,8 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
                 "value": ZFS_DEFAULT_VALUE,
             }, job=True)
 
-            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
-            assert_run_count(0)
+            assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", "", check=False)
+            assert_update_initramfs_run_count(0)
         finally:
             call("tunable.delete", tunable["id"], job=True)
 

--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -155,12 +155,14 @@ def test_zfs_lifecycle():
                 mock_binary(binary, code=code, exitcode=exitcode, remote=True)
             )
 
+        zfs_modprobe_path = "/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
+
         def assert_default_value():
-            assert_ssh_both_nodes("cat /etc/modprobe.d/zfs.conf", "", check=False)
+            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
             assert_ssh_both_nodes(f"cat /sys/module/zfs/parameters/{ZFS}", f"{ZFS_DEFAULT_VALUE}\n")
 
         def assert_new_value():
-            assert_ssh_both_nodes("cat /etc/modprobe.d/zfs.conf", f"options zfs {ZFS}={ZFS_NEW_VALUE}\n", check=False)
+            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", f"options zfs {ZFS}={ZFS_NEW_VALUE}\n", check=False)
             assert_ssh_both_nodes(f"cat /sys/module/zfs/parameters/{ZFS}", f"{ZFS_NEW_VALUE}\n")
 
         def assert_update_initramfs_run_count(value):

--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -99,7 +99,7 @@ def test_udev_lifecycle():
     def assert_exists():
         assert_ssh_both_nodes(
             "cat /etc/udev/rules.d/10-disable-usb.rules",
-            f"BUS==\"usb\", OPTIONS+=\"ignore_device\"\n",
+            "BUS==\"usb\", OPTIONS+=\"ignore_device\"\n",
         )
 
     def assert_does_not_exist():
@@ -166,7 +166,7 @@ def test_zfs_lifecycle():
             assert_ssh_both_nodes(f"cat /sys/module/zfs/parameters/{ZFS}", f"{ZFS_NEW_VALUE}\n")
 
         def assert_update_initramfs_run_count(value):
-            assert_ssh_both_nodes(f"cat /tmp/mock-update-initramfs-run-count", f"{value}\n")
+            assert_ssh_both_nodes("cat /tmp/mock-update-initramfs-run-count", f"{value}\n")
 
         assert_default_value()
 
@@ -197,6 +197,81 @@ def test_zfs_lifecycle():
 
         assert_default_value()
         assert_update_initramfs_run_count(4)
+
+
+def test_zfs_no_rebuild_when_modprobe_unchanged():
+    """
+    Cover update_initramfs's change-detection optimization: when a ZFS
+    tunable mutation does not change the materialized modprobe file
+    content, update-initramfs must NOT be invoked. Only enabled tunables
+    contribute to the file, so updating the value of a *disabled* tunable
+    leaves the file unchanged and must not trigger an initramfs rebuild.
+
+    Without this test, a regression that always passed force=True (or that
+    skipped the write_zfs_modprobe content comparison) would silently
+    rebuild the initrd on every tunable update.
+    """
+    binary = "/usr/sbin/update-initramfs"
+    code = textwrap.dedent("""\
+        import os
+
+        path = "/tmp/mock-update-initramfs-run-count"
+        if os.path.exists(path):
+            run_count = int(open(path).read().strip())
+        else:
+            run_count = 0
+
+        run_count += 1
+
+        with open(path, "w") as f:
+            f.write(f"{run_count}\\n")
+    """)
+
+    zfs_modprobe_path = "/data/subsystems/initramfs/truenas_zfs_modprobe.conf"
+    counter_path = "/tmp/mock-update-initramfs-run-count"
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock_binary(binary, code=code, exitcode=0))
+        if ha:
+            stack.enter_context(
+                mock_binary(binary, code=code, exitcode=0, remote=True)
+            )
+
+        # Reset counter so we can assert absolute values.
+        assert_ssh_both_nodes(f"rm -f {counter_path} && echo ok", "ok\n")
+
+        def assert_run_count(value):
+            assert_ssh_both_nodes(
+                f"cat {counter_path} 2>/dev/null || echo 0",
+                f"{value}\n", check=False,
+            )
+
+        # Disabled ZFS tunable: do_create's ZFS branch is gated on `enabled`,
+        # so update_initramfs is not called and the modprobe file is untouched.
+        tunable = call("tunable.create", {
+            "type": "ZFS",
+            "var": ZFS,
+            "value": ZFS_NEW_VALUE,
+            "enabled": False,
+        }, job=True)
+        try:
+            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
+            assert_run_count(0)
+
+            # Real DB-level mutation (old != new at field level, so do_update
+            # does not short-circuit). update_initramfs runs, but
+            # write_zfs_modprobe sees no enabled ZFS tunables -> file content
+            # is unchanged (still empty) -> returns False ->
+            # boot.update_initramfs is called with force=False -> the existing
+            # initrd is kept and the mocked update-initramfs is never invoked.
+            call("tunable.update", tunable["id"], {
+                "value": ZFS_DEFAULT_VALUE,
+            }, job=True)
+
+            assert_ssh_both_nodes(f"cat {zfs_modprobe_path}", "", check=False)
+            assert_run_count(0)
+        finally:
+            call("tunable.delete", tunable["id"], job=True)
 
 
 def test_arc_max_set():

--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -234,6 +234,10 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
     skipped the write_zfs_modprobe content comparison) would silently
     rebuild the initrd on every tunable update.
     """
+    # Distinct values are required for the test to actually exercise
+    # do_update's full path (otherwise it short-circuits on entry-equality).
+    assert ZFS_NEW_VALUE != ZFS_DEFAULT_VALUE
+
     with mock_update_initramfs():
         # Disabled ZFS tunable: do_create's ZFS branch is gated on `enabled`,
         # so update_initramfs is not called and the modprobe file is untouched.
@@ -247,15 +251,19 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
             assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", "", check=False)
             assert_update_initramfs_run_count(0)
 
-            # Real DB-level mutation (old != new at field level, so do_update
-            # does not short-circuit). update_initramfs runs, but
-            # write_zfs_modprobe sees no enabled ZFS tunables -> file content
-            # is unchanged (still empty) -> returns False ->
-            # boot.update_initramfs is called with force=False -> the existing
-            # initrd is kept and the mocked update-initramfs is never invoked.
+            # Real value change. do_update's old != new short-circuit at
+            # crud.py:121 does NOT fire, so update_initramfs is invoked.
+            # write_zfs_modprobe queries enabled ZFS tunables, finds none,
+            # produces empty content matching the already-empty (missing)
+            # modprobe file, and returns False — so boot.update_initramfs
+            # runs with force=False and the existing initrd is kept.
             call("tunable.update", tunable["id"], {
                 "value": ZFS_DEFAULT_VALUE,
             }, job=True)
+
+            # Confirm do_update actually ran the update (proves we are not
+            # accidentally hitting the entry-equality short-circuit).
+            assert call("tunable.get_instance", tunable["id"])["value"] == ZFS_DEFAULT_VALUE
 
             assert_ssh_both_nodes(f"cat {ZFS_MODPROBE_PATH}", "", check=False)
             assert_update_initramfs_run_count(0)


### PR DESCRIPTION
The same principles outlined in https://github.com/truenas/middleware/pull/18842 apply here. We don't need to have our `truenas-initrd.py` try to load the database on the executing system to try and figure out what tunables are set and then generate init hook scripts etc. The `truenas-initrd.py` needs to be as simple/clean/clear as possible because we've already silently broken it and the consequences are profound. This is just another step to further reduce the complexity of the script.