### PR TITLE
Initial GPU Usage Implementation

### DIFF
--- a/src/freenas/usr/lib/netdata/conf.d/python.d.conf
+++ b/src/freenas/usr/lib/netdata/conf.d/python.d.conf
@@ -1,8 +1,10 @@
 enabled: yes
 default_run: no
 cputemp: yes
+gputemp: yes
 truenas_arcstats: yes
 truenas_cpu_usage: yes
+truenas_gpu_usage: yes
 truenas_disk_stats: yes
 truenas_disk_temp: yes
 truenas_meminfo: yes

--- a/src/freenas/usr/libexec/netdata/python.d/gputemp.chart.py
+++ b/src/freenas/usr/libexec/netdata/python.d/gputemp.chart.py
@@ -1,0 +1,37 @@
+from copy import deepcopy
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from middlewared.utils.metrics.gpu_usage import get_gpu_usage
+
+ORDER = [
+    'temperatures',
+]
+
+# This is a prototype of chart definition which is used to dynamically create self.definitions
+CHARTS = {
+    'temperatures': {
+        'options': [None, 'Temperature', 'Celsius', 'temperature', 'sensors.temperature', 'line'],
+        'lines': []
+    }
+}
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = deepcopy(ORDER)
+        self.definitions = deepcopy(CHARTS)
+
+    def get_data(self):
+        data: dict[str, float] = {}
+        for (name, info) in get_gpu_usage():
+            data[name] = info['temperature']
+        return data
+
+    def check(self):
+        data = self.get_data()
+        for i in data:
+            self.definitions['temperatures']['lines'].append([str(i)])
+
+        return bool(data)

--- a/src/freenas/usr/libexec/netdata/python.d/truenas_gpu_usage.chart.py
+++ b/src/freenas/usr/libexec/netdata/python.d/truenas_gpu_usage.chart.py
@@ -1,0 +1,30 @@
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from middlewared.plugins.reporting.realtime_reporting import get_gpu_stats
+from middlewared.utils.metrics.gpu_usage import get_gpu_usage
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.old_stats = {}
+
+    def check(self):
+        self.add_gpu_usage_to_charts()
+        return True
+
+    def get_data(self):
+        data, self.old_stats = get_gpu_stats(self.old_stats)
+        return data
+
+    def add_gpu_usage_to_charts(self):
+        data, self.old_stats = get_gpu_usage()
+        self.charts.add_chart([
+            'gpu', 'gpu', 'gpu', 'GPU USAGE%',
+            'gpu.usage',
+            'Gpu usage',
+            'line',
+        ])
+
+        for gpu_name in filter(lambda s: s.startswith('gpu'), data.keys()):
+            self.charts['gpu'].add_dimension([f'{gpu_name}', f'{gpu_name}', 'absolute'])

--- a/src/middlewared/middlewared/api/v27_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v27_0_0/reporting.py
@@ -187,6 +187,31 @@ class ReportingRealtimeEventSourceEvent(BaseModel):
     """ZFS performance metrics for real-time monitoring."""
     pools: dict
     """Storage pool statistics for real-time monitoring."""
+    gpu: "ReportingRealtimeEventSourceEventGPU"
+    """GPU usage metrics for real-time monitoring."""
+
+
+class ReportingRealtimeEventSourceEventGPU(BaseModel):
+    index: int
+    """GPU device index."""
+    name: str
+    """GPU device name."""
+    gpu_utilization: float | None
+    """GPU core utilization percentage."""
+    memory_utilization: float | None
+    """GPU memory utilization percentage."""
+    memory_total: int | None
+    """Total GPU memory in MiB."""
+    memory_used: int | None
+    """Used GPU memory in MiB."""
+    memory_free: int | None
+    """Free GPU memory in MiB."""
+    temperature: int | None
+    """GPU temperature in degrees Celsius."""
+    fan_speed: int | None
+    """GPU fan speed percentage."""
+    power_draw: float | None
+    """GPU power draw in watts."""
 
 
 class ReportingRealtimeEventSourceEventDisks(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v27_0_0/reporting.py
@@ -60,14 +60,16 @@ class ReportingQuery(BaseModel):
 
 class GraphIdentifier(BaseModel):
     name: typing.Literal[
-        'cpu', 'cputemp', 'disk', 'interface', 'load', 'processes', 'memory', 'uptime', 'arcactualrate', 'arcrate',
-        'arcsize', 'arcresult', 'disktemp', 'upscharge', 'upsruntime', 'upsvoltage', 'upscurrent', 'upsfrequency',
-        'upsload', 'upstemperature',
+        'cpu', 'gpu','cputemp', 'gputemp', 'disk', 'interface', 'load', 'processes', 'memory', 'uptime',
+        'arcactualrate', 'arcrate', 'arcsize', 'arcresult', 'disktemp', 'upscharge', 'upsruntime', 'upsvoltage',
+        'upscurrent', 'upsfrequency', 'upsload', 'upstemperature',
     ]
     """Type of performance metric to retrieve.
 
     * `cpu`: CPU usage statistics
+    * `gpu`: GPU usage statistics
     * `cputemp`: CPU temperature readings
+    * `gputemp`: GPU temperature readings
     * `disk`: Disk I/O statistics
     * `interface`: Network interface statistics
     * `load`: System load averages

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -10,6 +10,7 @@ from .realtime_reporting import (
     get_arc_stats,
     get_cpu_stats,
     get_disk_stats,
+    get_gpu_stats,
     get_interface_stats,
     get_memory_info,
     get_pool_stats,
@@ -23,7 +24,7 @@ def get_disks_with_identifiers() -> dict[str, str]:
 class RealtimeEventSource(EventSource):
     """
     Retrieve real time statistics for CPU, network,
-    virtual memory and zfs arc.
+    virtual memory, zfs arc, storage pools, and GPU.
     """
 
     args = ReportingRealtimeEventSourceArgs
@@ -86,6 +87,7 @@ class ReportingRealtimeService(Service):
                     ]
                 ),
                 'pools': get_pool_stats(netdata_metrics),
+                'gpu': get_gpu_stats(),
             })
 
         return data

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -87,7 +87,7 @@ class ReportingRealtimeService(Service):
                     ]
                 ),
                 'pools': get_pool_stats(netdata_metrics),
-                'gpu': get_gpu_stats(),
+                'gpu': get_gpu_stats(netdata_metrics),
             })
 
         return data

--- a/src/middlewared/middlewared/plugins/reporting/gpu_temperatures.py
+++ b/src/middlewared/middlewared/plugins/reporting/gpu_temperatures.py
@@ -1,0 +1,15 @@
+from middlewared.service import Service, private
+
+
+class ReportingService(Service):
+
+    @private
+    async def gpu_temperatures(self):
+        netdata_metrics = await self.middleware.call('netdata.get_all_metrics')
+        data = {}
+        temp_retrieved = False
+        for name, gpu_temp in netdata_metrics.get('gputemp.temperatures', {'dimensions': {}})['dimensions'].items():
+            data[name] = gpu_temp['value']
+            if not temp_retrieved:
+                temp_retrieved = bool(gpu_temp['value'])
+        return data if temp_retrieved else {}

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -486,3 +486,22 @@ class UPSTemperaturePlugin(UPSBase):
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
         return f'upsd_{self.UPS_IDENTIFIER}.temperature'
+
+class GPUPlugin(GraphBase):
+
+    title = 'GPU Usage'
+    uses_identifiers = False
+    vertical_label = '%GPU'
+
+    def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
+        return 'truenas_gpu_usage.gpu'
+
+class GPUTempPlugin(GraphBase):
+
+    title = 'GPU Temperature'
+    uses_identifiers = False
+    vertical_label = 'Celsius'
+    skip_zero_values_in_aggregation = True
+
+    def get_chart_name(self, identifier: typing.Optional[str]) -> str:
+        return 'gputemp.temperatures'

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/__init__.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/__init__.py
@@ -1,5 +1,6 @@
 from .arcstat import get_arc_stats  # noqa
 from .cpu import get_cpu_stats  # noqa
+from .gpu import get_gpu_stats  # noqa
 from .ifstat import get_interface_stats  # noqa
 from .iostat import get_disk_stats  # noqa
 from .memory import get_memory_info  # noqa

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/gpu.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/gpu.py
@@ -1,12 +1,23 @@
 from middlewared.utils.metrics.gpu_usage import get_gpu_usage
 
+from .utils import safely_retrieve_dimension
 
-def get_gpu_stats() -> dict:
-    """
-    Retrieve GPU usage statistics for all detected GPUs.
+def get_gpu_stats(netdata_metrics: dict | None = None) -> dict:
+    data = {}
+    for name, info in get_gpu_usage().items():
+        if netdata_metrics is None:
+            data[name] = {
+                'usage': info['gpu_utilization'],
+                'temp': info['temperature']
+            }
+        else:
+            data[name] = {
+                'usage': safely_retrieve_dimension(
+                    netdata_metrics, 'truenas_gpu_usage.gpu', name, 0
+                ),
+                'temp': safely_retrieve_dimension(
+                    netdata_metrics, 'gputemp.temperatures', name,
+                ) or None
+            }
 
-    Returns a dictionary keyed by GPU identifier (e.g. 'gpu0', 'gpu1')
-    with usage metrics for each GPU. Returns an empty dict if no GPUs
-    are detected.
-    """
-    return get_gpu_usage()
+    return data

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/gpu.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/gpu.py
@@ -1,0 +1,12 @@
+from middlewared.utils.metrics.gpu_usage import get_gpu_usage
+
+
+def get_gpu_stats() -> dict:
+    """
+    Retrieve GPU usage statistics for all detected GPUs.
+
+    Returns a dictionary keyed by GPU identifier (e.g. 'gpu0', 'gpu1')
+    with usage metrics for each GPU. Returns an empty dict if no GPUs
+    are detected.
+    """
+    return get_gpu_usage()

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -12,6 +12,7 @@ from middlewared.utils.zfs import query_imported_fast_impl
 
 from .netdata import ClientConnectError, Netdata
 from .utils import TIER_0_POINT_SIZE, TIER_1_POINT_SIZE, calculate_disk_space_for_netdata, get_metrics_approximation
+from ...utils.metrics.gpu_usage import get_gpu_usage
 
 logger = logging.getLogger('netdata_api')
 
@@ -71,6 +72,7 @@ class NetdataService(Service):
         return get_metrics_approximation(
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
+            len(get_gpu_usage()),
             self.middleware.call_sync('interface.query', [], {'count': True}),
             len(query_imported_fast_impl()),
             self.middleware.call_sync('datastore.query', 'vm.vm', [], {'count': True}),

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -6,6 +6,7 @@ import typing
 from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 
 from .netdata.graph_base import GraphBase
+from ...utils.metrics.gpu_usage import get_gpu_usage
 
 # https://learn.netdata.cloud/docs/netdata-agent/configuration/optimizing-metrics-database/
 # change-how-long-netdata-stores-metrics
@@ -53,7 +54,7 @@ def get_netdata_state_path() -> str:
 
 
 def get_metrics_approximation(
-    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int,
+    disk_count: int, core_count: int, gpu_count: int, interface_count: int, pool_count: int, vms_count: int,
     systemd_service_count: int, containers_count: typing.Optional[int] = 10,
 ) -> dict:
     data = {
@@ -121,6 +122,12 @@ def get_metrics_approximation(
 
             # cputemp
             'cputemp.temperatures': core_count + 1,
+
+            # gpu usage
+            'gpu.usage': gpu_count,
+
+            # gputemp
+            'gputemp.temperatures': gpu_count,
 
             # ups
             'nut_ups.charge': 1,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -3,21 +3,23 @@ import pytest
 from middlewared.plugins.reporting.utils import calculate_disk_space_for_netdata, get_metrics_approximation
 
 
-@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 699, 300: 10}),
-    (1600, 32, 4, 4, 10, 1, {1: 8754, 300: 1612}),
-    (10, 16, 2, 2, 12, 3, {1: 838, 300: 16}),
-])
+@pytest.mark.parametrize(
+    'disk_count,core_count,gpu_count,interface_count,pool_count,services_count,vms_count,expected_output', [
+        (4, 2, 1, 1, 2, 10, 2, {1: 701, 300: 10}),
+        (1600, 32, 1, 4, 4, 10, 1, {1: 8756, 300: 1612}),
+        (10, 16, 2, 2, 2, 12, 3, {1: 842, 300: 16}),
+    ]
+)
 def test_netdata_metrics_count_approximation(
-    disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
+    disk_count, core_count, gpu_count, interface_count, pool_count, services_count, vms_count, expected_output
 ):
     assert get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, gpu_count, interface_count, pool_count, vms_count, services_count
     ) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
+    'disk_count,core_count,gpu_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
         (4, 2, 1, 2, 10, 2, 7, 1, 1, 403),
         (4, 2, 1, 2, 10, 1, 7, 4, 60, 25),
@@ -30,11 +32,11 @@ def test_netdata_metrics_count_approximation(
     ],
 )
 def test_netdata_disk_space_approximation(
-        disk_count, core_count, interface_count, pool_count, services_count,
+        disk_count, core_count, gpu_count, interface_count, pool_count, services_count,
         vms_count, days, bytes_per_point, tier_interval, expected_output
 ):
     assert calculate_disk_space_for_netdata(get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, gpu_count, interface_count, pool_count, vms_count, services_count
     ), days, bytes_per_point, tier_interval) == expected_output
 
 
@@ -55,7 +57,7 @@ def test_netdata_days_approximation(
         disk_count, core_count, interface_count, pool_count, services_count, vms_count, days, bytes_per_point,
         tier_interval):
     metric_intervals = get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, 1, interface_count, pool_count, vms_count, services_count
     )
     disk_size = calculate_disk_space_for_netdata(metric_intervals, days, bytes_per_point, tier_interval)
     total_metrics = metric_intervals[1] + (metric_intervals[300] / 300)

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_graphs.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_graphs.py
@@ -13,6 +13,8 @@ from middlewared.plugins.reporting.netdata.graphs import (
     DemandMetadataAccessesPerSecondPlugin,
     DISKPlugin,
     DiskTempPlugin,
+    GPUPlugin,
+    GPUTempPlugin,
     InterfacePlugin,
     LoadPlugin,
     MemoryPlugin,
@@ -37,6 +39,8 @@ from middlewared.pytest.unit.middleware import Middleware
     (DemandMetadataAccessesPerSecondPlugin, 'demand_metadata_accesses_per_second', ['time']),
     (ARCSizePlugin, 'arc_size', ['time']),
     (DiskTempPlugin, 'sda', ['time', 'temperature_value']),
+    (GPUPlugin, 'gpu', ['time']),
+    (GPUTempPlugin, 'gputemp', ['time']),
 ])
 @pytest.mark.asyncio
 async def test_netdata_client_malformed_response_error(obj, identifier, legend):

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -7,6 +7,7 @@ from middlewared.plugins.reporting.realtime_reporting import (
     get_interface_stats,
     get_memory_info,
     get_pool_stats,
+    get_gpu_stats,
 )
 from middlewared.plugins.reporting.realtime_reporting.utils import normalize_value, safely_retrieve_dimension
 
@@ -36,6 +37,23 @@ NETDATA_ALL_METRICS = {
             }
         }
     },
+    'gputemp.temperatures': {
+        'name': 'gputemp.temperatures',
+        'family': 'temperature',
+        'context': 'sensors.temperature',
+        'units': 'Celsius',
+        'last_updated': 1737452189,
+        'dimensions': {
+            'Intel A770': {
+                'name': 'Intel A770',
+                'value': 43
+            },
+            'Nvidia RTX A5000': {
+                'name': 'Nvidia RTX A5000',
+                'value': 68
+            }
+        }
+    },
     'truenas_cpu_usage.cpu': {
         'name': 'truenas_cpu_usage.cpu',
         'family': 'cpu.usage',
@@ -58,6 +76,23 @@ NETDATA_ALL_METRICS = {
             'cpu2': {
                 'name': 'cpu2',
                 'value': 4
+            }
+        }
+    },
+    'truenas_gpu_usage.gpu': {
+        'name': 'truenas_gpu_usage.gpu',
+        'family': 'gpu.usage',
+        'context': 'Gpu usage',
+        'units': 'GPU USAGE%',
+        'last_updated': 1737452189,
+        'dimensions': {
+            'Intel A770': {
+                'name': 'Intel A770',
+                'value': 5
+            },
+            'Nvidia RTX A5000': {
+                'name': 'Nvidia RTX A5000',
+                'value': 27
             }
         }
     },
@@ -806,6 +841,20 @@ def test_cpu_stats():
             ),
             'temp': safely_retrieve_dimension(
                 NETDATA_ALL_METRICS, 'cputemp.temperatures', metric,
+            ) or None
+        }
+
+def test_gpu_stats():
+    gpu_stat = get_gpu_stats(NETDATA_ALL_METRICS)
+    for metric, value in gpu_stat.items():
+        assert value == {
+            'usage': safely_retrieve_dimension(
+                NETDATA_ALL_METRICS,
+                'truenas_gpu_usage.gpu',
+                f'{metric}', 0
+            ),
+            'temp': safely_retrieve_dimension(
+                NETDATA_ALL_METRICS, 'gputemp.temperatures', metric,
             ) or None
         }
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_gpu_usage_util.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_gpu_usage_util.py
@@ -1,0 +1,287 @@
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from middlewared.utils.metrics.gpu_usage import (
+    get_gpu_usage, _get_nvidia_gpu_usage, _get_amd_gpu_usage, _get_intel_gpu_usage,
+)
+
+NVIDIA_SMI_OUTPUT = (
+    '0, NVIDIA GeForce RTX 3080, 45, 30, 10240, 3072, 7168, 65, 55, 220.50\n'
+    '1, NVIDIA GeForce RTX 3070, 12, 8, 8192, 1024, 7168, 58, 40, 180.25\n'
+)
+
+NVIDIA_SMI_OUTPUT_UNAVAILABLE = (
+    '0, NVIDIA Tesla T4, 30, 15, 15360, 2048, 13312, 52, [Not Supported], 70.00\n'
+)
+
+ROCM_SMI_JSON_OUTPUT = json.dumps({
+    'card0': {
+        'GPU use (%)': '45',
+        'GPU memory use (%)': '30',
+        'Temperature (Sensor edge) (C)': '65',
+        'Temperature (Sensor junction) (C)': '75',
+        'Average Graphics Package Power (W)': '220.50',
+        'Fan Speed (%)': '55',
+        'Card Series': 'Radeon RX 7900 XT',
+        'Card Model': '0x744c',
+        'VRAM Total Memory (B)': '21458059264',
+        'VRAM Total Used Memory (B)': '3221225472',
+    },
+    'card1': {
+        'GPU use (%)': '12',
+        'GPU memory use (%)': '8',
+        'Temperature (Sensor edge) (C)': '58',
+        'Average Graphics Package Power (W)': '180.25',
+        'Fan Speed (%)': '40',
+        'Card Series': 'Radeon RX 7800 XT',
+        'VRAM Total Memory (B)': '17179869184',
+        'VRAM Total Used Memory (B)': '1073741824',
+    },
+})
+
+XPU_SMI_DISCOVERY_DUMP = (
+    'Device ID,Device Name,Memory Physical Size\n'
+    '0,"Intel Data Center GPU Flex 170","15258 MiB"\n'
+    '1,"Intel Arc A770","15258 MiB"\n'
+)
+
+XPU_SMI_DUMP_OUTPUT = (
+    'Timestamp, DeviceId, GPU Utilization (%), GPU Power (W), GPU Core Temperature (C), '
+    'GPU Memory Utilization (%), GPU Memory Used (MiB)\n'
+    '06:14:46.000,    0, 35.00, 120.50, 55, 40.00, 4096\n'
+    '06:14:46.000,    1, 10.00, 80.25, 42, 15.00, 2048\n'
+)
+
+
+def test_get_gpu_usage_nvidia():
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = NVIDIA_SMI_OUTPUT
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/nvidia-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = get_gpu_usage()
+
+    assert 'gpu0' in result
+    assert 'gpu1' in result
+    assert result['gpu0'] == {
+        'index': 0,
+        'name': 'NVIDIA GeForce RTX 3080',
+        'gpu_utilization': 45.0,
+        'memory_utilization': 30.0,
+        'memory_total': 10240,
+        'memory_used': 3072,
+        'memory_free': 7168,
+        'temperature': 65,
+        'fan_speed': 55,
+        'power_draw': 220.50,
+    }
+    assert result['gpu1']['index'] == 1
+    assert result['gpu1']['name'] == 'NVIDIA GeForce RTX 3070'
+    assert result['gpu1']['gpu_utilization'] == 12.0
+
+
+def test_get_gpu_usage_no_nvidia_smi():
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value=None):
+        result = get_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_gpu_usage_nvidia_smi_failure():
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ''
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/nvidia-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = get_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_gpu_usage_unsupported_fields():
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = NVIDIA_SMI_OUTPUT_UNAVAILABLE
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/nvidia-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = _get_nvidia_gpu_usage()
+
+    assert 'gpu0' in result
+    assert result['gpu0']['fan_speed'] is None
+    assert result['gpu0']['gpu_utilization'] == 30.0
+    assert result['gpu0']['temperature'] == 52
+
+
+def test_get_gpu_usage_timeout():
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/nvidia-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', side_effect=subprocess.TimeoutExpired('nvidia-smi', 5)):
+        result = get_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_amd_gpu_usage():
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = ROCM_SMI_JSON_OUTPUT
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/opt/rocm/bin/rocm-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = _get_amd_gpu_usage()
+
+    assert 'gpu0' in result
+    assert 'gpu1' in result
+    assert result['gpu0']['index'] == 0
+    assert result['gpu0']['name'] == 'Radeon RX 7900 XT'
+    assert result['gpu0']['gpu_utilization'] == 45.0
+    assert result['gpu0']['memory_utilization'] == 30.0
+    assert result['gpu0']['memory_total'] == 20464
+    assert result['gpu0']['memory_used'] == 3072
+    assert result['gpu0']['memory_free'] == 20464 - 3072
+    assert result['gpu0']['temperature'] == 65
+    assert result['gpu0']['fan_speed'] == 55
+    assert result['gpu0']['power_draw'] == 220.50
+    assert result['gpu1']['name'] == 'Radeon RX 7800 XT'
+    assert result['gpu1']['gpu_utilization'] == 12.0
+
+
+def test_get_amd_gpu_usage_no_rocm_smi():
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value=None):
+        result = _get_amd_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_amd_gpu_usage_failure():
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ''
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/opt/rocm/bin/rocm-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = _get_amd_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_amd_gpu_usage_invalid_json():
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = 'not valid json'
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/opt/rocm/bin/rocm-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = _get_amd_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_amd_gpu_usage_missing_fields():
+    """Test AMD GPU parsing when some fields are missing from JSON."""
+    sparse_data = json.dumps({
+        'card0': {
+            'GPU use (%)': '50',
+            'Card Series': 'AMD Instinct MI250',
+        },
+    })
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = sparse_data
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/opt/rocm/bin/rocm-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', return_value=mock_result):
+        result = _get_amd_gpu_usage()
+
+    assert 'gpu0' in result
+    assert result['gpu0']['gpu_utilization'] == 50.0
+    assert result['gpu0']['name'] == 'AMD Instinct MI250'
+    assert result['gpu0']['temperature'] is None
+    assert result['gpu0']['power_draw'] is None
+    assert result['gpu0']['memory_total'] is None
+
+
+def test_get_intel_gpu_usage():
+    mock_discovery = MagicMock()
+    mock_discovery.returncode = 0
+    mock_discovery.stdout = XPU_SMI_DISCOVERY_DUMP
+
+    mock_dump = MagicMock()
+    mock_dump.returncode = 0
+    mock_dump.stdout = XPU_SMI_DUMP_OUTPUT
+
+    def run_side_effect(cmd):
+        if 'discovery' in cmd:
+            return mock_discovery
+        return mock_dump
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/xpu-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', side_effect=run_side_effect):
+        result = _get_intel_gpu_usage()
+
+    assert 'gpu0' in result
+    assert 'gpu1' in result
+    assert result['gpu0']['index'] == 0
+    assert result['gpu0']['name'] == 'Intel Data Center GPU Flex 170'
+    assert result['gpu0']['gpu_utilization'] == 35.0
+    assert result['gpu0']['power_draw'] == 120.50
+    assert result['gpu0']['temperature'] == 55
+    assert result['gpu0']['memory_utilization'] == 40.0
+    assert result['gpu0']['memory_used'] == 4096
+    assert result['gpu1']['name'] == 'Intel Arc A770'
+    assert result['gpu1']['gpu_utilization'] == 10.0
+
+
+def test_get_intel_gpu_usage_no_xpu_smi():
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value=None):
+        result = _get_intel_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_intel_gpu_usage_dump_failure():
+    mock_discovery = MagicMock()
+    mock_discovery.returncode = 0
+    mock_discovery.stdout = XPU_SMI_DISCOVERY_DUMP
+
+    mock_dump = MagicMock()
+    mock_dump.returncode = 1
+    mock_dump.stdout = ''
+
+    def run_side_effect(cmd):
+        if 'discovery' in cmd:
+            return mock_discovery
+        return mock_dump
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/xpu-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', side_effect=run_side_effect):
+        result = _get_intel_gpu_usage()
+
+    assert result == {}
+
+
+def test_get_intel_gpu_usage_discovery_failure():
+    """Test Intel GPU parsing when discovery fails but dump works."""
+    mock_discovery = MagicMock()
+    mock_discovery.returncode = 1
+    mock_discovery.stdout = ''
+
+    mock_dump = MagicMock()
+    mock_dump.returncode = 0
+    mock_dump.stdout = XPU_SMI_DUMP_OUTPUT
+
+    def run_side_effect(cmd):
+        if 'discovery' in cmd:
+            return mock_discovery
+        return mock_dump
+
+    with patch('middlewared.utils.metrics.gpu_usage.shutil.which', return_value='/usr/bin/xpu-smi'), \
+         patch('middlewared.utils.metrics.gpu_usage.subprocess.run', side_effect=run_side_effect):
+        result = _get_intel_gpu_usage()
+
+    assert 'gpu0' in result
+    assert result['gpu0']['name'] == 'Intel GPU 0'
+    assert result['gpu0']['gpu_utilization'] == 35.0

--- a/src/middlewared/middlewared/utils/metrics/gpu_usage.py
+++ b/src/middlewared/middlewared/utils/metrics/gpu_usage.py
@@ -1,0 +1,319 @@
+import json
+import logging
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+NVIDIA_SMI_QUERY_FIELDS = (
+    'index',
+    'name',
+    'utilization.gpu',
+    'utilization.memory',
+    'memory.total',
+    'memory.used',
+    'memory.free',
+    'temperature.gpu',
+    'fan.speed',
+    'power.draw',
+)
+
+# xpu-smi dump metric IDs:
+# 0 = GPU Utilization (%)
+# 1 = GPU Power (W)
+# 3 = GPU Core Temperature (C)
+# 5 = GPU Memory Utilization (%)
+# 18 = GPU Memory Used (MiB)
+XPU_SMI_METRIC_IDS = '0,1,3,5,18'
+
+# xpu-smi discovery dump metric IDs:
+# 0 = Device ID
+# 1 = Device Name
+# 16 = Memory Physical Size (MiB)
+XPU_SMI_DISCOVERY_IDS = '0,1,16'
+
+
+def get_gpu_usage() -> dict[str, dict]:
+    """
+    Retrieve GPU usage statistics from all supported GPU vendors.
+
+    Attempts to query GPU metrics using nvidia-smi, rocm-smi, and xpu-smi.
+    Returns a dictionary keyed by GPU identifier (e.g. 'gpu0', 'gpu1') with
+    usage details for each GPU.
+
+    Returns:
+        dict[str, dict]: Dictionary containing GPU usage metrics for each
+            detected GPU. Returns empty dict if no supported GPUs are found
+            or the query tools are unavailable.
+    """
+    gpus = {}
+    gpus.update(_get_nvidia_gpu_usage())
+    gpus.update(_get_amd_gpu_usage())
+    gpus.update(_get_intel_gpu_usage())
+    return gpus
+
+
+def _get_nvidia_gpu_usage() -> dict[str, dict]:
+    """Query NVIDIA GPUs using nvidia-smi."""
+    nvidia_smi = shutil.which('nvidia-smi')
+    if not nvidia_smi:
+        return {}
+
+    try:
+        result = subprocess.run(
+            [
+                nvidia_smi,
+                '--query-gpu=' + ','.join(NVIDIA_SMI_QUERY_FIELDS),
+                '--format=csv,noheader,nounits',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug('Failed to query nvidia-smi: %s', e)
+        return {}
+
+    if result.returncode != 0:
+        logger.debug('nvidia-smi returned non-zero exit code: %d', result.returncode)
+        return {}
+
+    gpus = {}
+    for line in result.stdout.strip().splitlines():
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) < len(NVIDIA_SMI_QUERY_FIELDS):
+            continue
+
+        index = parts[0]
+        gpu_key = f'gpu{index}'
+        gpus[gpu_key] = {
+            'index': int(index),
+            'name': parts[1],
+            'gpu_utilization': _parse_float(parts[2]),
+            'memory_utilization': _parse_float(parts[3]),
+            'memory_total': _parse_int(parts[4]),
+            'memory_used': _parse_int(parts[5]),
+            'memory_free': _parse_int(parts[6]),
+            'temperature': _parse_int(parts[7]),
+            'fan_speed': _parse_int(parts[8]),
+            'power_draw': _parse_float(parts[9]),
+        }
+
+    return gpus
+
+
+def _get_amd_gpu_usage() -> dict[str, dict]:
+    """Query AMD GPUs using rocm-smi with JSON output."""
+    rocm_smi = shutil.which('rocm-smi')
+    if not rocm_smi:
+        return {}
+
+    try:
+        result = subprocess.run(
+            [
+                rocm_smi,
+                '--showuse', '--showmemuse', '--showtemp',
+                '--showpower', '--showfan', '--showproductname',
+                '--showmeminfo', 'vram',
+                '--json',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug('Failed to query rocm-smi: %s', e)
+        return {}
+
+    if result.returncode != 0:
+        logger.debug('rocm-smi returned non-zero exit code: %d', result.returncode)
+        return {}
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.debug('Failed to parse rocm-smi JSON output: %s', e)
+        return {}
+
+    gpus = {}
+    for card_index, (card_key, card_data) in enumerate(sorted(data.items())):
+        if not card_key.startswith('card'):
+            continue
+
+        vram_total_bytes = _parse_int(card_data.get('VRAM Total Memory (B)'))
+        vram_used_bytes = _parse_int(card_data.get('VRAM Total Used Memory (B)'))
+        vram_total_mib = int(vram_total_bytes / (1024 * 1024)) if vram_total_bytes is not None else None
+        vram_used_mib = int(vram_used_bytes / (1024 * 1024)) if vram_used_bytes is not None else None
+        vram_free_mib = (vram_total_mib - vram_used_mib) if (
+            vram_total_mib is not None and vram_used_mib is not None
+        ) else None
+
+        gpu_use = _parse_float(card_data.get('GPU use (%)'))
+        mem_use = _parse_float(card_data.get('GPU memory use (%)'))
+
+        temperature = _amd_parse_temperature(card_data)
+        power_draw = _amd_parse_power(card_data)
+
+        fan_speed_raw = card_data.get('Fan Speed (%)')
+        fan_speed = _parse_int(fan_speed_raw) if fan_speed_raw else None
+
+        name = card_data.get('Card Series') or card_data.get('Card Model') or f'AMD GPU {card_key}'
+
+        gpu_key = f'gpu{card_index}'
+        gpus[gpu_key] = {
+            'index': card_index,
+            'name': name,
+            'gpu_utilization': gpu_use,
+            'memory_utilization': mem_use,
+            'memory_total': vram_total_mib,
+            'memory_used': vram_used_mib,
+            'memory_free': vram_free_mib,
+            'temperature': temperature,
+            'fan_speed': fan_speed,
+            'power_draw': power_draw,
+        }
+
+    return gpus
+
+
+def _amd_parse_temperature(card_data: dict) -> int | None:
+    """Extract temperature from AMD GPU data, trying common key patterns."""
+    for key in card_data:
+        if 'temperature' in key.lower() and 'edge' in key.lower():
+            val = _parse_int(card_data[key])
+            if val is not None:
+                return val
+    for key in card_data:
+        if 'temperature' in key.lower() and '(c)' in key.lower():
+            val = _parse_int(card_data[key])
+            if val is not None:
+                return val
+    return None
+
+
+def _amd_parse_power(card_data: dict) -> float | None:
+    """Extract power draw from AMD GPU data, trying common key patterns."""
+    for key in card_data:
+        if 'power' in key.lower() and '(w)' in key.lower():
+            return _parse_float(card_data[key])
+    return None
+
+
+def _get_intel_gpu_usage() -> dict[str, dict]:
+    """Query Intel GPUs using xpu-smi."""
+    xpu_smi = shutil.which('xpu-smi')
+    if not xpu_smi:
+        return {}
+
+    discovery = _xpu_smi_discover(xpu_smi)
+
+    try:
+        result = subprocess.run(
+            [
+                xpu_smi, 'dump',
+                '-d', '-1',
+                '-m', XPU_SMI_METRIC_IDS,
+                '-n', '1',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug('Failed to query xpu-smi dump: %s', e)
+        return {}
+
+    if result.returncode != 0:
+        logger.debug('xpu-smi dump returned non-zero exit code: %d', result.returncode)
+        return {}
+
+    gpus = {}
+    for line in result.stdout.strip().splitlines():
+        if line.startswith('Timestamp'):
+            continue
+
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) < 6:
+            continue
+
+        device_id = parts[1].strip()
+        gpu_key = f'gpu{device_id}'
+        device_id_int = _parse_int(device_id)
+        if device_id_int is None:
+            continue
+
+        info: tuple[str, int] | None = discovery.get(device_id_int)
+
+        vram_total_mib = info[1] if info is not None else None
+        vram_used_mib = _parse_int(parts[6]) if len(parts) == 7 else None
+        vram_free_mib = (vram_total_mib - vram_used_mib) if (
+                vram_total_mib is not None and vram_used_mib is not None
+        ) else None
+
+        gpus[gpu_key] = {
+            'index': device_id_int,
+            'name': info[0] if info is not None else f'Intel GPU {device_id}',
+            'gpu_utilization': _parse_float(parts[2]),
+            'memory_utilization': _parse_float(parts[5]),
+            'memory_total': vram_total_mib,
+            'memory_used': vram_used_mib,
+            'memory_free': vram_free_mib,
+            'temperature': _parse_int(parts[4]),
+            'fan_speed': None,
+            'power_draw': _parse_float(parts[3]),
+        }
+
+    return gpus
+
+
+def _xpu_smi_discover(xpu_smi: str) -> dict[int, tuple[str, int]]:
+    """Get Intel GPU device names via xpu-smi discovery --dump."""
+    try:
+        result = subprocess.run(
+            [xpu_smi, 'discovery', '--dump', XPU_SMI_DISCOVERY_IDS],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug('Failed to query xpu-smi discovery: %s', e)
+        return {}
+
+    if result.returncode != 0:
+        return {}
+
+    gpus = {}
+    for line in result.stdout.strip().splitlines():
+        if line.startswith('Device'):
+            continue
+
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) < 3:
+            continue
+
+        device_id = parts[0].strip()
+        device_name = parts[1].replace('"', '')
+        memory_total_mb = _parse_int(parts[2].replace('"', '').replace(' MiB', ''))
+        device_id_int = _parse_int(device_id)
+        if device_id_int is None:
+            continue
+
+        gpus[device_id_int] = (device_name, memory_total_mb)
+
+    return gpus
+
+
+def _parse_float(value: str) -> float | None:
+    """Parse a float value, returning None for unavailable readings."""
+    try:
+        return round(float(value), 2)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_int(value: str) -> int | None:
+    """Parse an integer value, returning None for unavailable readings."""
+    try:
+        return int(float(value))
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
Initial GPU usage endpoint implementation.

This is a rough draft to get it started.  
I've never touched TrueNas before so I'm not sure if I got all the usages correct.

Things to be looked at:
- Should probably get rid of `gputemp` and instead do `truenas_gpu_temp` like disk.
- I probably messed up a chart, since I was using CPU's as a reference but GPU's don't have cores. Plus there can be multiple GPU's.

Possible future extensions:
- Connecting it up to the alerts system, like CPU temperature.
- More GPU stats could be included, although I wanted to keep it simple.
- Linking the internal `get_gpu()` id's with these id's. They don't touch each other currently.

Needed for https://github.com/truenas/webui/discussions/9865
Would be incredibly useful to have the GPU stats in the dashboard and reporting when doing gpu-heavy operations.