### PR TITLE
NAS-140840 / 27.0.0-BETA.1 / Clear rsync one-shot alerts on task delete (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -483,6 +483,8 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
         Delete Rsync Task of `id`.
         """
         res = await self.middleware.call('datastore.delete', self._config.datastore, id_)
+        for klass in ('RsyncSuccess', 'RsyncFailed'):
+            await self.middleware.call('alert.oneshot_delete', klass, id_)
         await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
         return res
 


### PR DESCRIPTION
### Summary

`RsyncFailed` / `RsyncSuccess` are `OneShotAlertClass` alerts with `deleted_automatically = False` (`alert/source/rsync.py:5,23`), keyed on the task id. They are created from `RsyncTaskService.run()` and cleared at the top of the next run, but `RsyncTaskService.do_delete()` was not clearing them. Deleting a task therefore left an orphaned critical alert in the panel that the UI could no longer associate with any task — dismissing it appeared to "stick" but on reload it was still there, and the rsync task section on Data Protection no longer had the row it referred to.

### Consistency with other task plugins

Plugins that use `OneShotAlertClass` for task alerts already do this cleanup in their `do_delete`. Rsync was the outlier:

- `cloud_sync.py:886` — `alert.oneshot_delete('CloudSyncTaskFailed', id_)`
- `cloud_backup/crud.py:142` — `alert.oneshot_delete('CloudBackupTaskFailed', id_)`
- `vmware.py:140,158` — `alert.oneshot_delete('VMWareLoginFailed', ...)`

Replication and periodic-snapshot alerts don't need analogous handling because they are produced by a polling `AlertSource` (`alert/source/replication.py:25`) that re-derives alerts from `replication.query` / `pool.snapshottask.query` on each tick, so deletions clean themselves up.

The generic `TaskLocked` one-shot alert is already cleared by the base class via `SharingTaskService.delete` →`remove_locked_alert` (`service/sharing_service.py:259-262`), which `RsyncTaskService` inherits through `TaskPathService`. No change needed there.

Original PR: https://github.com/truenas/middleware/pull/18880
