### PR TITLE
NAS-140944 / 27.0.0-BETA.1 / Do not expect JSON output from TNC delete calls

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/internal.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/internal.py
@@ -79,6 +79,7 @@ async def unset_registration_details(
         get_account_service_url(config).format(**creds),
         "delete",
         headers=auth_headers(config),
+        get_response=False,
     )
     if response["error"]:
         if response["status_code"] == 401:


### PR DESCRIPTION
This commit fixes a case where TNC's `DELETE /v1/systems/:id` endpoint now returns 200 with an empty/non-JSON body, causing `unset_registration_details` to crash with `aiohttp.ContentTypeError` while attempting to decode the response as JSON. Passing `get_response=False` skips the body decode since the response payload is not used.