### PR TITLE
NAS-140882 / 27.0.0-BETA.1 / only update initramfs on value change

### DIFF
--- a/src/middlewared/middlewared/plugins/tunable/crud.py
+++ b/src/middlewared/middlewared/plugins/tunable/crud.py
@@ -132,13 +132,18 @@ class TunableServicePart(CRUDServicePart[TunableEntry]):
                 else:
                     await self.to_thread(reset_sysctl, self.middleware, new, failover_licensed)
             elif new.type == 'ZFS':
-                if new.enabled:
-                    await self.to_thread(set_zfs_parameter, self.middleware, new.var, new.value, failover_licensed)
-                else:
-                    await self.to_thread(reset_zfs_parameter, self.middleware, new, failover_licensed)
+                # Skip the kernel write and initramfs rebuild when neither
+                # `value` nor `enabled` changed — those are the only fields
+                # that affect the live ZFS parameter or the modprobe file.
+                # A comment-only edit doesn't need to touch either.
+                if old.value != new.value or old.enabled != new.enabled:
+                    if new.enabled:
+                        await self.to_thread(set_zfs_parameter, self.middleware, new.var, new.value, failover_licensed)
+                    else:
+                        await self.to_thread(reset_zfs_parameter, self.middleware, new, failover_licensed)
 
-                if data.update_initramfs:
-                    await update_initramfs(self.middleware, failover_licensed)
+                    if data.update_initramfs:
+                        await update_initramfs(self.middleware, failover_licensed)
             else:
                 await handle_tunable_change(self.middleware, new.model_dump(), failover_licensed)
         except Exception:

--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -271,6 +271,36 @@ def test_zfs_no_rebuild_when_modprobe_unchanged():
             call("tunable.delete", tunable["id"], job=True)
 
 
+def test_zfs_no_rebuild_on_metadata_only_change():
+    """
+    do_update must not invoke `update-initramfs` (or rewrite the live ZFS
+    parameter) when a ZFS tunable's `value`/`enabled` haven't changed.
+    Editing a cosmetic field like `comment` doesn't affect kernel state or
+    the modprobe file, so the kernel write and initramfs rebuild are
+    skipped entirely.
+    """
+    with mock_update_initramfs():
+        tunable = call("tunable.create", {
+            "type": "ZFS",
+            "var": ZFS,
+            "value": ZFS_NEW_VALUE,
+        }, job=True)
+        try:
+            # Create on enabled tunable bumps the counter once.
+            assert_update_initramfs_run_count(1)
+
+            call("tunable.update", tunable["id"], {
+                "comment": "metadata-only change",
+            }, job=True)
+
+            # The update persisted in the DB...
+            assert call("tunable.get_instance", tunable["id"])["comment"] == "metadata-only change"
+            # ...but do_update skipped the kernel write and initramfs path.
+            assert_update_initramfs_run_count(1)
+        finally:
+            call("tunable.delete", tunable["id"], job=True)
+
+
 def test_arc_max_set():
     tunable = call("tunable.create", {"type": "ZFS", "var": "zfs_arc_max", "value": "8675309"}, job=True)
     try:


### PR DESCRIPTION
When a tunable is updated, we only need to regenerate initramfs if the actual value or enabled state is changed. If someone changes the comment, there is no reason to regenerate it. Adds a test to validate this scenario too.