### PR TITLE
NAS-140732 / 27.0.0-BETA.1 / Handle missing compose service label in app query

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -224,7 +224,11 @@ def translate_resources_to_desired_workflow(app_resources: dict[str, Any]) -> di
     host_ips = set()
     workloads['containers'] = len(app_resources['containers'])
     for container in app_resources['containers']:
-        service_name = container['Config']['Labels'][COMPOSE_SERVICE_KEY]
+        service_name = (
+            container['Config']['Labels'].get(COMPOSE_SERVICE_KEY)
+            or container.get('Name', '').lstrip('/')
+            or 'unknown'
+        )
         container_ports_config = []
         images.add(container['Config']['Image'])
         for container_port, host_config in container.get('NetworkSettings', {}).get('Ports', {}).items():


### PR DESCRIPTION
This commit adds fixes for app.query crashing with KeyError when a container tagged with the com.docker.compose.project label is missing the com.docker.compose.service label. A single such container would take down the entire apps panel since the unconditional label lookup in translate_resources_to_desired_workflow raised before any app data could be returned.

The label is now read defensively, falling back to the container name (or 'unknown') for the displayed service_name. The container is still counted and its ports, volumes, images, and state are still aggregated normally.

This can potentially happen when user has manually deployed containers.