### PR TITLE
NAS-140965 / 27.0.0-BETA.1 / Prevent TNC certificate reuse in apps and DS

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -20,6 +20,7 @@ from middlewared.api.current import (
     ContainerDetails,
     ZFSResourceQuery,
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.plugins.zfs_.utils import paths_to_datasets_impl
 from middlewared.service import CallError, ServiceContext
 
@@ -58,7 +59,12 @@ async def certificate_choices(context: ServiceContext) -> AppCertificateChoices:
         AppCertificate(id=cert.id, name=cert.name)
         for cert in await context.call2(
             context.s.certificate.query,
-            [['cert_type_CSR', '=', False], ['cert_type_CA', '=', False], ['parsed', '=', True]],
+            [
+                ['cert_type_CSR', '=', False],
+                ['cert_type_CA', '=', False],
+                ['parsed', '=', True],
+                ['name', '!^', TNC_CERT_PREFIX],
+            ],
         )
     ]
 

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -102,6 +102,13 @@ async def validate_certificate(
 
     if not any(choice.id == value for choice in await certificate_choices(context)):
         verrors.add(schema_name, 'Unable to locate certificate.')
+        return
+
+    sub_verrors = await context.call2(
+        context.s.certificate.cert_services_validation, value, schema_name, False,
+    )
+    if sub_verrors:
+        verrors.extend(sub_verrors)
 
 
 def _acl_path_has_data(path: str) -> bool:

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -16,6 +16,7 @@ from middlewared.api.current import (
     QueryOptions,
 )
 from middlewared.plugins.directoryservices_.util_cache import expire_cache
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import ConfigService, job, private
 from middlewared.service_exception import CallError, MatchNotFound, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -388,9 +389,16 @@ class DirectoryServices(ConfigService):
         if new['credential'] and new['credential']['credential_type'] == DSCredType.LDAP_MTLS:
             cert_name = new['credential']['client_certificate']
             try:
-                self.middleware.call_sync('certificate.query', [['name', '=', cert_name]], {'get': True})
+                cert = self.call_sync2(self.s.certificate.query, [['name', '=', cert_name]], QueryOptions(get=True))
             except MatchNotFound:
                 verrors.add(f'{SCHEMA}.credential.client_certificate', 'Unknown client certificate.')
+            else:
+                if cert.name.startswith(TNC_CERT_PREFIX):
+                    verrors.add(
+                        f'{SCHEMA}.credential.client_certificate',
+                        f'Certificate "{cert.name}" is reserved for TrueNAS Connect service '
+                        'and cannot be used by other services',
+                    )
 
         if not new['enable'] and new['credential'] and new['credential']['credential_type'] == DSCredType.KERBEROS_USER:
             if new['service_type'] in (DSType.AD.value, DSType.IPA.value):
@@ -885,12 +893,13 @@ class DirectoryServices(ConfigService):
         certificate to TrueNAS may also be required. """
         return {
             i.name: i.name
-            for i in await self.middleware.call2(
+            for i in await self.call2(
                 self.s.certificate.query,
                 [
                     ['cert_type', '=', 'CERTIFICATE'],
                     ['cert_type_CSR', '=', False],
                     ['cert_type_CA', '=', False],
+                    ['name', '!^', TNC_CERT_PREFIX],
                 ],
             )
         }

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -5,6 +5,7 @@ from middlewared.api.current import (
     SystemAdvancedSyslogCertificateChoicesArgs,
     SystemAdvancedSyslogCertificateChoicesResult,
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import Service
 
 
@@ -27,7 +28,11 @@ class SystemAdvancedService(Service):
             i.id: i.name
             for i in await self.middleware.call2(
                 self.s.certificate.query,
-                [['cert_type_CSR', '=', False], ['cert_type_CA', '=', False]],
+                [
+                    ['cert_type_CSR', '=', False],
+                    ['cert_type_CA', '=', False],
+                    ['name', '!^', TNC_CERT_PREFIX],
+                ],
             )
         }
 

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -15,6 +15,7 @@ from middlewared.api.current import (
     SystemGeneralUiV6addressChoicesArgs,
     SystemGeneralUiV6addressChoicesResult,
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import CallError, Service, private
 
 from .utils import HTTPS_PROTOCOLS
@@ -82,7 +83,11 @@ class SystemGeneralService(Service):
             i.id: i.name
             for i in await self.middleware.call2(
                 self.s.certificate.query,
-                [("cert_type_CSR", "=", False), ("cert_type_CA", "=", False)],
+                [
+                    ("cert_type_CSR", "=", False),
+                    ("cert_type_CA", "=", False),
+                    ("name", "!^", TNC_CERT_PREFIX),
+                ],
             )
         }
 


### PR DESCRIPTION
This commit fixes an issue where TNC certificates could be selected by apps and directory services because their validation paths did not run cert_services_validation. TNC certs also appeared in cert choice dropdowns across apps, directory services, system general UI and system advanced syslog.

Filter TNC certs out of all cert choices methods and add the missing validation hooks so that new users cannot attach a TNC cert to any non-TNC consumer. For directory services LDAP_MTLS the validation is a narrow TNC-prefix check to preserve compatibility with legacy client certs.