### PR TITLE
NAS-140934 / 27.0.0-BETA.1 / Expand sharing protocol tests for NFS

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -21,6 +21,7 @@ from middlewared.test.integration.utils.system import reset_systemd_svcs as rese
 from auto_config import hostname, password, pool_name, user, ha
 from functions import async_SSH_done, async_SSH_start
 from protocols import SSH_NFS, nfs_share
+from protocols.pynfs_proto import PynfsClient, PynfsClient3
 from truenas_api_client import ClientException
 
 MOUNTPOINT = f"/tmp/nfs-{hostname}"
@@ -224,6 +225,16 @@ def set_nfs_service_state(do_what=None, expect_to_pass=True, fail_check=False):
         assert retval == test_res[do_what], f"Expected {test_res[do_what]} for NFS started result, but found {retval}"
 
     return retval
+
+
+def _nfs_client(vers, **kwargs):
+    """Pure-RPC client (PynfsClient3 for v3, PynfsClient for v4.x).
+    Use in place of ``SSH_NFS`` for tests where the kernel NFS client
+    isn't itself under test.  See ``protocols.pynfs_proto``."""
+    if int(vers) == 3:
+        return PynfsClient3(truenas_server.ip, NFS_PATH, vers=vers,
+                            **kwargs)
+    return PynfsClient(truenas_server.ip, NFS_PATH, vers=vers, **kwargs)
 
 
 def get_client_nfs_port():
@@ -684,8 +695,7 @@ class TestNFSops:
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
 
-        with SSH_NFS(truenas_server.ip, NFS_PATH, vers=vers, user=user,
-                     password=password, ip=truenas_server.ip) as n:
+        with _nfs_client(vers) as n:
             n.create('testfile')
             n.mkdir('testdir')
             contents = n.ls('.')
@@ -720,8 +730,10 @@ class TestNFSops:
         p = async_SSH_start("tcpdump -A -v -t -i lo -s 1514 port nfs -c12", user, password, hostip)
         # Give some time so that the tcpdump has started before we proceed
         sleep(2)
-        with SSH_NFS(hostip, NFS_PATH, vers=4, user=user, password=password, ip=hostip):
-            # Wait a couple seconds then collect
+        with _nfs_client(4):
+            # Wait a couple seconds then collect.  pynfs's
+            # EXCHANGE_ID + CREATE_SESSION goes over the same
+            # tcp/2049 stream tcpdump is watching.
             outs, errs = async_SSH_done(p, 2)
 
         # Process the results
@@ -734,8 +746,7 @@ class TestNFSops:
     def test_server_side_copy(self, start_nfs, nfs_dataset_and_share):
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
-        with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4, user=user,
-                     password=password, ip=truenas_server.ip) as n:
+        with _nfs_client(4) as n:
             n.server_side_copy('ssc1', 'ssc2')
 
     @pytest.mark.parametrize('nfsd,cores,expected', [
@@ -986,8 +997,7 @@ class TestNFSops:
             assert "rw" in parsed[0]['opts'][0]['parameters'], str(parsed)
 
             # Mount the share locally and create a file and dir
-            with SSH_NFS(truenas_server.ip, NFS_PATH,
-                         user=user, password=password, ip=truenas_server.ip) as n:
+            with _nfs_client(3) as n:
                 n.create("testfile_should_pass")
                 n.mkdir("testdir_should_pass")
 
@@ -999,18 +1009,19 @@ class TestNFSops:
             assert len(parsed) == 1, str(parsed)
             assert "rw" not in parsed[0]['opts'][0]['parameters'], str(parsed)
 
-            # Attempt create and delete
-            with SSH_NFS(truenas_server.ip, NFS_PATH,
-                         user=user, password=password, ip=truenas_server.ip) as n:
+            # Attempt create and delete.  PynfsClient3 raises
+            # RuntimeError with "status=30" (NFS3ERR_ROFS) on a
+            # read-only export.
+            with _nfs_client(3) as n:
                 with pytest.raises(RuntimeError) as re:
                     n.create("testfile_should_fail")
                     assert False, "Should not have been able to create a new file"
-                assert 'cannot touch' in str(re), re
+                assert 'status=30' in str(re), re
 
                 with pytest.raises(RuntimeError) as re:
                     n.mkdir("testdir_should_fail")
                     assert False, "Should not have been able to create a new directory"
-                assert 'cannot create directory' in str(re), re
+                assert 'status=30' in str(re), re
 
     def test_share_maproot(self, start_nfs, nfs_dataset_and_share):
         """
@@ -1179,22 +1190,27 @@ class TestNFSops:
             assert len(parsed) == 1, str(parsed)
             assert 'insecure' not in parsed[0]['opts'][0]['parameters'], str(parsed)
 
-            # Confirm we allow mounts from 'root' ports
-            with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4,
-                         user=user, password=password, ip=truenas_server.ip):
+            # Confirm we allow connections from privileged ports.
+            # ``secure=True`` makes pynfs bind a port < 1024 (same
+            # source-port range the kernel client picks by default).
+            with _nfs_client(4, secure=True):
                 client_port = get_client_nfs_port()
                 assert client_port[1] is not None, f"Failed to get client port: f{client_port[0]}"
                 assert int(client_port[1]) < 1024, \
                     f"client_port is not in 'root' range: {client_port[1]}\n{client_port[0]}"
 
-            # Confirm we block mounts from 'non-root' ports
-            # Cannot use pytest.raises because it messes with the output text
-            try:
-                with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4, options=['noresvport'],
-                             user=user, password=password, ip=truenas_server.ip):
-                    assert False, "Unexpected success with mount"
-            except Exception as e:
-                assert 'Operation not permitted' in str(e), e
+            # Confirm we block FH access from non-privileged ports.
+            # ``secure=False`` makes pynfs use an ephemeral source
+            # port (>= 1024).  The kernel only enforces
+            # source-port-must-be-privileged inside fh_verify (see
+            # nfsd_originating_port_ok in fs/nfsd/nfsfh.c), so the
+            # RPC-layer EXCHANGE_ID/CREATE_SESSION/RECLAIM_COMPLETE
+            # still go through -- the rejection lands on the first
+            # op that walks an FH (here, READDIR via ls), which
+            # comes back as NFS4ERR_PERM (status=1).
+            with pytest.raises(AssertionError, match=r"status=1\b"):
+                with _nfs_client(4, secure=False) as n:
+                    n.ls(".")
 
             # --- Test: allow_nonroot is True ---
             new_nfs_conf = call('nfs.update', {"allow_nonroot": True})
@@ -1204,17 +1220,16 @@ class TestNFSops:
             assert len(parsed) == 1, str(parsed)
             assert 'insecure' in parsed[0]['opts'][0]['parameters'], str(parsed)
 
-            # Confirm we allow mounts from 'root' ports
-            with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4,
-                         user=user, password=password, ip=truenas_server.ip):
+            # Confirm we allow connections from privileged ports.
+            with _nfs_client(4, secure=True):
                 client_port = get_client_nfs_port()
                 assert client_port[1] is not None, "Failed to get client port"
                 assert int(client_port[1]) < 1024, \
                     f"client_port is not in 'root' range: {client_port[1]}\n{client_port[0]}"
 
-            # Confirm we allow mounts from 'non-root' ports
-            with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4, options=['noresvport'],
-                         user=user, password=password, ip=truenas_server.ip):
+            # Confirm we allow connections from non-privileged
+            # ports.
+            with _nfs_client(4, secure=False):
                 client_port = get_client_nfs_port()
                 assert client_port[1] is not None, "Failed to get client port"
                 assert int(client_port[1]) >= 1024, \
@@ -1232,6 +1247,11 @@ class TestNFSops:
         We perform loopback mounts on the TrueNAS server and
         then check the syslog and daemon.log for rpc.mountd messages.
         The mountd filter is applied to syslog and daemon.log.
+
+        Stays on SSH_NFS (kernel ``mount.nfs`` even with vers=4 issues a
+        compat-mountd RPC that ``rpc.mountd`` logs); pynfs's NFSv4
+        client goes straight to PUTROOTFH/LOOKUP and never touches
+        mountd, so it can't trigger the log entries we're filtering.
         """
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
@@ -1294,13 +1314,11 @@ class TestNFSops:
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
 
-        with SSH_NFS(truenas_server.ip, NFS_PATH, vers=3,
-                     user=user, password=password, ip=truenas_server.ip):
+        with _nfs_client(3):
             res = call('nfs.get_nfs3_clients', [], {'count': True})
             assert int(res) != 0
 
-        with SSH_NFS(truenas_server.ip, NFS_PATH, vers=4,
-                     user=user, password=password, ip=truenas_server.ip):
+        with _nfs_client(4):
             res = call('nfs.get_nfs4_clients')
             assert len(res) == 1, f"Expected to find 1, but found {len(res)}"
 

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -743,12 +743,6 @@ class TestNFSops:
         assert len(lines) > 12, f"Unexpected number of lines output by tcpdump: {outs}, errs: {errs}"
         assert expected_scope_value in output, {errs}
 
-    def test_server_side_copy(self, start_nfs, nfs_dataset_and_share):
-        assert start_nfs is True
-        assert nfs_dataset_and_share['nfsid'] is not None
-        with _nfs_client(4) as n:
-            n.server_side_copy('ssc1', 'ssc2')
-
     @pytest.mark.parametrize('nfsd,cores,expected', [
         pp(50, 1, {'nfsd': 50, 'mountd': 12, 'managed': False}, id="User set 50: expect 12 mountd"),
         pp(None, 12, {'nfsd': 12, 'mountd': 3, 'managed': True}, id="12 cores: expect 12 nfsd, 3 mountd"),

--- a/tests/api2/test_usage_reporting.py
+++ b/tests/api2/test_usage_reporting.py
@@ -3,14 +3,15 @@ import time
 
 import pytest
 
-from auto_config import password, pool_name, user
+from auto_config import pool_name
 from middlewared.test.integration.assets.ftp import ftp_server
 from middlewared.test.integration.assets.nfs import nfs_server
 from middlewared.test.integration.assets.pool import dataset as nfs_dataset
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server, client
 from middlewared.test.integration.utils.shell import webshell_exec
-from protocols import SSH_NFS, ftp_connection, nfs_share
+from protocols import ftp_connection, nfs_share
+from protocols.pynfs_proto import PynfsClient3
 
 
 class GatherTypes:
@@ -71,9 +72,11 @@ def test_nfs_reporting(get_usage_sample):
                 time.sleep(2)
                 baseline_sample = call('usage.gather')['NFS']['num_clients']
 
-                # Establish a new connection.
-                with SSH_NFS(truenas_server.ip, nfs_path,
-                             user=user, password=password, ip=truenas_server.ip):
+                # Establish a new v3 connection.  pynfs's
+                # ``PynfsClient3`` does the actual MOUNT + portmapper
+                # bind, which the appliance counts as a v3 client
+                # exactly the way kernel ``mount.nfs`` did.
+                with PynfsClient3(truenas_server.ip, nfs_path):
                     usage_sample = call('usage.gather')
                     assert usage_sample['NFS']['num_clients'] == baseline_sample + 1
 

--- a/tests/protocols/pynfs_proto.py
+++ b/tests/protocols/pynfs_proto.py
@@ -1,0 +1,835 @@
+"""Pure-RPC NFS clients for the middleware test suite.
+
+Two context-manager classes that replace ``SSH_NFS`` for tests where
+the kernel NFS client itself isn't under test:
+
+* ``PynfsClient`` - NFSv4.1/4.2.  Goes through pynfs's ``NFS4Client``
+  (EXCHANGE_ID + CREATE_SESSION + RECLAIM_COMPLETE) and issues every
+  op as a single COMPOUND.  No ``mount.nfs``, no ssh-into-the-
+  appliance, no kernel-NFS-client involvement.
+
+* ``PynfsClient3`` - NFSv3.  Uses pynfs's already-shipped
+  ``nfs3client.NFS3Client`` (auto-resolves nfsd via portmapper, gets
+  the export root FH from mountd, binds a privileged source port).
+
+Why this exists
+---------------
+
+``SSH_NFS`` mounts the appliance to itself and shells out to
+``mount.nfs``/``getfattr``/``nfs4_getfacl``/etc.  Self-mounting is
+fragile and mixes server protocol behaviour with the kernel NFS
+client and userspace-tool behaviour, so a failure is hard to
+attribute.  For tests that are really about server-side protocol
+handling, going through pynfs gets us deterministic, fast, and
+decoupled coverage.
+
+When NOT to use these
+---------------------
+
+The kernel-mount path is the right tool when the test is *about* the
+kernel NFS client or about ``rpc.mountd`` (e.g. server-side mountd
+syslog inspection).  Stay on ``SSH_NFS`` for those.
+
+Operation surface
+-----------------
+
+The method names mirror ``SSH_NFS`` (``mkdir`` / ``rmdir`` / ``ls`` /
+``unlink`` / ``create`` / ``rename`` / ``server_side_copy``) so test
+migrations are 1:1 method-name-preserving renames.  ACL/xattr surface
+exists on ``PynfsClient`` only (they're NFSv4-only attributes).
+"""
+
+import secrets
+
+import nfs4lib
+import nfs_ops
+import nfs3client
+import rpc
+from nfs4client import NFS4Client
+from rpc.rpc_const import AUTH_SYS
+from xdrdef.nfs4_const import (
+    FATTR4_DACL,
+    FATTR4_ACL,
+    FATTR4_FILEID,
+    FATTR4_MODE,
+    OPEN4_CREATE,
+    OPEN4_SHARE_ACCESS_BOTH,
+    OPEN4_SHARE_DENY_NONE,
+    OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+    GUARDED4,
+    CLAIM_NULL,
+    NF4DIR,
+    SETXATTR4_CREATE,
+    SETXATTR4_REPLACE,
+    SETXATTR4_EITHER,
+    ACL4_AUTO_INHERIT,
+    ACL4_PROTECTED,
+    ACL4_DEFAULTED,
+)
+from xdrdef.nfs4_type import (
+    openflag4,
+    createhow4,
+    open_claim4,
+    open_owner4,
+    createtype4,
+    nfsacl41,
+    nfsace4,
+)
+from xdrdef.nfs3_const import (
+    NFSPROC3_LOOKUP,
+    NFSPROC3_READDIR,
+    NFSPROC3_CREATE,
+    NFSPROC3_MKDIR,
+    NFSPROC3_REMOVE,
+    NFSPROC3_RMDIR,
+    NFSPROC3_RENAME,
+    NFS3_OK,
+    UNCHECKED,
+    DONT_CHANGE,
+)
+from xdrdef.mnt3_const import MOUNTPROC3_MNT
+from xdrdef.nfs3_type import (
+    diropargs3,
+    nfs_fh3,
+    sattr3,
+    set_mode3,
+    set_uid3,
+    set_gid3,
+    set_size3,
+    set_atime,
+    set_mtime,
+    createhow3,
+)
+
+
+op = nfs_ops.NFS4ops()
+op3 = nfs_ops.NFS3ops()
+
+
+# ----------------------------------------------------------------------
+# NFSv4.1/4.2
+# ----------------------------------------------------------------------
+
+
+def _components(rel):
+    """Split a forward-slash path into pynfs LOOKUP components.
+
+    Accepts ``""``, ``"."``, ``"a"``, ``"a/b/c"``.  Strips a leading
+    ``/`` since pynfs's ``use_obj`` wants components relative to the
+    chain it builds (PUTROOTFH then LOOKUPs).
+    """
+    rel = rel.lstrip("/")
+    if not rel or rel == ".":
+        return []
+    return [c.encode() for c in rel.split("/") if c]
+
+
+class PynfsClient:
+    """NFSv4.1/4.2 RPC client for tests.
+
+    Usage::
+
+        with PynfsClient(host, "/mnt/tank/share") as n:
+            n.mkdir("subdir")
+            assert "subdir" in n.ls(".")
+
+    All path arguments are relative to the export's root path
+    (``self._export``); SSH_NFS-compatible.  Absolute paths are
+    rejected to mirror SSH_NFS's behaviour and so that callers don't
+    accidentally pass server-side paths.
+    """
+
+    # --- lifecycle -----------------------------------------------------
+
+    def __init__(
+        self,
+        host,
+        export_path,
+        vers=4.2,
+        uid=0,
+        gid=0,
+        owner_name=None,
+        secure=False,
+        **_ignored,
+    ):
+        """``vers`` accepts 4, 4.1, 4.2 (or "4.x" string) — gets
+        normalised to a minorversion int.  ``secure`` binds a
+        privileged source port (<1024); default False uses an
+        ephemeral port, which is what kernel ``mount.nfs -o
+        noresvport`` does.  Other SSH_NFS kwargs (``user``,
+        ``password``, ``ip``, ``localpath``, ``kerberos``,
+        ``options``) are accepted-and-ignored so callers can swap
+        ``SSH_NFS`` for ``PynfsClient`` without touching kwargs.
+        """
+        self._host = host.encode() if isinstance(host, str) else host
+        self._export = export_path
+        self._minorversion = _normalize_minorversion(vers)
+        self._uid = uid
+        self._gid = gid
+        self._secure = secure
+        self._owner_name = owner_name or (
+            b"truenas-pynfs-" + secrets.token_hex(4).encode()
+        )
+        # Set in __enter__
+        self._client = None
+        self._clt = None
+        self._sess = None
+
+    def __enter__(self):
+        c = NFS4Client(
+            self._host, 2049, minorversion=self._minorversion, secure=self._secure
+        )
+        sec = rpc.security.instance(AUTH_SYS)
+        c.set_cred(sec.init_cred(uid=self._uid, gid=self._gid, name=b"truenas-test"))
+        clt = None
+        sess = None
+        try:
+            clt = c.new_client(self._owner_name)
+            sess = clt.create_session()
+            sess.compound([op.reclaim_complete(False)])
+        except Exception:
+            self._teardown(c, clt, sess)
+            raise
+        self._client, self._clt, self._sess = c, clt, sess
+        return self
+
+    def __exit__(self, *exc):
+        self._teardown(self._client, self._clt, self._sess)
+        self._client = self._clt = self._sess = None
+
+    @staticmethod
+    def _teardown(c, clt, sess):
+        # DESTROY_SESSION + DESTROY_CLIENTID via the *connection-level*
+        # dispatcher (no SEQUENCE prefix); the session-level path would
+        # try to update slot state after the session is destroyed.
+        if c is None:
+            return
+        if sess is not None:
+            try:
+                c.compound([op.destroy_session(sess.sessionid)])
+            except Exception:
+                pass
+            c.sessions.pop(sess.sessionid, None)
+        if clt is not None:
+            try:
+                c.compound([op.destroy_clientid(clt.clientid)])
+            except Exception:
+                pass
+            c.clients.pop(clt.clientid, None)
+        # c.stop() terminates the polling thread and closes sockets.
+        # Without it the appliance keeps the connection open and ZFS
+        # umount races with subsequent pool.dataset.delete (EZFS_BUSY).
+        try:
+            c.stop()
+        except Exception:
+            pass
+
+    # --- helpers -------------------------------------------------------
+
+    def _validate_rel(self, path):
+        if path.startswith("/"):
+            raise ValueError(f"{path}: absolute paths not supported; pass relative")
+
+    def _full_components(self, rel):
+        """Combine the export path and ``rel`` into component bytes."""
+        return _components(self._export) + _components(rel)
+
+    def _split_parent_name(self, rel):
+        """Return (parent_full_components, leaf_bytes)."""
+        self._validate_rel(rel)
+        parts = _components(rel)
+        if not parts:
+            raise ValueError("empty path; need a non-root target")
+        return _components(self._export) + parts[:-1], parts[-1]
+
+    def _expect_ok(self, res, label):
+        assert res.status == 0, f"{label} failed: status={res.status}"
+        return res
+
+    # --- op methods (mirroring SSH_NFS) --------------------------------
+
+    def mkdir(self, path):
+        self._validate_rel(path)
+        parent, name = self._split_parent_name(path)
+        res = self._sess.compound(
+            nfs4lib.use_obj(parent)
+            + [op.create(createtype4(NF4DIR), name, {FATTR4_MODE: 0o755})]
+        )
+        self._expect_ok(res, f"mkdir({path!r})")
+
+    def create(self, path, is_dir=False):
+        if is_dir:
+            return self.mkdir(path)
+        self._validate_rel(path)
+        parent, name = self._split_parent_name(path)
+        openflag = openflag4(
+            OPEN4_CREATE,
+            createhow4(GUARDED4, {FATTR4_MODE: 0o644}, self._sess.c.verifier),
+        )
+        openclaim = open_claim4(CLAIM_NULL, name)
+        res = self._sess.compound(
+            nfs4lib.use_obj(parent)
+            + [
+                op.open(
+                    0,
+                    OPEN4_SHARE_ACCESS_BOTH | OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+                    OPEN4_SHARE_DENY_NONE,
+                    open_owner4(self._clt.clientid, b"pynfs-create-owner"),
+                    openflag,
+                    openclaim,
+                ),
+                op.getfh(),
+            ]
+        )
+        self._expect_ok(res, f"create({path!r})")
+
+    def rmdir(self, path):
+        self._validate_rel(path)
+        parent, name = self._split_parent_name(path)
+        res = self._sess.compound(nfs4lib.use_obj(parent) + [op.remove(name)])
+        self._expect_ok(res, f"rmdir({path!r})")
+
+    def unlink(self, path):
+        self._validate_rel(path)
+        parent, name = self._split_parent_name(path)
+        res = self._sess.compound(nfs4lib.use_obj(parent) + [op.remove(name)])
+        self._expect_ok(res, f"unlink({path!r})")
+
+    def rename(self, src, dst):
+        self._validate_rel(src)
+        self._validate_rel(dst)
+        src_parent, src_name = self._split_parent_name(src)
+        dst_parent, dst_name = self._split_parent_name(dst)
+        # OP_RENAME requires saved-fh (source) + current-fh (target).
+        # Walk to source parent, SAVEFH; walk to dest parent (current
+        # at end of chain); RENAME(src_name, dst_name).
+        res = self._sess.compound(
+            nfs4lib.use_obj(src_parent)
+            + [op.savefh()]
+            + nfs4lib.use_obj(dst_parent)
+            + [op.rename(src_name, dst_name)]
+        )
+        self._expect_ok(res, f"rename({src!r}, {dst!r})")
+
+    def ls(self, path="."):
+        """Return a list of entry names (bytes->str-decoded)."""
+        self._validate_rel(path)
+        bitmap = nfs4lib.list2bitmap([FATTR4_FILEID])
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path))
+            + [op.readdir(0, b"\0" * 8, 8192, 65536, bitmap)]
+        )
+        self._expect_ok(res, f"ls({path!r})")
+        return [e.name.decode() for e in res.resarray[-1].reply.entries]
+
+    def server_side_copy(self, src, dst):
+        """NFSv4.2 OP_CLONE.  Source must already exist; dest is
+        created if needed (we OPEN+CREATE it).  Mirrors SSH_NFS's
+        helper which writes 'canary' and copy_file_range's it; here
+        we use the protocol-native CLONE op."""
+        self._validate_rel(src)
+        self._validate_rel(dst)
+        # Pre-populate src so there's something to copy.
+        self.create(src)
+        with self._open_for_write(src) as src_state:
+            self._sess.compound(
+                nfs4lib.use_obj(self._full_components(src))
+                + [op.write(src_state, 0, 2, b"canary")]
+            )  # FILE_SYNC4
+        self.create(dst)
+        # OP_CLONE: src_fh is saved, dst_fh is current.
+        src_state2 = self._open_stateid(src)
+        dst_state2 = self._open_stateid(dst)
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(src))
+            + [op.savefh()]
+            + nfs4lib.use_obj(self._full_components(dst))
+            + [op.clone(src_state2, dst_state2, 0, 0, 0)]
+        )
+        self._expect_ok(res, f"server_side_copy({src!r}, {dst!r})")
+
+    # --- xattr (NFSv4.2) -----------------------------------------------
+
+    def _strip_user_prefix(self, name):
+        """SSH_NFS callers pass ``user.foo``.  NFSv4.2 wire format
+        omits the namespace prefix (Linux nfsd prepends it server-
+        side) — strip it here for SSH_NFS compatibility."""
+        if isinstance(name, str):
+            name = name.encode()
+        if name.startswith(b"user."):
+            name = name[len(b"user.") :]
+        return name
+
+    def setxattr(self, path, xattr_name, value, mode=SETXATTR4_EITHER):
+        self._validate_rel(path)
+        if isinstance(value, str):
+            value = value.encode()
+        key = self._strip_user_prefix(xattr_name)
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path))
+            + [op.setxattr(mode, key, value)]
+        )
+        self._expect_ok(res, f"setxattr({path!r}, {xattr_name!r})")
+
+    def getxattr(self, path, xattr_name):
+        self._validate_rel(path)
+        key = self._strip_user_prefix(xattr_name)
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path)) + [op.getxattr(key)]
+        )
+        self._expect_ok(res, f"getxattr({path!r}, {xattr_name!r})")
+        # Mirror SSH_NFS which returns the bytes (as str via stdout)
+        return res.resarray[-1].gxr_value.decode()
+
+    # --- ACL (NFSv4.1+ DACL via SETATTR/GETATTR) -----------------------
+
+    def getacl(self, path):
+        """Return the DACL as a list of dict ACEs (matches SSH_NFS
+        ``getacl`` shape).  v4.1+ only; pynfs's installed tree only
+        speaks v4.1+ anyway."""
+        self._validate_rel(path)
+        bitmap = nfs4lib.list2bitmap([FATTR4_DACL])
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path)) + [op.getattr(bitmap)]
+        )
+        self._expect_ok(res, f"getacl({path!r})")
+        dacl = res.resarray[-1].obj_attributes[FATTR4_DACL]
+        return [_ace_to_dict(a) for a in dacl.na41_aces]
+
+    def setacl(self, path, acl):
+        """Set DACL from a list of dict ACEs (SSH_NFS shape)."""
+        self._validate_rel(path)
+        aces = [_dict_to_ace(d) for d in acl]
+        new_dacl = nfsacl41(0, aces)
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path))
+            + [op.setattr(_zero_stateid(), {FATTR4_DACL: new_dacl})]
+        )
+        self._expect_ok(res, f"setacl({path!r})")
+
+    def getaclflag(self, path):
+        """Return the ACL flag string SSH_NFS exposes
+        (auto-inherit / protected / defaulted / none)."""
+        self._validate_rel(path)
+        bitmap = nfs4lib.list2bitmap([FATTR4_DACL])
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path)) + [op.getattr(bitmap)]
+        )
+        self._expect_ok(res, f"getaclflag({path!r})")
+        flag = res.resarray[-1].obj_attributes[FATTR4_DACL].na41_flag
+        if flag & ACL4_AUTO_INHERIT:
+            return "auto-inherit"
+        if flag & ACL4_PROTECTED:
+            return "protected"
+        if flag & ACL4_DEFAULTED:
+            return "defaulted"
+        return "none"
+
+    def setaclflag(self, path, value):
+        self._validate_rel(path)
+        flag_bit = {
+            "auto-inherit": ACL4_AUTO_INHERIT,
+            "protected": ACL4_PROTECTED,
+            "defaulted": ACL4_DEFAULTED,
+            "none": 0,
+        }[value]
+        # Fetch existing ACEs so we just twiddle the flag.
+        bitmap = nfs4lib.list2bitmap([FATTR4_DACL])
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path)) + [op.getattr(bitmap)]
+        )
+        self._expect_ok(res, f"setaclflag({path!r}) [getattr]")
+        existing = res.resarray[-1].obj_attributes[FATTR4_DACL]
+        new_dacl = nfsacl41(flag_bit, existing.na41_aces)
+        res = self._sess.compound(
+            nfs4lib.use_obj(self._full_components(path))
+            + [op.setattr(_zero_stateid(), {FATTR4_DACL: new_dacl})]
+        )
+        self._expect_ok(res, f"setaclflag({path!r})")
+
+    # --- internal: stateful OPEN -------------------------------------
+
+    class _StateCtx:
+        def __init__(self, owner, parent_walker, sess, path):
+            self.owner = owner
+            self.parent = parent_walker
+            self.sess = sess
+            self.path = path
+            self.state = None
+
+        def __enter__(self):
+            res = self.sess.compound(
+                self.parent
+                + [
+                    op.open(
+                        0,
+                        OPEN4_SHARE_ACCESS_BOTH | OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+                        OPEN4_SHARE_DENY_NONE,
+                        self.owner,
+                        openflag4(0, None),
+                        open_claim4(CLAIM_NULL, self.path),
+                    ),
+                    op.getfh(),
+                ]
+            )
+            assert res.status == 0
+            self.state = res.resarray[-2].stateid
+            return self.state
+
+        def __exit__(self, *_):
+            self.sess.compound(self.parent + [op.close(0, self.state)])
+
+    def _open_for_write(self, path):
+        parent, name = self._split_parent_name(path)
+        owner = open_owner4(self._clt.clientid, b"pynfs-write-owner")
+        return self._StateCtx(owner, nfs4lib.use_obj(parent), self._sess, name)
+
+    def _open_stateid(self, path):
+        """Return a current stateid for OP_CLONE."""
+        parent, name = self._split_parent_name(path)
+        res = self._sess.compound(
+            nfs4lib.use_obj(parent)
+            + [
+                op.open(
+                    0,
+                    OPEN4_SHARE_ACCESS_BOTH | OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+                    OPEN4_SHARE_DENY_NONE,
+                    open_owner4(self._clt.clientid, b"pynfs-clone-owner"),
+                    openflag4(0, None),
+                    open_claim4(CLAIM_NULL, name),
+                )
+            ]
+        )
+        self._expect_ok(res, f"_open_stateid({path!r})")
+        return res.resarray[-1].stateid
+
+
+def _normalize_minorversion(vers):
+    """Accept 4, 4.1, 4.2, '4', '4.1', '4.2' → return 1 or 2."""
+    if isinstance(vers, str):
+        vers = float(vers)
+    if int(vers) != 4:
+        raise ValueError(
+            f"PynfsClient only speaks v4.x; got vers={vers!r}.  "
+            f"Use PynfsClient3 for v3."
+        )
+    # 4 -> 1 (default to v4.1 minimum); 4.1 -> 1; 4.2 -> 2
+    if vers == 4 or vers == 4.1:
+        return 1
+    if vers == 4.2:
+        return 2
+    raise ValueError(f"unsupported NFSv4 minorversion: {vers!r}")
+
+
+def _zero_stateid():
+    """Anonymous stateid used for SETATTR-without-OPEN."""
+    from xdrdef.nfs4_type import stateid4
+
+    return stateid4(0, b"\0" * 12)
+
+
+def _ace_to_dict(ace):
+    """nfsace4 -> SSH_NFS-shaped dict ACE."""
+    # Reuses the same vocabulary as nfs_proto.NFS.perms / .flags.
+    PERM_BITS = [
+        ("READ_DATA", 0x00001),
+        ("WRITE_DATA", 0x00002),
+        ("APPEND_DATA", 0x00004),
+        ("READ_NAMED_ATTRS", 0x00008),
+        ("WRITE_NAMED_ATTRS", 0x00010),
+        ("EXECUTE", 0x00020),
+        ("DELETE_CHILD", 0x00040),
+        ("READ_ATTRIBUTES", 0x00080),
+        ("WRITE_ATTRIBUTES", 0x00100),
+        ("DELETE", 0x10000),
+        ("READ_ACL", 0x20000),
+        ("WRITE_ACL", 0x40000),
+        ("WRITE_OWNER", 0x80000),
+        ("SYNCHRONIZE", 0x100000),
+    ]
+    FLAG_BITS = [
+        ("FILE_INHERIT", 0x01),
+        ("DIRECTORY_INHERIT", 0x02),
+        ("NO_PROPAGATE_INHERIT", 0x04),
+        ("INHERIT_ONLY", 0x08),
+        ("INHERITED", 0x80),
+    ]
+    perms = {name: bool(ace.access_mask & bit) for name, bit in PERM_BITS}
+    flags = {name: bool(ace.flag & bit) for name, bit in FLAG_BITS}
+    is_group = bool(ace.flag & 0x40)  # NFS4_ACE_IDENTIFIER_GROUP
+    who = ace.who.decode() if isinstance(ace.who, bytes) else ace.who
+    if who == "OWNER@":
+        tag, who_id = "owner@", -1
+    elif who == "GROUP@":
+        tag, who_id = "group@", -1
+    elif who == "EVERYONE@":
+        tag, who_id = "everyone@", -1
+    else:
+        tag = "GROUP" if is_group else "USER"
+        who_id = int(who) if who.lstrip("-").isdigit() else -1
+    return {
+        "tag": tag,
+        "id": who_id,
+        "perms": perms,
+        "flags": flags,
+        "type": "ALLOW" if ace.type == 0 else "DENY",
+    }
+
+
+def _dict_to_ace(d):
+    """SSH_NFS-shaped dict ACE -> nfsace4."""
+    PERM_BITS = {
+        "READ_DATA": 0x00001,
+        "WRITE_DATA": 0x00002,
+        "APPEND_DATA": 0x00004,
+        "READ_NAMED_ATTRS": 0x00008,
+        "WRITE_NAMED_ATTRS": 0x00010,
+        "EXECUTE": 0x00020,
+        "DELETE_CHILD": 0x00040,
+        "READ_ATTRIBUTES": 0x00080,
+        "WRITE_ATTRIBUTES": 0x00100,
+        "DELETE": 0x10000,
+        "READ_ACL": 0x20000,
+        "WRITE_ACL": 0x40000,
+        "WRITE_OWNER": 0x80000,
+        "SYNCHRONIZE": 0x100000,
+    }
+    FLAG_BITS = {
+        "FILE_INHERIT": 0x01,
+        "DIRECTORY_INHERIT": 0x02,
+        "NO_PROPAGATE_INHERIT": 0x04,
+        "INHERIT_ONLY": 0x08,
+        "INHERITED": 0x80,
+    }
+    mask = 0
+    for k, v in d.get("perms", {}).items():
+        if v:
+            mask |= PERM_BITS[k]
+    flag = 0
+    for k, v in d.get("flags", {}).items():
+        if v:
+            flag |= FLAG_BITS[k]
+    tag = d["tag"]
+    if tag == "owner@":
+        who = b"OWNER@"
+    elif tag == "group@":
+        who = b"GROUP@"
+    elif tag == "everyone@":
+        who = b"EVERYONE@"
+    elif tag == "GROUP":
+        flag |= 0x40  # NFS4_ACE_IDENTIFIER_GROUP
+        who = str(d["id"]).encode()
+    elif tag == "USER":
+        who = str(d["id"]).encode()
+    else:
+        raise ValueError(f"unknown ACE tag: {tag!r}")
+    return nfsace4(
+        type=0 if d["type"] == "ALLOW" else 1, flag=flag, access_mask=mask, who=who
+    )
+
+
+# ----------------------------------------------------------------------
+# NFSv3
+# ----------------------------------------------------------------------
+
+
+class PynfsClient3:
+    """NFSv3 RPC client for tests.
+
+    Mirrors the file-op surface of ``SSH_NFS``: ``mkdir``, ``rmdir``,
+    ``create``, ``unlink``, ``rename``, ``ls``.  ACL/xattr methods are
+    intentionally absent — those attributes don't exist in v3.
+
+    Path arguments are relative to the export root; absolute paths are
+    rejected.
+    """
+
+    def __init__(
+        self, host, export_path, vers=3, uid=0, gid=0, secureport=False, **_ignored
+    ):
+        """``secureport=True`` makes pynfs bind a privileged source
+        port (<1024).  Default False uses an ephemeral port; matches
+        ``PynfsClient`` and works on shares with ``allow_nonroot=True``
+        (or whose kernel doesn't enforce ``secure``).  Tests against a
+        ``secure``-only share set this True."""
+        if int(vers) != 3:
+            raise ValueError(
+                f"PynfsClient3 only speaks v3; got vers={vers!r}.  "
+                f"Use PynfsClient for v4.x."
+            )
+        self._host = host if isinstance(host, str) else host.decode()
+        self._export = export_path
+        self._uid = uid
+        self._gid = gid
+        self._secureport = secureport
+        # Set in __enter__
+        self._c = None
+        self._rootfh = None
+
+    def __enter__(self):
+        # NFS3Client auto-resolves nfsd's port via portmapper, opens
+        # the connection, and sets up Mnt3Client for mountd.
+        c = nfs3client.NFS3Client(self._host, secureport=self._secureport)
+        sec = rpc.security.instance(AUTH_SYS)
+        c.set_cred(sec.init_cred(uid=self._uid, gid=self._gid))
+
+        # Get the export's root file handle from mountd.  We can't
+        # use ``c.mntclnt.get_rootfh`` -- it wraps the path as a
+        # ``str`` subclass but ``mnt3_pack.pack_dirpath`` ultimately
+        # calls ``xdrlib3.pack_fstring`` which only accepts bytes.
+        # Build the same XDR call manually with a bytes-typed
+        # ``dirpath`` argument.
+        class dirpath(bytes):
+            pass
+
+        path_bytes = (
+            self._export.encode() if isinstance(self._export, str) else self._export
+        )
+        if not path_bytes.startswith(b"/"):
+            path_bytes = b"/" + path_bytes
+        res = c.mntclnt.proc(MOUNTPROC3_MNT, dirpath(path_bytes), "mountres3")
+        if res.fhs_status != 0:
+            raise RuntimeError(
+                f"MOUNT for {self._export!r} failed: fhs_status={res.fhs_status}"
+            )
+        self._rootfh = nfs_fh3(res.mountinfo.fhandle)
+        # (no NULL warm-up: pynfs's NFS3Client.null_async passes
+        # data="" which the rpc layer concatenates to the bytes
+        # header and crashes; the MOUNT call above already proves
+        # the path is reachable.)
+        self._c = c
+        return self
+
+    def __exit__(self, *exc):
+        # No explicit UMNT — closing the pipe drops the v3 client
+        # registration on the server.
+        if self._c is not None:
+            try:
+                self._c.stop()
+            except Exception:
+                pass
+        self._c = None
+        self._rootfh = None
+
+    # --- helpers -------------------------------------------------------
+
+    def _validate_rel(self, path):
+        if path.startswith("/"):
+            raise ValueError(f"{path}: absolute paths not supported; pass relative")
+
+    def _lookup(self, components):
+        """Walk LOOKUP from rootfh through components; return final FH.
+        ``components`` is a list of bytes."""
+        fh = self._rootfh
+        for comp in components:
+            arg = op3.lookup(diropargs3(fh, comp))
+            res = self._c.proc(NFSPROC3_LOOKUP, arg)
+            if res.status != NFS3_OK:
+                raise RuntimeError(f"LOOKUP({comp!r}) failed: status={res.status}")
+            fh = res.resok.object
+        return fh
+
+    def _split_parent_name(self, rel):
+        self._validate_rel(rel)
+        parts = [c.encode() for c in rel.lstrip("/").split("/") if c]
+        if not parts:
+            raise ValueError("empty path; need a non-root target")
+        parent_fh = self._lookup(parts[:-1])
+        return parent_fh, parts[-1]
+
+    @staticmethod
+    def _default_sattr():
+        return sattr3(
+            mode=set_mode3(True, 0o644),
+            uid=set_uid3(False),
+            gid=set_gid3(False),
+            size=set_size3(False),
+            atime=set_atime(DONT_CHANGE),
+            mtime=set_mtime(DONT_CHANGE),
+        )
+
+    # --- op methods ---------------------------------------------------
+
+    def mkdir(self, path):
+        parent_fh, name = self._split_parent_name(path)
+        attrs = sattr3(
+            mode=set_mode3(True, 0o755),
+            uid=set_uid3(False),
+            gid=set_gid3(False),
+            size=set_size3(False),
+            atime=set_atime(DONT_CHANGE),
+            mtime=set_mtime(DONT_CHANGE),
+        )
+        arg = op3.mkdir(diropargs3(parent_fh, name), attrs)
+        res = self._c.proc(NFSPROC3_MKDIR, arg)
+        if res.status != NFS3_OK:
+            raise RuntimeError(f"mkdir({path!r}): status={res.status}")
+
+    def rmdir(self, path):
+        parent_fh, name = self._split_parent_name(path)
+        arg = op3.rmdir(diropargs3(parent_fh, name))
+        res = self._c.proc(NFSPROC3_RMDIR, arg)
+        if res.status != NFS3_OK:
+            raise RuntimeError(f"rmdir({path!r}): status={res.status}")
+
+    def unlink(self, path):
+        parent_fh, name = self._split_parent_name(path)
+        arg = op3.remove(diropargs3(parent_fh, name))
+        res = self._c.proc(NFSPROC3_REMOVE, arg)
+        if res.status != NFS3_OK:
+            raise RuntimeError(f"unlink({path!r}): status={res.status}")
+
+    def create(self, path, is_dir=False):
+        if is_dir:
+            return self.mkdir(path)
+        parent_fh, name = self._split_parent_name(path)
+        how = createhow3(UNCHECKED, self._default_sattr())
+        arg = op3.create(diropargs3(parent_fh, name), how)
+        res = self._c.proc(NFSPROC3_CREATE, arg)
+        if res.status != NFS3_OK:
+            raise RuntimeError(f"create({path!r}): status={res.status}")
+
+    def rename(self, src, dst):
+        src_parent_fh, src_name = self._split_parent_name(src)
+        dst_parent_fh, dst_name = self._split_parent_name(dst)
+        arg = op3.rename(
+            diropargs3(src_parent_fh, src_name), diropargs3(dst_parent_fh, dst_name)
+        )
+        res = self._c.proc(NFSPROC3_RENAME, arg)
+        if res.status != NFS3_OK:
+            raise RuntimeError(f"rename({src!r}, {dst!r}): status={res.status}")
+
+    def ls(self, path="."):
+        """Return a list of entry names (str-decoded)."""
+        self._validate_rel(path)
+        parts = [c.encode() for c in path.lstrip("/").split("/") if c and c != "."]
+        fh = self._lookup(parts)
+        # READDIR3 takes (dir, cookie, cookieverf, count); walk
+        # multiple replies if eof not yet set.
+        cookie = 0
+        cookieverf = b"\0" * 8
+        names = []
+        while True:
+            arg = op3.readdir(fh, cookie, cookieverf, 8192)
+            res = self._c.proc(NFSPROC3_READDIR, arg)
+            if res.status != NFS3_OK:
+                raise RuntimeError(f"ls({path!r}): readdir status={res.status}")
+            ok = res.resok
+            entry = ok.reply.entries
+            while entry is not None:
+                if isinstance(entry, list):
+                    if not entry:
+                        break
+                    entry = entry[0]
+                name = entry.name.decode()
+                # Filter ``.`` / ``..`` so v3 ls() output matches v4
+                # READDIR (which omits them) and SSH_NFS's ``ls``
+                # output (the kernel client filters too).
+                if name not in (".", ".."):
+                    names.append(name)
+                cookie = entry.cookie
+                entry = entry.nextentry
+            cookieverf = ok.cookieverf
+            if ok.reply.eof:
+                break
+        return names

--- a/tests/protocols/pynfs_proto.py
+++ b/tests/protocols/pynfs_proto.py
@@ -180,7 +180,11 @@ class PynfsClient:
             self._host, 2049, minorversion=self._minorversion, secure=self._secure
         )
         sec = rpc.security.instance(AUTH_SYS)
-        c.set_cred(sec.init_cred(uid=self._uid, gid=self._gid, name=b"truenas-test"))
+        # gids=[] avoids pynfs's default supplementary GIDs of [3, 17, 100],
+        # which would otherwise grant the caller spurious group-membership
+        # access in DAC/ACL checks.
+        c.set_cred(sec.init_cred(
+            uid=self._uid, gid=self._gid, name=b"truenas-test", gids=[]))
         clt = None
         sess = None
         try:
@@ -278,7 +282,6 @@ class PynfsClient:
                     openflag,
                     openclaim,
                 ),
-                op.getfh(),
             ]
         )
         self._expect_ok(res, f"create({path!r})")
@@ -322,31 +325,35 @@ class PynfsClient:
         self._expect_ok(res, f"ls({path!r})")
         return [e.name.decode() for e in res.resarray[-1].reply.entries]
 
-    def server_side_copy(self, src, dst):
-        """NFSv4.2 OP_CLONE.  Source must already exist; dest is
-        created if needed (we OPEN+CREATE it).  Mirrors SSH_NFS's
-        helper which writes 'canary' and copy_file_range's it; here
-        we use the protocol-native CLONE op."""
+    def write(self, path, data, offset=0):
+        """OP_WRITE ``data`` to existing ``path`` at ``offset`` with
+        stable=FILE_SYNC4.  ``path`` must already exist."""
+        self._validate_rel(path)
+        if isinstance(data, str):
+            data = data.encode()
+        with self._open_for_write(path) as state:
+            res = self._sess.compound(
+                nfs4lib.use_obj(self._full_components(path))
+                + [op.write(state, offset, 2, data)]  # stable=2 -> FILE_SYNC4
+            )
+            self._expect_ok(res, f"write({path!r})")
+
+    def clone(self, src, dst):
+        """NFSv4.2 OP_CLONE: clone existing src to existing dst.  Both
+        files must already exist (caller's responsibility).  Length 0
+        means clone-to-EOF."""
         self._validate_rel(src)
         self._validate_rel(dst)
-        # Pre-populate src so there's something to copy.
-        self.create(src)
-        with self._open_for_write(src) as src_state:
-            self._sess.compound(
-                nfs4lib.use_obj(self._full_components(src))
-                + [op.write(src_state, 0, 2, b"canary")]
-            )  # FILE_SYNC4
-        self.create(dst)
+        src_state = self._open_stateid(src)
+        dst_state = self._open_stateid(dst)
         # OP_CLONE: src_fh is saved, dst_fh is current.
-        src_state2 = self._open_stateid(src)
-        dst_state2 = self._open_stateid(dst)
         res = self._sess.compound(
             nfs4lib.use_obj(self._full_components(src))
             + [op.savefh()]
             + nfs4lib.use_obj(self._full_components(dst))
-            + [op.clone(src_state2, dst_state2, 0, 0, 0)]
+            + [op.clone(src_state, dst_state, 0, 0, 0)]
         )
-        self._expect_ok(res, f"server_side_copy({src!r}, {dst!r})")
+        self._expect_ok(res, f"clone({src!r}, {dst!r})")
 
     # --- xattr (NFSv4.2) -----------------------------------------------
 
@@ -671,7 +678,8 @@ class PynfsClient3:
         # the connection, and sets up Mnt3Client for mountd.
         c = nfs3client.NFS3Client(self._host, secureport=self._secureport)
         sec = rpc.security.instance(AUTH_SYS)
-        c.set_cred(sec.init_cred(uid=self._uid, gid=self._gid))
+        # gids=[] avoids pynfs's default supplementary GIDs of [3, 17, 100].
+        c.set_cred(sec.init_cred(uid=self._uid, gid=self._gid, gids=[]))
 
         # Get the export's root file handle from mountd.  We can't
         # use ``c.mntclnt.get_rootfh`` -- it wraps the path as a

--- a/tests/protocols/pynfs_proto.py
+++ b/tests/protocols/pynfs_proto.py
@@ -183,8 +183,9 @@ class PynfsClient:
         # gids=[] avoids pynfs's default supplementary GIDs of [3, 17, 100],
         # which would otherwise grant the caller spurious group-membership
         # access in DAC/ACL checks.
-        c.set_cred(sec.init_cred(
-            uid=self._uid, gid=self._gid, name=b"truenas-test", gids=[]))
+        c.set_cred(
+            sec.init_cred(uid=self._uid, gid=self._gid, name=b"truenas-test", gids=[])
+        )
         clt = None
         sess = None
         try:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,5 +11,7 @@ wheel
 cython-iscsi @ git+https://github.com/truenas/cython-iscsi.git@tester
 PYSCSI @ git+https://github.com/truenas/python-scsi.git@tester
 nvmeof-client @ git+https://github.com/truenas/truenas_pynvmeof_client.git
+pynfs @ git+https://github.com/truenas/pynfs.git@truenas-pynfs-0.5
+xdrlib3
 zeroconf
 pyotp

--- a/tests/sharing_protocols/nfs/conftest.py
+++ b/tests/sharing_protocols/nfs/conftest.py
@@ -1,0 +1,90 @@
+"""Shared fixtures for NFS sharing-protocol tests.
+
+Two helpers here:
+
+* ``start_nfs`` - **session-scoped** fixture that starts nfsd and
+  flips ``nfs.config.allow_nonroot=True`` for the entire pytest
+  session, then restores the previous setting and stops nfsd at
+  session end.  Session scope is required: a per-module
+  start/stop cycle causes the appliance-side auth subsystem to
+  return ``AUTH_BADCRED`` on the first ``EXCHANGE_ID`` issued in
+  each subsequent module.
+
+* ``nfs_dataset`` - context-manager factory that wraps
+  ``pool.dataset.create``/``delete`` with sleep+retry on the delete.
+  ``sharing.nfs.delete`` removes the export but the kernel takes a
+  brief moment to release the underlying ZFS mountpoint; the eager
+  ``pool.dataset.delete`` from the standard ``dataset`` asset races
+  that and returns ``EZFS_BUSY``.  Same pattern as
+  ``tests/api2/test_300_nfs.py:nfs_dataset``.
+"""
+
+import contextlib
+from time import sleep
+
+import pytest
+
+from middlewared.service_exception import InstanceNotFound
+from middlewared.test.integration.assets.nfs import nfs_server
+from middlewared.test.integration.utils import call, pool
+
+
+@pytest.fixture(scope="session")
+def start_nfs():
+    """Session-scoped fixture: start nfsd once, flip
+    ``allow_nonroot=True`` once, hold across all NFS test modules,
+    restore on session teardown.
+
+    ``allow_nonroot`` writes ``insecure`` into the export options;
+    without it, Linux nfsd enforces source-port-must-be-privileged
+    and rejects pynfs's ephemeral-port operations with
+    ``NFS4ERR_PERM`` (test_300_nfs.py::test_share_maproot documents
+    this behavior).
+    """
+    with nfs_server():
+        prev_allow_nonroot = call("nfs.config")["allow_nonroot"]
+        if not prev_allow_nonroot:
+            call("nfs.update", {"allow_nonroot": True})
+        try:
+            yield
+        finally:
+            if not prev_allow_nonroot:
+                call("nfs.update", {"allow_nonroot": False})
+
+
+@contextlib.contextmanager
+def _nfs_dataset_cm(name, data=None):
+    full = f"{pool}/{name}"
+    call("pool.dataset.create", {"name": full, **(data or {})})
+    try:
+        yield full
+    finally:
+        deleted = False
+        # First attempt - may race with NFS export teardown.
+        try:
+            call("pool.dataset.delete", full, {"recursive": True})
+            deleted = True
+        except InstanceNotFound:
+            deleted = True
+        except Exception:
+            pass
+
+        # Retry: sleep briefly to let the kernel release the export,
+        # then poll until delete succeeds or the dataset is gone.
+        if not deleted:
+            sleep(2)
+            for _ in range(6):
+                try:
+                    call("pool.dataset.delete", full, {"recursive": True})
+                    break
+                except InstanceNotFound:
+                    break
+                except Exception:
+                    sleep(10)
+
+
+@pytest.fixture
+def nfs_dataset():
+    """Yield a context-manager factory for NFS-test datasets with
+    EZFS_BUSY-tolerant cleanup."""
+    return _nfs_dataset_cm

--- a/tests/sharing_protocols/nfs/test_nfs_acl.py
+++ b/tests/sharing_protocols/nfs/test_nfs_acl.py
@@ -1,126 +1,488 @@
+"""NFSv4 ACL/DACL protocol tests, exercised directly via pynfs.
+
+Three coverage areas:
+
+1. **GETATTR vs READDIR consistency**: an ACL set via ``filesystem.setacl``
+   must read back identically through both ``OP_GETATTR`` on the file and
+   the per-entry attrs returned by ``OP_READDIR`` on the parent.  Catches
+   regressions like the DACL ordering bug fixed in
+   ``fs/nfsd/nfs4xdr.c`` (see ``test_nfs_dacl_readdir.py``).
+
+2. **NFS SETATTR roundtrip**: an ACL set via ``OP_SETATTR`` over the wire
+   must be readable back via ``OP_GETATTR`` and via ``filesystem.getacl``
+   (server-side).
+
+3. **Minor-version coverage**: NFSv4.0 uses ``FATTR4_ACL`` (no aclflag);
+   NFSv4.1/4.2 use ``FATTR4_DACL`` (aclflag + ACE list).  The tests
+   exercise both encodings.
+"""
+import secrets
+
 import pytest
+import rpc
+import nfs4lib
+import nfs_ops
+from nfs4client import NFS4Client
+from rpc.rpc_const import AUTH_SYS
+from xdrdef.nfs4_const import (
+    FATTR4_ACL, FATTR4_DACL,
+    ACE4_ACCESS_ALLOWED_ACE_TYPE,
+    ACE4_FILE_INHERIT_ACE, ACE4_DIRECTORY_INHERIT_ACE,
+    ACE4_INHERIT_ONLY_ACE, ACE4_NO_PROPAGATE_INHERIT_ACE,
+    ACE4_INHERITED_ACE, ACE4_IDENTIFIER_GROUP,
+    ACE4_READ_DATA, ACE4_WRITE_DATA, ACE4_EXECUTE,
+    ACE4_APPEND_DATA, ACE4_DELETE_CHILD, ACE4_DELETE,
+    ACE4_READ_ATTRIBUTES, ACE4_WRITE_ATTRIBUTES,
+    ACE4_READ_NAMED_ATTRS, ACE4_WRITE_NAMED_ATTRS,
+    ACE4_READ_ACL, ACE4_WRITE_ACL, ACE4_WRITE_OWNER, ACE4_SYNCHRONIZE,
+    ACL4_AUTO_INHERIT, ACL4_PROTECTED, ACL4_DEFAULTED,
+)
+from xdrdef.nfs4_type import nfsace4, nfsacl41, stateid4
 
-from middlewared.test.integration.assets.nfs import nfs_server
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.utils import call, password
+from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
-from protocols import SSH_NFS, nfs_share
+from protocols import nfs_share
+
+op = nfs_ops.NFS4ops()
 
 
-@pytest.fixture(scope='module')
-def start_nfs():
-    with nfs_server():
-        yield
+# ---------------------------------------------------------------------------
+# JSON-ACL <-> NFSv4 wire mapping
+# ---------------------------------------------------------------------------
 
+# These mirror the dict-shaped ACEs accepted by ``filesystem.setacl`` /
+# returned by ``filesystem.getacl``.  We translate to/from the NFSv4 wire
+# representation so the tests can use a single source of truth.
 
-TEST_PERMS = {
-    "READ_DATA": True,
-    "WRITE_DATA": True,
-    "EXECUTE": True,
-    "APPEND_DATA": True,
-    "DELETE_CHILD": True,
-    "DELETE": True,
-    "READ_ATTRIBUTES": True,
-    "WRITE_ATTRIBUTES": True,
-    "READ_NAMED_ATTRS": True,
-    "WRITE_NAMED_ATTRS": True,
-    "READ_ACL": True,
-    "WRITE_ACL": True,
-    "WRITE_OWNER": True,
-    "SYNCHRONIZE": True,
+_PERM_BITS = {
+    "READ_DATA":         ACE4_READ_DATA,
+    "WRITE_DATA":        ACE4_WRITE_DATA,
+    "EXECUTE":           ACE4_EXECUTE,
+    "APPEND_DATA":       ACE4_APPEND_DATA,
+    "DELETE_CHILD":      ACE4_DELETE_CHILD,
+    "DELETE":            ACE4_DELETE,
+    "READ_ATTRIBUTES":   ACE4_READ_ATTRIBUTES,
+    "WRITE_ATTRIBUTES":  ACE4_WRITE_ATTRIBUTES,
+    "READ_NAMED_ATTRS":  ACE4_READ_NAMED_ATTRS,
+    "WRITE_NAMED_ATTRS": ACE4_WRITE_NAMED_ATTRS,
+    "READ_ACL":          ACE4_READ_ACL,
+    "WRITE_ACL":         ACE4_WRITE_ACL,
+    "WRITE_OWNER":       ACE4_WRITE_OWNER,
+    "SYNCHRONIZE":       ACE4_SYNCHRONIZE,
 }
 
-TEST_FLAGS = {
-    "FILE_INHERIT": True,
-    "DIRECTORY_INHERIT": True,
-    "INHERIT_ONLY": False,
-    "NO_PROPAGATE_INHERIT": False,
-    "INHERITED": False,
+_FLAG_BITS = {
+    "FILE_INHERIT":         ACE4_FILE_INHERIT_ACE,
+    "DIRECTORY_INHERIT":    ACE4_DIRECTORY_INHERIT_ACE,
+    "INHERIT_ONLY":         ACE4_INHERIT_ONLY_ACE,
+    "NO_PROPAGATE_INHERIT": ACE4_NO_PROPAGATE_INHERIT_ACE,
+    "INHERITED":            ACE4_INHERITED_ACE,
 }
+
+_BUILTIN_WHO = {"owner@", "group@", "everyone@"}
+
+
+def _ace_to_dict(ace, who_resolver=None):
+    """Convert a pynfs ``nfsace4`` to the dict shape returned by
+    ``filesystem.getacl``.  Loses no information; deterministic."""
+    perms = {name: bool(ace.access_mask & bit) for name, bit in _PERM_BITS.items()}
+    flags = {name: bool(ace.flag & bit) for name, bit in _FLAG_BITS.items()}
+    who = ace.who.decode()
+    if who.lower() in _BUILTIN_WHO:
+        tag, ident = who.lower(), -1
+    else:
+        if ace.flag & ACE4_IDENTIFIER_GROUP:
+            tag = "GROUP"
+        else:
+            tag = "USER"
+        ident = int(who) if who.isdigit() else None
+    return {
+        "type": "ALLOW" if ace.type == ACE4_ACCESS_ALLOWED_ACE_TYPE else "DENY",
+        "tag": tag,
+        "id": ident,
+        "perms": perms,
+        "flags": flags,
+    }
+
+
+def _dict_to_ace(entry):
+    """Convert a ``filesystem.setacl``-shape dict into a pynfs ``nfsace4``."""
+    mask = 0
+    for name, on in entry["perms"].items():
+        if on:
+            mask |= _PERM_BITS[name]
+    flag = 0
+    for name, on in entry.get("flags", {}).items():
+        if on:
+            flag |= _FLAG_BITS[name]
+    tag = entry["tag"]
+    if tag in _BUILTIN_WHO:
+        who = tag.upper().encode()
+    elif tag == "GROUP":
+        flag |= ACE4_IDENTIFIER_GROUP
+        who = str(entry["id"]).encode()
+    elif tag == "USER":
+        who = str(entry["id"]).encode()
+    else:
+        raise ValueError(f"unknown ACE tag: {tag!r}")
+    return nfsace4(
+        type=ACE4_ACCESS_ALLOWED_ACE_TYPE if entry["type"] == "ALLOW" else 1,
+        flag=flag,
+        access_mask=mask,
+        who=who,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test inputs
+# ---------------------------------------------------------------------------
+
+FULL_CONTROL = frozenset(_PERM_BITS)
+READ_ONLY = frozenset({"READ_DATA", "READ_ATTRIBUTES", "READ_ACL", "SYNCHRONIZE"})
+
+
+def _ace(tag, ident, allow):
+    """Build an ALLOW ACE with no inherit flags.  ``allow`` is the
+    set of permission names that are True; every other name in
+    ``_PERM_BITS`` is False."""
+    allow = frozenset(allow)
+    return {
+        "tag": tag,
+        "id": ident,
+        "type": "ALLOW",
+        "perms": {name: (name in allow) for name in _PERM_BITS},
+        "flags": {name: False for name in _FLAG_BITS},
+    }
+
+
+# Five distinguishable ALLOW ACEs.
+TEST_ACL = [
+    _ace("owner@",    -1,    FULL_CONTROL),
+    _ace("group@",    -1,    FULL_CONTROL - {"WRITE_OWNER"}),
+    _ace("everyone@", -1,    READ_ONLY),
+    _ace("USER",      65534, FULL_CONTROL - {"WRITE_OWNER", "DELETE"}),
+    _ace("GROUP",     666,   READ_ONLY),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# ``start_nfs`` is provided by ``conftest.py`` at session scope so the
+# nfsd start/stop cycle doesn't run between modules; the appliance-side
+# auth subsystem returned AUTH_BADCRED on the first EXCHANGE_ID issued
+# in each module that ran *after* a module-scoped restart.
+
+
+def _make_session(minorversion):
+    """Open a fresh pynfs NFSv4.1+ connection, EXCHANGE_ID, CREATE_SESSION,
+    RECLAIM_COMPLETE.  If any step after EXCHANGE_ID raises, tear down
+    the partially-created server-side state before re-raising so that a
+    failed setup doesn't leak a clientid that would haunt later tests
+    (showing up as AUTH_BADCRED or NFS4ERR_CLID_INUSE).
+    """
+    c = NFS4Client(truenas_server.ip.encode(), 2049, minorversion=minorversion)
+    sec = rpc.security.instance(AUTH_SYS)
+    c.set_cred(sec.init_cred(uid=0, gid=0, name=b"truenas-test"))
+    clt = None
+    sess = None
+    try:
+        clt = c.new_client(b"truenas-acl-test-" + secrets.token_hex(4).encode())
+        sess = clt.create_session()
+        sess.compound([op.reclaim_complete(False)])
+        return c, clt, sess
+    except Exception:
+        _close_session(c, clt, sess)
+        raise
+
+
+def _close_session(c, clt, sess):
+    """Tear down a session + client + the underlying pynfs polling
+    thread and TCP socket.
+
+    Server-side teardown:
+      * DESTROY_SESSION is sent via ``c.compound()`` (connection-level
+        dispatcher) rather than ``sess.compound()`` because the
+        session-level path prepends OP_SEQUENCE and updates pynfs's
+        local slot state from the response - which is invalid once
+        the session is destroyed and can leave the server-side
+        clientid lingering, tripping AUTH_BADCRED on later
+        EXCHANGE_IDs from the same source.  RFC 5661 allows both
+        DESTROY_SESSION and DESTROY_CLIENTID to appear without a
+        preceding SEQUENCE.
+      * Drop the local pynfs registries
+        (``c.sessions``/``c.clients``) so memory doesn't accumulate
+        across tests.
+
+    Client-side teardown - the load-bearing piece:
+      * ``c.stop()`` buzzes the connection-level alarm with the stop
+        signal; pynfs's polling thread (started as a daemon by
+        ``rpc.Client.__init__``) sees the flag, exits the select
+        loop, and as part of its exit path closes every socket in
+        ``self.sockets``.  Without this, the daemon thread keeps
+        running across tests holding the socket open, the appliance
+        sees the connection as still alive, and ``zfs umount`` of
+        the underlying dataset fails with ``EZFS_BUSY`` at fixture
+        teardown.  See ``rpc/rpc.py:start()`` for the loop and
+        ``rpc/rpc.py:_buzz_stop()`` for the signal handler.
+    """
+    if sess is not None:
+        try:
+            c.compound([op.destroy_session(sess.sessionid)])
+        except Exception:
+            pass
+        c.sessions.pop(sess.sessionid, None)
+    if clt is not None:
+        try:
+            c.compound([op.destroy_clientid(clt.clientid)])
+        except Exception:
+            pass
+        c.clients.pop(clt.clientid, None)
+    try:
+        c.stop()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fattr_for_minor(minorversion):
+    """The wire attribute number used to ship NFSv4 ACL data in this version."""
+    return FATTR4_ACL if minorversion == 0 else FATTR4_DACL
+
+
+def _path_components(path):
+    return [c.encode() for c in path.lstrip("/").split("/")]
+
+
+def _getattr_acl(sess, path, minorversion):
+    """Return the (aces, aclflag) pair from a single-file GETATTR."""
+    fattr = _fattr_for_minor(minorversion)
+    bitmap = nfs4lib.list2bitmap([fattr])
+    ops = nfs4lib.use_obj(_path_components(path)) + [op.getattr(bitmap)]
+    res = sess.compound(ops)
+    assert res.status == 0, f"GETATTR compound failed: {res.status}"
+    attrs = res.resarray[-1].obj_attributes
+    assert fattr in attrs, f"server didn't return attr {fattr}"
+    if minorversion == 0:
+        # FATTR4_ACL: nfsace4<>; pynfs returns a list directly here.
+        return list(attrs[fattr]), None
+    dacl = attrs[fattr]
+    return list(dacl.na41_aces), dacl.na41_flag
+
+
+def _readdir_aces(sess, parent_path, minorversion):
+    """Return {entry_name: (aces, aclflag)} from a parent-directory READDIR."""
+    fattr = _fattr_for_minor(minorversion)
+    bitmap = nfs4lib.list2bitmap([fattr])
+    ops = nfs4lib.use_obj(_path_components(parent_path)) + [
+        op.readdir(0, b"\0" * 8, 8192, 65536, bitmap),
+    ]
+    res = sess.compound(ops)
+    assert res.status == 0, f"READDIR compound failed: {res.status}"
+    rd = res.resarray[-1]
+    out = {}
+    for e in rd.reply.entries:
+        name = e.name.decode()
+        if fattr not in e.attrs:
+            continue
+        if minorversion == 0:
+            out[name] = (list(e.attrs[fattr]), None)
+        else:
+            d = e.attrs[fattr]
+            out[name] = (list(d.na41_aces), d.na41_flag)
+    return out
+
+
+def _aces_equivalent(got, expected):
+    """Compare ACE lists ignoring ZFS-side normalization of ACE flags
+    (the server may add IDENTIFIER_GROUP for ``group@``, etc.)."""
+    if len(got) != len(expected):
+        return False
+    for g, e in zip(got, expected):
+        gd = _ace_to_dict(g)
+        ed = _ace_to_dict(e)
+        # Drop synthesized id field on builtin who tags before comparing.
+        for d in (gd, ed):
+            if d["tag"] in _BUILTIN_WHO and d["id"] != -1:
+                d["id"] = -1
+        if gd != ed:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Shares are exported with no_root_squash (maproot=root) so that the
+# pynfs client's AUTH_SYS uid=0 isn't squashed to nobody, which would
+# return NFS4ERR_PERM for SETATTR and (on default-mode dirs) READDIR.
+# See ``tests/api2/test_300_nfs.py::test_share_maproot`` for the
+# TrueNAS-side behavior this works around.
+NFS_SHARE_OPTS = {"mapall_user": "root", "mapall_group": "root"}
+
+
+# pynfs's installed ``nfs4.1/`` tree only speaks NFSv4.1+ session setup
+# (EXCHANGE_ID + CREATE_SESSION).  NFSv4.0 needs SETCLIENTID, which
+# lives in pynfs's ``nfs4.0/`` tree and is not shipped on install.
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("minorversion", [
+    pytest.param(1, id="NFSv4.1"),
+    pytest.param(2, id="NFSv4.2"),
+])
+def test_acl_get_via_getattr_and_readdir_match(start_nfs, minorversion, nfs_dataset):
+    """ACL set via ``filesystem.setacl`` reads back identically through
+    NFS GETATTR (single file) and through NFS READDIR (parent directory).
+    Direct guard for the kind of asymmetry that produced the DACL
+    ordering bug."""
+    ds_name = f"nfs_acl_match_v{minorversion}"
+    expected_aces = [_dict_to_ace(d) for d in TEST_ACL]
+
+    with nfs_dataset(ds_name, data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        for fname in ("a.txt", "b.txt", "c.txt"):
+            ssh(f"touch {path}/{fname}")
+            call("filesystem.setacl",
+                 {"path": f"{path}/{fname}", "dacl": TEST_ACL,
+                  "options": {"validate_effective_acl": False}}, job=True)
+
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session(minorversion)
+            try:
+                # READDIR view, indexed by name.
+                rd_aces = _readdir_aces(sess, path, minorversion)
+                assert set(rd_aces) == {"a.txt", "b.txt", "c.txt"}
+
+                for fname in ("a.txt", "b.txt", "c.txt"):
+                    ga_aces, ga_flag = _getattr_acl(
+                        sess, f"{path}/{fname}", minorversion)
+                    rd_entry_aces, rd_entry_flag = rd_aces[fname]
+
+                    # Invariant: GETATTR and READDIR return the same wire ACL.
+                    assert ga_flag == rd_entry_flag, (
+                        f"{fname}: aclflag mismatch GETATTR={ga_flag!r} "
+                        f"READDIR={rd_entry_flag!r}")
+                    assert _aces_equivalent(ga_aces, rd_entry_aces), (
+                        f"{fname}: ACE list differs between GETATTR and "
+                        f"READDIR\n  GETATTR={[_ace_to_dict(a) for a in ga_aces]}"
+                        f"\n  READDIR={[_ace_to_dict(a) for a in rd_entry_aces]}")
+
+                    # Round-trip: what we get matches what filesystem.setacl
+                    # accepted (modulo ZFS normalization).
+                    assert _aces_equivalent(ga_aces, expected_aces), (
+                        f"{fname}: ACE list does not match what was set\n"
+                        f"  got={[_ace_to_dict(a) for a in ga_aces]}\n"
+                        f"  expected={TEST_ACL}")
+            finally:
+                _close_session(c, clt, sess)
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("version,test_acl_flag", [
-    pytest.param(4.2, True, id="NFSv4.2"),
-    pytest.param(4.1, True, id="NFSv4.1"),
-    pytest.param(4.0, False, id="NFSv4.0"),
+@pytest.mark.parametrize("minorversion", [
+    pytest.param(1, id="NFSv4.1"),
+    pytest.param(2, id="NFSv4.2"),
 ])
-def test_nfsv4_acl_support(start_nfs, version, test_acl_flag):
+def test_dacl_setattr_roundtrip(start_nfs, minorversion, nfs_dataset):
+    """SETATTR(FATTR4_DACL) over the wire round-trips via GETATTR,
+    READDIR, and ``filesystem.getacl`` (NFSv4.1+ only - FATTR4_DACL is
+    not in v4.0).  Also verifies the ACL flag is preserved."""
+    ds_name = f"nfs_dacl_setattr_v{minorversion}"
+    chosen_flag = ACL4_PROTECTED  # auto-inherit/protected/defaulted
+
+    with nfs_dataset(ds_name, data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/file.txt")
+        # Start from a known mode so the ACL we set isn't equal to the
+        # synthesized default.
+        ssh(f"chmod 0600 {path}/file.txt")
+
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session(minorversion)
+            try:
+                aces = [_dict_to_ace(d) for d in TEST_ACL]
+                new_dacl = nfsacl41(na41_flag=chosen_flag, na41_aces=aces)
+                zero_stateid = stateid4(0, b"\0" * 12)
+                set_ops = nfs4lib.use_obj(_path_components(f"{path}/file.txt")) + [
+                    op.setattr(zero_stateid, {FATTR4_DACL: new_dacl}),
+                ]
+                res = sess.compound(set_ops)
+                assert res.status == 0, f"SETATTR failed: {res.status}"
+
+                # Verify via GETATTR.
+                ga_aces, ga_flag = _getattr_acl(
+                    sess, f"{path}/file.txt", minorversion)
+                assert ga_flag == chosen_flag, (
+                    f"aclflag not preserved: set {chosen_flag} got {ga_flag}")
+                assert _aces_equivalent(ga_aces, aces)
+
+                # Verify via READDIR.
+                rd_aces = _readdir_aces(sess, path, minorversion)
+                assert "file.txt" in rd_aces
+                rd_entry_aces, rd_entry_flag = rd_aces["file.txt"]
+                assert rd_entry_flag == ga_flag
+                assert _aces_equivalent(rd_entry_aces, ga_aces)
+
+                # Verify via filesystem.getacl (server-side view).
+                fs = call("filesystem.getacl", f"{path}/file.txt", False)
+                assert fs["aclflags"]["protected"] is True, fs["aclflags"]
+                assert fs["aclflags"]["autoinherit"] is False
+                assert fs["aclflags"]["defaulted"] is False
+                # Same ACE count - content equivalence checked above via NFS.
+                assert len(fs["acl"]) == len(aces)
+            finally:
+                _close_session(c, clt, sess)
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("acl_flag,fs_key", [
+    pytest.param(ACL4_AUTO_INHERIT, "autoinherit", id="auto-inherit"),
+    pytest.param(ACL4_PROTECTED,    "protected",   id="protected"),
+    pytest.param(ACL4_DEFAULTED,    "defaulted",   id="defaulted"),
+])
+def test_dacl_aclflag_via_setattr(start_nfs, acl_flag, fs_key, nfs_dataset):
+    """Each individual NFSv4.1 ACL flag (auto-inherit / protected /
+    defaulted) round-trips through SETATTR(DACL) and is reflected in
+    ``filesystem.getacl``'s ``aclflags`` dict.
+
+    Targets a regular file rather than the dataset root: TrueNAS's
+    ``filesystem_acl.dacl`` validator requires directory ACLs to carry
+    at least one ACE with ``FILE_INHERIT`` or ``DIRECTORY_INHERIT``,
+    and our ``TEST_ACL`` doesn't.  The aclflag itself is on the ACL
+    container (``nfsacl41.na41_flag``), not specific to dirs vs files,
+    so testing on a file gives equivalent coverage.
     """
-    Validate reading and setting NFSv4 ACLs through an NFSv4 mount for
-    NFSv4.2, NFSv4.1, and NFSv4.0:
-    1) Create and locally mount an NFSv4 share on the TrueNAS server.
-    2) Iterate through all permissions options: set via NFS client, read back
-       via NFS client, and verify via filesystem API.
-    3) Repeat for each supported ACE flag.
-    4) For NFSv4.1/NFSv4.2, repeat for each supported acl_flag.
-    """
-    theacl = [
-        {"tag": "owner@", "id": -1, "perms": TEST_PERMS.copy(), "flags": TEST_FLAGS.copy(), "type": "ALLOW"},
-        {"tag": "group@", "id": -1, "perms": TEST_PERMS.copy(), "flags": TEST_FLAGS.copy(), "type": "ALLOW"},
-        {"tag": "everyone@", "id": -1, "perms": TEST_PERMS.copy(), "flags": TEST_FLAGS.copy(), "type": "ALLOW"},
-        {"tag": "USER", "id": 65534, "perms": TEST_PERMS.copy(), "flags": TEST_FLAGS.copy(), "type": "ALLOW"},
-        {"tag": "GROUP", "id": 666, "perms": TEST_PERMS.copy(), "flags": TEST_FLAGS.copy(), "type": "ALLOW"},
-    ]
+    with nfs_dataset("nfs_aclflag_each",
+                 data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/file.txt")
+        target = f"{path}/file.txt"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session(2)
+            try:
+                aces = [_dict_to_ace(d) for d in TEST_ACL]
+                new_dacl = nfsacl41(na41_flag=acl_flag, na41_aces=aces)
+                zero_stateid = stateid4(0, b"\0" * 12)
+                res = sess.compound(
+                    nfs4lib.use_obj(_path_components(target)) +
+                    [op.setattr(zero_stateid, {FATTR4_DACL: new_dacl})])
+                assert res.status == 0
 
-    # Use version-specific dataset name so a cleanup failure in one version
-    # does not prevent other versions from running.
-    ds_name = f'test_nfs4_acl_v{str(version).replace(".", "_")}'
+                # NFS GETATTR sees the flag.
+                _, ga_flag = _getattr_acl(sess, target, 2)
+                assert ga_flag == acl_flag, (
+                    f"server returned aclflag {ga_flag}, expected {acl_flag}")
 
-    with dataset(ds_name, data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
-        acl_nfs_path = f'/mnt/{ds}'
-        call('filesystem.setacl', {
-            'path': acl_nfs_path,
-            'dacl': theacl,
-            'options': {'validate_effective_acl': False},
-        }, job=True)
-        with nfs_share(acl_nfs_path):
-            with SSH_NFS(truenas_server.ip, acl_nfs_path, vers=version,
-                         user='root', password=password(), ip=truenas_server.ip) as n:
-                nfsacl = n.getacl(".")
-                for idx, ace in enumerate(nfsacl):
-                    assert ace == theacl[idx], str(ace)
-
-                for perm in TEST_PERMS:
-                    if perm == 'SYNCHRONIZE':
-                        # Break on SYNCHRONIZE due to Linux tool limitation
-                        break
-
-                    theacl[4]['perms'][perm] = False
-                    n.setacl(".", theacl)
-                    nfsacl = n.getacl(".")
-                    for idx, ace in enumerate(nfsacl):
-                        assert ace == theacl[idx], str(ace)
-
-                    result = call('filesystem.getacl', acl_nfs_path, False)
-                    for idx, ace in enumerate(result['acl']):
-                        assert ace == {**nfsacl[idx], "who": None}, str(ace)
-
-                for flag in ("INHERIT_ONLY", "NO_PROPAGATE_INHERIT"):
-                    theacl[4]['flags'][flag] = True
-                    n.setacl(".", theacl)
-                    nfsacl = n.getacl(".")
-                    for idx, ace in enumerate(nfsacl):
-                        assert ace == theacl[idx], str(ace)
-
-                    result = call('filesystem.getacl', acl_nfs_path, False)
-                    for idx, ace in enumerate(result['acl']):
-                        assert ace == {**nfsacl[idx], "who": None}, str(ace)
-
-                if test_acl_flag:
-                    assert 'none' == n.getaclflag(".")
-                    for acl_flag in ['auto-inherit', 'protected', 'defaulted']:
-                        n.setaclflag(".", acl_flag)
-                        assert acl_flag == n.getaclflag(".")
-
-                        result = call('filesystem.getacl', acl_nfs_path, False)
-
-                        # Normalize flag name for comparison to plugin equivalent
-                        flag_is_set = 'autoinherit' if acl_flag == 'auto-inherit' else acl_flag
-
-                        nfs41_flags = result['aclflags']
-                        for flag in ['autoinherit', 'protected', 'defaulted']:
-                            if flag == flag_is_set:
-                                assert nfs41_flags[flag], nfs41_flags
-                            else:
-                                assert not nfs41_flags[flag], nfs41_flags
+                # filesystem.getacl agrees.
+                fs = call("filesystem.getacl", target, False)
+                fs_flags = fs["aclflags"]
+                for key in ("autoinherit", "protected", "defaulted"):
+                    expected = (key == fs_key)
+                    assert fs_flags[key] is expected, (
+                        f"{key}={fs_flags[key]} expected {expected}; "
+                        f"all={fs_flags}")
+            finally:
+                _close_session(c, clt, sess)

--- a/tests/sharing_protocols/nfs/test_nfs_acl.py
+++ b/tests/sharing_protocols/nfs/test_nfs_acl.py
@@ -431,8 +431,12 @@ def test_dacl_setattr_roundtrip(start_nfs, minorversion, nfs_dataset):
                 assert fs["aclflags"]["protected"] is True, fs["aclflags"]
                 assert fs["aclflags"]["autoinherit"] is False
                 assert fs["aclflags"]["defaulted"] is False
-                # Same ACE count - content equivalence checked above via NFS.
-                assert len(fs["acl"]) == len(aces)
+                # Content equivalence: convert filesystem.getacl's dict ACEs
+                # back to the wire shape and compare against the ACEs we set.
+                fs_aces_wire = [_dict_to_ace(d) for d in fs["acl"]]
+                assert _aces_equivalent(fs_aces_wire, aces), (
+                    f"filesystem.getacl ACE list does not match what was set "
+                    f"via NFS\n  got={fs['acl']}\n  expected={TEST_ACL}")
             finally:
                 _close_session(c, clt, sess)
 

--- a/tests/sharing_protocols/nfs/test_nfs_dacl_posix_backing.py
+++ b/tests/sharing_protocols/nfs/test_nfs_dacl_posix_backing.py
@@ -1,0 +1,355 @@
+"""NFSv4 ACL/DACL behavior on POSIXACL-backed datasets.
+
+Two coverage areas:
+
+* **DACL guard (gate on ``IS_NFSV4ACL``)** -- the TrueNAS DACL
+  extension in ``fs/nfsd/nfs4xdr.c`` exposes ``FATTR4_DACL`` (bit 58)
+  only on inodes where ``IS_NFSV4ACL`` is true.  Three kernel places
+  enforce this and each is exercised below:
+
+  1. ``nfsd4_encode_fattr4_supported_attrs`` strips bit 58 from the
+     advertised ``supported_attrs``.
+  2. ``nfsd4_encode_fattr4`` (the GETATTR / READDIR encoder) clears
+     bit 58 from ``attrmask`` so a client that ignores
+     ``supported_attrs`` doesn't get a flag=0 POSIX-translated fake
+     DACL.
+  3. ``check_attr_support`` in ``nfs4proc.c`` rejects SETATTR on
+     bit 58 with ``NFS4ERR_ATTRNOTSUPP``.
+
+* **FATTR4_ACL still works on POSIX** (bit 12) -- negative control for
+  the DACL guard.  ``check_attr_support`` allows ``FATTR4_ACL`` on
+  POSIXACL inodes; SETATTR with a POSIX1E-compatible ACE list must
+  succeed, GETATTR must return it (not stripped), and the POSIX
+  side must reflect the named-group + MASK semantics.
+"""
+
+import secrets
+
+import pytest
+import rpc
+import nfs4lib
+import nfs_ops
+from nfs4client import NFS4Client
+from rpc.rpc_const import AUTH_SYS
+from xdrdef.nfs4_const import (
+    ACE4_ACCESS_ALLOWED_ACE_TYPE,
+    ACE4_APPEND_DATA,
+    ACE4_EXECUTE,
+    ACE4_IDENTIFIER_GROUP,
+    ACE4_READ_ACL,
+    ACE4_READ_ATTRIBUTES,
+    ACE4_READ_DATA,
+    ACE4_SYNCHRONIZE,
+    ACE4_WRITE_DATA,
+    FATTR4_ACL,
+    FATTR4_DACL,
+    FATTR4_FILEID,
+    FATTR4_SUPPORTED_ATTRS,
+    NFS4ERR_ATTRNOTSUPP,
+)
+from xdrdef.nfs4_type import nfsace4, nfsacl41, stateid4
+
+from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
+from protocols import nfs_share
+
+op = nfs_ops.NFS4ops()
+
+
+NFS_SHARE_OPTS = {"mapall_user": "root", "mapall_group": "root"}
+NFSV4_DATA = {"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}
+POSIX_DATA = {"acltype": "POSIX", "aclmode": "DISCARD"}
+
+
+# ``start_nfs`` is provided by ``conftest.py`` at session scope.
+
+
+def _make_session(minorversion=2):
+    """Open a fresh pynfs NFSv4.1+ connection (EXCHANGE_ID +
+    CREATE_SESSION + RECLAIM_COMPLETE).  Tear down partial state on
+    failure so a botched setup doesn't leave a server-side clientid
+    that haunts later tests."""
+    c = NFS4Client(truenas_server.ip.encode(), 2049, minorversion=minorversion)
+    sec = rpc.security.instance(AUTH_SYS)
+    c.set_cred(sec.init_cred(uid=0, gid=0, name=b"truenas-test"))
+    clt = None
+    sess = None
+    try:
+        clt = c.new_client(b"truenas-dacl-posix-" + secrets.token_hex(4).encode())
+        sess = clt.create_session()
+        sess.compound([op.reclaim_complete(False)])
+        return c, clt, sess
+    except Exception:
+        _close_session(c, clt, sess)
+        raise
+
+
+def _close_session(c, clt, sess):
+    """Server-side DESTROY_SESSION+DESTROY_CLIENTID via the
+    connection-level dispatcher (no SEQUENCE prefix), then ``c.stop()``
+    so pynfs's polling thread exits and releases the socket -- without
+    that, ZFS umount races with the still-open connection at fixture
+    teardown and EZFS_BUSY's the dataset delete."""
+    if sess is not None:
+        try:
+            c.compound([op.destroy_session(sess.sessionid)])
+        except Exception:
+            pass
+        c.sessions.pop(sess.sessionid, None)
+    if clt is not None:
+        try:
+            c.compound([op.destroy_clientid(clt.clientid)])
+        except Exception:
+            pass
+        c.clients.pop(clt.clientid, None)
+    try:
+        c.stop()
+    except Exception:
+        pass
+
+
+def _path_components(path):
+    return [c.encode() for c in path.lstrip("/").split("/")]
+
+
+def _has_dacl_bit(bitmap):
+    """Return True iff bit ``FATTR4_DACL`` is set.
+
+    pynfs's Fancy decoder collapses the wire ``bitmap4`` (an array of
+    u32s) into a single Python integer (``FancyNFS4Unpacker.filter_bitmap4``
+    in ``nfs4lib.py``), so we just test the bit directly.
+    """
+    return bool(bitmap & (1 << FATTR4_DACL))
+
+
+def test_supported_attrs_dacl_only_on_nfsv4acl(start_nfs, nfs_dataset):
+    """``supported_attrs`` must advertise FATTR4_DACL on an NFSv4ACL
+    backing and *not* advertise it on a POSIXACL backing -- mirrors
+    ``nfsd4_encode_fattr4_supported_attrs`` in ``nfs4xdr.c``."""
+    with (
+        nfs_dataset("nfs_dacl_supp_v4", data=NFSV4_DATA) as nfsv4_ds,
+        nfs_dataset("nfs_dacl_supp_posix", data=POSIX_DATA) as posix_ds,
+    ):
+        nfsv4_path = f"/mnt/{nfsv4_ds}"
+        posix_path = f"/mnt/{posix_ds}"
+
+        for path, expected_dacl, label in (
+            (nfsv4_path, True, "NFSV4"),
+            (posix_path, False, "POSIX"),
+        ):
+            with nfs_share(path, NFS_SHARE_OPTS):
+                c, clt, sess = _make_session()
+                try:
+                    bitmap = nfs4lib.list2bitmap([FATTR4_SUPPORTED_ATTRS])
+                    ops = nfs4lib.use_obj(_path_components(path)) + [
+                        op.getattr(bitmap),
+                    ]
+                    res = sess.compound(ops)
+                    assert res.status == 0, (
+                        f"{label}: GETATTR(SUPPORTED_ATTRS) status={res.status}"
+                    )
+                    attrs = res.resarray[-1].obj_attributes
+                    assert FATTR4_SUPPORTED_ATTRS in attrs, (
+                        f"{label}: server didn't return SUPPORTED_ATTRS"
+                    )
+                    supp_bitmap = attrs[FATTR4_SUPPORTED_ATTRS]
+                    has_dacl = _has_dacl_bit(supp_bitmap)
+                    assert has_dacl is expected_dacl, (
+                        f"{label}: supported_attrs DACL bit = {has_dacl}, "
+                        f"expected {expected_dacl}.  bitmap={supp_bitmap}"
+                    )
+                finally:
+                    _close_session(c, clt, sess)
+
+
+@pytest.mark.parametrize("rpc_op", ["getattr", "readdir"])
+def test_dacl_stripped_on_posix_backing(start_nfs, nfs_dataset, rpc_op):
+    """A client that requests FATTR4_DACL on a POSIXACL backing must
+    receive a response with bit 58 *cleared* in the returned attrmask
+    -- the server stripped it (``nfsd4_encode_fattr4`` clears
+    ``attrmask[1] & FATTR4_WORD1_DACL`` when ``!IS_NFSV4ACL``).
+
+    Verifies both code paths (GETATTR on a single FH, READDIR on the
+    parent directory)."""
+    with nfs_dataset("nfs_dacl_posix_strip", data=POSIX_DATA) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/x.txt")
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session()
+            try:
+                bitmap = nfs4lib.list2bitmap([FATTR4_FILEID, FATTR4_DACL])
+                if rpc_op == "getattr":
+                    ops = nfs4lib.use_obj(_path_components(f"{path}/x.txt")) + [
+                        op.getattr(bitmap)
+                    ]
+                    res = sess.compound(ops)
+                    assert res.status == 0, f"GETATTR status={res.status}"
+                    returned = res.resarray[-1].obj_attributes
+                    assert FATTR4_DACL not in returned, (
+                        f"server returned DACL on POSIXACL backing -- "
+                        f"IS_NFSV4ACL guard not effective.  "
+                        f"obj_attributes keys={sorted(returned)}"
+                    )
+                else:  # readdir
+                    ops = nfs4lib.use_obj(_path_components(path)) + [
+                        op.readdir(0, b"\0" * 8, 8192, 65536, bitmap),
+                    ]
+                    res = sess.compound(ops)
+                    assert res.status == 0, f"READDIR status={res.status}"
+                    entries = list(res.resarray[-1].reply.entries)
+                    names = {e.name.decode() for e in entries}
+                    assert "x.txt" in names, names
+                    for e in entries:
+                        if e.name.decode() != "x.txt":
+                            continue
+                        assert FATTR4_DACL not in e.attrs, (
+                            f"server returned DACL in READDIR entry "
+                            f"on POSIXACL backing.  attrs keys="
+                            f"{sorted(e.attrs)}"
+                        )
+            finally:
+                _close_session(c, clt, sess)
+
+
+def test_setattr_dacl_rejected_on_posix_backing(start_nfs, nfs_dataset):
+    """SETATTR(FATTR4_DACL) on a POSIXACL backing must return
+    ``NFS4ERR_ATTRNOTSUPP`` -- ``check_attr_support`` in
+    ``nfs4proc.c`` rejects DACL writes when ``!IS_NFSV4ACL``."""
+    with nfs_dataset("nfs_dacl_posix_setattr", data=POSIX_DATA) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/x.txt")
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session()
+            try:
+                ace = nfsace4(
+                    type=ACE4_ACCESS_ALLOWED_ACE_TYPE,
+                    flag=0,
+                    access_mask=(ACE4_READ_DATA | ACE4_READ_ATTRIBUTES | ACE4_READ_ACL),
+                    who=b"OWNER@",
+                )
+                new_dacl = nfsacl41(na41_flag=0, na41_aces=[ace])
+                zero_stateid = stateid4(0, b"\0" * 12)
+                ops = nfs4lib.use_obj(_path_components(f"{path}/x.txt")) + [
+                    op.setattr(zero_stateid, {FATTR4_DACL: new_dacl})
+                ]
+                res = sess.compound(ops)
+                assert res.status == NFS4ERR_ATTRNOTSUPP, (
+                    f"SETATTR(DACL) on POSIXACL backing returned "
+                    f"status={res.status}, expected "
+                    f"NFS4ERR_ATTRNOTSUPP ({NFS4ERR_ATTRNOTSUPP})"
+                )
+            finally:
+                _close_session(c, clt, sess)
+
+
+def test_setattr_acl_posix1e_compatible_on_posix_backing(start_nfs, nfs_dataset):
+    """SETATTR(FATTR4_ACL) with a POSIX1E-compatible ACE list on a
+    POSIXACL backing must succeed and round-trip.
+
+    Negative control for the ``IS_NFSV4ACL`` DACL guard: ``FATTR4_ACL``
+    (bit 12) is allowed on POSIXACL inodes
+    (``check_attr_support`` in ``nfs4proc.c``), so the guard must not
+    bleed across attribute numbers.
+
+    The test ACL includes an explicit ``GROUP:0`` ALLOW entry, which
+    forces the kernel to materialize a POSIX1E ``MASK`` entry alongside
+    the named-group ``ACL_GROUP``.  The translation goes through
+    ``nfs4_acl_nfsv4_to_posix`` -> ``set_posix_acl`` (see
+    ``fs/nfsd/nfs4acl.c`` and ``fs/nfsd/vfs.c``).
+
+    Round-trip via NFSv4 is lossy by design (DENY ordering, mask
+    synthesis, derived deny entries), so we don't byte-compare; we
+    assert structural survival of every principal we set, plus the
+    POSIX-side view via ``filesystem.getacl``.
+    """
+    R = ACE4_READ_DATA | ACE4_READ_ATTRIBUTES | ACE4_READ_ACL | ACE4_SYNCHRONIZE
+    W = ACE4_WRITE_DATA | ACE4_APPEND_DATA
+    X = ACE4_EXECUTE
+    with nfs_dataset("nfs_dacl_posix_acl_set", data=POSIX_DATA) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/x.txt")
+        target = f"{path}/x.txt"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            c, clt, sess = _make_session()
+            try:
+                aces = [
+                    nfsace4(
+                        type=ACE4_ACCESS_ALLOWED_ACE_TYPE,
+                        flag=0,
+                        access_mask=R | W | X,
+                        who=b"OWNER@",
+                    ),
+                    nfsace4(
+                        type=ACE4_ACCESS_ALLOWED_ACE_TYPE,
+                        flag=0,
+                        access_mask=R | X,
+                        who=b"GROUP@",
+                    ),
+                    nfsace4(
+                        type=ACE4_ACCESS_ALLOWED_ACE_TYPE,
+                        flag=ACE4_IDENTIFIER_GROUP,
+                        access_mask=R | W | X,
+                        who=b"0",
+                    ),
+                    nfsace4(
+                        type=ACE4_ACCESS_ALLOWED_ACE_TYPE,
+                        flag=0,
+                        access_mask=R,
+                        who=b"EVERYONE@",
+                    ),
+                ]
+                zero_stateid = stateid4(0, b"\0" * 12)
+                set_ops = nfs4lib.use_obj(_path_components(target)) + [
+                    op.setattr(zero_stateid, {FATTR4_ACL: aces}),
+                ]
+                res = sess.compound(set_ops)
+                assert res.status == 0, (
+                    f"SETATTR(FATTR4_ACL) on POSIXACL backing failed: "
+                    f"status={res.status}.  IS_NFSV4ACL guard may have "
+                    f"bled into the FATTR4_ACL path."
+                )
+
+                # GETATTR must still return FATTR4_ACL on POSIX (only
+                # FATTR4_DACL is gated by IS_NFSV4ACL).
+                bitmap = nfs4lib.list2bitmap([FATTR4_ACL])
+                get_ops = nfs4lib.use_obj(_path_components(target)) + [
+                    op.getattr(bitmap),
+                ]
+                res = sess.compound(get_ops)
+                assert res.status == 0, f"GETATTR status={res.status}"
+                returned = res.resarray[-1].obj_attributes
+                assert FATTR4_ACL in returned, (
+                    f"server didn't return FATTR4_ACL on POSIXACL "
+                    f"backing.  obj_attributes keys={sorted(returned)}"
+                )
+                got_aces = list(returned[FATTR4_ACL])
+                whos = {bytes(a.who) for a in got_aces}
+                assert {b"OWNER@", b"GROUP@", b"EVERYONE@"} <= whos, whos
+                # Named group must survive as ASCII GID with the
+                # IDENTIFIER_GROUP flag set on at least one ACE.
+                named_group_aces = [
+                    a
+                    for a in got_aces
+                    if (a.flag & ACE4_IDENTIFIER_GROUP) and bytes(a.who) == b"0"
+                ]
+                assert named_group_aces, (
+                    f"named GROUP:0 entry didn't round-trip via NFSv4 "
+                    f"GETATTR.  who-strings={whos}"
+                )
+
+                # Server-side POSIX1E view: USER_OBJ + GROUP_OBJ +
+                # GROUP:0 + MASK (synthesized because of the named
+                # group) + OTHER.
+                fs = call("filesystem.getacl", target, False)
+                assert fs["acltype"] == "POSIX1E", fs["acltype"]
+                tags = {(e["tag"], e.get("id")) for e in fs["acl"]}
+                tag_names = {t for t, _ in tags}
+                assert {"USER_OBJ", "GROUP_OBJ", "OTHER"} <= tag_names, tags
+                assert "MASK" in tag_names, (
+                    f"MASK entry not synthesized for ACL with named group: {tags}"
+                )
+                assert ("GROUP", 0) in tags, (
+                    f"named POSIX GROUP:0 entry missing: {tags}"
+                )
+            finally:
+                _close_session(c, clt, sess)

--- a/tests/sharing_protocols/nfs/test_nfs_dacl_readdir.py
+++ b/tests/sharing_protocols/nfs/test_nfs_dacl_readdir.py
@@ -1,0 +1,658 @@
+"""Regression test for NFSv4 DACL fattr4 ordering (READDIR + GETATTR).
+
+Invariant: when a reply carries ``FATTR4_DACL`` (bit 58) together with
+any attribute numbered higher than 58 (e.g. ``FATTR4_XATTR_SUPPORT`` =
+82), the DACL bytes must appear in the on-the-wire ``attr_vals`` blob
+in attribute-number order.  RFC 8881 §3.3.7 requires fattr4
+attributes to be encoded in increasing attribute-number order; a DACL
+emitted out of order causes the client to decode garbage at the DACL
+slot.  Both READDIR (per-entry attrs) and GETATTR (single-FH attrs)
+go through the same kernel encoder path
+(``nfsd4_encode_fattr4``), so we exercise both.
+
+Detection strategy
+==================
+
+Relying on pynfs's bitmap-driven decoder to raise on misaligned bytes
+is unreliable: lucky byte alignment can let the decoder run through
+without complaint and hide the bug.  Instead we capture the raw
+``attr_vals`` bytes (via the plain ``NFS4Unpacker``, not the Fancy
+variant) and walk them manually in attribute-number order, asserting
+that every length, type, and offset is plausible and that the walk
+consumes exactly the number of bytes the server delivered.  Any
+deviation - leftover bytes, a 4-byte 0/1 bool that decoded as
+``0x1E01FF``, an ACE whose ``who_len`` would overrun the buffer - fires
+a deterministic ``AssertionError``.
+"""
+
+import secrets
+import struct
+
+import pytest
+import rpc
+import nfs4lib
+import nfs_ops
+from nfs4client import NFS4Client
+from rpc.rpc_const import AUTH_SYS
+from xdrdef.nfs4_const import (
+    FATTR4_FILEID,
+    FATTR4_MODE,
+    FATTR4_OWNER,
+    FATTR4_OWNER_GROUP,
+    FATTR4_DACL,
+    FATTR4_XATTR_SUPPORT,
+    OP_GETATTR,
+    OP_READDIR,
+)
+from xdrdef.nfs4_pack import NFS4Unpacker
+
+from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
+from protocols import nfs_share
+
+op = nfs_ops.NFS4ops()
+
+
+# Shares are exported with ``mapall_user/group=root`` so that the pynfs
+# client's AUTH_SYS uid=0 isn't squashed to nobody, which would return
+# NFS4ERR_PERM for SETATTR and (on default-mode dirs) READDIR.  See
+# ``tests/api2/test_300_nfs.py::test_share_maproot``.
+NFS_SHARE_OPTS = {"mapall_user": "root", "mapall_group": "root"}
+
+# ``acltype=NFSV4`` is the kernel-side gate for ``IS_NFSV4ACL(inode)``,
+# which the DACL fetch path now requires (see ``nfs4xdr.c``).
+NFSV4_DATA = {"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}
+
+
+# Five distinguishable ACEs - including USER:65534 and GROUP:666 so that
+# any wire-misalignment produces obviously-wrong who-strings (ASCII
+# digits where the encoder should have written ALLOW-type ints, and
+# vice-versa).
+KNOWN_ACL = [
+    {
+        "tag": "owner@",
+        "id": -1,
+        "perms": {
+            "READ_DATA": True,
+            "WRITE_DATA": True,
+            "EXECUTE": True,
+            "APPEND_DATA": True,
+            "READ_ATTRIBUTES": True,
+            "WRITE_ATTRIBUTES": True,
+            "READ_ACL": True,
+            "WRITE_ACL": True,
+            "READ_NAMED_ATTRS": True,
+            "WRITE_NAMED_ATTRS": True,
+            "WRITE_OWNER": True,
+            "DELETE_CHILD": True,
+            "DELETE": True,
+            "SYNCHRONIZE": True,
+        },
+        "flags": {},
+        "type": "ALLOW",
+    },
+    {
+        "tag": "group@",
+        "id": -1,
+        "perms": {
+            "READ_DATA": True,
+            "EXECUTE": True,
+            "READ_ATTRIBUTES": True,
+            "READ_ACL": True,
+            "READ_NAMED_ATTRS": True,
+            "SYNCHRONIZE": True,
+        },
+        "flags": {},
+        "type": "ALLOW",
+    },
+    {
+        "tag": "everyone@",
+        "id": -1,
+        "perms": {
+            "READ_DATA": True,
+            "EXECUTE": True,
+            "READ_ATTRIBUTES": True,
+            "READ_ACL": True,
+            "READ_NAMED_ATTRS": True,
+            "SYNCHRONIZE": True,
+        },
+        "flags": {},
+        "type": "ALLOW",
+    },
+    {
+        "tag": "USER",
+        "id": 65534,
+        "perms": {
+            "READ_DATA": True,
+            "READ_ATTRIBUTES": True,
+            "READ_ACL": True,
+            "SYNCHRONIZE": True,
+        },
+        "flags": {},
+        "type": "ALLOW",
+    },
+    {
+        "tag": "GROUP",
+        "id": 666,
+        "perms": {
+            "READ_DATA": True,
+            "READ_ATTRIBUTES": True,
+            "READ_ACL": True,
+            "SYNCHRONIZE": True,
+        },
+        "flags": {},
+        "type": "ALLOW",
+    },
+]
+
+
+# ``start_nfs`` is provided by ``conftest.py`` at session scope.
+
+
+@pytest.fixture
+def session42():
+    """Factory fixture: returns a callable that opens a pynfs NFSv4.2
+    client + session.  The caller MUST invoke it inside a
+    ``with nfs_share(...):`` block - EXCHANGE_ID is rejected with
+    ``AUTH_BADCRED`` if no NFS export is currently active for the
+    source IP, because Linux nfsd's ``svcauth_unix_accept`` requires
+    the client's IP to appear in some export's host list.
+
+    NFSv4.2 (minorversion=2) is required: ``FATTR4_XATTR_SUPPORT``
+    (bit 82) is only advertised by the server's supported_attrs in
+    v4.2, so a v4.1 server filters it out of the response, neutering
+    the bug-trigger condition.
+    """
+    opened = []
+
+    def _open():
+        c = NFS4Client(truenas_server.ip.encode(), 2049, minorversion=2)
+        sec = rpc.security.instance(AUTH_SYS)
+        c.set_cred(sec.init_cred(uid=0, gid=0, name=b"truenas-test"))
+        clt = None
+        sess = None
+        try:
+            clt = c.new_client(b"truenas-dacl-test-" + secrets.token_hex(4).encode())
+            sess = clt.create_session()
+            sess.compound([op.reclaim_complete(False)])
+        except Exception:
+            _teardown(c, clt, sess)
+            raise
+        opened.append((c, clt, sess))
+        return sess
+
+    yield _open
+
+    for c, clt, sess in opened:
+        _teardown(c, clt, sess)
+
+
+def _teardown(c, clt, sess):
+    """Server-side teardown via ``c.compound`` (connection-level, no
+    SEQUENCE prefix), then ``c.stop()`` to terminate the polling thread
+    and release the socket so the underlying ZFS dataset can unmount
+    cleanly.
+    """
+    if sess is not None:
+        try:
+            c.compound([op.destroy_session(sess.sessionid)])
+        except Exception:
+            pass
+        c.sessions.pop(sess.sessionid, None)
+    if clt is not None:
+        try:
+            c.compound([op.destroy_clientid(clt.clientid)])
+        except Exception:
+            pass
+        c.clients.pop(clt.clientid, None)
+    try:
+        c.stop()
+    except Exception:
+        pass
+
+
+def _components(path):
+    return [c.encode() for c in path.lstrip("/").split("/")]
+
+
+def _readdir_raw(sess, share_path, attr_list):
+    """Issue PUTROOTFH+LOOKUP*+READDIR via the session, but parse the
+    response with the *plain* ``NFS4Unpacker`` (not Fancy) so the
+    per-entry ``attr_vals`` stays as raw opaque bytes.
+
+    Slot management: we reserve a session slot via
+    ``sess._prepare_compound`` so the server's slot replay cache stays
+    coherent; we send via ``sess.c.compound_async`` and receive raw
+    bytes via ``sess.c.c1.listen``; we mark the slot free with
+    ``slot.inuse = False`` rather than calling
+    ``sess.update_seq_state`` because that would re-enter the Fancy
+    decode path.
+
+    Returns a list of ``(name, attrmask_bits, raw_attr_vals)`` tuples,
+    one per directory entry.
+    """
+    bitmap = nfs4lib.list2bitmap(attr_list)
+    ops = nfs4lib.use_obj(_components(share_path)) + [
+        op.readdir(0, b"\0" * 8, 8192, 65536, bitmap),
+    ]
+    slot, seq_op = sess._prepare_compound({})
+    try:
+        xid = sess.c.compound_async([seq_op] + ops)
+        header, raw = sess.c.c1.listen(xid)
+    finally:
+        slot.inuse = False
+
+    p = NFS4Unpacker(raw)
+    result = p.unpack_COMPOUND4res()
+    assert result.status == 0, f"compound failed: status={result.status}"
+
+    rd = next((r for r in result.resarray if r.resop == OP_READDIR), None)
+    assert rd is not None, "READDIR result missing"
+    assert rd.opreaddir.status == 0, f"READDIR status {rd.opreaddir.status}"
+
+    out = []
+    cur = rd.opreaddir.resok4.reply.entries
+    # Plain unpacker leaves dirlist4 entries as a chain (each entry's
+    # nextentry is a list of 0 or 1 entries forming the rest of the
+    # chain).
+    while cur:
+        if isinstance(cur, list):
+            cur = cur[0] if cur else None
+            if cur is None:
+                break
+        bits = []
+        for w, word in enumerate(cur.attrs.attrmask):
+            for b in range(32):
+                if word & (1 << b):
+                    bits.append(w * 32 + b)
+        out.append((bytes(cur.name), bits, bytes(cur.attrs.attr_vals)))
+        cur = cur.nextentry
+    return out
+
+
+def _getattr_raw(sess, file_path, attr_list):
+    """Issue PUTROOTFH+LOOKUP*+GETATTR on a single file and parse the
+    response with the plain ``NFS4Unpacker`` so ``attr_vals`` stays as
+    raw opaque bytes.  Same slot-management pattern as
+    ``_readdir_raw``.
+
+    Returns ``(attrmask_bits, raw_attr_vals)``.
+    """
+    bitmap = nfs4lib.list2bitmap(attr_list)
+    ops = nfs4lib.use_obj(_components(file_path)) + [op.getattr(bitmap)]
+    slot, seq_op = sess._prepare_compound({})
+    try:
+        xid = sess.c.compound_async([seq_op] + ops)
+        header, raw = sess.c.c1.listen(xid)
+    finally:
+        slot.inuse = False
+
+    p = NFS4Unpacker(raw)
+    result = p.unpack_COMPOUND4res()
+    assert result.status == 0, f"compound failed: status={result.status}"
+
+    ga = next((r for r in result.resarray if r.resop == OP_GETATTR), None)
+    assert ga is not None, "GETATTR result missing"
+    assert ga.opgetattr.status == 0, f"GETATTR status {ga.opgetattr.status}"
+
+    fattr = ga.opgetattr.resok4.obj_attributes
+    bits = []
+    for w, word in enumerate(fattr.attrmask):
+        for b in range(32):
+            if word & (1 << b):
+                bits.append(w * 32 + b)
+    return bits, bytes(fattr.attr_vals)
+
+
+def _walk_attr_vals_rfc_order(bits, attr_vals):
+    """Walk ``attr_vals`` in RFC 8881 attribute-number order, asserting
+    plausibility of every length, type, and offset, plus exact
+    consumption of all bytes.
+
+    A misaligned wire (the TrueNAS DACL ordering bug) shows up here as:
+    - DACL ``naces`` decoded as a giant integer (because the next 4
+      wire bytes after pynfs's mis-anchored ``aclflag`` aren't a count
+      but the raw bytes of a higher-numbered attribute);
+    - ACE ``who_len`` exceeding the remaining buffer;
+    - ``XATTR_SUPPORT`` u32 not equal to 0 or 1;
+    - extra bytes left over after walking every requested attribute.
+
+    Returns a dict ``{bit: value}`` of decoded attribute values.
+    """
+    cur = 0
+    end = len(attr_vals)
+    decoded = {}
+
+    def _u32():
+        nonlocal cur
+        assert cur + 4 <= end, f"out of bytes at offset {cur} (len {end}) reading u32"
+        v = struct.unpack(">I", attr_vals[cur : cur + 4])[0]
+        cur += 4
+        return v
+
+    def _u64():
+        nonlocal cur
+        assert cur + 8 <= end, f"out of bytes at offset {cur} (len {end}) reading u64"
+        v = struct.unpack(">Q", attr_vals[cur : cur + 8])[0]
+        cur += 8
+        return v
+
+    def _opaque(max_len):
+        nonlocal cur
+        l = _u32()
+        assert l <= max_len, (
+            f"unreasonable opaque length {l} at offset {cur - 4} "
+            f"(max expected {max_len})"
+        )
+        assert cur + l <= end, f"opaque length {l} would overrun buffer at offset {cur}"
+        v = bytes(attr_vals[cur : cur + l])
+        cur += l
+        cur += (-l) % 4
+        return v
+
+    for bit in sorted(bits):
+        if bit == FATTR4_FILEID:
+            decoded[bit] = _u64()
+        elif bit == FATTR4_MODE:
+            decoded[bit] = _u32()
+        elif bit == FATTR4_OWNER or bit == FATTR4_OWNER_GROUP:
+            decoded[bit] = _opaque(max_len=64)
+        elif bit == FATTR4_DACL:
+            aclflag = _u32()
+            naces = _u32()
+            assert naces <= 64, (
+                f"DACL: implausible ACE count {naces} (>64); "
+                f"likely bytes are misaligned -- DACL ordering bug"
+            )
+            aces = []
+            for i in range(naces):
+                t = _u32()
+                f = _u32()
+                m = _u32()
+                w = _opaque(max_len=64)
+                aces.append((t, f, m, w))
+            decoded[bit] = (aclflag, naces, aces)
+        elif bit == FATTR4_XATTR_SUPPORT:
+            v = _u32()
+            assert v in (0, 1), (
+                f"XATTR_SUPPORT must be 0 or 1, got {v} -- bytes "
+                f"likely came from another attribute slot"
+            )
+            decoded[bit] = bool(v)
+        else:
+            raise NotImplementedError(
+                f"_walk_attr_vals_rfc_order: bit {bit} not handled"
+            )
+
+    assert cur == end, (
+        f"attr_vals walk consumed {cur} bytes but length is {end} "
+        f"({end - cur} extra) -- DACL ordering bug"
+    )
+    return decoded
+
+
+def _expected_who(ace_id, ace_tag):
+    if ace_tag == "owner@":
+        return b"OWNER@"
+    if ace_tag == "group@":
+        return b"GROUP@"
+    if ace_tag == "everyone@":
+        return b"EVERYONE@"
+    if ace_tag == "USER":
+        return f"{ace_id}".encode()
+    if ace_tag == "GROUP":
+        return f"{ace_id}".encode()
+    raise AssertionError(f"unknown tag {ace_tag}")
+
+
+def test_dacl_readdir_with_high_attr(start_nfs, session42, nfs_dataset):
+    """Bug catcher: bitmap = FATTR4_DACL (58) + FATTR4_XATTR_SUPPORT (82).
+
+    On a buggy kernel the encoder's post-loop append puts DACL bytes
+    *after* the XATTR_SUPPORT bytes that the bitmap-iteration loop
+    already wrote at bit-58's wire position.  We capture the raw
+    ``attr_vals`` (no Fancy decoder), walk it in RFC 8881
+    attribute-number order, and assert every length and the final
+    offset.  Mis-ordering shows up as implausible ACE counts,
+    overrunning ``who_len`` values, an XATTR_SUPPORT u32 that isn't a
+    bool, or leftover bytes.
+    """
+    with nfs_dataset(
+        "test_dacl_rd_hi",
+        data=NFSV4_DATA,
+    ) as ds:
+        path = f"/mnt/{ds}"
+        for name in ("a.txt", "b.txt", "c.txt"):
+            ssh(f"touch {path}/{name}")
+            call(
+                "filesystem.setacl",
+                {
+                    "path": f"{path}/{name}",
+                    "dacl": KNOWN_ACL,
+                    "options": {"validate_effective_acl": False},
+                },
+                job=True,
+            )
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            entries = _readdir_raw(
+                sess,
+                path,
+                [
+                    FATTR4_FILEID,
+                    FATTR4_MODE,
+                    FATTR4_OWNER,
+                    FATTR4_OWNER_GROUP,
+                    FATTR4_DACL,
+                    FATTR4_XATTR_SUPPORT,
+                ],
+            )
+            names = {n.decode() for n, _, _ in entries}
+            assert names == {"a.txt", "b.txt", "c.txt"}, names
+
+            for name, bits, attr_vals in entries:
+                fname = name.decode()
+                hexdump = (
+                    f"  raw attr_vals ({len(attr_vals)} bytes): "
+                    f"{attr_vals.hex()}\n"
+                    f"  attrmask bits returned: {sorted(bits)}"
+                )
+
+                # Sanity: server didn't filter XATTR_SUPPORT or DACL
+                # out of the response.  (Either filter would mean we're
+                # not actually exercising the bug-trigger condition.)
+                assert FATTR4_DACL in bits, (
+                    f"{fname}: server didn't return DACL.\n{hexdump}"
+                )
+                assert FATTR4_XATTR_SUPPORT in bits, (
+                    f"{fname}: server filtered XATTR_SUPPORT out -- test "
+                    f"isn't exercising the bug.  Confirm NFSv4.2 and "
+                    f"that the dataset reports xattr support.\n{hexdump}"
+                )
+
+                # Primary check: in RFC 8881 order, XATTR_SUPPORT (bit 82,
+                # the highest-numbered attribute we requested) is the
+                # LAST attribute on the wire, so attr_vals MUST end with
+                # a 4-byte 0/1 bool.  On a buggy kernel the post-loop
+                # DACL append puts the last ACE's who-string + padding
+                # at the tail, never a bare 0/1.
+                last4 = bytes(attr_vals[-4:])
+                assert last4 in (b"\x00\x00\x00\x00", b"\x00\x00\x00\x01"), (
+                    f"{fname}: last 4 bytes of attr_vals = "
+                    f"{last4.hex()}, expected XATTR_SUPPORT bool "
+                    f"(00000000 or 00000001) since it's the highest-"
+                    f"numbered attribute requested.  TrueNAS DACL "
+                    f"ordering bug: server placed DACL bytes AFTER "
+                    f"XATTR_SUPPORT, so the tail is part of an ACE "
+                    f"who-string + padding, not a bool.\n{hexdump}"
+                )
+
+                # Secondary check: byte-walk in RFC order.  Each step
+                # asserts plausibility (lengths <= 64, XATTR_SUPPORT
+                # u32 in {0,1}, total bytes consumed == len).  This
+                # catches misalignments that don't happen to leave a
+                # bool at the tail.
+                walk_error = None
+                decoded = None
+                try:
+                    decoded = _walk_attr_vals_rfc_order(bits, attr_vals)
+                except AssertionError as e:
+                    walk_error = e
+
+                assert walk_error is None, (
+                    f"{fname}: attr_vals byte layout doesn't match "
+                    f"RFC 8881 attribute-number ordering -- the TrueNAS "
+                    f"DACL ordering bug.  The server appended DACL "
+                    f"bytes after attr-vals for higher-numbered "
+                    f"attributes (here, XATTR_SUPPORT at bit 82 vs "
+                    f"DACL at bit 58).\n{hexdump}\n"
+                    f"  walk failed: {walk_error}"
+                )
+
+                # Decoded values sanity:
+                assert decoded[FATTR4_XATTR_SUPPORT] is True, (
+                    f"{fname}: XATTR_SUPPORT="
+                    f"{decoded[FATTR4_XATTR_SUPPORT]}, expected True on "
+                    f"a ZFS dataset with xattrs enabled.\n{hexdump}"
+                )
+                aclflag, naces, aces = decoded[FATTR4_DACL]
+                assert naces == len(KNOWN_ACL), (
+                    f"{fname}: DACL ACE count {naces} != expected "
+                    f"{len(KNOWN_ACL)}.\n{hexdump}"
+                )
+                # who-strings must match KNOWN_ACL ordering.
+                for i, (ace, expected) in enumerate(zip(aces, KNOWN_ACL)):
+                    t, f, m, w = ace
+                    expected_who = _expected_who(expected["id"], expected["tag"])
+                    assert w == expected_who, (
+                        f"{fname}: ACE[{i}] who={w!r}, expected "
+                        f"{expected_who!r}.\n{hexdump}"
+                    )
+
+
+def test_dacl_getattr_with_high_attr(start_nfs, session42, nfs_dataset):
+    """GETATTR sibling of ``test_dacl_readdir_with_high_attr``.
+
+    GETATTR and READDIR share ``nfsd4_encode_fattr4`` server-side, so a
+    DACL ordering regression should surface on both paths.  Same raw
+    byte-walk approach: capture ``attr_vals`` with the plain unpacker,
+    walk in RFC 8881 attribute-number order, assert plausibility and
+    exact byte consumption.
+    """
+    with nfs_dataset(
+        "test_dacl_ga_hi",
+        data=NFSV4_DATA,
+    ) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/x.txt")
+        call(
+            "filesystem.setacl",
+            {
+                "path": f"{path}/x.txt",
+                "dacl": KNOWN_ACL,
+                "options": {"validate_effective_acl": False},
+            },
+            job=True,
+        )
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            bits, attr_vals = _getattr_raw(
+                sess,
+                f"{path}/x.txt",
+                [
+                    FATTR4_FILEID,
+                    FATTR4_MODE,
+                    FATTR4_OWNER,
+                    FATTR4_OWNER_GROUP,
+                    FATTR4_DACL,
+                    FATTR4_XATTR_SUPPORT,
+                ],
+            )
+            hexdump = (
+                f"  raw attr_vals ({len(attr_vals)} bytes): "
+                f"{attr_vals.hex()}\n"
+                f"  attrmask bits returned: {sorted(bits)}"
+            )
+
+            assert FATTR4_DACL in bits, f"server didn't return DACL.\n{hexdump}"
+            assert FATTR4_XATTR_SUPPORT in bits, (
+                f"server filtered XATTR_SUPPORT out -- test isn't "
+                f"exercising the bug.  Confirm NFSv4.2 and that the "
+                f"dataset reports xattr support.\n{hexdump}"
+            )
+
+            # Same tail-bool sentry as the READDIR test: highest-numbered
+            # attribute requested is XATTR_SUPPORT, so attr_vals must end
+            # with a 4-byte 0/1 bool.
+            last4 = bytes(attr_vals[-4:])
+            assert last4 in (b"\x00\x00\x00\x00", b"\x00\x00\x00\x01"), (
+                f"last 4 bytes of attr_vals = {last4.hex()}, expected "
+                f"XATTR_SUPPORT bool (00000000 or 00000001).  TrueNAS "
+                f"DACL ordering bug: server placed DACL bytes AFTER "
+                f"XATTR_SUPPORT.\n{hexdump}"
+            )
+
+            walk_error = None
+            decoded = None
+            try:
+                decoded = _walk_attr_vals_rfc_order(bits, attr_vals)
+            except AssertionError as e:
+                walk_error = e
+
+            assert walk_error is None, (
+                f"attr_vals byte layout doesn't match RFC 8881 "
+                f"attribute-number ordering -- the TrueNAS DACL "
+                f"ordering bug.\n{hexdump}\n  walk failed: {walk_error}"
+            )
+
+            assert decoded[FATTR4_XATTR_SUPPORT] is True, (
+                f"XATTR_SUPPORT={decoded[FATTR4_XATTR_SUPPORT]}, "
+                f"expected True on a ZFS dataset with xattrs "
+                f"enabled.\n{hexdump}"
+            )
+            aclflag, naces, aces = decoded[FATTR4_DACL]
+            assert naces == len(KNOWN_ACL), (
+                f"DACL ACE count {naces} != expected {len(KNOWN_ACL)}.\n{hexdump}"
+            )
+            for i, (ace, expected) in enumerate(zip(aces, KNOWN_ACL)):
+                t, f, m, w = ace
+                expected_who = _expected_who(expected["id"], expected["tag"])
+                assert w == expected_who, (
+                    f"ACE[{i}] who={w!r}, expected {expected_who!r}.\n{hexdump}"
+                )
+
+
+def test_dacl_readdir_low_only_negative_control(start_nfs, session42, nfs_dataset):
+    """Negative control: bitmap has FATTR4_DACL but no bit > 58.
+
+    The post-loop append happens to land at the right wire position,
+    so this passes on broken AND fixed kernels.  Its purpose is to
+    isolate the bug as ordering-specific (not a wholesale DACL
+    encoding fault).
+    """
+    with nfs_dataset(
+        "test_dacl_rd_lo",
+        data=NFSV4_DATA,
+    ) as ds:
+        path = f"/mnt/{ds}"
+        ssh(f"touch {path}/x.txt")
+        call(
+            "filesystem.setacl",
+            {
+                "path": f"{path}/x.txt",
+                "dacl": KNOWN_ACL,
+                "options": {"validate_effective_acl": False},
+            },
+            job=True,
+        )
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            entries = _readdir_raw(
+                sess, path, [FATTR4_FILEID, FATTR4_MODE, FATTR4_DACL]
+            )
+            assert len(entries) == 1
+            name, bits, attr_vals = entries[0]
+            assert name == b"x.txt"
+            decoded = _walk_attr_vals_rfc_order(bits, attr_vals)
+            aclflag, naces, aces = decoded[FATTR4_DACL]
+            assert naces == len(KNOWN_ACL)

--- a/tests/sharing_protocols/nfs/test_nfs_server_side_copy.py
+++ b/tests/sharing_protocols/nfs/test_nfs_server_side_copy.py
@@ -6,6 +6,7 @@ copy that silently fell back to a byte-for-byte transfer would still
 pass a protocol-only smoke check but wouldn't move pool
 ``bcloneused``.
 """
+
 import secrets
 
 import pytest
@@ -30,10 +31,13 @@ PAYLOAD_SIZE = 1 << 20
 
 def _bcloneused():
     """Return pool ``bcloneused`` (bytes) via the zpool query API."""
-    res = call("zpool.query_impl", {
-        "pool_names": [pool],
-        "properties": ["bcloneused"],
-    })
+    res = call(
+        "zpool.query_impl",
+        {
+            "pool_names": [pool],
+            "properties": ["bcloneused"],
+        },
+    )
     return int(res[0]["properties"]["bcloneused"]["value"])
 
 
@@ -69,4 +73,5 @@ def test_server_side_copy(start_nfs, nfs_dataset):
 
             assert after > before, (
                 f"bcloneused did not increase after OP_CLONE: "
-                f"before={before} after={after}")
+                f"before={before} after={after}"
+            )

--- a/tests/sharing_protocols/nfs/test_nfs_server_side_copy.py
+++ b/tests/sharing_protocols/nfs/test_nfs_server_side_copy.py
@@ -1,0 +1,72 @@
+"""NFSv4.2 server-side copy (OP_CLONE) protocol test.
+
+Drives the full create + write + clone sequence over NFSv4.2 and
+confirms that ZFS block cloning actually fires on the appliance - a
+copy that silently fell back to a byte-for-byte transfer would still
+pass a protocol-only smoke check but wouldn't move pool
+``bcloneused``.
+"""
+import secrets
+
+import pytest
+
+from middlewared.test.integration.utils import call, pool, ssh
+from middlewared.test.integration.utils.client import truenas_server
+from protocols import nfs_share
+from protocols.pynfs_proto import PynfsClient
+
+
+# Shares are exported with maproot=root so the pynfs client's
+# AUTH_SYS uid=0 isn't squashed.  See tests/api2/test_300_nfs.py
+# ::test_share_maproot for the squash behavior we're avoiding.
+NFS_SHARE_OPTS = {"mapall_user": "root", "mapall_group": "root"}
+
+# 1 MiB - large enough to span multiple ZFS records at the default
+# 128 KiB recordsize, so block cloning has something to dedup.  A
+# few-byte payload would clone successfully but wouldn't move
+# ``bcloneused``.
+PAYLOAD_SIZE = 1 << 20
+
+
+def _bcloneused():
+    """Return pool ``bcloneused`` (bytes) via the zpool query API."""
+    res = call("zpool.query_impl", {
+        "pool_names": [pool],
+        "properties": ["bcloneused"],
+    })
+    return int(res[0]["properties"]["bcloneused"]["value"])
+
+
+@pytest.mark.timeout(300)
+def test_server_side_copy(start_nfs, nfs_dataset):
+    """Full NFSv4.2 server-side copy (create + write + OP_CLONE)
+    triggers ZFS block cloning, visible as an increase in pool
+    ``bcloneused``."""
+    with nfs_dataset("nfs_ssc") as ds:
+        path = f"/mnt/{ds}"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            with PynfsClient(truenas_server.ip, path, vers=4.2) as n:
+                # Random bytes so ZFS doesn't elide the write via
+                # zero-block / embedded-block detection, which would
+                # leave nothing in the BRT to clone.
+                payload = secrets.token_bytes(PAYLOAD_SIZE)
+                n.create("src")
+                n.write("src", payload)
+                n.create("dst")
+
+                # Sync first so the baseline isn't moving from prior
+                # async writes elsewhere on the pool.
+                ssh(f"zpool sync {pool}")
+                before = _bcloneused()
+
+                n.clone("src", "dst")
+
+                # OP_CLONE updates the BRT in the txg in which the
+                # request commits; force a sync so the counter we
+                # read reflects the just-completed clone.
+                ssh(f"zpool sync {pool}")
+                after = _bcloneused()
+
+            assert after > before, (
+                f"bcloneused did not increase after OP_CLONE: "
+                f"before={before} after={after}")

--- a/tests/sharing_protocols/nfs/test_nfs_snapdir.py
+++ b/tests/sharing_protocols/nfs/test_nfs_snapdir.py
@@ -1,21 +1,15 @@
+from time import sleep
+
 import pytest
 
+from middlewared.service_exception import InstanceNotFound, ValidationErrors
 from middlewared.test.integration.assets.filesystem import directory
-from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.product import product_type
-from middlewared.test.integration.utils import call, ssh, password
+from middlewared.test.integration.utils import call, pool, ssh
 from middlewared.test.integration.utils.client import truenas_server
-from middlewared.service_exception import ValidationErrors
-from protocols import SSH_NFS
+from protocols.pynfs_proto import PynfsClient, PynfsClient3
 
 SNAPDIR_EXPORTS_ENTRY = 'zfs_snapdir'
-
-
-@pytest.fixture(scope='module')
-def start_nfs():
-    call('service.control', 'START', 'nfs', job=True)
-    yield
-    call('service.control', 'STOP', 'nfs', job=True)
 
 
 @pytest.fixture(scope='function')
@@ -26,10 +20,35 @@ def enterprise():
 
 @pytest.fixture(scope='module')
 def nfs_dataset():
-    with dataset('nfs_snapdir') as ds:
-        ssh(f'echo -n Cats > /mnt/{ds}/canary')
-        call('pool.snapshot.create', {'dataset': ds, 'name': 'now'})
-        yield ds
+    """Module-scoped dataset with EZFS_BUSY-tolerant cleanup -- the
+    standard ``dataset`` asset does a single-shot ``pool.dataset.delete``
+    and races with NFS server-side state release after pynfs sessions
+    close."""
+    name = f"{pool}/nfs_snapdir"
+    call("pool.dataset.create", {"name": name})
+    try:
+        ssh(f'echo -n Cats > /mnt/{name}/canary')
+        call('pool.snapshot.create', {'dataset': name, 'name': 'now'})
+        yield name
+    finally:
+        deleted = False
+        try:
+            call("pool.dataset.delete", name, {"recursive": True})
+            deleted = True
+        except InstanceNotFound:
+            deleted = True
+        except Exception:
+            pass
+        if not deleted:
+            sleep(2)
+            for _ in range(6):
+                try:
+                    call("pool.dataset.delete", name, {"recursive": True})
+                    break
+                except InstanceNotFound:
+                    break
+                except Exception:
+                    sleep(10)
 
 
 @pytest.fixture(scope='function')
@@ -112,15 +131,25 @@ def test__snapdir_functional(start_nfs, enterprise, nfs_dataset, nfs_export, ver
     assert share['expose_snapshots'] is True
     call('service.control', 'STOP', 'nfs', job=True)
     call('service.control', 'START', 'nfs', {'silent': False}, job=True)
-    with SSH_NFS(
-        hostname=truenas_server.ip,
-        path=f'/mnt/{nfs_dataset}',
-        vers=vers,
-        user='root',
-        password=password(),
-        ip=truenas_server.ip
-    ) as n:
+    if int(vers) == 4:
+        # Restarting nfsd puts it into a ~90 s grace period during
+        # which state-changing NFSv4 ops are rejected with
+        # NFS4ERR_GRACE.  Linux nfsd exposes a knob to end grace
+        # immediately, but right after restart the write can return
+        # EBUSY while the kernel's per-net state finishes coming up,
+        # so poll briefly.  NFSv3 readdir doesn't trip grace.
+        for _ in range(40):
+            r = ssh('echo Y > /proc/fs/nfsd/v4_end_grace',
+                    check=False, complete_response=True)
+            if r['result']:
+                break
+            sleep(0.25)
+        else:
+            pytest.fail(f'v4_end_grace still busy after 10s: {r["output"]}')
 
+    export = f'/mnt/{nfs_dataset}'
+    cls = PynfsClient3 if int(vers) == 3 else PynfsClient
+    with cls(truenas_server.ip, export, vers=vers) as n:
         contents = n.ls('.')
         assert 'canary' in contents
 

--- a/tests/sharing_protocols/nfs/test_nfs_xattr.py
+++ b/tests/sharing_protocols/nfs/test_nfs_xattr.py
@@ -1,37 +1,302 @@
+"""NFSv4.2 user-extended-attribute protocol tests, exercised via pynfs.
+
+Replaces the previous SSH-driven test that mounted the share with the
+Linux NFSv4.2 client and shelled out to ``getfattr``/``setfattr``.  The
+direct-protocol version exercises ``OP_SETXATTR``, ``OP_GETXATTR``,
+``OP_LISTXATTRS``, and ``OP_REMOVEXATTR`` on the wire and validates
+that the ``FATTR4_XATTR_SUPPORT`` attribute reads back identically
+through both single-file ``OP_GETATTR`` and per-entry ``OP_READDIR``.
+
+Wire-format note: the user-namespace prefix ``user.`` is **not** sent on
+the wire.  Linux nfsd prepends it to the attribute name received from
+the client (``fs/nfsd/nfs4xdr.c:nfsd4_decode_xattr_name``).
+"""
+import secrets
+
 import pytest
+import rpc
+import nfs4lib
+import nfs_ops
+from nfs4client import NFS4Client
+from rpc.rpc_const import AUTH_SYS
+from xdrdef.nfs4_const import (
+    FATTR4_FILEID, FATTR4_MODE, FATTR4_XATTR_SUPPORT,
+    OPEN4_CREATE, OPEN4_SHARE_ACCESS_BOTH, OPEN4_SHARE_DENY_NONE,
+    OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+    GUARDED4, CLAIM_NULL,
+    SETXATTR4_CREATE, SETXATTR4_REPLACE, SETXATTR4_EITHER,
+    NF4DIR,
+)
+from xdrdef.nfs4_type import (
+    openflag4, createhow4, open_claim4, open_owner4, createtype4,
+)
 
-from middlewared.test.integration.assets.nfs import nfs_server
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.utils import password
 from middlewared.test.integration.utils.client import truenas_server
-from protocols import SSH_NFS, nfs_share
+from protocols import nfs_share
+
+op = nfs_ops.NFS4ops()
 
 
-@pytest.fixture(scope='module')
-def start_nfs():
-    with nfs_server():
-        yield
+# Shares are exported with no_root_squash (maproot=root) so that the
+# pynfs client's AUTH_SYS uid=0 isn't squashed to nobody, which would
+# return NFS4ERR_PERM for SETATTR-style ops.  See
+# ``tests/api2/test_300_nfs.py::test_share_maproot``.
+NFS_SHARE_OPTS = {"mapall_user": "root", "mapall_group": "root"}
 
 
-def test_xattr_support(start_nfs):
+# ``start_nfs`` is provided by ``conftest.py`` at session scope.
+
+
+@pytest.fixture
+def session42():
+    """Factory fixture: returns a callable that opens a pynfs NFSv4.2
+    client + session.  Caller MUST invoke it inside a
+    ``with nfs_share(...):`` block - EXCHANGE_ID is rejected with
+    ``AUTH_BADCRED`` if no NFS export is currently active for the
+    source IP, because Linux nfsd's ``svcauth_unix_accept`` requires
+    the client's IP to appear in some export's host list.
+
+    All sessions opened via the factory are torn down at fixture
+    teardown.  See ``test_nfs_dacl_readdir.py`` for the rationale on
+    each cleanup step.
     """
-    Perform basic validation of NFSv4.2 xattr support.
-    Mount path via NFS 4.2, create a file and dir, and write + read xattr on each.
-    """
-    with dataset('test_nfs4_xattr', mode='777') as ds:
-        with nfs_share(f'/mnt/{ds}'):
-            for i in range(2):
-                try:
-                    with SSH_NFS(truenas_server.ip, f'/mnt/{ds}', vers=4.2,
-                                 user='root', password=password(), ip=truenas_server.ip, timeout=20) as n:
-                        n.create("testfile")
-                        n.setxattr("testfile", "user.testxattr", "the_contents")
-                        assert n.getxattr("testfile", "user.testxattr") == "the_contents"
+    opened = []
 
-                        n.create("testdir", True)
-                        n.setxattr("testdir", "user.testxattr2", "the_contents2")
-                        assert n.getxattr("testdir", "user.testxattr2") == "the_contents2"
-                        break
-                except Exception:
-                    # Get one retry pass
-                    pass
+    def _open():
+        c = NFS4Client(truenas_server.ip.encode(), 2049, minorversion=2)
+        sec = rpc.security.instance(AUTH_SYS)
+        c.set_cred(sec.init_cred(uid=0, gid=0, name=b"truenas-test"))
+        clt = None
+        sess = None
+        try:
+            clt = c.new_client(
+                b"truenas-xattr-test-" + secrets.token_hex(4).encode())
+            sess = clt.create_session()
+            sess.compound([op.reclaim_complete(False)])
+        except Exception:
+            _teardown(c, clt, sess)
+            raise
+        opened.append((c, clt, sess))
+        return sess
+
+    yield _open
+
+    for c, clt, sess in opened:
+        _teardown(c, clt, sess)
+
+
+def _teardown(c, clt, sess):
+    if sess is not None:
+        try:
+            c.compound([op.destroy_session(sess.sessionid)])
+        except Exception:
+            pass
+        c.sessions.pop(sess.sessionid, None)
+    if clt is not None:
+        try:
+            c.compound([op.destroy_clientid(clt.clientid)])
+        except Exception:
+            pass
+        c.clients.pop(clt.clientid, None)
+    try:
+        c.stop()
+    except Exception:
+        pass
+
+
+def _components(path):
+    return [c.encode() for c in path.lstrip("/").split("/")]
+
+
+def _open_create_file(sess, share_path, name, clt_clientid):
+    """Issue OPEN+CREATE for a regular file under share_path."""
+    openflag = openflag4(
+        OPEN4_CREATE,
+        createhow4(GUARDED4, {FATTR4_MODE: 0o644}, sess.c.verifier),
+    )
+    openclaim = open_claim4(CLAIM_NULL, name)
+    return nfs4lib.use_obj(_components(share_path)) + [
+        op.open(0,
+                OPEN4_SHARE_ACCESS_BOTH | OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+                OPEN4_SHARE_DENY_NONE,
+                open_owner4(clt_clientid, b"xattr-test-owner"),
+                openflag, openclaim),
+        op.getfh(),
+    ]
+
+
+def _create_dir(sess, share_path, name):
+    return nfs4lib.use_obj(_components(share_path)) + [
+        op.create(createtype4(NF4DIR), name, {FATTR4_MODE: 0o755}),
+    ]
+
+
+def _setxattr(sess, target_path, key, value, mode=SETXATTR4_EITHER):
+    res = sess.compound(
+        nfs4lib.use_obj(_components(target_path))
+        + [op.setxattr(mode, key, value)])
+    assert res.status == 0, f"SETXATTR failed: {res.status}"
+    return res
+
+
+def _getxattr(sess, target_path, key):
+    res = sess.compound(
+        nfs4lib.use_obj(_components(target_path)) + [op.getxattr(key)])
+    return res
+
+
+def _listxattrs(sess, target_path):
+    res = sess.compound(
+        nfs4lib.use_obj(_components(target_path))
+        + [op.listxattrs(0, 8192)])
+    assert res.status == 0, f"LISTXATTRS failed: {res.status}"
+    r = res.resarray[-1]
+    return list(r.lxr_names), bool(r.lxr_eof)
+
+
+def _removexattr(sess, target_path, key):
+    res = sess.compound(
+        nfs4lib.use_obj(_components(target_path))
+        + [op.removexattr(key)])
+    assert res.status == 0, f"REMOVEXATTR failed: {res.status}"
+
+
+def _getattr_xattr_support(sess, target_path):
+    bitmap = nfs4lib.list2bitmap([FATTR4_XATTR_SUPPORT])
+    res = sess.compound(
+        nfs4lib.use_obj(_components(target_path)) + [op.getattr(bitmap)])
+    assert res.status == 0
+    return res.resarray[-1].obj_attributes[FATTR4_XATTR_SUPPORT]
+
+
+def _readdir_xattr_support(sess, parent_path):
+    bitmap = nfs4lib.list2bitmap([FATTR4_FILEID, FATTR4_XATTR_SUPPORT])
+    res = sess.compound(
+        nfs4lib.use_obj(_components(parent_path))
+        + [op.readdir(0, b"\0" * 8, 8192, 65536, bitmap)])
+    assert res.status == 0, f"READDIR failed: {res.status}"
+    return {
+        e.name.decode(): e.attrs.get(FATTR4_XATTR_SUPPORT)
+        for e in res.resarray[-1].reply.entries
+    }
+
+
+def test_xattr_roundtrip_on_file(start_nfs, session42, nfs_dataset):
+    """SETXATTR/GETXATTR/LISTXATTRS/REMOVEXATTR round-trip on a regular
+    file, plus FATTR4_XATTR_SUPPORT consistency between GETATTR and
+    READDIR."""
+    with nfs_dataset("nfs_xattr_file", data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        fname = b"testfile"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            # Create the file via OPEN+CREATE.
+            res = sess.compound(
+                _open_create_file(sess, path, fname,
+                                  sess.client.clientid))
+            assert res.status == 0
+
+            file_path = f"{path}/testfile"
+            key = b"testxattr"           # wire form (no "user." prefix)
+            value = b"the_contents"
+
+            # Pre-set: empty list, GETXATTR returns NOXATTR.
+            assert _listxattrs(sess, file_path) == ([], True)
+            res = _getxattr(sess, file_path, key)
+            # NFS4ERR_NOXATTR = 10095 in RFC 8276.
+            assert res.status != 0
+
+            # Set it.
+            _setxattr(sess, file_path, key, value)
+
+            # Direct GETXATTR.
+            res = _getxattr(sess, file_path, key)
+            assert res.status == 0
+            assert res.resarray[-1].gxr_value == value
+
+            # LISTXATTRS reflects it.
+            assert _listxattrs(sess, file_path) == ([key], True)
+
+            # FATTR4_XATTR_SUPPORT consistency: same value via GETATTR
+            # and via READDIR-of-parent (per-entry attrs).
+            ga = _getattr_xattr_support(sess, file_path)
+            rd = _readdir_xattr_support(sess, path)
+            assert "testfile" in rd
+            assert ga is True
+            assert rd["testfile"] is True
+
+            # Remove and confirm it's gone.
+            _removexattr(sess, file_path, key)
+            assert _listxattrs(sess, file_path) == ([], True)
+            res = _getxattr(sess, file_path, key)
+            assert res.status != 0
+
+
+def test_xattr_roundtrip_on_directory(start_nfs, session42, nfs_dataset):
+    """Directory variant: NFSv4.2 user xattrs work the same on dirs."""
+    with nfs_dataset("nfs_xattr_dir", data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        dname = b"testdir"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            res = sess.compound(_create_dir(sess, path, dname))
+            assert res.status == 0
+
+            dir_path = f"{path}/testdir"
+            key = b"dirxattr"
+            value = b"on_a_dir"
+
+            _setxattr(sess, dir_path, key, value)
+            res = _getxattr(sess, dir_path, key)
+            assert res.status == 0
+            assert res.resarray[-1].gxr_value == value
+            assert _listxattrs(sess, dir_path) == ([key], True)
+
+            ga = _getattr_xattr_support(sess, dir_path)
+            rd = _readdir_xattr_support(sess, path)
+            assert "testdir" in rd
+            assert ga is True
+            assert rd["testdir"] is True
+
+            _removexattr(sess, dir_path, key)
+            assert _listxattrs(sess, dir_path) == ([], True)
+
+
+def test_setxattr_create_replace_modes(start_nfs, session42, nfs_dataset):
+    """``setxattr_option4`` enforces CREATE-only and REPLACE-only
+    semantics correctly.  Smoke-tests the option enum."""
+    with nfs_dataset("nfs_xattr_modes", data={"acltype": "NFSV4", "aclmode": "PASSTHROUGH"}) as ds:
+        path = f"/mnt/{ds}"
+        fname = b"modesfile"
+        key = b"modeskey"
+        with nfs_share(path, NFS_SHARE_OPTS):
+            sess = session42()
+            res = sess.compound(
+                _open_create_file(sess, path, fname,
+                                  sess.client.clientid))
+            assert res.status == 0
+
+            file_path = f"{path}/modesfile"
+
+            # REPLACE on a missing key -> error (NFS4ERR_NOXATTR).
+            res = sess.compound(
+                nfs4lib.use_obj(_components(file_path))
+                + [op.setxattr(SETXATTR4_REPLACE, key, b"v1")])
+            assert res.status != 0, "REPLACE on missing xattr should fail"
+
+            # CREATE on a missing key -> ok.
+            _setxattr(sess, file_path, key, b"v1", SETXATTR4_CREATE)
+
+            # CREATE on existing key -> error (NFS4ERR_EXIST).
+            res = sess.compound(
+                nfs4lib.use_obj(_components(file_path))
+                + [op.setxattr(SETXATTR4_CREATE, key, b"v2")])
+            assert res.status != 0, "CREATE on existing xattr should fail"
+
+            # REPLACE on existing key -> ok, value updated.
+            _setxattr(sess, file_path, key, b"v3", SETXATTR4_REPLACE)
+            res = _getxattr(sess, file_path, key)
+            assert res.status == 0
+            assert res.resarray[-1].gxr_value == b"v3"
+
+            _removexattr(sess, file_path, key)

--- a/tests/sharing_protocols/nfs/test_nfs_xattr.py
+++ b/tests/sharing_protocols/nfs/test_nfs_xattr.py
@@ -21,6 +21,7 @@ from nfs4client import NFS4Client
 from rpc.rpc_const import AUTH_SYS
 from xdrdef.nfs4_const import (
     FATTR4_FILEID, FATTR4_MODE, FATTR4_XATTR_SUPPORT,
+    NFS4ERR_EXIST, NFS4ERR_NOXATTR,
     OPEN4_CREATE, OPEN4_SHARE_ACCESS_BOTH, OPEN4_SHARE_DENY_NONE,
     OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
     GUARDED4, CLAIM_NULL,
@@ -203,8 +204,8 @@ def test_xattr_roundtrip_on_file(start_nfs, session42, nfs_dataset):
             # Pre-set: empty list, GETXATTR returns NOXATTR.
             assert _listxattrs(sess, file_path) == ([], True)
             res = _getxattr(sess, file_path, key)
-            # NFS4ERR_NOXATTR = 10095 in RFC 8276.
-            assert res.status != 0
+            assert res.status == NFS4ERR_NOXATTR, (
+                f"expected NFS4ERR_NOXATTR, got status={res.status}")
 
             # Set it.
             _setxattr(sess, file_path, key, value)
@@ -229,7 +230,8 @@ def test_xattr_roundtrip_on_file(start_nfs, session42, nfs_dataset):
             _removexattr(sess, file_path, key)
             assert _listxattrs(sess, file_path) == ([], True)
             res = _getxattr(sess, file_path, key)
-            assert res.status != 0
+            assert res.status == NFS4ERR_NOXATTR, (
+                f"expected NFS4ERR_NOXATTR, got status={res.status}")
 
 
 def test_xattr_roundtrip_on_directory(start_nfs, session42, nfs_dataset):
@@ -282,7 +284,9 @@ def test_setxattr_create_replace_modes(start_nfs, session42, nfs_dataset):
             res = sess.compound(
                 nfs4lib.use_obj(_components(file_path))
                 + [op.setxattr(SETXATTR4_REPLACE, key, b"v1")])
-            assert res.status != 0, "REPLACE on missing xattr should fail"
+            assert res.status == NFS4ERR_NOXATTR, (
+                f"REPLACE on missing xattr: expected NFS4ERR_NOXATTR, "
+                f"got status={res.status}")
 
             # CREATE on a missing key -> ok.
             _setxattr(sess, file_path, key, b"v1", SETXATTR4_CREATE)
@@ -291,7 +295,9 @@ def test_setxattr_create_replace_modes(start_nfs, session42, nfs_dataset):
             res = sess.compound(
                 nfs4lib.use_obj(_components(file_path))
                 + [op.setxattr(SETXATTR4_CREATE, key, b"v2")])
-            assert res.status != 0, "CREATE on existing xattr should fail"
+            assert res.status == NFS4ERR_EXIST, (
+                f"CREATE on existing xattr: expected NFS4ERR_EXIST, "
+                f"got status={res.status}")
 
             # REPLACE on existing key -> ok, value updated.
             _setxattr(sess, file_path, key, b"v3", SETXATTR4_REPLACE)


### PR DESCRIPTION
This commit converts some NFS tests into using lower-level pynfs library to explicitly test server behavior and expands test coverage for readdir operations.

Originally tests were executed via the linux NFS client which was extremely limiting in how we can exercise server in a fine-grained manner. This had the practical impact that a bug in an ACL-related server response for non-Linux clients was undetected ( where READDIR also requests NFS4.1 DACL -- linux never does this).