### PR TITLE
NAS-140966 / 26.0.0-RC.1 / Move UPLOADED_DB_PATH to utils.db to break import cycle (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -15,7 +15,7 @@ from middlewared.api.current import (
     ConfigSaveArgs, ConfigSaveResult, ConfigUploadArgs, ConfigUploadResult, ConfigResetArgs, ConfigResetResult
 )
 from middlewared.service import CallError, Service, job, private
-from middlewared.utils.db import FREENAS_DATABASE
+from middlewared.utils.db import FREENAS_DATABASE, UPLOADED_DB_PATH
 from middlewared.utils.privilege import credential_has_full_admin
 from middlewared.utils.pwenc import pwenc_generate_secret, pwenc_rename, PWENC_FILE_SECRET, PWENC_FILE_SECRET_MODE
 
@@ -27,7 +27,6 @@ CONFIG_FILES = {
     'snmp_engine_id': '/data/subsystems/snmp/truenas_pysnmp.conf',
 }
 RE_CONFIG_BACKUP = re.compile(r'.*(\d{4}-\d{2}-\d{2})-(\d+)\.db$')
-UPLOADED_DB_PATH = '/data/uploaded.db'
 PWENC_UPLOADED = '/data/pwenc_secret_uploaded'
 ADMIN_KEYS_UPLOADED = '/data/admin_authorized_keys_uploaded'
 TRUENAS_ADMIN_KEYS_UPLOADED = '/data/truenas_admin_authorized_keys_uploaded'

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -5,9 +5,9 @@ import logging
 import os
 import typing
 
-from middlewared.plugins.config import UPLOADED_DB_PATH
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils import sw_info
+from middlewared.utils.db import UPLOADED_DB_PATH
 
 from .utils import can_update
 from .utils_linux import mount_update

--- a/src/middlewared/middlewared/utils/db.py
+++ b/src/middlewared/middlewared/utils/db.py
@@ -3,6 +3,7 @@ from typing import Any
 
 FREENAS_DATABASE = '/data/freenas-v1.db'
 FREENAS_DATABASE_MODE = 0o600
+UPLOADED_DB_PATH = '/data/uploaded.db'
 
 
 def dict_factory(cursor: sqlite3.Cursor, row: sqlite3.Row) -> dict[str, Any]:


### PR DESCRIPTION
Preexisting fragility caused to manifest by PR #18918

Original PR: https://github.com/truenas/middleware/pull/18932
