### PR TITLE
NAS-140884 / 27.0.0-BETA.1 / write debug kernel to initramfs file

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -30,7 +30,6 @@ BOOT_POOL_NAME = BOOT_POOL_DISKS = None
 
 
 class BootUpdateInitramfsOptions(BaseModel):
-    database: str | None = None
     force: bool = False
 
 
@@ -233,8 +232,6 @@ class BootService(Service):
         Returns true if initramfs was updated and false otherwise.
         """
         args = ['/']
-        if options['database']:
-            args.extend(['-d', options['database']])
         if options['force']:
             args.extend(['-f'])
 
@@ -319,10 +316,6 @@ class BootService(Service):
             )
 
 
-async def on_config_upload(middleware, path):
-    await middleware.call('boot.update_initramfs', {'database': path})
-
-
 async def setup(middleware):
     global BOOT_POOL_NAME
 
@@ -350,5 +343,3 @@ async def setup(middleware):
             break
     else:
         middleware.logger.error('Failed to detect boot pool name.')
-
-    middleware.register_hook('config.on_upload', on_config_upload, sync=True)

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -1,3 +1,4 @@
+import asyncio
 from copy import deepcopy
 import re
 import tempfile
@@ -20,6 +21,8 @@ from middlewared.service import ConfigService, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run
 from middlewared.utils.service.settings import SettingsHelper
+
+from .debug_kernel import write_debug_kernel_flag
 
 settings = SettingsHelper()
 
@@ -254,6 +257,9 @@ class SystemAdvancedService(ConfigService):
 
             if original_data['debugkernel'] != config_data['debugkernel']:
                 generate_grub = True
+                # Keep the on-disk flag in sync on every transition so
+                # truenas-initrd.py reads the right value on the next regen.
+                await asyncio.to_thread(write_debug_kernel_flag, self.middleware)
 
             if original_data['nvidia'] != config_data['nvidia']:
                 await self.middleware.call('system.advanced.handle_nvidia_toggle')

--- a/src/middlewared/middlewared/plugins/system_advanced/debug_kernel.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/debug_kernel.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING
+
+from truenas_os_pyutils.io import atomic_write
+
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
+
+
+# Materialized from system.advanced.config['debugkernel']. truenas-initrd.py
+# reads this file to decide whether to (re)build the debug kernel's initrd
+# alongside the production kernel's. Lives under /data so it survives BE
+# upgrades (the installer rsyncs /data into the new BE).
+DEBUG_KERNEL_FLAG_PATH = "/data/subsystems/initramfs/debug_kernel"
+
+
+def write_debug_kernel_flag(middleware: Middleware) -> bool:
+    """
+    Materialize the `debugkernel` setting to a stable path under /data.
+
+    Returns True if the file changed (caller should force an initramfs
+    rebuild so truenas-initrd.py picks up the new value).
+
+    Sync — call from a thread (`asyncio.to_thread`) when invoked from a
+    coroutine.
+    """
+    desired = "0\n"
+    if middleware.call_sync("system.advanced.config")["debugkernel"]:
+        desired = "1\n"
+
+    try:
+        with open(DEBUG_KERNEL_FLAG_PATH) as f:
+            existing = f.read()
+    except FileNotFoundError:
+        existing = ""
+    if existing == desired:
+        return False
+    os.makedirs(os.path.dirname(DEBUG_KERNEL_FLAG_PATH), exist_ok=True)
+    with atomic_write(DEBUG_KERNEL_FLAG_PATH, "w") as f:
+        f.write(desired)
+    return True
+
+
+async def _event_system_ready(middleware, event_type, args):
+    # Don't block boot
+    middleware.create_task(_reconcile(middleware))
+
+
+async def _reconcile(middleware):
+    try:
+        changed = await asyncio.to_thread(write_debug_kernel_flag, middleware)
+        if changed:
+            # Flag drifted from the live DB (factory install, upgrade from a
+            # release that didn't write it, config upload, etc.). Force a
+            # rebuild so the new flag value is honored on next boot.
+            await middleware.call("boot.update_initramfs", {"force": True})
+    except Exception:
+        middleware.logger.error("Failed to reconcile debug_kernel flag", exc_info=True)
+
+
+async def setup(middleware):
+    middleware.event_subscribe("system.ready", _event_system_ready)


### PR DESCRIPTION
Same justification for doing this as outlined in https://github.com/truenas/middleware/pull/18878