### PR TITLE
NAS-140922 / 27.0.0-BETA.1 / improve VMFlags

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -85,7 +85,9 @@ from middlewared.api.current import (
     VMVirtualizationDetailsResult,
 )
 from middlewared.service import GenericCRUDService, job, private
+from middlewared.utils.cpu import cpu_info
 from middlewared.utils.libvirt.utils import NGINX_PREFIX
+from truenas_pylibvirt.utils import kvm_supported
 
 from .capabilities import guest_architecture_and_machine_choices
 from .clone import clone_vm
@@ -103,7 +105,6 @@ from .info import (
     port_wizard,
     random_mac,
     resolution_choices,
-    supports_virtualization,
     virtualization_details,
     vm_flags,
 )
@@ -278,11 +279,11 @@ class VMService(GenericCRUDService[VMEntry]):
         return cpu_model_choices()
 
     @api_method(VMFlagsArgs, VMFlagsResult, roles=['VM_READ'], check_annotations=True)
-    async def flags(self) -> VMFlags:
+    def flags(self) -> VMFlags:
         """
         Returns a dictionary with CPU flags for the hypervisor.
         """
-        return await vm_flags(self.context)
+        return vm_flags()
 
     @api_method(VMGetAvailableMemoryArgs, VMGetAvailableMemoryResult, roles=['VM_READ'], check_annotations=True)
     async def get_available_memory(self, overcommit: bool) -> int:
@@ -501,7 +502,7 @@ class VMService(GenericCRUDService[VMEntry]):
         """
         Returns "true" if system supports virtualization, "false" otherwise
         """
-        return supports_virtualization()
+        return kvm_supported()
 
     @api_method(VMSuspendArgs, VMSuspendResult, roles=['VM_WRITE'], check_annotations=True)
     def suspend(self, id_: int) -> None:

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -85,7 +85,6 @@ from middlewared.api.current import (
     VMVirtualizationDetailsResult,
 )
 from middlewared.service import GenericCRUDService, job, private
-from middlewared.utils.cpu import cpu_info
 from middlewared.utils.libvirt.utils import NGINX_PREFIX
 from truenas_pylibvirt.utils import kvm_supported
 

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import functools
 import typing
 
+from truenas_pylibvirt.utils import kvm_supported
+
 from middlewared.api import api_method
 from middlewared.api.current import (
     VMBootloaderOptions,
@@ -86,7 +88,6 @@ from middlewared.api.current import (
 )
 from middlewared.service import GenericCRUDService, job, private
 from middlewared.utils.libvirt.utils import NGINX_PREFIX
-from truenas_pylibvirt.utils import kvm_supported
 
 from .capabilities import guest_architecture_and_machine_choices
 from .clone import clone_vm

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -8,6 +8,7 @@ import uuid
 
 from truenas_pylibvirt import DomainDoesNotExistError
 from truenas_pylibvirt.domain.base.configuration import parse_numeric_set
+from truenas_pylibvirt.utils import kvm_supported
 
 from middlewared.api.current import (
     QueryOptions,
@@ -30,7 +31,6 @@ from .info import (
     bootloader_ovmf_choices,
     cpu_model_choices,
     license_active,
-    supports_virtualization,
     vm_flags,
 )
 from .lifecycle import pylibvirt_vm
@@ -281,7 +281,7 @@ class VMServicePart(CRUDServicePart[VMEntry]):
 
         vcpus = data.vcpus * data.cores * data.threads
         if vcpus:
-            flags = await vm_flags(self)
+            flags = vm_flags()
             if vcpus > MAXIMUM_SUPPORTED_VCPUS:
                 verrors.add(
                     f'{schema_name}.vcpus',
@@ -295,7 +295,7 @@ class VMServicePart(CRUDServicePart[VMEntry]):
             elif flags.amd_rvi:
                 if vcpus > 1 and flags.amd_asids is False:
                     verrors.add(f'{schema_name}.vcpus', 'Only one virtual CPU is allowed in this system.')
-            elif not await self.to_thread(supports_virtualization):
+            elif not kvm_supported():
                 verrors.add(schema_name, 'This system does not support virtualization.')
 
         if data.arch_type or data.machine_type:

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -20,7 +20,7 @@ from middlewared.api.current import (
     VMVirtualizationDetails,
 )
 from middlewared.service import ServiceContext
-from middlewared.utils import run
+from middlewared.utils.cpu import cpu_info
 from middlewared.utils.libvirt.display import DisplayDelegate
 from middlewared.utils.libvirt.nic import NICDelegate
 
@@ -34,8 +34,6 @@ BOOT_LOADER_OPTIONS = {
     'UEFI_CSM': 'Legacy BIOS',
 }
 MAXIMUM_SUPPORTED_VCPUS = 255
-RE_VENDOR_AMD = re.compile(r'AuthenticAMD')
-RE_VENDOR_INTEL = re.compile(r'GenuineIntel')
 
 
 def resolution_choices() -> dict[str, str]:
@@ -84,21 +82,6 @@ def log_file_download(context: ServiceContext, job: Job, vm_id: int) -> None:
             shutil.copyfileobj(f, job.pipes.output.w)
 
 
-def supports_virtualization() -> bool:
-    return kvm_supported()
-
-
-def amd_supports_svm() -> bool:
-    try:
-        with open('/proc/cpuinfo', 'r') as f:
-            for line in f:
-                if line.startswith('flags') and 'svm' in line.split():
-                    return True
-    except Exception:
-        pass
-    return False
-
-
 async def license_active(context: ServiceContext) -> bool:
     can_run_vms = True
     if await context.middleware.call('system.is_ha_capable'):
@@ -108,40 +91,35 @@ async def license_active(context: ServiceContext) -> bool:
 
 
 def virtualization_details() -> VMVirtualizationDetails:
-    return VMVirtualizationDetails(
-        supported=kvm_supported(),
-        error=None if kvm_supported() else 'Your CPU does not support KVM extensions',
-    )
+    supported = kvm_supported()
+    error = None
+    if not supported:
+        error = 'Your CPU does not support KVM extensions'
+    return VMVirtualizationDetails(supported=supported, error=error)
 
 
-async def vm_flags(context: ServiceContext) -> VMFlags:
+def vm_flags() -> VMFlags:
     flags = VMFlags(
         intel_vmx=False,
         unrestricted_guest=False,
         amd_rvi=False,
         amd_asids=False,
     )
-    if not await context.to_thread(supports_virtualization):
+    if not kvm_supported():
         return flags
 
-    cp = await run(['lscpu'], check=False)
-    if cp.returncode:
-        context.logger.error('Failed to retrieve CPU details: %s', cp.stderr.decode())
-        return flags
-
-    if RE_VENDOR_INTEL.findall(cp.stdout.decode()):
-        flags.intel_vmx = True
-        unrestricted_guest_path = '/sys/module/kvm_intel/parameters/unrestricted_guest'
-
-        def read_unrestricted_guest() -> None:
-            if os.path.exists(unrestricted_guest_path):
-                with open(unrestricted_guest_path, 'r') as f:
+    ci = cpu_info()  # cpu_info() is cached
+    match ci['vendor_id']:
+        case 'GenuineIntel':
+            flags.intel_vmx = 'vmx' in ci['cpu_flags']
+            try:
+                with open('/sys/module/kvm_intel/parameters/unrestricted_guest') as f:
                     flags.unrestricted_guest = f.read().strip().lower() == 'y'
-
-        await context.middleware.run_in_thread(read_unrestricted_guest)
-    elif RE_VENDOR_AMD.findall(cp.stdout.decode()):
-        flags.amd_rvi = True
-        flags.amd_asids = await context.middleware.run_in_thread(amd_supports_svm)
+            except Exception:
+                pass
+        case 'AuthenticAMD':
+            flags.amd_rvi = 'npt' in ci['cpu_flags']
+            flags.amd_asids = 'svm' in ci['cpu_flags']
 
     return flags
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -68,7 +68,7 @@ async def test_vm_creation_for_licensed_and_unlicensed_systems(is_licensed):
     m['system.feature_enabled'] = lambda *args: is_licensed
     m['datastore.query'] = lambda *args, **kwargs: []
 
-    with patch('middlewared.plugins.vm.crud.vm_flags', new=AsyncMock(return_value=VM_FLAGS)):
+    with patch('middlewared.plugins.vm.crud.vm_flags', new=MagicMock(return_value=VM_FLAGS)):
         verrors = ValidationErrors()
         data = VMCreate(**VM_PAYLOAD)
         await vm_svc._svc_part.validate(verrors, 'vm_create', data)
@@ -108,7 +108,7 @@ async def test_vm_secure_boot_ovmf_validation(enable_secure_boot, bootloader_ovm
     data = VMCreate(**payload)
 
     with (
-        patch('middlewared.plugins.vm.crud.vm_flags', new=AsyncMock(return_value=VM_FLAGS)),
+        patch('middlewared.plugins.vm.crud.vm_flags', new=MagicMock(return_value=VM_FLAGS)),
         patch('middlewared.plugins.vm.crud.bootloader_ovmf_choices', return_value=ovmf_choices),
         patch.object(vm_svc._svc_part, '_create', new=mock_result),
     ):

--- a/src/middlewared/middlewared/utils/cpu.py
+++ b/src/middlewared/middlewared/utils/cpu.py
@@ -29,6 +29,10 @@ sensors = None
 class CpuInfo(typing.TypedDict):
     cpu_model: str | None
     """The CPU model"""
+    vendor_id: str | None
+    """The CPU vendor id (e.g. 'GenuineIntel', 'AuthenticAMD')"""
+    cpu_flags: tuple[str, ...]
+    """The CPU feature flags as reported in /proc/cpuinfo"""
     core_count: int | None
     """The total number of online CPUs"""
     physical_core_count: int
@@ -50,11 +54,19 @@ def cpu_info() -> CpuInfo:
 def cpu_info_impl() -> CpuInfo:
     cc = os.sysconf('SC_NPROCESSORS_ONLN') or None
 
-    cm = None
+    cm: str | None = None
+    vid: str | None = None
+    cf: tuple[str, ...] = ()
     with open('/proc/cpuinfo', 'rb') as f:
-        for line in filter(lambda x: x.startswith(b'model name'), f):
-            cm = line.split(b':')[-1].strip().decode() or None
-            break
+        for line in f:
+            if cm is None and line.startswith(b'model name'):
+                cm = line.split(b':', 1)[-1].strip().decode() or None
+            elif vid is None and line.startswith(b'vendor_id'):
+                vid = line.split(b':', 1)[-1].strip().decode() or None
+            elif not cf and line.startswith(b'flags'):
+                cf = tuple(line.split(b':', 1)[-1].strip().decode().split())
+            if cm is not None and vid is not None and cf:
+                break
 
     pcc: set[str] = set()
     ht_map: dict[str, str] = dict()
@@ -95,6 +107,8 @@ def cpu_info_impl() -> CpuInfo:
 
     return CpuInfo(
         cpu_model=cm,
+        vendor_id=vid,
+        cpu_flags=cf,
         core_count=cc,
         physical_core_count=len(pcc),
         ht_map=ht_map,


### PR DESCRIPTION
`vm.flags` previously fork+exec'd `lscpu` and regex-parsed its output to
detect the CPU vendor. Replace that with a single read of `/proc/cpuinfo`
via the existing `cpu_info()` helper, which already opens the file for
`cpu_model`.

Changes:

- `middlewared.utils.cpu.CpuInfo` gains `vendor_id: str | None` and
  `cpu_flags: tuple[str, ...]`. Both are populated in the same
  `/proc/cpuinfo` pass that already read `model name`.
- `vm_flags()` now reads from `cpu_info()` instead of `lscpu`. With no
  subprocess to await, the function is synchronous.
- `amd_rvi` was previously set to `True` on every AMD CPU regardless of
  capability. It now correctly reflects the `npt` feature flag.
- `vm.supports_virtualization` and `crud.py`'s validator call
  `kvm_supported()` directly instead of going through a one-line wrapper.
- `vm/info.py` no longer needs `lscpu`, the `RE_VENDOR_*` regexes, or the
  `supports_virtualization` / `amd_supports_svm` helpers.