### PR TITLE
NAS-140972 / 27.0.0-BETA.1 / Synchronize timezone state across HA controllers

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -731,6 +731,24 @@ class FailoverEventsService(Service):
         self.run_call('systemdataset.setup')
         logger.info('Done configuring system dataset')
 
+        # Re-apply the configured timezone from the (already replicated) DB row.
+        # If the standby was down or disconnected during the active's last
+        # timezone update, its clock state did not converge -- the new master
+        # would otherwise run with a stale /etc/localtime, TZ env and
+        # systemd-timedated cache until reboot. Done before critical services
+        # restart so they inherit the right TZ. Best-effort: a stale clock is
+        # degraded, not a takeover blocker.
+        logger.info('Synchronizing timezone to current configuration')
+        try:
+            tz = self.run_call('system.general.config')['timezone']
+            self.run_call('system.general.apply_timezone_to_running_system', tz)
+            logger.info('Done synchronizing timezone')
+        except Exception:
+            logger.exception(
+                'Failed to synchronize timezone on become-master; '
+                'new master may run with stale clock state until next reboot'
+            )
+
         # now we restart the services, prioritizing the "critical" services
         logger.info('Restarting critical services.')
         self.run_call('failover.events.restart_services', {'critical': True})

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -15,6 +15,7 @@ from middlewared.service import ConfigService, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run
 from middlewared.utils.service.settings import SettingsHelper
+from middlewared.utils.timezone_choices import effective_timezone
 
 settings = SettingsHelper()
 
@@ -228,23 +229,19 @@ class SystemGeneralService(ConfigService):
 
         if config['timezone'] != new_config['timezone']:
             await self.middleware.call('zettarepl.update_config', {'timezone': new_config['timezone']})
-            await (await self.middleware.call('service.control', 'RELOAD', 'timeservices')).wait(raise_error=True)
-            await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
-            # Notify systemd-timedated of the zone change. We do not do this in ix-etc because when on boot
-            # ix-etc.service runs Before sysinit.target, while systemd-timedated.service is ordered
-            # After it, so a D-Bus call from there would deadlock. By the time system.general.update
-            # runs interactively those targets have long been reached. Without this call timedatectl
-            # status and any subscriber to timedated's PropertiesChanged signal (journald, chrony,
-            # cron in some configurations) keep reporting the previous zone until the next reboot.
-            cp = await run(
-                ['timedatectl', 'set-timezone', new_config['timezone']],
-                check=False, encoding='utf-8',
-            )
-            if cp.returncode:
-                self.logger.warning(
-                    'timedatectl set-timezone %r failed: %s',
-                    new_config['timezone'], cp.stderr,
-                )
+            await self.apply_timezone_to_running_system(new_config['timezone'])
+            if await self.middleware.call('failover.licensed'):
+                try:
+                    await self.middleware.call(
+                        'failover.call_remote',
+                        'system.general.apply_timezone_to_running_system',
+                        [new_config['timezone']],
+                        {'raise_connect_error': False, 'timeout': 30},
+                    )
+                except Exception:
+                    self.logger.warning(
+                        'Failed to apply timezone on standby controller', exc_info=True
+                    )
 
         if config['ds_auth'] != new_config['ds_auth']:
             await self.middleware.call('etc.generate', 'pam')
@@ -279,6 +276,36 @@ class SystemGeneralService(ConfigService):
                 break
 
         return await self.config()
+
+    @private
+    async def apply_timezone_to_running_system(self, timezone):
+        # Apply the configured timezone to the running system. Reused by the
+        # interactive update path, by failover.call_remote from the active to
+        # propagate to the standby, and by vrrp_master on become-master so a
+        # newly-promoted node converges to the DB's timezone without a reboot.
+        tz = effective_timezone(timezone)
+        ha_options = {'ha_propagate': False}
+        await (await self.middleware.call(
+            'service.control', 'RELOAD', 'timeservices', ha_options,
+        )).wait(raise_error=True)
+        # Restart cron so it inherits the new TZ env from middlewared.
+        await (await self.middleware.call(
+            'service.control', 'RESTART', 'cron', ha_options,
+        )).wait(raise_error=True)
+        # Update systemd-timedated's cache so `timedatectl status` and journald
+        # (which subscribes to timedated's PropertiesChanged signal) reflect the
+        # change without a reboot. We do not do this from ix-etc because at boot
+        # ix-etc.service runs Before sysinit.target while systemd-timedated is
+        # ordered After it, so a D-Bus call from there would deadlock. This
+        # method only runs from contexts that come after sysinit.target.
+        cp = await run(
+            ['timedatectl', 'set-timezone', tz],
+            check=False, encoding='utf-8',
+        )
+        if cp.returncode:
+            self.logger.warning(
+                'timedatectl set-timezone %r failed: %s', tz, cp.stderr,
+            )
 
     @private
     async def set_kbdlayout(self):


### PR DESCRIPTION
This commit fixes an issue where on HA systems, a timezone change on the active controller did not fully propagate to the standby, leaving its systemd-timedated cache stale until the next reboot.

The fix applies the timezone on both nodes from a shared helper, and re-applies it on become-master so a promotion still converges when the standby was down or disconnected during the update.