### PR TITLE
NAS-140958 / 26.0.0-RC.1 / fix update crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -10,7 +10,6 @@ import time
 from typing import Any, Callable, Iterable, Sequence, TypeVar
 
 from .prctl import die_with_parent
-from .threading import io_thread_pool_executor
 
 
 # Define Product Strings
@@ -81,15 +80,11 @@ async def run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes] |
     kwargs.setdefault('close_fds', True)
     kwargs['preexec_fn'] = die_with_parent
 
-    loop = asyncio.get_event_loop()
     subprocess_identifier = f"{time.monotonic()}: {args!r}"
     try:
         currently_running_subprocesses.add(subprocess_identifier)
         try:
-            return await loop.run_in_executor(
-                io_thread_pool_executor,
-                functools.partial(subprocess.run, args, **kwargs),
-            )
+            return await asyncio.to_thread(subprocess.run, args, **kwargs)
         finally:
             currently_running_subprocesses.discard(subprocess_identifier)
     except OSError as e:


### PR DESCRIPTION
We don't officially support jumping multiple major versions when doing updates. We have always said that you need to go to the next major version during upgrade process. However, internally, I was working on something unrelated and tried to bump an internal system from a nightly running 25.04 to latest 27 nightly. It failed in a rather peculiar way. The long-story kept short is that it's failing on an import in `utils/__init__.py` which is kind of gross. The very simple solution is to remove the import which I've done in this PR. It's safe to remove this import because we already set the default executor in`main.py`.  With the changes in this PR, I was able to upgrade the system without issues.The crash looked something like this:
```
Status: Preparing GRUB configuration
[EFAULT] Error: Command ['chroot', '/tmp/tmp9p1rlsk3', '/usr/local/bin/truenas-grub.py'] failed with exit code -6: Fatal Python error: init_py_struct_prop_state: Hidden property in zfs_prop_table. [src/libzfs/py_zfs_prop.c:148]
Python runtime state: initialized

Current thread 0x00007f7328236100 (most recent call first):
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1320 in create_module
  File "<frozen importlib._bootstrap>", line 813 in module_from_spec
  File "<frozen importlib._bootstrap>", line 921 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/lib/python3/dist-packages/middlewared/utils/threading.py", line 10 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1026 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/lib/python3/dist-packages/middlewared/utils/__init__.py", line 13 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1026 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1310 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/local/bin/truenas-grub.py", line 7 in <module>

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 489, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 536, in __run_body
    rv = await self.middleware.run_in_thread(self.method, *args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1300, in run_in_thread
    return await self.run_in_executor(io_thread_pool_executor, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1297, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 178, in nf
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update.py", line 352, in manual
    self.middleware.call_sync(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1668, in call_sync
    return methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install_linux.py", line 50, in install
    self.middleware.call_sync("update.install_scale", mounted, progress_callback, options)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1668, in call_sync
    return methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install.py", line 52, in install_scale
    self._execute_truenas_install(mounted, command, progress_callback)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install.py", line 83, in _execute_truenas_install
    raise CallError(result or f"Abnormal installer process termination with code {p.returncode}")
middlewared.service_exception.CallError: [EFAULT] Error: Command ['chroot', '/tmp/tmp9p1rlsk3', '/usr/local/bin/truenas-grub.py'] failed with exit code -6: Fatal Python error: init_py_struct_prop_state: Hidden property in zfs_prop_table. [src/libzfs/py_zfs_prop.c:148]
Python runtime state: initialized

Current thread 0x00007f7328236100 (most recent call first):
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1320 in create_module
  File "<frozen importlib._bootstrap>", line 813 in module_from_spec
  File "<frozen importlib._bootstrap>", line 921 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/lib/python3/dist-packages/middlewared/utils/threading.py", line 10 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1026 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/lib/python3/dist-packages/middlewared/utils/__init__.py", line 13 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1026 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1310 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/local/bin/truenas-grub.py", line 7 in <module>
 

Original PR: https://github.com/truenas/middleware/pull/18923
