### PR TITLE
NAS-140810 / 27.0.0-BETA.1 / Fall back to UTC when configured timezone is unavailable

### DIFF
--- a/src/middlewared/middlewared/alert/source/__init__.py
+++ b/src/middlewared/middlewared/alert/source/__init__.py
@@ -55,6 +55,7 @@ from middlewared.alert.source import (  # noqa: F401
     snapshot_count,
     ssh_login_failures,
     syslog_ng,
+    timezone,
     truecommand,
     truenas_connect,
     truenas_verify,

--- a/src/middlewared/middlewared/alert/source/timezone.py
+++ b/src/middlewared/middlewared/alert/source/timezone.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from middlewared.alert.base import AlertCategory, AlertClassConfig, AlertLevel, OneShotAlertClass
+
+
+@dataclass(kw_only=True)
+class TimezoneNotAvailableAlert(OneShotAlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.SYSTEM,
+        level=AlertLevel.WARNING,
+        title="Configured Timezone Not Available",
+        text=(
+            "The configured timezone %(timezone)r is not available on this system. "
+            "The system clock has been set to UTC. Select a different timezone in "
+            "System Settings -> General to clear this alert."
+        ),
+        keys=[],
+    )
+
+    timezone: str

--- a/src/middlewared/middlewared/etc_files/localtime_config.py
+++ b/src/middlewared/middlewared/etc_files/localtime_config.py
@@ -21,10 +21,8 @@ def localtime_configuration(middleware):
             middleware.services.alert.oneshot_delete, "TimezoneNotAvailable", None
         )
     else:
-        # tzdata legacy aliases (Japan, GB, Hongkong, ...) were moved to the
-        # `tzdata-legacy` package in Debian; if the user's saved zone is one of
-        # those and that package isn't installed, the symlink target won't
-        # exist. Fall back to UTC and raise an alert so the user sees the
+        # If the user's saved zone is one where the symlink does not exist,
+        # fall back to UTC and raise an alert so the user sees the
         # divergence between their saved configuration and the running clock.
         target_tz = FALLBACK_TZ
         middleware.logger.warning(

--- a/src/middlewared/middlewared/etc_files/localtime_config.py
+++ b/src/middlewared/middlewared/etc_files/localtime_config.py
@@ -1,24 +1,46 @@
 import contextlib
 import os
-import subprocess
+
+from middlewared.alert.source.timezone import TimezoneNotAvailableAlert
+from middlewared.utils.timezone_choices import (
+    FALLBACK_TZ,
+    ZONEINFO_DIR,
+    timezone_is_available,
+)
+
+DEFAULT_TZ = "America/Los_Angeles"
 
 
 def localtime_configuration(middleware):
-    system_config = middleware.call_sync('system.general.config')
-    if not system_config['timezone']:
-        system_config['timezone'] = 'America/Los_Angeles'
+    system_config = middleware.call_sync("system.general.config")
+    configured_tz = system_config["timezone"] or DEFAULT_TZ
+
+    if timezone_is_available(configured_tz):
+        target_tz = configured_tz
+        middleware.call_sync2(
+            middleware.services.alert.oneshot_delete, "TimezoneNotAvailable", None
+        )
+    else:
+        # tzdata legacy aliases (Japan, GB, Hongkong, ...) were moved to the
+        # `tzdata-legacy` package in Debian; if the user's saved zone is one of
+        # those and that package isn't installed, the symlink target won't
+        # exist. Fall back to UTC and raise an alert so the user sees the
+        # divergence between their saved configuration and the running clock.
+        target_tz = FALLBACK_TZ
+        middleware.logger.warning(
+            "Configured timezone %r not found under %s; falling back to %s",
+            configured_tz, ZONEINFO_DIR, FALLBACK_TZ,
+        )
+        middleware.call_sync2(
+            middleware.services.alert.oneshot_create,
+            TimezoneNotAvailableAlert(timezone=configured_tz),
+        )
 
     with contextlib.suppress(OSError):
-        os.unlink('/etc/localtime')
-    os.symlink(os.path.join('/usr/share/zoneinfo', system_config['timezone']), '/etc/localtime')
-    cp = subprocess.Popen(
-        ['systemctl', 'daemon-reload'], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-    )
-    stderr = cp.communicate()[1]
-    if cp.returncode:
-        middleware.logger.error(
-            'Failed to reload systemctl daemon after timezone configuration: %s', stderr.decode()
-        )
+        os.unlink("/etc/localtime")
+    # Relative target matches the systemd/Debian convention written by
+    # `timedatectl set-timezone`.
+    os.symlink(os.path.join("..", "usr", "share", "zoneinfo", target_tz), "/etc/localtime")
 
 
 def render(service, middleware):

--- a/src/middlewared/middlewared/plugins/apps/logs.py
+++ b/src/middlewared/middlewared/plugins/apps/logs.py
@@ -12,6 +12,7 @@ from middlewared.api.current import (
 )
 from middlewared.event import TypedEventSource
 from middlewared.service import CallError
+from middlewared.utils.timezone_choices import effective_timezone
 
 from .ix_apps.docker.utils import get_docker_client
 from .ix_apps.utils import AppState
@@ -66,7 +67,7 @@ class AppContainerLogsFollowTailEventSource(
         tail_lines: int | str = self.typed_arg.tail_lines or 'all'
 
         self.validate_log_args(app_name, container_id)
-        tz = ZoneInfo(self.middleware.call_sync('system.general.config')['timezone'])
+        tz = ZoneInfo(effective_timezone(self.middleware.call_sync('system.general.config')['timezone']))
         with get_docker_client() as docker_client:
             try:
                 container = docker_client.containers.get(container_id)

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -6,6 +6,7 @@ from middlewared.plugins.service_.services.base import SimpleService
 from middlewared.plugins.service_.services.base_interface import ServiceInterface
 from middlewared.plugins.service_.services.base_state import ServiceState
 from middlewared.plugins.service_.services.dbus_router import system_dbus
+from middlewared.utils.timezone_choices import effective_timezone
 
 
 class PseudoServiceBase(ServiceInterface):
@@ -210,7 +211,9 @@ class TimeservicesService(PseudoServiceBase):
         await (await self.middleware.call("service.control", "RESTART", "ntpd")).wait(raise_error=True)
 
         settings = await self.middleware.call("datastore.config", "system.settings")
-        await self.middleware.call("core.environ_update", {"TZ": settings["stg_timezone"]})
+        await self.middleware.call(
+            "core.environ_update", {"TZ": effective_timezone(settings["stg_timezone"])}
+        )
 
 
 class UserService(PseudoServiceBase):

--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 from middlewared.utils import BOOTREADY
+from middlewared.utils.timezone_choices import effective_timezone
 
 from .utils import BOOTENV_FIRSTBOOT_SENTINEL, FIRST_INSTALL_SENTINEL, lifecycle_conf
 
@@ -45,6 +46,7 @@ async def setup(middleware):
     await middleware.run_in_thread(firstboot_after_upgrade, middleware)
 
     settings = await middleware.call('system.general.config')
-    middleware.logger.debug('Setting timezone to %r', settings['timezone'])
-    await middleware.call('core.environ_update', {'TZ': settings['timezone']})
+    tz = effective_timezone(settings['timezone'])
+    middleware.logger.debug('Setting timezone to %r', tz)
+    await middleware.call('core.environ_update', {'TZ': tz})
     await middleware.call('sysctl.set_zvol_volmode', 2)

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -230,6 +230,21 @@ class SystemGeneralService(ConfigService):
             await self.middleware.call('zettarepl.update_config', {'timezone': new_config['timezone']})
             await (await self.middleware.call('service.control', 'RELOAD', 'timeservices')).wait(raise_error=True)
             await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
+            # Notify systemd-timedated of the zone change. We do not do this in ix-etc because when on boot
+            # ix-etc.service runs Before sysinit.target, while systemd-timedated.service is ordered
+            # After it, so a D-Bus call from there would deadlock. By the time system.general.update
+            # runs interactively those targets have long been reached. Without this call timedatectl
+            # status and any subscriber to timedated's PropertiesChanged signal (journald, chrony,
+            # cron in some configurations) keep reporting the previous zone until the next reboot.
+            cp = await run(
+                ['timedatectl', 'set-timezone', new_config['timezone']],
+                check=False, encoding='utf-8',
+            )
+            if cp.returncode:
+                self.logger.warning(
+                    'timedatectl set-timezone %r failed: %s',
+                    new_config['timezone'], cp.stderr,
+                )
 
         if config['ds_auth'] != new_config['ds_auth']:
             await self.middleware.call('etc.generate', 'pam')

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -670,7 +670,7 @@ class ZettareplService(Service):
     async def get_definition(self):
         config = await self.middleware.call("replication.config.config")
         # Sanitize against a stale DB value left over from an upgrade (e.g. a
-        # legacy alias like "Japan" without tzdata-legacy installed) -- the
+        # legacy alias like "Japan") -- the
         # ZoneInfo lookup downstream would otherwise raise ZoneInfoNotFoundError.
         timezone = effective_timezone(
             (await self.middleware.call("system.general.config"))["timezone"]

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -64,6 +64,7 @@ from middlewared.utils.size import format_size
 from middlewared.utils.string import make_sentence
 from middlewared.utils.threading import start_daemon_thread
 from middlewared.utils.time_utils import utc_now
+from middlewared.utils.timezone_choices import effective_timezone
 
 INVALID_DATASETS = (
     re.compile(r"boot-pool($|/)"),
@@ -668,7 +669,12 @@ class ZettareplService(Service):
 
     async def get_definition(self):
         config = await self.middleware.call("replication.config.config")
-        timezone = (await self.middleware.call("system.general.config"))["timezone"]
+        # Sanitize against a stale DB value left over from an upgrade (e.g. a
+        # legacy alias like "Japan" without tzdata-legacy installed) -- the
+        # ZoneInfo lookup downstream would otherwise raise ZoneInfoNotFoundError.
+        timezone = effective_timezone(
+            (await self.middleware.call("system.general.config"))["timezone"]
+        )
 
         pools = {pool["name"]: pool for pool in await self.middleware.call("pool.query")}
 

--- a/src/middlewared/middlewared/utils/timezone_choices.py
+++ b/src/middlewared/middlewared/utils/timezone_choices.py
@@ -12,9 +12,7 @@ def _available_zones() -> frozenset[str]:
     # Walk /usr/share/zoneinfo once and collect every name that resolves to a
     # real file (regular file or non-dangling symlink). Building a set up-front
     # lets the validator and dropdown do O(1) membership checks against ~600
-    # candidates from tzdata.zi instead of one stat() per candidate. Cached for
-    # the lifetime of the process; if the admin installs `tzdata-legacy`,
-    # restart middlewared to refresh.
+    # candidates from tzdata.zi instead of one stat() per candidate.
     found: set[str] = set()
     pending: list[str] = [""]
     while pending:
@@ -40,7 +38,7 @@ def timezone_is_available(name: str) -> bool:
 def effective_timezone(name: str) -> str:
     # Used at runtime by consumers (zettarepl scheduler, TZ env var, ...) so
     # that a stale DB value left over from an upgrade -- e.g. "Japan" without
-    # tzdata-legacy installed -- cannot crash them. The user-visible alert is
+    # -- cannot crash them. The user-visible alert is
     # raised exactly once, by the localtime etc renderer.
     return name if timezone_is_available(name) else FALLBACK_TZ
 
@@ -49,8 +47,8 @@ def effective_timezone(name: str) -> str:
 def tz_choices() -> tuple[tuple[str, str], ...]:
     # Logic deduced from what timedatectl list-timezones does, with an
     # additional on-disk existence check: tzdata.zi declares all historical
-    # aliases (e.g. "Japan", "GB", "Hongkong"), but on Debian trixie those
-    # symlinks ship in `tzdata-legacy` which is not installed by default. Keep
+    # aliases (e.g. "Japan", "GB", "Hongkong"), but on Debian trixie we
+    # don't have those in by default. Keep
     # only entries whose zone file actually resolves so we never offer the user
     # a name that would produce a dangling /etc/localtime.
     available = _available_zones()

--- a/src/middlewared/middlewared/utils/timezone_choices.py
+++ b/src/middlewared/middlewared/utils/timezone_choices.py
@@ -16,25 +16,20 @@ def _available_zones() -> frozenset[str]:
     # the lifetime of the process; if the admin installs `tzdata-legacy`,
     # restart middlewared to refresh.
     found: set[str] = set()
-
-    def walk(rel: str) -> None:
+    pending: list[str] = [""]
+    while pending:
+        rel = pending.pop()
         path = os.path.join(ZONEINFO_DIR, rel) if rel else ZONEINFO_DIR
-        try:
-            scan = os.scandir(path)
-        except OSError:
-            return
-        with scan as it:
+        with os.scandir(path) as it:
             for entry in it:
                 name = f"{rel}/{entry.name}" if rel else entry.name
                 if entry.is_dir(follow_symlinks=False):
-                    walk(name)
+                    pending.append(name)
                 elif entry.is_file(follow_symlinks=True):
                     # is_file(follow_symlinks=True) is False for dangling
                     # symlinks because the underlying stat() fails -- exactly
                     # the filter we want.
                     found.add(name)
-
-    walk("")
     return frozenset(found)
 
 

--- a/src/middlewared/middlewared/utils/timezone_choices.py
+++ b/src/middlewared/middlewared/utils/timezone_choices.py
@@ -1,15 +1,69 @@
 from functools import cache
+import os
 
-__all__ = ("tz_choices",)
+ZONEINFO_DIR = "/usr/share/zoneinfo"
+FALLBACK_TZ = "UTC"
+
+__all__ = ("tz_choices", "timezone_is_available", "effective_timezone")
+
+
+@cache
+def _available_zones() -> frozenset[str]:
+    # Walk /usr/share/zoneinfo once and collect every name that resolves to a
+    # real file (regular file or non-dangling symlink). Building a set up-front
+    # lets the validator and dropdown do O(1) membership checks against ~600
+    # candidates from tzdata.zi instead of one stat() per candidate. Cached for
+    # the lifetime of the process; if the admin installs `tzdata-legacy`,
+    # restart middlewared to refresh.
+    found: set[str] = set()
+
+    def walk(rel: str) -> None:
+        path = os.path.join(ZONEINFO_DIR, rel) if rel else ZONEINFO_DIR
+        try:
+            scan = os.scandir(path)
+        except OSError:
+            return
+        with scan as it:
+            for entry in it:
+                name = f"{rel}/{entry.name}" if rel else entry.name
+                if entry.is_dir(follow_symlinks=False):
+                    walk(name)
+                elif entry.is_file(follow_symlinks=True):
+                    # is_file(follow_symlinks=True) is False for dangling
+                    # symlinks because the underlying stat() fails -- exactly
+                    # the filter we want.
+                    found.add(name)
+
+    walk("")
+    return frozenset(found)
+
+
+def timezone_is_available(name: str) -> bool:
+    return bool(name) and name in _available_zones()
+
+
+def effective_timezone(name: str) -> str:
+    # Used at runtime by consumers (zettarepl scheduler, TZ env var, ...) so
+    # that a stale DB value left over from an upgrade -- e.g. "Japan" without
+    # tzdata-legacy installed -- cannot crash them. The user-visible alert is
+    # raised exactly once, by the localtime etc renderer.
+    return name if timezone_is_available(name) else FALLBACK_TZ
 
 
 @cache
 def tz_choices() -> tuple[tuple[str, str], ...]:
-    # Logic deduced from what timedatectl list-timezones does
-    tz: list[tuple[str, str]] = list()
-    with open("/usr/share/zoneinfo/tzdata.zi") as f:
-        for line in filter(lambda x: x[0] in ("Z", "L"), f):
+    # Logic deduced from what timedatectl list-timezones does, with an
+    # additional on-disk existence check: tzdata.zi declares all historical
+    # aliases (e.g. "Japan", "GB", "Hongkong"), but on Debian trixie those
+    # symlinks ship in `tzdata-legacy` which is not installed by default. Keep
+    # only entries whose zone file actually resolves so we never offer the user
+    # a name that would produce a dangling /etc/localtime.
+    available = _available_zones()
+    tz: list[tuple[str, str]] = []
+    with open(os.path.join(ZONEINFO_DIR, "tzdata.zi")) as f:
+        for line in filter(lambda x: x and x[0] in ("Z", "L"), f):
             index = 1 if line[0] == "Z" else 2
-            tz_choice = line.split()[index].strip()
-            tz.append((tz_choice, tz_choice))
+            name = line.split()[index].strip()
+            if name in available:
+                tz.append((name, name))
     return tuple(tz)


### PR DESCRIPTION
This commit fixes an issue where users upgrading from older TrueNAS versions could end up with a timezone selected that is no longer available on the system, silently leaving the clock on UTC with no indication to the operator.

Debian moved a large set of legacy timezone aliases (Japan, GB, Hongkong, Iran, Israel, Cuba, Egypt, all capitalised Australia/*, Brazil/*, Canada/*, etc.) out of the core `tzdata` package into a new `tzdata-legacy` package which is not installed by default on trixie:

  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1040997

The names are still listed in `/usr/share/zoneinfo/tzdata.zi` as historical Link entries, but the corresponding files under `/usr/share/zoneinfo/` are gone. The middleware was parsing `tzdata.zi` directly and offering all 598 entries in the dropdown, including 113 that no longer resolve to a real file. Selecting one of those (e.g. "Japan") produced a dangling
`/etc/localtime -> /usr/share/zoneinfo/Japan` symlink which glibc silently treats as UTC.

Changes:

* `tz_choices()` and the validator now drop entries whose zone file does not exist on disk, so the dropdown only contains usable timezones. A single `os.scandir` walk over `/usr/share/zoneinfo` builds a frozenset for O(1) membership checks.

* The localtime etc renderer now detects a missing zone, writes `/etc/localtime` pointing at UTC instead of a dangling target, and raises a one-shot `TimezoneNotAvailableAlert` so the operator is informed of the divergence between the saved configuration and the running clock. The alert clears automatically on the next render once the zone is available again. The symlink is now written as a relative path matching the systemd/Debian convention.

* The bogus `systemctl daemon-reload` previously issued by the renderer is removed - it never affected timezone state.

* On interactive timezone changes, `system.general.update` now invokes `timedatectl set-timezone` after applying the symlink. This is the recommended way to manage timezones on trixie - it goes through `systemd-timedated` over D-Bus, which emits a `PropertiesChanged` signal so `journald`, `chrony`, `cron` and anything else subscribed (including `timedatectl status` itself) immediately reflect the new zone instead of waiting for a reboot. See `man:org.freedesktop.timedate1(5)` and `man:systemd-timedated.service(8)`.

  This call is intentionally only made on the interactive path. The etc renderer also runs from `ix-etc.service` during early boot, which is ordered Before `sysinit.target` and `basic.target`, while `systemd-timedated.service` is ordered After those targets - the D-Bus call from there would deadlock.

* Downstream consumers of the saved timezone (zettarepl scheduler, the boot-time `TZ` environment variable in `system.setup`, and `TimeservicesService.reload`) now route the value through a new `effective_timezone()` helper so a stale legacy alias left over from an upgrade cannot crash `ZoneInfo()` or set a bogus `TZ` variable.