### PR TITLE
NAS-140901 / 27.0.0-BETA.1 / Skip unsupported CI tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/iscsi.py
+++ b/src/middlewared/middlewared/test/integration/assets/iscsi.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import platform
 import time
 
+from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import RunOnRunnerException, call, run_on_runner
 
 # We could be running these tests on a Linux or FreeBSD test-runner, so the commands
@@ -156,3 +157,36 @@ def target_login_test_freebsd(portal_ip, target_name, check_surfaced_luns=None):
             return True
         finally:
             run_on_runner(['iscsictl', '-R', '-t', target_name], check=False)
+
+
+def lio_supported() -> bool:
+    """Return True if LIO mode (2) is accepted by the API.
+
+    Probes by stopping the iSCSI service if it is running, attempting to set
+    mode=2, then restoring the original mode and service running state.
+    """
+    _SERVICE = "iscsitarget"
+    _LIO_MODE = 2
+
+    cfg = call("iscsi.global.config")
+    original_mode = cfg["mode"]
+    was_running = call("service.started", _SERVICE)
+
+    if was_running:
+        call("service.control", "STOP", _SERVICE, job=True)
+
+    accepted = True
+    try:
+        call("iscsi.global.update", {"mode": _LIO_MODE})
+    except ValidationErrors as e:
+        if any(err.attribute == "iscsi_update.mode" for err in e.errors):
+            accepted = False
+        else:
+            raise
+    finally:
+        if accepted:
+            call("iscsi.global.update", {"mode": original_mode})
+        if was_running:
+            call("service.control", "START", _SERVICE, job=True)
+
+    return accepted

--- a/tests/sharing_protocols/iscsi/test_264_iscsi_mode_compat.py
+++ b/tests/sharing_protocols/iscsi/test_264_iscsi_mode_compat.py
@@ -33,6 +33,7 @@ from assets.websocket.iscsi import (
 from assets.websocket.pool import zvol as zvol_dataset
 from assets.websocket.service import ensure_service_enabled
 from auto_config import pool_name
+from middlewared.test.integration.assets.iscsi import lio_supported
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.utils.client import truenas_server
 from protocols import ISCSIDiscover, iscsi_scsi_connection
@@ -176,6 +177,14 @@ def _vendor_nibbles_from_naa(naa_hex):
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _require_lio():
+    """Skip entire module if LIO mode (2) is not supported by the API."""
+    if not lio_supported():
+        pytest.skip('LIO mode (2) not accepted by API')
+    yield
 
 
 @pytest.fixture(scope='module')

--- a/tests/sharing_protocols/iscsi/test_265_iscsi_portal_binding.py
+++ b/tests/sharing_protocols/iscsi/test_265_iscsi_portal_binding.py
@@ -40,6 +40,7 @@ from assets.websocket.iscsi import (
 from assets.websocket.pool import zvol as zvol_dataset
 from auto_config import pool_name
 from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.iscsi import lio_supported
 from middlewared.test.integration.utils import call
 from protocols import ISCSIDiscover, iscsi_scsi_connection
 from assets.websocket.service import ensure_service_enabled
@@ -119,6 +120,14 @@ def file_extent(dataset_path, filename, filesize_mb, extent_name):
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _require_lio():
+    """Skip entire module if LIO mode (2) is not supported by the API."""
+    if not lio_supported():
+        pytest.skip('LIO mode (2) not accepted by API')
+    yield
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Skip LIO CI tests for now.

----

Passing (or skipping) CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/2187/).