### PR TITLE
NAS-140980 / 27.0.0-BETA.1 / Fix NFS test failures from pynfs migration

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -584,6 +584,24 @@ def start_nfs():
         yield nfs_start
 
 
+@pytest.fixture
+def nfs_allow_nonroot():
+    """Set allow_nonroot=True for the test duration so pynfs's
+    ephemeral source ports are accepted at the RPC layer (export
+    line gets 'insecure').  Pynfs runs in the test process as the
+    test user without CAP_NET_BIND_SERVICE; without this, mountd
+    returns ACCES on v3 and nfsd squashes uid=0 to nobody on v4.
+    SSH_NFS didn't need this because mount.nfs is SETUID-root."""
+    prev = call("nfs.config")["allow_nonroot"]
+    if not prev:
+        call("nfs.update", {"allow_nonroot": True})
+    try:
+        yield
+    finally:
+        if not prev:
+            call("nfs.update", {"allow_nonroot": False})
+
+
 @pytest.fixture(scope="function")
 def nfs_running():
     """The NFS ops tests need to enter and exit with NFS running"""
@@ -691,7 +709,8 @@ class TestNFSops:
         # ----------------------------------------------------------------------
 
     @pytest.mark.parametrize('vers', [3, 4])
-    def test_basic_nfs_ops(self, start_nfs, nfs_dataset_and_share, vers):
+    def test_basic_nfs_ops(self, start_nfs, nfs_dataset_and_share,
+                           nfs_allow_nonroot, vers):
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
 
@@ -708,7 +727,8 @@ class TestNFSops:
             assert 'testdir' not in contents
             assert 'testfile' not in contents
 
-    def test_nfs_scope_setting(self, start_nfs, nfs_dataset_and_share):
+    def test_nfs_scope_setting(self, start_nfs, nfs_dataset_and_share,
+                               nfs_allow_nonroot):
         """
         Test NFS share with scope configuration
         Confirm the scope setting is correctd.
@@ -974,7 +994,7 @@ class TestNFSops:
                 # The entry should not be present
                 assert len(exports_hosts) == 1, str(parsed)
 
-    def test_share_ro(self, start_nfs, nfs_dataset_and_share):
+    def test_share_ro(self, start_nfs, nfs_dataset_and_share, nfs_allow_nonroot):
         """
         Verify that toggling `ro` will cause appropriate change in
         exports file. We also verify with write tests on a local mount.
@@ -1297,7 +1317,8 @@ class TestNFSops:
             assert 'rpc.mountd' not in daemon_data, \
                 f"Unexpectedly found rcp.mountd messages in daemon.log:\n{daemon_data}"
 
-    def test_client_status(self, start_nfs, nfs_dataset_and_share):
+    def test_client_status(self, start_nfs, nfs_dataset_and_share,
+                           nfs_allow_nonroot):
         """
         This test checks the function of API endpoints to list NFSv3 and
         NFSv4 clients by performing loopback mounts on the remote TrueNAS

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -747,7 +747,11 @@ class TestNFSops:
         confirm_nfs_config_settings([[['nfsd', 'scope'], expected_scope_value]])
 
         # Confirm NFS reports the expected scope value
-        p = async_SSH_start("tcpdump -A -v -t -i lo -s 1514 port nfs -c12", user, password, hostip)
+        # ``-i any`` so the capture works regardless of whether the
+        # client is on the appliance (loopback, as with the older
+        # SSH_NFS path) or on the test runner (external interface,
+        # as with PynfsClient since #18912).
+        p = async_SSH_start("tcpdump -A -v -t -i any -s 1514 port nfs -c12", user, password, hostip)
         # Give some time so that the tcpdump has started before we proceed
         sleep(2)
         with _nfs_client(4):

--- a/tests/api2/test_usage_reporting.py
+++ b/tests/api2/test_usage_reporting.py
@@ -76,9 +76,22 @@ def test_nfs_reporting(get_usage_sample):
                 # ``PynfsClient3`` does the actual MOUNT + portmapper
                 # bind, which the appliance counts as a v3 client
                 # exactly the way kernel ``mount.nfs`` did.
-                with PynfsClient3(truenas_server.ip, nfs_path):
-                    usage_sample = call('usage.gather')
-                    assert usage_sample['NFS']['num_clients'] == baseline_sample + 1
+                #
+                # Pynfs runs in the test process as a non-root user
+                # without CAP_NET_BIND_SERVICE, so its source port is
+                # ephemeral; flip allow_nonroot=True so the export
+                # accepts that.  SSH_NFS didn't need this because
+                # mount.nfs binds privileged ports as SETUID-root.
+                prev_allow_nonroot = call('nfs.config')['allow_nonroot']
+                if not prev_allow_nonroot:
+                    call('nfs.update', {'allow_nonroot': True})
+                try:
+                    with PynfsClient3(truenas_server.ip, nfs_path):
+                        usage_sample = call('usage.gather')
+                        assert usage_sample['NFS']['num_clients'] == baseline_sample + 1
+                finally:
+                    if not prev_allow_nonroot:
+                        call('nfs.update', {'allow_nonroot': False})
 
 
 def test_ftp_reporting(get_usage_sample):


### PR DESCRIPTION
[Seven tests have been failing since pynfs migration](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/8877/#showFailuresLink):
```
  test_300_nfs.py::test_basic_nfs_ops[3,4]
  test_300_nfs.py::test_nfs_scope_setting
  test_300_nfs.py::test_share_ro
  test_300_nfs.py::test_client_status
  test_300_nfs.py::test_nonroot_behavior
  test_usage_reporting.py::test_nfs_reporting
```
Two root causes, both from the migration moving the NFS client out of the kernel and into the test process:

1. pynfs uses an ephemeral source port by default.  With the server's default `allow_nonroot=False`, the export carries `secure`, so mountd returns ACCES on v3 and nfsd squashes uid=0 to nobody on v4. SSH_NFS didn't hit this because `mount.nfs` is SETUID-root and always bound a privileged port.

2. `test_nfs_scope_setting`'s tcpdump runs with `-i lo`, which only captured traffic when the client ran on the same host as nfsd. With the pynfs client now in the test process, the traffic comes in over the network and never touches loopback.

`test_nonroot_behavior` is a separate case. It explicitly binds a privileged port via `secure=True`, which requires root.  After discussion with @anodos325, it will be fixed in the test pipeline by invoking `runtest.py` with sudo.

### Testing:
- http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/8884/console passing previously FAILED `test_300_nfs` tests.