### PR TITLE
NAS-140886 / 27.0.0-BETA.1 / Simplify `LongString`

### DIFF
--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -11,7 +11,7 @@ from pydantic.main import ModelT
 from pydantic.types import SecretType
 from pydantic_core import SchemaSerializer, core_schema
 
-from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
+from middlewared.api.base.types.string import SECRET_VALUE
 from middlewared.utils.lang import undefined
 from middlewared.utils.typing_ import is_union
 
@@ -35,10 +35,7 @@ def _serialize_secret(value: Secret[SecretType], info: core_schema.Serialization
     Return the hidden value if "expose_secrets" was passed to `model_dump`. Otherwise, return the redaction string.
     """
     if isinstance(info.context, dict) and info.context.get("expose_secrets") is True:
-        return_val = value.get_secret_value()
-        if isinstance(return_val, LongStringWrapper):
-            return_val = return_val.value
-        return return_val
+        return value.get_secret_value()
     else:
         # always serialize Secret as if info.mode="json" (never return a Secret object)
         return SECRET_VALUE
@@ -103,10 +100,15 @@ def _apply_model_serializer(cls: type["BaseModel"], model_serializer: PydanticDe
     cls.model_rebuild(force=True)
 
 
-def _annotate_not_required(annotation: type[Any] | None):
+def _annotate_not_required(annotation: type[Any] | None, metadata: list[Any] = ()):
     if get_origin(annotation) is Secret:
-        new_annotation = Secret[get_args(annotation)[0] | _NotRequired]
+        inner = get_args(annotation)[0]
+        if metadata:
+            inner = Annotated[inner, *metadata]
+        new_annotation = Secret[inner | _NotRequired]
     else:
+        if metadata:
+            annotation = Annotated[annotation, *metadata]
         new_annotation = annotation | _NotRequired
 
     return new_annotation
@@ -126,7 +128,12 @@ class _BaseModelMetaclass(ModelMetaclass):
             if field.default is NotRequired:
                 # Update annotation of any field with a default of `NotRequired` since fields
                 # are serialized according to their annotation, not their value.
-                field.annotation = _annotate_not_required(field.annotation)
+                # Field metadata (e.g. `MaxLen`) is folded into the inner annotation so the
+                # constraint applies to the typed arm of the union rather than only to the
+                # union as a whole — otherwise the model config's `str_max_length` wins for
+                # the bare `str` arm.
+                field.annotation = _annotate_not_required(field.annotation, field.metadata)
+                field.metadata = []
                 has_not_required = True
 
         if has_not_required:

--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -1,17 +1,13 @@
-from typing import Annotated, Any
+from typing import Annotated
 import uuid
 
 from pydantic import (
     AfterValidator,
-    BeforeValidator,
     Field,
-    GetCoreSchemaHandler,
-    PlainSerializer,
 )
 from pydantic import (
     HttpUrl as _HttpUrl,
 )
-from pydantic_core import CoreSchema, PydanticKnownError, core_schema
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base.validators import email_validator, time_validator
@@ -22,48 +18,6 @@ __all__ = [
     "HttpUrl", "LongString", "NonEmptyString", "LongNonEmptyString", "SECRET_VALUE", "TimeString", "NetbiosDomain",
     "NetbiosName", "SnapshotNameSchema", "EmailString", "SmbShareName", "UUIDv4String",
 ]
-
-
-class LongStringWrapper:
-    """
-    We have to box our long strings in this class to bypass the global limit for string length.
-    """
-
-    max_length = 2048000  # historic maximum length of string in filesystem.file_receive
-    __normalize_as__ = str
-
-    def __init__(self, value):
-        if isinstance(value, LongStringWrapper):
-            value = value.value
-
-        if not isinstance(value, str):
-            raise PydanticKnownError("string_type")
-
-        if len(value) > self.max_length:
-            raise PydanticKnownError("string_too_long", {"max_length": self.max_length})
-
-        self.value = value
-
-    def __len__(self):
-        return len(self.value)
-
-    def __eq__(self, other):
-        return isinstance(other, LongStringWrapper) and self.value == other.value
-
-    def __repr__(self):
-        return f"LongStringWrapper({self.value})"
-
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
-    ) -> CoreSchema:
-        return core_schema.json_or_python_schema(
-            json_schema=core_schema.str_schema(),
-            python_schema=core_schema.no_info_after_validator_function(
-                cls,
-                core_schema.is_instance_schema(LongStringWrapper),
-            ),
-        )
 
 
 def uuidv4_validator(value):
@@ -77,11 +31,7 @@ def uuidv4_validator(value):
 
 HttpUrl = Annotated[_HttpUrl, AfterValidator(str)]
 # By default, our strings are no more than 1024 characters long. This string is 2**31-1 characters long (SQLite limit).
-LongString = Annotated[
-    LongStringWrapper,
-    BeforeValidator(LongStringWrapper),
-    PlainSerializer(lambda x: x.value if isinstance(x, LongStringWrapper) else x),
-]
+LongString = Annotated[str, Field(max_length=2 ** 31 - 1)]
 NonEmptyString = Annotated[str, Field(min_length=1)]
 LongNonEmptyString = Annotated[LongString, Field(min_length=1)]
 TimeString = Annotated[str, AfterValidator(time_validator), Field(examples=["00:00", "06:30", "18:00", "23:00"])]

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_schema_construction_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_schema_construction_utils.py
@@ -252,14 +252,7 @@ def test_text_field_type():
     model = generate_pydantic_model(schema, 'TestText', NOT_PROVIDED)
     # Should accept long text
     long_text = 'x' * 10000  # 10KB text
-    m = model(content=long_text)
-    # LongString type returns a wrapper object, need to access its value
-    # Check that the content was set (it's a LongStringWrapper object)
-    assert hasattr(m.content, '__str__')
-    # Check field type is LongString
-    field_type = model.model_fields['content'].annotation
-    # The annotation might be wrapped, so check if LongString is in the string representation
-    assert 'LongString' in str(field_type)
+    model(content=long_text)
 
 
 def test_path_field_type():
@@ -2450,34 +2443,6 @@ def test_valid_chars_with_immutable_field():
     # Cannot change even to another valid pattern
     with pytest.raises(ValidationError):
         model_update(instance_id='i-5678efgh')
-
-
-def test_valid_chars_with_text_field_type():
-    """Test valid_chars with text (LongString) field type"""
-    # Note: valid_chars with text type currently has issues because LongString
-    # wraps the value and the validator expects a string
-    # This test documents the current limitation
-    schema = [
-        {
-            'variable': 'config_content',
-            'schema': {
-                'type': 'text',  # LongString type
-                'valid_chars': '^[A-Za-z0-9\n\r\t =]+$',  # Allow alphanumeric, newlines, tabs, spaces, equals
-                'required': True
-            }
-        }
-    ]
-
-    model = generate_pydantic_model(schema, 'TestTextValidChars', NOT_PROVIDED)
-
-    # Currently this fails because LongStringWrapper is not a string
-    # Documenting this as a known limitation
-    with pytest.raises(TypeError) as exc_info:
-        config = """key1=value1
-key2=value2
-section=data"""
-        model(config_content=config)
-    assert "expected string or bytes-like object, got 'LongStringWrapper'" in str(exc_info.value)
 
 
 def test_valid_chars_error_message():


### PR DESCRIPTION
Our current `LongString` implementation boxes all strings in `LongStringWrapper`. Sometimes it's transparent, but sometimes we need to unbox it explicitly, which leads to quite ugly code. This is a better implementation that does not need that.