### PR TITLE
NAS-140911 / 27.0.0-BETA.1 / fix the build (remove isodate)

### DIFF
--- a/src/middlewared/middlewared/plugins/zettarepl_/snapshot_removal_date.py
+++ b/src/middlewared/middlewared/plugins/zettarepl_/snapshot_removal_date.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
+from datetime import datetime
 import errno
 import subprocess
 
 from dateutil.tz import tzlocal
-import isodate
 from zettarepl.snapshot.list import list_snapshots
 from zettarepl.snapshot.name import parse_snapshot_name
 from zettarepl.snapshot.task.snapshot_owner import PeriodicSnapshotTaskSnapshotOwner
@@ -43,7 +43,7 @@ class ZettareplService(Service):
             snapshot_pool = snapshot.split("/")[0]
 
             try:
-                destroy_at = isodate.parse_datetime(destroy_at)
+                destroy_at = datetime.fromisoformat(destroy_at)
             except Exception as e:
                 self.middleware.logger.warning("Error parsing snapshot %r %s: %r", snapshot, property_name, e)
                 continue
@@ -154,7 +154,7 @@ class ZettareplService(Service):
 
             if property_name in sup:
                 try:
-                    property_destroy_at = isodate.parse_datetime(sup[property_name])
+                    property_destroy_at = datetime.fromisoformat(sup[property_name])
                 except Exception:
                     self.logger.warning(
                         "Error parsing snapshot %r %s",

--- a/src/middlewared/middlewared/sqlalchemy.py
+++ b/src/middlewared/middlewared/sqlalchemy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 from typing import Any
 
-import isodate
 from sqlalchemy import CHAR, Boolean, ForeignKey, Index, Integer, SmallInteger, String, Table, Text, UniqueConstraint
 from sqlalchemy import JSON as NativeJSON
 from sqlalchemy import Column as _Column
@@ -156,18 +155,18 @@ class Time(UserDefinedType[datetime.time]):
             return None
 
         if isinstance(value, str):
-            parsed = isodate.parse_time(value)
+            parsed = datetime.time.fromisoformat(value)
         else:
             parsed = value
 
-        return parsed.isoformat()  # type: ignore[no-any-return]
+        return parsed.isoformat()
 
     def bind_processor(self, dialect: Any) -> Any:
         return self._bind_processor
 
     def _result_processor(self, value: str) -> datetime.time:
         try:
-            return isodate.parse_time(value)  # type: ignore[no-any-return]
+            return datetime.time.fromisoformat(value)
         except Exception:
             return datetime.time()
 

--- a/src/middlewared/pyproject.toml
+++ b/src/middlewared/pyproject.toml
@@ -32,7 +32,7 @@ plugins = ["sqlalchemy.ext.mypy.plugin"]
 module = [
     "acme.*", "apps_ci.*", "apps_schema.*", "apps_validation.*", "boto3.*", "botocore.*",
     "catalog_reader.*", "certbot_dns_cloudflare.*", "certbot_dns_digitalocean.*", "influxdb.*",
-    "isodate.*", "ixhardware.*", "josepy.*", "lexicon.*", "licenselib.*", "mako.*", "pam.*", "samba.*", "pyctdb.*",
+    "ixhardware.*", "josepy.*", "lexicon.*", "licenselib.*", "mako.*", "pam.*", "samba.*", "pyctdb.*",
     "pyudev.*", "tdb.*", "truenas_pysnmp.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
`isodate` was never a declared
dependency of middleware — it was being pulled in transitively (via
`zettarepl`), and our code happened to work by pure chance. The
zettarepl change that drops it (https://github.com/truenas/zettarepl/pull/357)
has already merged, so `import isodate` now fails at import time and
any module that touches it can't load. This PR removes our two
remaining usages and unbreaks the build.

### Changes

- **`src/middlewared/middlewared/sqlalchemy.py`** — the `Time` UDT used
  `isodate.parse_time` on bind/result. Replaced with
  `datetime.time.fromisoformat`. Both sides of the column already round-
  trip through `time.isoformat()`, so the format read back is always
  standard extended ISO 8601 — exactly what `fromisoformat` accepts on
  Python 3.11+. The two `# type: ignore[no-any-return]` comments were
  dropped since the stdlib calls have proper return-type annotations.

- **`src/middlewared/middlewared/plugins/zettarepl_/snapshot_removal_date.py`**
  — `isodate.parse_datetime` was used to parse the ZFS snapshot removal-
  date user property. Replaced with `datetime.fromisoformat`. The
  property is written by middleware itself via `destroy_at.isoformat()`,
  so the values being read back are always standard extended format.
  Both call sites are already wrapped in `try/except` with graceful
  fallbacks (warn-and-skip, default `time()`), so any input that
  `fromisoformat` rejects but `isodate` would have accepted (basic
  format without separators, ordinal/week dates) hits the existing
  error path rather than crashing.

- **`src/middlewared/pyproject.toml`** — removed the leftover
  `"isodate.*"` entry from the mypy `ignore_missing_imports` override.
  It was a tell that we never had a declared dep: the only reason the
  override existed was that mypy couldn't find stubs for a module we
  weren't actually depending on.

### Why this worked before

`isodate` ships in the Debian package archive and was being installed
as a transitive dep of `zettarepl`. Middleware never declared it in
`debian/control` or anywhere else, so as soon as the zettarepl edge
went away the import broke. The leftover `"isodate.*"` line in the
mypy override was the only trace of it in middleware's own config —
itself a tell that we never had a declared dep, since the override
only existed because mypy couldn't find stubs for a module we weren't
actually depending on.