### PR TITLE
NAS-140915 / 27.0.0-BETA.1 / Add recursion for filesystem.set_zfs_attributes

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v26_0_0/filesystem.py
@@ -376,17 +376,30 @@ class ZFSFileAttrsData(BaseModel):
     """ SPARSE MS-DOS attribute. Is presented to SMB clients, but has no impact on local filesystem. """
 
 
+FilesystemZFSAttrRecursiveTarget = Literal['FILES', 'DIRECTORIES']
+
+
+class FilesystemSetZfsAttributesOptions(BaseModel):
+    recursive: list[FilesystemZFSAttrRecursiveTarget] | None = None
+    """If set, walk the tree under `path` and apply attributes to entries whose type \
+    appears in the list (`FILES`, `DIRECTORIES`, or both). The root `path` is included \
+    only if its type matches the filter. `null` means no recursion (operate on `path` \
+    only). An empty list is rejected."""
+
+
 @single_argument_args('set_zfs_file_attributes')
 class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
-    """Path to the file to set ZFS attributes on."""
+    """Path to the file or directory to set ZFS attributes on."""
     zfs_file_attributes: ZFSFileAttrsData
     """ZFS file attributes to set."""
+    options: FilesystemSetZfsAttributesOptions = Field(default=FilesystemSetZfsAttributesOptions())
+    """Additional options including recursion behavior."""
 
 
 class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
-    """The updated ZFS file attributes."""
+    """The updated ZFS file attributes for the root `path`."""
 
 
 class FilesystemGetZfsAttributesArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v27_0_0/filesystem.py
@@ -376,17 +376,30 @@ class ZFSFileAttrsData(BaseModel):
     """ SPARSE MS-DOS attribute. Is presented to SMB clients, but has no impact on local filesystem. """
 
 
+FilesystemZFSAttrRecursiveTarget = Literal['FILES', 'DIRECTORIES']
+
+
+class FilesystemSetZfsAttributesOptions(BaseModel):
+    recursive: list[FilesystemZFSAttrRecursiveTarget] | None = None
+    """If set, walk the tree under `path` and apply attributes to entries whose type \
+    appears in the list (`FILES`, `DIRECTORIES`, or both). The root `path` is included \
+    only if its type matches the filter. `null` means no recursion (operate on `path` \
+    only). An empty list is rejected."""
+
+
 @single_argument_args('set_zfs_file_attributes')
 class FilesystemSetZfsAttributesArgs(BaseModel):
     path: NonEmptyString
-    """Path to the file to set ZFS attributes on."""
+    """Path to the file or directory to set ZFS attributes on."""
     zfs_file_attributes: ZFSFileAttrsData
     """ZFS file attributes to set."""
+    options: FilesystemSetZfsAttributesOptions = Field(default=FilesystemSetZfsAttributesOptions())
+    """Additional options including recursion behavior."""
 
 
 class FilesystemSetZfsAttributesResult(BaseModel):
     result: ZFSFileAttrsData
-    """The updated ZFS file attributes."""
+    """The updated ZFS file attributes for the root `path`."""
 
 
 class FilesystemGetZfsAttributesArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -79,6 +79,7 @@ from middlewared.utils.account.authenticator import AccountFlag, UserPamAuthenti
 from middlewared.utils.account.faillock import reset_tally, tally_locked_users
 from middlewared.utils.crypto import check_unixhash, generate_nt_hash, generate_string, sha512_crypt
 from middlewared.utils.directoryservices.constants import DSStatus, DSType
+from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.filter_list import filter_list
 from middlewared.utils.nss import grp, pwd
 from middlewared.utils.nss.nss_common import NssModule
@@ -2560,10 +2561,11 @@ async def setup(middleware):
     try:
         # ensure that our default home path is always immutable. If it's not immutable then
         # pam_mkhomedir will start creating dirs within it on user login
-        await middleware.call('filesystem.set_zfs_attributes', {
-            'path': DEFAULT_HOME_PATH,
-            'zfs_file_attributes': {'immutable': True}
-        })
+        await middleware.run_in_thread(
+            fs_attrs.set_zfs_file_attributes_dict,
+            DEFAULT_HOME_PATH,
+            {'immutable': True},
+        )
     except Exception:
         middleware.logger.error('Failed to set immutable property on %r', DEFAULT_HOME_PATH, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -43,7 +43,8 @@ from middlewared.api.current import (
 from middlewared.event import EventSource
 from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
-from middlewared.service import CallError, Service, filterable_api_method, job, private
+from middlewared.plugins.filesystem_.utils import apply_zfs_attrs_recursive
+from middlewared.service import CallError, Service, ValidationErrors, filterable_api_method, job, private
 from middlewared.utils.filesystem import attrs, stat_x
 from middlewared.utils.filesystem.acl import ACL_UNDEFINED_ID, acl_is_present
 from middlewared.utils.filesystem.constants import FileType
@@ -155,38 +156,79 @@ class FilesystemService(Service):
         audit='Filesystem set ZFS attributes',
         audit_extended=lambda data: data['path']
     )
-    def set_zfs_attributes(self, data):
+    @job(lock=lambda args: f'zfs_attrs_change:{args[0]["path"]}')
+    def set_zfs_attributes(self, job, data):
         """
-        Set special ZFS-related file flags on the specified path
+        Set special ZFS-related file flags on the specified path.
 
-        `readonly` - this maps to READONLY MS-DOS attribute. When set, file may not be
-        written to (toggling does not impact existing file opens).
+        `readonly` - READONLY MS-DOS attribute. When set, file may not be written to
+        (toggling does not impact existing file opens).
 
-        `hidden` - this maps to HIDDEN MS-DOS attribute. When set, the SMB HIDDEN flag
-        is set and file is "hidden" from the perspective of SMB clients.
+        `hidden` - HIDDEN MS-DOS attribute. When set, the SMB HIDDEN flag is set and
+        file is "hidden" from the perspective of SMB clients.
 
-        `system` - this maps to SYSTEM MS-DOS attribute. Is presented to SMB clients, but
-        has no impact on local filesystem.
+        `system` - SYSTEM MS-DOS attribute. Is presented to SMB clients, but has no
+        impact on local filesystem.
 
-        `archive` - this maps to ARCHIVE MS-DOS attribute. Value is reset to True whenever
-        file is modified.
+        `archive` - ARCHIVE MS-DOS attribute. Value is reset to True whenever file is
+        modified.
 
         `immutable` - file may not be altered or deleted. Also appears as IMMUTABLE in
-        attributes in `filesystem.stat` output and as STATX_ATTR_IMMUTABLE in statx() response.
+        attributes in `filesystem.stat` output and as STATX_ATTR_IMMUTABLE in statx().
 
         `nounlink` - file may be altered but not deleted.
 
-        `appendonly` - file may only be opened with O_APPEND flag. Also appears as APPEND in
-        attributes in `filesystem.stat` output and as STATX_ATTR_APPEND in statx() response.
+        `appendonly` - file may only be opened with O_APPEND flag. Also appears as
+        APPEND in attributes in `filesystem.stat` output and as STATX_ATTR_APPEND in
+        statx() response.
 
-        `offline` - this maps to OFFLINE MS-DOS attribute. Is presented to SMB clients, but
-        has no impact on local filesystem.
+        `offline` - OFFLINE MS-DOS attribute. Is presented to SMB clients, but has no
+        impact on local filesystem.
 
-        `sparse` - maps to SPARSE MS-DOS attribute. Is presented to SMB clients, but has
-        no impact on local filesystem.
+        `sparse` - SPARSE MS-DOS attribute. Is presented to SMB clients, but has no
+        impact on local filesystem.
+
+        `options.recursive` - if set to a non-empty list of `FILES`/`DIRECTORIES`,
+        the path is treated as the root of a tree walk and attributes are applied to
+        descendants of the matching type. The root `path` itself is included only if
+        its type matches the filter. `null` (the default) preserves the legacy
+        single-path behavior. Recursion stops at dataset boundaries.
         """
+        recursive = data['options']['recursive']
+        if recursive is not None and len(recursive) == 0:
+            verrors = ValidationErrors()
+            verrors.add(
+                'filesystem.set_zfs_attributes.options.recursive',
+                'Must be null or a non-empty list of FILES/DIRECTORIES.',
+            )
+            verrors.check()
+
+        job.set_progress(0, 'Setting ZFS attributes')
         try:
-            return attrs.set_zfs_file_attributes_dict(data['path'], data['zfs_file_attributes'])
+            if recursive is None:
+                # Legacy single-path semantics — cheap path, no walker.
+                return attrs.set_zfs_file_attributes_dict(
+                    data['path'], data['zfs_file_attributes']
+                )
+
+            try:
+                fd = truenas_os.openat2(
+                    data['path'], os.O_RDWR, resolve=truenas_os.RESOLVE_NO_SYMLINKS
+                )
+                is_dir = False
+            except IsADirectoryError:
+                fd = truenas_os.openat2(
+                    data['path'], os.O_DIRECTORY, resolve=truenas_os.RESOLVE_NO_SYMLINKS
+                )
+                is_dir = True
+
+            try:
+                return apply_zfs_attrs_recursive(
+                    fd, is_dir, data['zfs_file_attributes'], recursive,
+                    job=job,
+                )
+            finally:
+                os.close(fd)
         except OSError as e:
             if e.errno == errno.ELOOP:
                 raise CallError('Symlinks are not permitted.', errno.ELOOP)

--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -22,7 +22,6 @@ from middlewared.api.current import (
     FilesystemSetpermResult,
 )
 from middlewared.service import Service, ValidationErrors, job, private
-from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.service_exception import CallError, MatchNotFound, ValidationError
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
@@ -179,9 +178,8 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem change owner', audit_extended=lambda data: data['path']
     )
-    @pass_thread_local_storage
     @job(lock="perm_change")
-    def chown(self, job, tls, data):
+    def chown(self, job, data):
         """
         Change owner or group of file at `path`.
 
@@ -229,7 +227,7 @@ class FilesystemService(Service):
             os.fchown(fd, uid, gid)
             if options['recursive']:
                 job.set_progress(10, f'Recursively changing owner of {data["path"]}.')
-                AclTool(fd, AclToolAction.CHOWN, uid, gid, ATChownOptions(traverse=options['traverse']), job, tls).run()
+                AclTool(fd, AclToolAction.CHOWN, uid, gid, ATChownOptions(traverse=options['traverse']), job).run()
         finally:
             os.close(fd)
         job.set_progress(100, 'Finished changing owner.')
@@ -239,9 +237,8 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set permission', audit_extended=lambda data: data['path']
     )
-    @pass_thread_local_storage
     @job(lock="perm_change")
-    def setperm(self, job, tls, data):
+    def setperm(self, job, data):
         """
         Set unix permissions on given `path`.
 
@@ -330,7 +327,7 @@ class FilesystemService(Service):
             if options['recursive']:
                 job.set_progress(10, f'Recursively setting permissions on {data["path"]}.')
                 AclTool(fd, AclToolAction.STRIP, uid, gid,
-                        ATPermOptions(traverse=options['traverse'], target_mode=mode), job, tls).run()
+                        ATPermOptions(traverse=options['traverse'], target_mode=mode), job).run()
         finally:
             os.close(fd)
         job.set_progress(100, 'Finished setting permissions.')
@@ -498,7 +495,7 @@ class FilesystemService(Service):
             )
 
     @private
-    def setacl_nfs4(self, job, tls, current_acl, data):
+    def setacl_nfs4(self, job, current_acl, data):
         job.set_progress(0, 'Preparing to set acl.')
         recursive = data['options'].get('recursive', False)
         do_strip = data['options'].get('stripacl', False)
@@ -545,14 +542,14 @@ class FilesystemService(Service):
 
             os.fchown(fd, data['uid'], data['gid'])
             if recursive:
-                AclTool(fd, action, data['uid'], data['gid'], acl_opts, job, tls).run()
+                AclTool(fd, action, data['uid'], data['gid'], acl_opts, job).run()
         finally:
             os.close(fd)
 
         job.set_progress(100, 'Finished setting NFSv4 ACL.')
 
     @private
-    def setacl_posix1e(self, job, tls, current_acl, data):
+    def setacl_posix1e(self, job, current_acl, data):
         job.set_progress(0, 'Preparing to set acl.')
         options = data['options']
         recursive = options.get('recursive', False)
@@ -629,7 +626,7 @@ class FilesystemService(Service):
 
             os.fchown(fd, data['uid'], data['gid'])
             if recursive:
-                AclTool(fd, action, data['uid'], data['gid'], acl_opts, job, tls).run()
+                AclTool(fd, action, data['uid'], data['gid'], acl_opts, job).run()
         finally:
             os.close(fd)
 
@@ -642,9 +639,8 @@ class FilesystemService(Service):
         audit='Filesystem set ACL',
         audit_extended=lambda data: data['path']
     )
-    @pass_thread_local_storage
     @job(lock="perm_change")
-    def setacl(self, job, tls, data):
+    def setacl(self, job, data):
         """
         Set ACL of a given path. Takes the following parameters:
         `path` full path to directory or file.
@@ -812,9 +808,9 @@ class FilesystemService(Service):
 
         match current_acl['acltype']:
             case FS_ACL_Type.NFS4:
-                self.setacl_nfs4(job, tls, current_acl, data)
+                self.setacl_nfs4(job, current_acl, data)
             case FS_ACL_Type.POSIX1E:
-                self.setacl_posix1e(job, tls, current_acl, data)
+                self.setacl_posix1e(job, current_acl, data)
             case FS_ACL_Type.DISABLED:
                 raise CallError(f"{data['path']}: ACLs disabled on path.", errno.EOPNOTSUPP)
             case _:

--- a/src/middlewared/middlewared/plugins/filesystem_/utils.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/utils.py
@@ -7,7 +7,6 @@ import types
 import truenas_os
 from truenas_os_pyutils.mount import statmount as _statmount
 
-from middlewared.plugins.zfs.object_count_impl import estimate_object_count_impl
 from middlewared.service_exception import CallError
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
@@ -16,6 +15,12 @@ from middlewared.utils.filesystem.acl import (
     nfs4acl_obj_to_dict,
     posixacl_dict_to_obj,
     posixacl_obj_to_dict,
+)
+from middlewared.utils.filesystem.attrs import (
+    dict_to_zfs_attributes_mask,
+    fget_zfs_file_attributes,
+    fset_zfs_file_attributes,
+    zfs_attributes_to_dict,
 )
 
 
@@ -76,67 +81,59 @@ def _get_mount_info(fd: int):
     return sm.mnt_point, sm.sb_source, (None if rel == '.' else rel), sm.mnt_id
 
 
-class AclTool:
+class _FsRecursionOp:
     """
-    Perform recursive ACL-related operations using fd-based operations via the
-    truenas_os extension.
+    Recursive filesystem operation engine.
+
+    Walks the tree under an open O_RDONLY directory `fd` via
+    truenas_os.iter_filesystem_contents, optionally crossing dataset
+    boundaries (options.traverse), and emits job progress updates throttled
+    to >= 1s. Subclasses implement `_apply_action_fd` to perform the
+    per-entry work and may override `_setup` for one-time precomputation.
 
     `fd` must be an open O_RDONLY descriptor for the root path of the
-    operation.  AclTool reads from it but does NOT close it; the caller owns
-    the descriptor lifetime.
-
-    If `job` is provided, progress updates are emitted no more frequently than
-    every 1 second.
+    operation. The base class reads from it but does NOT close it; the
+    caller owns the descriptor lifetime.
     """
 
+    _label = 'fsrecursion'
+
+    # ZFS datasets have 6 internal objects (master node, SA attrs, unlinked
+    # set, root dir, SA attr registration, SA attr layouts) reported in
+    # f_files; subtract them so progress reflects user-visible objects. For
+    # non-ZFS filesystems the offset is harmless (estimate is approximate).
+    _ZFS_INTERNAL_OBJECTS = 6
+
     __slots__ = (
-        'fd', 'action', 'uid', 'gid', 'options', 'job', 'tls',
-        'nfs4_inh', 'posix_file_acl', '_action_fd_fn',
+        'fd', 'options', 'job',
         'total_objects', 'cumulative_processed', 'last_report_time',
     )
 
-    _OPTIONS_TYPE = types.MappingProxyType({
-        AclToolAction.CHOWN: ATChownOptions,
-        AclToolAction.STRIP: ATPermOptions,
-        AclToolAction.CLONE: ATAclOptions,
-        AclToolAction.INHERIT: ATAclOptions,
-    })
-
-    _ACTION_FN = types.MappingProxyType({
-        AclToolAction.CHOWN: '_do_chown',
-        AclToolAction.STRIP: '_do_strip',
-        AclToolAction.CLONE: '_do_acl',
-        AclToolAction.INHERIT: '_do_acl',
-    })
-
-    def __init__(self, fd, action, uid, gid, options, job=None, tls=None):
-        expected = self._OPTIONS_TYPE[action]
-        if not isinstance(options, expected):
-            raise TypeError(f'{action}: expected {expected.__name__}, got {type(options).__name__}')
+    def __init__(self, fd, options, job=None):
         self.fd = fd
-        self.action = action
-        self.uid = uid
-        self.gid = gid
         self.options = options
         self.job = job
-        self.tls = tls
         self.total_objects = 0
         self.cumulative_processed = 0
         self.last_report_time = time.monotonic()
-        self.nfs4_inh = None
-        self.posix_file_acl = None
-        self._action_fd_fn = getattr(self, self._ACTION_FN[action])
 
     def _estimate_total(self, fs_name, mnt_id):
-        """Populate self.total_objects before iteration begins."""
-        if self.job is None or self.tls is None:
+        """Populate self.total_objects before iteration begins.
+
+        Uses fstatvfs(f_files - f_ffree) on the root fd plus statvfs() on each
+        child mount when traverse is enabled. No libzfs handle required.
+        """
+        if self.job is None:
             return
         # Subdirectory: dataset-wide estimate would dwarf actual work
-        mountpoint, _, rel_path, _ = _get_mount_info(self.fd)
+        _, _, rel_path, _ = _get_mount_info(self.fd)
         if rel_path is not None:
             return
         try:
-            self.total_objects = estimate_object_count_impl(self.tls, fs_name)
+            sv = os.fstatvfs(self.fd)
+            self.total_objects = max(
+                sv.f_files - sv.f_ffree - self._ZFS_INTERNAL_OBJECTS, 0
+            )
             if self.options.traverse:
                 real_path = os.readlink(f'/proc/self/fd/{self.fd}')
                 _sm_flags = (
@@ -149,8 +146,13 @@ class AclTool:
                         continue
                     if entry.fs_type == 'zfs' and entry.sb_source and '@' in entry.sb_source:
                         continue
-                    if entry.fs_type == 'zfs' and entry.sb_source:
-                        self.total_objects += estimate_object_count_impl(self.tls, entry.sb_source)
+                    try:
+                        sv = os.statvfs(entry.mnt_point)
+                    except OSError:
+                        continue
+                    self.total_objects += max(
+                        sv.f_files - sv.f_ffree - self._ZFS_INTERNAL_OBJECTS, 0
+                    )
         except Exception:
             self.total_objects = 0
 
@@ -168,31 +170,15 @@ class AclTool:
             f'Processing {state.current_directory} ({self.cumulative_processed:,} files processed)',
         )
 
-    def _do_chown(self, fd, isdir, depth):
-        os.fchown(fd, self.uid, self.gid)
+    def _setup(self):
+        """Override for one-time setup before walk begins (default: no-op)."""
 
-    def _do_strip(self, fd, isdir, depth):
-        truenas_os.fsetacl(fd, None)
-        if self.uid != ACL_UNDEFINED_ID or self.gid != ACL_UNDEFINED_ID:
-            os.fchown(fd, self.uid, self.gid)
-        if self.options.target_mode is not None:
-            os.fchmod(fd, self.options.target_mode & 0o7777)
-
-    def _do_acl(self, fd, isdir, depth):
-        if self.nfs4_inh is not None:
-            # NFS4: use precomputed depth/type-specific inherited ACL
-            truenas_os.fsetacl(fd, self.nfs4_inh.pick(depth, isdir))
-        elif not isdir:
-            # POSIX1E file: use precomputed file-inherited ACL
-            truenas_os.fsetacl(fd, self.posix_file_acl)
-        else:
-            # POSIX1E dir: apply root ACL directly
-            truenas_os.fsetacl(fd, self.options.target_acl)
-        if self.uid != ACL_UNDEFINED_ID or self.gid != ACL_UNDEFINED_ID:
-            os.fchown(fd, self.uid, self.gid)
+    def _apply_action_fd(self, fd, isdir, depth):
+        """Subclass hook: apply the operation to a single open fd."""
+        raise NotImplementedError
 
     def _apply_action(self, item, it, depth_offset=0):
-        self._action_fd_fn(item.fd, item.isdir, depth_offset + len(it.dir_stack()))
+        self._apply_action_fd(item.fd, item.isdir, depth_offset + len(it.dir_stack()))
 
     def _process_mount(self, mnt_point, fs, rel, depth_offset=0):
         reporting_cb = self._report_progress if self.job is not None else None
@@ -209,18 +195,13 @@ class AclTool:
                 try:
                     self._apply_action(item, it, depth_offset)
                 except OSError as e:
-                    raise CallError(f'acltool [{self.action}] failed on item in {mnt_point}: {e}')
+                    raise CallError(f'{self._label} failed on item in {mnt_point}: {e}')
 
     def run(self):
         mountpoint, fs_name, rel_path, mnt_id = _get_mount_info(self.fd)
 
         self._estimate_total(fs_name, mnt_id)
-
-        if self.action in (AclToolAction.CLONE, AclToolAction.INHERIT):
-            if isinstance(self.options.target_acl, truenas_os.NFS4ACL):
-                self.nfs4_inh = _NFS4InheritedAcls.from_root(self.options.target_acl)
-            elif isinstance(self.options.target_acl, truenas_os.POSIXACL):
-                self.posix_file_acl = self.options.target_acl.generate_inherited_acl(is_dir=False)
+        self._setup()
 
         self._process_mount(mountpoint, fs_name, rel_path)
 
@@ -248,12 +229,152 @@ class AclTool:
                 try:
                     try:
                         self.cumulative_processed += 1
-                        self._action_fd_fn(child_fd, True, child_depth)
+                        self._apply_action_fd(child_fd, True, child_depth)
                     except OSError as e:
-                        raise CallError(f'acltool [{self.action}] failed on {child_mnt}: {e}')
+                        raise CallError(f'{self._label} failed on {child_mnt}: {e}')
                     self._process_mount(child_mnt, entry.sb_source, None, depth_offset=child_depth)
                 finally:
                     os.close(child_fd)
+
+
+class AclTool(_FsRecursionOp):
+    """
+    Perform recursive ACL-related operations using fd-based operations via the
+    truenas_os extension.
+    """
+
+    __slots__ = (
+        'action', 'uid', 'gid', 'nfs4_inh', 'posix_file_acl', '_action_fd_fn',
+    )
+
+    _OPTIONS_TYPE = types.MappingProxyType({
+        AclToolAction.CHOWN: ATChownOptions,
+        AclToolAction.STRIP: ATPermOptions,
+        AclToolAction.CLONE: ATAclOptions,
+        AclToolAction.INHERIT: ATAclOptions,
+    })
+
+    _ACTION_FN = types.MappingProxyType({
+        AclToolAction.CHOWN: '_do_chown',
+        AclToolAction.STRIP: '_do_strip',
+        AclToolAction.CLONE: '_do_acl',
+        AclToolAction.INHERIT: '_do_acl',
+    })
+
+    def __init__(self, fd, action, uid, gid, options, job=None):
+        expected = self._OPTIONS_TYPE[action]
+        if not isinstance(options, expected):
+            raise TypeError(f'{action}: expected {expected.__name__}, got {type(options).__name__}')
+        super().__init__(fd, options, job)
+        self.action = action
+        self.uid = uid
+        self.gid = gid
+        self.nfs4_inh = None
+        self.posix_file_acl = None
+        self._action_fd_fn = getattr(self, self._ACTION_FN[action])
+
+    @property
+    def _label(self):
+        return f'acltool [{self.action}]'
+
+    def _setup(self):
+        if self.action in (AclToolAction.CLONE, AclToolAction.INHERIT):
+            if isinstance(self.options.target_acl, truenas_os.NFS4ACL):
+                self.nfs4_inh = _NFS4InheritedAcls.from_root(self.options.target_acl)
+            elif isinstance(self.options.target_acl, truenas_os.POSIXACL):
+                self.posix_file_acl = self.options.target_acl.generate_inherited_acl(is_dir=False)
+
+    def _apply_action_fd(self, fd, isdir, depth):
+        self._action_fd_fn(fd, isdir, depth)
+
+    def _do_chown(self, fd, isdir, depth):
+        os.fchown(fd, self.uid, self.gid)
+
+    def _do_strip(self, fd, isdir, depth):
+        truenas_os.fsetacl(fd, None)
+        if self.uid != ACL_UNDEFINED_ID or self.gid != ACL_UNDEFINED_ID:
+            os.fchown(fd, self.uid, self.gid)
+        if self.options.target_mode is not None:
+            os.fchmod(fd, self.options.target_mode & 0o7777)
+
+    def _do_acl(self, fd, isdir, depth):
+        if self.nfs4_inh is not None:
+            # NFS4: use precomputed depth/type-specific inherited ACL
+            truenas_os.fsetacl(fd, self.nfs4_inh.pick(depth, isdir))
+        elif not isdir:
+            # POSIX1E file: use precomputed file-inherited ACL
+            truenas_os.fsetacl(fd, self.posix_file_acl)
+        else:
+            # POSIX1E dir: apply root ACL directly
+            truenas_os.fsetacl(fd, self.options.target_acl)
+        if self.uid != ACL_UNDEFINED_ID or self.gid != ACL_UNDEFINED_ID:
+            os.fchown(fd, self.uid, self.gid)
+
+
+class ZfsAttrTool(_FsRecursionOp):
+    """
+    Recursively apply a ZFS attribute change to a tree under an open dir fd.
+
+    `attrs_dict` is keyed by lower-case ZFS attr name (None values stripped).
+    Only entries whose type (file or directory) matches `targets` receive
+    the change. Symlinks are skipped (inherited from base walk).
+
+    `targets` is a sequence containing 'FILES', 'DIRECTORIES', or both.
+    """
+
+    _label = 'set_zfs_attributes'
+
+    __slots__ = ('attrs_dict', '_apply_to_files', '_apply_to_dirs')
+
+    def __init__(self, fd, attrs_dict, targets, job=None):
+        super().__init__(fd, ATBaseOptions(traverse=False), job)
+        self.attrs_dict = {k: v for k, v in attrs_dict.items() if v is not None}
+        self._apply_to_files = 'FILES' in targets
+        self._apply_to_dirs = 'DIRECTORIES' in targets
+
+    def _apply_action_fd(self, fd, isdir, depth):
+        if isdir and not self._apply_to_dirs:
+            return
+        if not isdir and not self._apply_to_files:
+            return
+        current = zfs_attributes_to_dict(fget_zfs_file_attributes(fd))
+        new = current | self.attrs_dict
+        if new == current:
+            return
+        fset_zfs_file_attributes(fd, dict_to_zfs_attributes_mask(new))
+
+
+def apply_zfs_attrs_recursive(fd, is_dir, attrs_in, targets, job=None):
+    """
+    Apply ZFS attribute changes to an open root fd and (if `is_dir`) walk
+    the tree under it applying the same change to descendants whose type is
+    in `targets`. The root fd is touched only if its type appears in
+    `targets`.
+
+    `targets` is a sequence containing 'FILES', 'DIRECTORIES', or both.
+    `attrs_in` is the dict from the API model (lower-case keys, bool|None
+    values; None values are ignored).
+
+    Returns the post-op attrs dict for the root, suitable as the API result.
+    """
+    apply_to_root = (
+        (is_dir and 'DIRECTORIES' in targets) or
+        (not is_dir and 'FILES' in targets)
+    )
+
+    current = zfs_attributes_to_dict(fget_zfs_file_attributes(fd))
+
+    if apply_to_root:
+        attrs_filtered = {k: v for k, v in attrs_in.items() if v is not None}
+        new = current | attrs_filtered
+        if new != current:
+            fset_zfs_file_attributes(fd, dict_to_zfs_attributes_mask(new))
+            current = zfs_attributes_to_dict(fget_zfs_file_attributes(fd))
+
+    if is_dir:
+        ZfsAttrTool(fd, attrs_in, targets, job=job).run()
+
+    return current
 
 
 def calculate_inherited_acl(theacl: dict, isdir: bool = True) -> list:

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -34,6 +34,7 @@ from middlewared.service import (
 from middlewared.service.decorators import pass_thread_local_storage
 import middlewared.sqlalchemy as sa
 from middlewared.utils import BOOT_POOL_NAME_VALID
+from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.filter_list import filter_list
 
 from .dataset_query_utils import generic_query
@@ -907,10 +908,11 @@ class PoolDatasetService(CRUDService):
         if dataset['locked'] and mountpoint and await self.middleware.run_in_thread(os.path.exists, mountpoint):
             # We would like to remove the immutable flag in this case so that it's mountpoint can be
             # cleaned automatically when we delete the dataset
-            await self.middleware.call('filesystem.set_zfs_attributes', {
-                'path': mountpoint,
-                'zfs_file_attributes': {'immutable': False}
-            })
+            await self.middleware.run_in_thread(
+                fs_attrs.set_zfs_file_attributes_dict,
+                mountpoint,
+                {'immutable': False},
+            )
 
         async with self.s.truesearch.remove_mountpoint(mountpoint):
             await self.call2(

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -18,6 +18,7 @@ from middlewared.api.current import (
 from middlewared.plugins.zfs.encryption import load_key
 from middlewared.service import CallError, Service, ValidationErrors, job, private
 from middlewared.service.decorators import pass_thread_local_storage
+from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.filesystem.directory import directory_is_empty
 
 from .utils import (
@@ -81,10 +82,11 @@ class PoolDatasetService(Service):
 
         if ds['mountpoint']:
             try:
-                await self.middleware.call('filesystem.set_zfs_attributes', {
-                    'path': ds['mountpoint'],
-                    'zfs_file_attributes': {'immutable': True}
-                })
+                await self.middleware.run_in_thread(
+                    fs_attrs.set_zfs_file_attributes_dict,
+                    ds['mountpoint'],
+                    {'immutable': True},
+                )
             except OSError as e:
                 # EROFS: dataset has readonly=on
                 # ENOENT: mountpoint directory doesn't exist on disk
@@ -262,10 +264,9 @@ class PoolDatasetService(Service):
                             continue
 
                     try:
-                        self.middleware.call_sync('filesystem.set_zfs_attributes', {
-                            'path': mount_path,
-                            'zfs_file_attributes': {'immutable': False}
-                        })
+                        fs_attrs.set_zfs_file_attributes_dict(
+                            mount_path, {'immutable': False},
+                        )
                     except OSError as e:
                         # It's ok to get `EROFS` because the dataset can have `readonly=on`
                         if e.errno != errno.EROFS:
@@ -303,10 +304,9 @@ class PoolDatasetService(Service):
                 else:
                     unlocked.append(ds['name'])
                     try:
-                        self.middleware.call_sync('filesystem.set_zfs_attributes', {
-                            'path': mount_path,
-                            'zfs_file_attributes': {'immutable': False}
-                        })
+                        fs_attrs.set_zfs_file_attributes_dict(
+                            mount_path, {'immutable': False},
+                        )
                     except Exception:
                         pass
 
@@ -328,10 +328,9 @@ class PoolDatasetService(Service):
                 mount_path = os.path.join('/mnt', ds)
                 if os.path.exists(mount_path):
                     try:
-                        self.middleware.call_sync('filesystem.set_zfs_attributes', {
-                            'path': mount_path,
-                            'zfs_file_attributes': {'immutable': True}
-                        })
+                        fs_attrs.set_zfs_file_attributes_dict(
+                            mount_path, {'immutable': True},
+                        )
                     except OSError as e:
                         # It's ok to get `EROFS` because the dataset can have `readonly=on`
                         if e.errno != errno.EROFS:

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -6,6 +6,7 @@ from middlewared.api import api_method
 from middlewared.api.current import PoolExportArgs, PoolExportResult
 from middlewared.service import CallError, Service, ValidationError, job, private
 from middlewared.utils.asyncio_ import asyncio_map
+from middlewared.utils.filesystem import attrs as fs_attrs
 
 
 class PoolService(Service):
@@ -78,10 +79,11 @@ class PoolService(Service):
                 await self.middleware.run_in_thread(os.path.exists, root_ds[0]['mountpoint'])
         ):
             # We should be removing immutable flag in this case if the path exists
-            await self.middleware.call('filesystem.set_zfs_attributes', {
-               'path': root_ds[0]['mountpoint'],
-               'zfs_file_attributes': {'immutable': False}
-            })
+            await self.middleware.run_in_thread(
+                fs_attrs.set_zfs_file_attributes_dict,
+                root_ds[0]['mountpoint'],
+                {'immutable': False},
+            )
 
         pool_count = await self.middleware.call('pool.query', [], {'count': True})
         if pool_count == 1 and await self.middleware.call('failover.licensed'):

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -17,6 +17,7 @@ from middlewared.api.current import (
 from middlewared.plugins.container.utils import container_dataset, container_dataset_mountpoint
 from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.service import CallError, InstanceNotFound, Service, ValidationError, job, private
+from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.zfs import query_imported_fast_impl
 
 from .utils import ZPOOL_CACHE_FILE
@@ -194,10 +195,11 @@ class PoolService(Service):
             encrypted_mountpoint = os.path.join('/mnt', encrypted_ds)
             if await self.middleware.run_in_thread(os.path.exists, encrypted_mountpoint):
                 try:
-                    await self.middleware.call('filesystem.set_zfs_attributes', {
-                        'path': encrypted_mountpoint,
-                        'zfs_file_attributes': {'immutable': True}
-                    })
+                    await self.middleware.run_in_thread(
+                        fs_attrs.set_zfs_file_attributes_dict,
+                        encrypted_mountpoint,
+                        {'immutable': True},
+                    )
                 except Exception as e:
                     self.logger.warning('Failed to set immutable flag at %r: %r', encrypted_mountpoint, e)
 
@@ -555,11 +557,10 @@ class PoolService(Service):
                     # setting the root path as immutable, in a perfect world, will prevent
                     # the scenario that is describe above
                     self.logger.debug('Setting immutable flag at %r', pool_mount)
-                    self.middleware.call_sync('filesystem.set_zfs_attributes', {
-                        'path': pool_mount,
-                        'zfs_file_attributes': {'immutable': True}
-                    })
-                except CallError as e:
+                    fs_attrs.set_zfs_file_attributes_dict(
+                        pool_mount, {'immutable': True},
+                    )
+                except OSError as e:
                     self.logger.error('Unable to set immutable flag at %r: %s', pool_mount, e)
 
     @private

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -69,7 +69,7 @@ def test_immutable_flag():
             call('filesystem.set_zfs_attributes', {
                 'path': d,
                 'zfs_file_attributes': {'immutable': flag_set}
-            })
+            }, job=True)
             # We test 2 things
             # 1) Writing content to the parent path fails/succeeds based on "set"
             # 2) "is_immutable_set" returns sane response
@@ -209,6 +209,159 @@ def test_fiilesystem_statfs_flags():
             assert p[2] in mount_flags, f"{base}: ({p[2]}) not in {mount_flags}"
 
 
+@pytest.fixture(scope="module")
+def attrs_recursive_tree():
+    """Tree with mixed files, directories, and a symlink for recursive attr tests."""
+    with create_dataset("zfs_attrs_recursive") as ds:
+        base = f"/mnt/{ds}"
+        ssh(
+            f"mkdir -p {base}/sub && "
+            f"touch {base}/a.txt {base}/b.txt {base}/sub/c.txt && "
+            f"ln -s a.txt {base}/lnk"
+        )
+        yield base
+
+
+def _hidden(path):
+    return call("filesystem.get_zfs_attributes", path)["hidden"]
+
+
+def test_recursive_files_only_skips_dirs_and_symlinks(attrs_recursive_tree):
+    base = attrs_recursive_tree
+    try:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": True},
+                "options": {"recursive": ["FILES"]},
+            },
+            job=True,
+        )
+        assert _hidden(f"{base}/a.txt") is True
+        assert _hidden(f"{base}/b.txt") is True
+        assert _hidden(f"{base}/sub/c.txt") is True
+        assert _hidden(base) is False
+        assert _hidden(f"{base}/sub") is False
+    finally:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": False},
+                "options": {"recursive": ["FILES", "DIRECTORIES"]},
+            },
+            job=True,
+        )
+
+
+def test_recursive_directories_only_skips_files(attrs_recursive_tree):
+    base = attrs_recursive_tree
+    try:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": True},
+                "options": {"recursive": ["DIRECTORIES"]},
+            },
+            job=True,
+        )
+        assert _hidden(base) is True
+        assert _hidden(f"{base}/sub") is True
+        assert _hidden(f"{base}/a.txt") is False
+        assert _hidden(f"{base}/sub/c.txt") is False
+    finally:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": False},
+                "options": {"recursive": ["FILES", "DIRECTORIES"]},
+            },
+            job=True,
+        )
+
+
+def test_recursive_both_applies_to_all_non_symlinks(attrs_recursive_tree):
+    base = attrs_recursive_tree
+    try:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": True},
+                "options": {"recursive": ["FILES", "DIRECTORIES"]},
+            },
+            job=True,
+        )
+        for p in (base, f"{base}/sub", f"{base}/a.txt", f"{base}/b.txt", f"{base}/sub/c.txt"):
+            assert _hidden(p) is True, p
+    finally:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": base,
+                "zfs_file_attributes": {"hidden": False},
+                "options": {"recursive": ["FILES", "DIRECTORIES"]},
+            },
+            job=True,
+        )
+
+
+def test_recursive_files_only_on_file_path_modifies_root(attrs_recursive_tree):
+    target = f"{attrs_recursive_tree}/a.txt"
+    try:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": target,
+                "zfs_file_attributes": {"hidden": True},
+                "options": {"recursive": ["FILES"]},
+            },
+            job=True,
+        )
+        assert _hidden(target) is True
+    finally:
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": target,
+                "zfs_file_attributes": {"hidden": False},
+            },
+            job=True,
+        )
+
+
+def test_recursive_directories_only_on_file_path_is_noop(attrs_recursive_tree):
+    target = f"{attrs_recursive_tree}/a.txt"
+    before = _hidden(target)
+    res = call(
+        "filesystem.set_zfs_attributes",
+        {
+            "path": target,
+            "zfs_file_attributes": {"hidden": not before},
+            "options": {"recursive": ["DIRECTORIES"]},
+        },
+        job=True,
+    )
+    assert res["hidden"] == before
+    assert _hidden(target) == before
+
+
+def test_recursive_empty_list_is_validation_error(attrs_recursive_tree):
+    with pytest.raises(Exception):
+        call(
+            "filesystem.set_zfs_attributes",
+            {
+                "path": attrs_recursive_tree,
+                "zfs_file_attributes": {"hidden": True},
+                "options": {"recursive": []},
+            },
+            job=True,
+        )
+
+
 def test_dosmodes():
     modes = ("readonly", "hidden", "system", "archive", "offline", "sparse")
     with create_dataset("dosmode_test") as ds:
@@ -222,6 +375,7 @@ def test_dosmodes():
                 res = call(
                     "filesystem.set_zfs_attributes",
                     {"path": p, "zfs_file_attributes": to_set},
+                    job=True,
                 )
                 expected_flags.update(to_set)
                 assert expected_flags == res

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -248,7 +248,7 @@ def set_immutable_state(path: str, want_immutable=True):
     call('filesystem.set_zfs_attributes', {
         'path': path,
         'zfs_file_attributes': {'immutable': want_immutable}
-    })
+    }, job=True)
     is_immutable = 'IMMUTABLE' in call('filesystem.stat', '/etc/exports.d')['attributes']
 
     assert is_immutable is want_immutable, f"Expected mutable filesystem: {want_immutable}"

--- a/tests/api2/test_dataset_unlock_validation.py
+++ b/tests/api2/test_dataset_unlock_validation.py
@@ -29,7 +29,7 @@ def test_encrypted_dataset_unlock_mount_validation(nested_dir, lock_dataset):
             call('filesystem.set_zfs_attributes', {
                 'path': mount_point,
                 'zfs_file_attributes': {'immutable': False}
-            })
+            }, job=True)
 
         ssh(f'mkdir -p {os.path.join(mount_point, nested_dir)}')
 


### PR DESCRIPTION
This commit expands the API for filesystem.set_zfs_attributes to include options for recursion. Specifically, we can do non-recursive, recursive on files only and recursive on directories only, or recursively on both files and directories.