### PR TITLE
NAS-140959 / 26.0.0-RC.1 / get rid of misleading bisect function (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -458,8 +458,10 @@ class AlertService(Service):
             return
 
         if issubclass(alert.klass, DismissableAlertClass):
-            related_alerts, unrelated_alerts = partition(lambda a: (a.node, a.klass) == (alert.node, alert.klass),
-                                                         self.alerts)
+            related_alerts, unrelated_alerts = partition(
+                lambda a: (a.node, a.klass) == (alert.node, alert.klass),
+                self.alerts
+            )
             left_alerts = await alert.klass(self.middleware).dismiss(related_alerts, alert)
             for deleted_alert in related_alerts:
                 if deleted_alert not in left_alerts:
@@ -1023,8 +1025,10 @@ class AlertService(Service):
             if not issubclass(klass, OneShotAlertClass):
                 raise CallError(f"Alert class {klassname!r} is not a one-shot alert source")
 
-            related_alerts, unrelated_alerts = partition(lambda a: (a.node, a.klass) == (self.node, klass),
-                                                         self.alerts)
+            related_alerts, unrelated_alerts = partition(
+                lambda a: (a.node, a.klass) == (self.node, klass),
+                self.alerts
+            )
             left_alerts = await klass(self.middleware).delete(related_alerts, query)
             for deleted_alert in related_alerts:
                 if deleted_alert not in left_alerts:

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from collections import defaultdict, namedtuple
+from collections.abc import Callable, Iterable
 import copy
 from datetime import datetime, timezone
 import errno
@@ -46,7 +47,6 @@ from middlewared.service import (
 )
 from middlewared.service_exception import CallError, NetworkActivityDisabled
 import middlewared.sqlalchemy as sa
-from middlewared.utils import bisect
 from middlewared.utils.plugins import load_modules, load_classes
 from middlewared.utils.python import get_middlewared_dir
 from middlewared.utils.time_utils import utc_now
@@ -162,6 +162,22 @@ def get_alert_level(alert, classes):
 
 def get_alert_policy(alert, classes):
     return classes.get(alert.klass.name, {}).get("policy", DEFAULT_POLICY)
+
+
+def partition[T](predicate: Callable[[T], Any], iterable: Iterable[T]) -> tuple[list[T], list[T]]:
+    """Split *iterable* into ``(matching, non_matching)`` lists by *predicate*.
+
+    Order within each list is preserved from the input. The predicate is
+    evaluated exactly once per item.
+    """
+    matching: list[T] = []
+    non_matching: list[T] = []
+    for item in iterable:
+        if predicate(item):
+            matching.append(item)
+        else:
+            non_matching.append(item)
+    return matching, non_matching
 
 
 class AlertSerializer:
@@ -442,8 +458,8 @@ class AlertService(Service):
             return
 
         if issubclass(alert.klass, DismissableAlertClass):
-            related_alerts, unrelated_alerts = bisect(lambda a: (a.node, a.klass) == (alert.node, alert.klass),
-                                                      self.alerts)
+            related_alerts, unrelated_alerts = partition(lambda a: (a.node, a.klass) == (alert.node, alert.klass),
+                                                         self.alerts)
             left_alerts = await alert.klass(self.middleware).dismiss(related_alerts, alert)
             for deleted_alert in related_alerts:
                 if deleted_alert not in left_alerts:
@@ -1007,8 +1023,8 @@ class AlertService(Service):
             if not issubclass(klass, OneShotAlertClass):
                 raise CallError(f"Alert class {klassname!r} is not a one-shot alert source")
 
-            related_alerts, unrelated_alerts = bisect(lambda a: (a.node, a.klass) == (self.node, klass),
-                                                      self.alerts)
+            related_alerts, unrelated_alerts = partition(lambda a: (a.node, a.klass) == (self.node, klass),
+                                                         self.alerts)
             left_alerts = await klass(self.middleware).delete(related_alerts, query)
             for deleted_alert in related_alerts:
                 if deleted_alert not in left_alerts:

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -7,7 +7,7 @@ import json
 import logging
 import subprocess
 import time
-from typing import Any, Callable, Iterable, Sequence, TypeVar
+from typing import Any, Sequence
 
 from .prctl import die_with_parent
 from .threading import io_thread_pool_executor
@@ -39,23 +39,9 @@ BRAND = ProductName.PRODUCT_NAME
 
 logger = logging.getLogger(__name__)
 
-_V = TypeVar('_V')
-
 
 class UnexpectedFailure(Exception):
     pass
-
-
-def bisect(condition: Callable[[_V], Any], iterable: Iterable[_V]) -> tuple[list[_V], list[_V]]:
-    a = []
-    b = []
-    for val in iterable:
-        if condition(val):
-            a.append(val)
-        else:
-            b.append(val)
-
-    return a, b
 
 
 currently_running_subprocesses: set[str] = set()


### PR DESCRIPTION
Remove the misleadingly-named `bisect` helper from `middlewared/utils/__init__.py`. Despite the name, it wasn't a bisection it was a partition (split an iterable into two lists by predicate), which collided with Python's stdlib `bisect` module that does binary search on sorted sequences.

It had a single caller (`plugins/alert/alert.py`, two call sites). Inlined as a small file-local `partition[T](...)` helper using PEP 695 generic syntax — no TypeVar boilerplate, no shared utility for one consumer.

## Change

- `middlewared/utils/__init__.py`: dropped `bisect`, the `_V` TypeVar, and the now-unused `Callable`/`Iterable`/`TypeVar` imports.
- `plugins/alert/alert.py`: added a local `partition` helper with docstring; updated both call sites; added `Iterable` to the `TYPE_CHECKING` block.

Original PR: https://github.com/truenas/middleware/pull/18925
