### PR TITLE
NAS-140892 / 27.0.0-BETA.1 / Expand usage of atomic_write and truenas_os

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/ssh/config.py
+++ b/src/middlewared/middlewared/etc_files/local/ssh/config.py
@@ -1,9 +1,9 @@
 import base64
-from contextlib import suppress
 import os
 import re
 import shutil
-import stat
+
+from truenas_os_pyutils.io import atomic_write
 
 SSH_CONFIG_PATH = '/etc/ssh'
 
@@ -17,64 +17,23 @@ SSH_KEYS = [
 DEFAULT_FILES = ['moduli', 'ssh_config', 'ssh_config.d', 'sshd_config', 'sshd_config.d']
 
 
-def generate_ssh_config(middleware, ssh_config, dirfd):
-    mode = 0o600
-
-    def opener(path, flags):
-        return os.open(path, flags, mode=mode, dir_fd=dirfd)
-
+def render(service, middleware, render_ctx):
+    ssh_config = render_ctx['ssh.config']
     for k in SSH_KEYS:
         s_key = re.sub(r'([.-])', '_', k).replace('ssh_', '', 1)
         if ssh_config[s_key]:
             decoded_key = base64.b64decode(ssh_config[s_key])
             if decoded_key:
                 mode = 0o644 if k.endswith('.pub') else 0o600
-
-                with open(k, 'wb', opener=opener) as f:
-                    st = os.fstat(f.fileno())
-                    if stat.S_ISREG(st.st_mode) == 0:
-                        middleware.logger.warning(
-                            "%s/%s: is not a regular file and will be removed. "
-                            "This may impact SSH access to the server.",
-                            SSH_CONFIG_PATH, k
-                        )
-                        with suppress(FileNotFoundError):
-                            os.remove(os.path.join(SSH_CONFIG_PATH, k))
-
-                    if stat.S_IMODE(st.st_mode) != mode:
-                        middleware.logger.debug(
-                            "%s/%s: file has unexpected permissions [%s]. "
-                            "Changing to new value [%s].",
-                            SSH_CONFIG_PATH, k, stat.S_IMODE(st.st_mode), mode
-                        )
-                        os.fchmod(f.fileno(), mode)
-
-                    if st.st_uid != 0 or st.st_gid != 0:
-                        middleware.logger.debug(
-                            "%s/%s: unexpected user or group ownership [%d:%d]. "
-                            "Changing to new value [0:0]. ",
-                            SSH_CONFIG_PATH, k, st.st_uid, st.st_gid
-                        )
-                        os.fchown(f.fileno(), 0, 0)
-
+                with atomic_write(os.path.join(SSH_CONFIG_PATH, k), 'wb', perms=mode) as f:
                     f.write(decoded_key)
 
     expected_files = SSH_KEYS + DEFAULT_FILES
-    with os.scandir(dirfd) as entries:
+    with os.scandir(SSH_CONFIG_PATH) as entries:
         for entry in filter(lambda x: x.name not in expected_files, entries):
             if entry.is_dir():
-                middleware.logger.debug("%s: removing unexpected directory.",
-                                        os.path.join(SSH_CONFIG_PATH, entry.name))
-                shutil.rmtree(os.path.join(SSH_CONFIG_PATH, entry.name))
+                middleware.logger.debug("%s: removing unexpected directory.", entry.path)
+                shutil.rmtree(entry.path)
             else:
-                middleware.logger.debug("%s: removing unexpected file.",
-                                        os.path.join(SSH_CONFIG_PATH, entry.name))
-                os.remove(entry.name, dir_fd=dirfd)
-
-
-def render(service, middleware, render_ctx):
-    dirfd = os.open(SSH_CONFIG_PATH, os.O_RDONLY | os.O_DIRECTORY)
-    try:
-        generate_ssh_config(middleware, render_ctx['ssh.config'], dirfd)
-    finally:
-        os.close(dirfd)
+                middleware.logger.debug("%s: removing unexpected file.", entry.path)
+                os.remove(entry.path)

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -256,11 +256,31 @@ class FilesystemService(Service):
         if p.exists():
             raise CallError(f'{path}: path already exists.', errno.EEXIST)
 
-        realpath = os.path.realpath(path)
-        if not realpath.startswith(('/mnt/', '/root/.ssh', '/home/admin/.ssh', '/home/truenas_admin/.ssh')):
-            raise CallError(f'{path}: path not permitted', errno.EPERM)
+        # Resolve the parent with no symlink follow and operate via dir_fd, so the
+        # prefix check below cannot be raced against the mkdir.
+        parent = os.path.dirname(path) or '/'
+        basename = os.path.basename(path)
+        try:
+            parent_fd = truenas_os.openat2(
+                parent, os.O_DIRECTORY,
+                resolve=truenas_os.RESOLVE_NO_SYMLINKS,
+            )
+        except OSError as e:
+            if e.errno == errno.ELOOP:
+                raise CallError(f'{path}: symlinks in path are not permitted', errno.EPERM)
+            if e.errno == errno.ENOENT:
+                raise CallError(f'{path}: parent directory does not exist', errno.ENOENT)
+            raise
 
-        os.mkdir(path, mode=mode)
+        try:
+            realpath = os.path.join(os.readlink(f'/proc/self/fd/{parent_fd}'), basename)
+            if not realpath.startswith(('/mnt/', '/root/.ssh', '/home/admin/.ssh', '/home/truenas_admin/.ssh')):
+                raise CallError(f'{path}: path not permitted', errno.EPERM)
+
+            os.mkdir(basename, mode=mode, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
         st = stat_x.statx_entry_impl(p)
         stat = st['st']
 

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -1,7 +1,8 @@
 from contextlib import suppress
 import os
-import tempfile
 import typing
+
+from truenas_os_pyutils.io import atomic_write
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -57,20 +58,13 @@ class NFSService(Service):
                     pass
             else:
                 # Replace rmtab excluding ip_to_clear
-                with tempfile.NamedTemporaryFile(
-                    mode='wt',
-                    dir=NFSServicePathInfo.STATEDIR.path(),
-                    delete=False
-                ) as outf:
+                with atomic_write(rmtab) as outf:
                     with open(rmtab, "r") as inf:
                         for entry in inf:
                             if entry.split(':')[0] in ip_to_clear:
                                 continue
                             else:
                                 outf.write(entry)
-                    outf.flush()
-                    os.fsync(outf.fileno())
-                    os.rename(outf.name, rmtab)
 
     @filterable_api_method(
         item=NFSGetNfs3ClientsEntry,

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import uuid
 
+import truenas_os
 from truenas_pylibzfs import ZFSError, ZFSException
 
 from middlewared.api import api_method
@@ -280,7 +281,13 @@ class PoolDatasetService(Service):
                         # we already checked above that path above is not a mountpoint and we didn't have a
                         # covert mount under us of this dataset. So we should be able to simply rename here.
                         try:
-                            os.rename(mount_path, f'{mount_path}-{str(uuid.uuid4())[:4]}-{datetime.now().isoformat()}')
+                            # AT_RENAME_NOREPLACE so a race that materializes the destination name surfaces
+                            # as an error instead of silently clobbering whatever appeared.
+                            truenas_os.renameat2(
+                                mount_path,
+                                f'{mount_path}-{str(uuid.uuid4())[:4]}-{datetime.now().isoformat()}',
+                                flags=truenas_os.AT_RENAME_NOREPLACE,
+                            )
                         except Exception as e:
                             self.logger.error('%s: failed to move unexpected directory or file from mount path',
                                               mount_path, exc_info=True)

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -8,7 +8,8 @@ import subprocess
 import threading
 import uuid
 
-from truenas_os_pyutils.mount import iter_mountinfo, statmount
+import truenas_os
+from truenas_os_pyutils.mount import iter_mountinfo, statmount, umount
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -392,9 +393,23 @@ class SystemDatasetService(ConfigService):
                 except Exception:
                     self.logger.warning("Failed to clear old core files.", exc_info=True)
 
-            subprocess.run(['umount', '/var/lib/systemd/coredump'], check=False)
+            # ValueError when /var/lib/systemd/coredump is not a mountpoint.
+            with suppress(OSError, ValueError):
+                umount('/var/lib/systemd/coredump')
             os.makedirs('/var/lib/systemd/coredump', exist_ok=True)
-            subprocess.run(['mount', '--bind', corepath, '/var/lib/systemd/coredump'])
+            with suppress(OSError):
+                tree_fd = truenas_os.open_tree(
+                    path=corepath,
+                    flags=truenas_os.OPEN_TREE_CLONE | truenas_os.OPEN_TREE_CLOEXEC,
+                )
+                try:
+                    truenas_os.move_mount(
+                        from_path='', from_dirfd=tree_fd,
+                        to_path='/var/lib/systemd/coredump',
+                        flags=truenas_os.MOVE_MOUNT_F_EMPTY_PATH,
+                    )
+                finally:
+                    os.close(tree_fd)
 
         return self.middleware.call_sync('systemdataset.config')
 
@@ -633,7 +648,8 @@ class SystemDatasetService(ConfigService):
                 os.mkdir(f'{MIDDLEWARE_RUN_DIR}/system.new')
             else:
                 # Make sure we clean up any previous attempts
-                subprocess.run(['umount', '-R', path], check=False)
+                with suppress(OSError, ValueError):
+                    umount(path, recursive=True)
         else:
             path = SYSDATASET_PATH
 
@@ -655,7 +671,8 @@ class SystemDatasetService(ConfigService):
                 # same way: non-fatal.
                 if cp.returncode in (0, 24):
                     # Let's make sure that we don't have coredump directory mounted
-                    subprocess.run(['umount', '/var/lib/systemd/coredump'], check=False)
+                    with suppress(OSError, ValueError):
+                        umount('/var/lib/systemd/coredump')
                     self.__umount(_from, config['uuid'])
                     self.__umount(_to, config['uuid'])
                     self.__mount(_to, config['uuid'], SYSDATASET_PATH)

--- a/src/middlewared/middlewared/utils/directoryservices/ipa.py
+++ b/src/middlewared/middlewared/utils/directoryservices/ipa.py
@@ -1,7 +1,7 @@
 from configparser import RawConfigParser
 from io import StringIO
-import os
-from tempfile import NamedTemporaryFile
+
+from truenas_os_pyutils.io import atomic_write
 
 from .ipa_constants import IPAPath
 
@@ -52,15 +52,9 @@ def generate_ipa_default_config(
 
 
 def _write_ipa_file(ipa_path: IPAPath, data: bytes) -> str:
-    with NamedTemporaryFile(dir=IPAPath.IPADIR.path, delete=False) as f:
+    with atomic_write(ipa_path.path, 'wb', tmppath=IPAPath.IPADIR.path, perms=ipa_path.perm) as f:
         f.write(data)
-        f.flush()
-        os.rename(f.name, ipa_path.path)
-        os.fchmod(f.fileno(), ipa_path.perm)
-        if not os.path.exists(ipa_path.path):
-            raise RuntimeError(f'{ipa_path.path}: failed to create file')
-
-        return ipa_path.path
+    return ipa_path.path
 
 
 def write_ipa_default_config(

--- a/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
@@ -11,9 +11,9 @@ from copy import deepcopy
 from enum import Enum, auto
 import ipaddress
 import logging
-import os
-from tempfile import NamedTemporaryFile
 from typing import Optional
+
+from truenas_os_pyutils.io import atomic_write
 
 from .krb5_constants import KRB_ETYPE, KRB_AppDefaults, KRB_LibDefaults, KRB_RealmProperty
 
@@ -392,9 +392,5 @@ class KRB5Conf():
         Write the stored krb5.conf file to the specified `path`
         """
         config = self.generate()
-        with NamedTemporaryFile(delete=False, dir=os.path.dirname(path)) as f:
-            f.write(config.encode())
-            f.flush()
-            os.fchmod(f.fileno(), 0o644)
-
-            os.rename(f.name, path)
+        with atomic_write(path, perms=0o644) as f:
+            f.write(config)


### PR DESCRIPTION
This commit expands the use of atomic_write across many areas of the product where we were basically hand-rolling the same.

Some subprocess calls in the system dataset plugin are also opportunistically replaced with syscalls to OS fd-based mount and unmount interfaces.