### PR TITLE
NAS-140959 / 27.0.0-BETA.1 / get rid of misleading bisect function

### DIFF
--- a/src/middlewared/middlewared/plugins/alert/alert.py
+++ b/src/middlewared/middlewared/plugins/alert/alert.py
@@ -52,11 +52,10 @@ from middlewared.plugins.failover_.remote import NETWORK_ERRORS
 from middlewared.service import Service, job, periodic, private
 from middlewared.service_exception import CallError, NetworkActivityDisabled
 import middlewared.sqlalchemy as sa
-from middlewared.utils import bisect
 from middlewared.utils.time_utils import utc_now
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from middlewared.main import Middleware
 
@@ -175,6 +174,22 @@ def get_alert_level(alert: Alert[Any], classes: dict[str, Any]) -> AlertLevel:
 
 def get_alert_policy(alert: Alert[Any], classes: dict[str, Any]) -> str:
     return classes.get(alert.instance.config.name, {}).get("policy", DEFAULT_POLICY)  # type: ignore
+
+
+def partition[T](predicate: Callable[[T], Any], iterable: Iterable[T]) -> tuple[list[T], list[T]]:
+    """Split *iterable* into ``(matching, non_matching)`` lists by *predicate*.
+
+    Order within each list is preserved from the input. The predicate is
+    evaluated exactly once per item.
+    """
+    matching: list[T] = []
+    non_matching: list[T] = []
+    for item in iterable:
+        if predicate(item):
+            matching.append(item)
+        else:
+            non_matching.append(item)
+    return matching, non_matching
 
 
 class AlertSerializer:
@@ -469,7 +484,7 @@ class AlertService(Service):
             return
 
         if isinstance(alert.instance, DismissableAlertClass):
-            related_alerts, unrelated_alerts = bisect(
+            related_alerts, unrelated_alerts = partition(
                 lambda a: (a.node, a.instance.config.name) == (alert.node, alert.instance.config.name),
                 self.alerts,
             )
@@ -1041,7 +1056,7 @@ class AlertService(Service):
             if not issubclass(klass_type, OneShotAlertClass):
                 raise CallError(f"Alert class {klassname!r} is not a one-shot alert class")
 
-            related_alerts, unrelated_alerts = bisect(
+            related_alerts, unrelated_alerts = partition(
                 lambda a: (a.node, a.instance.config.name) == (self.node, klass_type.config.name),
                 self.alerts
             )

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import time
 import typing
-from typing import Any, Callable, Iterable, Sequence, TypeVar
+from typing import Any, Sequence
 
 from .prctl import die_with_parent
 from .threading import io_thread_pool_executor
@@ -39,23 +39,9 @@ BRAND = ProductName.PRODUCT_NAME
 
 logger = logging.getLogger(__name__)
 
-_V = TypeVar('_V')
-
 
 class UnexpectedFailure(Exception):
     pass
-
-
-def bisect(condition: Callable[[_V], Any], iterable: Iterable[_V]) -> tuple[list[_V], list[_V]]:
-    a = []
-    b = []
-    for val in iterable:
-        if condition(val):
-            a.append(val)
-        else:
-            b.append(val)
-
-    return a, b
 
 
 currently_running_subprocesses: set[str] = set()


### PR DESCRIPTION
Remove the misleadingly-named `bisect` helper from `middlewared/utils/__init__.py`. Despite the name, it wasn't a bisection it was a partition (split an iterable into two lists by predicate), which collided with Python's stdlib `bisect` module that does binary search on sorted sequences.

It had a single caller (`plugins/alert/alert.py`, two call sites). Inlined as a small file-local `partition[T](...)` helper using PEP 695 generic syntax — no TypeVar boilerplate, no shared utility for one consumer.

## Change

- `middlewared/utils/__init__.py`: dropped `bisect`, the `_V` TypeVar, and the now-unused `Callable`/`Iterable`/`TypeVar` imports.
- `plugins/alert/alert.py`: added a local `partition` helper with docstring; updated both call sites; added `Iterable` to the `TYPE_CHECKING` block.