### PR TITLE
NAS-140944 / 26.0.0-RC.1 / Do not expect JSON output from TNC delete calls (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -243,6 +243,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         # We need to revoke the user account now
         response = await self._call(
             get_account_service_url(config).format(**creds), 'delete', headers=await self.auth_headers(config),
+            get_response=False,
         )
         if response['error']:
             if response['status_code'] == 401:


### PR DESCRIPTION
This commit fixes a case where TNC's `DELETE /v1/systems/:id` endpoint now returns 200 with an empty/non-JSON body, causing `unset_registration_details` to crash with `aiohttp.ContentTypeError` while attempting to decode the response as JSON. Passing `get_response=False` skips the body decode since the response payload is not used.

Original PR: https://github.com/truenas/middleware/pull/18936
