### PR TITLE
NAS-140965 / 26.0.0-RC.1 / Prevent TNC certificate reuse in apps and DS (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -10,6 +10,7 @@ from middlewared.api.current import (
     AppIpChoicesArgs, AppIpChoicesResult, AppAvailableSpaceArgs,
     AppAvailableSpaceResult, AppGpuChoicesArgs, AppGpuChoicesResult,
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.plugins.zfs_.utils import paths_to_datasets_impl
 from middlewared.service import private, Service
 
@@ -55,7 +56,13 @@ class AppService(Service):
         Returns certificates which can be used by applications.
         """
         return await self.middleware.call(
-            'certificate.query', [['cert_type_CSR', '=', False], ['cert_type_CA', '=', False], ['parsed', '=', True]],
+            'certificate.query',
+            [
+                ['cert_type_CSR', '=', False],
+                ['cert_type_CA', '=', False],
+                ['parsed', '=', True],
+                ['name', '!^', TNC_CERT_PREFIX],
+            ],
             {'select': ['name', 'id']}
         )
 

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -90,6 +90,13 @@ class AppSchemaService(Service):
 
         if not filter_list(await self.middleware.call('app.certificate_choices'), [['id', '=', value]]):
             verrors.add(schema_name, 'Unable to locate certificate.')
+            return
+
+        sub_verrors = await self.middleware.call(
+            'certificate.cert_services_validation', value, schema_name, False,
+        )
+        if sub_verrors:
+            verrors.extend(sub_verrors)
 
     def validate_acl_entries(self, verrors, value, question, schema_name, app_data):
         try:

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -11,6 +11,7 @@ from middlewared.api.current import (
     DirectoryServicesSyncKeytabArgs, DirectoryServicesSyncKeytabResult,
 )
 from middlewared.plugins.directoryservices_.util_cache import expire_cache
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import ConfigService, private, job
 from middlewared.service_exception import CallError, MatchNotFound, ValidationErrors
 from middlewared.utils.directoryservices.ad import get_domain_info, lookup_dc
@@ -381,9 +382,18 @@ class DirectoryServices(ConfigService):
         if new['credential'] and new['credential']['credential_type'] == DSCredType.LDAP_MTLS:
             cert_name = new['credential']['client_certificate']
             try:
-                self.middleware.call_sync('certificate.query', [['name', '=', cert_name]], {'get': True})
+                cert = self.middleware.call_sync(
+                    'certificate.query', [['name', '=', cert_name]], {'get': True}
+                )
             except MatchNotFound:
                 verrors.add(f'{SCHEMA}.credential.client_certificate', 'Unknown client certificate.')
+            else:
+                if cert['name'].startswith(TNC_CERT_PREFIX):
+                    verrors.add(
+                        f'{SCHEMA}.credential.client_certificate',
+                        f'Certificate "{cert["name"]}" is reserved for TrueNAS Connect service '
+                        'and cannot be used by other services',
+                    )
 
         if not new['enable'] and new['credential'] and new['credential']['credential_type'] == DSCredType.KERBEROS_USER:
             if new['service_type'] in (DSType.AD.value, DSType.IPA.value):
@@ -882,7 +892,8 @@ class DirectoryServices(ConfigService):
                 'certificate.query', [
                     ['cert_type', '=', 'CERTIFICATE'],
                     ['cert_type_CSR', '=', False],
-                    ['cert_type_CA', '=', False]
+                    ['cert_type_CA', '=', False],
+                    ['name', '!^', TNC_CERT_PREFIX],
                 ]
             )
         }

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -3,6 +3,7 @@ from middlewared.api.current import (
     SystemAdvancedSyslogCertificateChoicesArgs, SystemAdvancedSyslogCertificateChoicesResult,
     SystemAdvancedSyslogCertificateAuthorityChoicesArgs, SystemAdvancedSyslogCertificateAuthorityChoicesResult
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import Service
 
 
@@ -26,7 +27,8 @@ class SystemAdvancedService(Service):
             for i in await self.middleware.call(
                 'certificate.query', [
                     ['cert_type_CSR', '=', False],
-                    ['cert_type_CA', '=', False]
+                    ['cert_type_CA', '=', False],
+                    ['name', '!^', TNC_CERT_PREFIX],
                 ]
             )
         }

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -15,6 +15,7 @@ from middlewared.api.current import (
     SystemGeneralUiV6addressChoicesArgs,
     SystemGeneralUiV6addressChoicesResult,
 )
+from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
 from middlewared.service import CallError, private, Service
 
 from .utils import HTTPS_PROTOCOLS
@@ -81,7 +82,12 @@ class SystemGeneralService(Service):
         return {
             i["id"]: i["name"]
             for i in await self.middleware.call(
-                "certificate.query", [("cert_type_CSR", "=", False), ("cert_type_CA", "=", False)]
+                "certificate.query",
+                [
+                    ("cert_type_CSR", "=", False),
+                    ("cert_type_CA", "=", False),
+                    ("name", "!^", TNC_CERT_PREFIX),
+                ],
             )
         }
 


### PR DESCRIPTION
This commit fixes an issue where TNC certificates could be selected by apps and directory services because their validation paths did not run cert_services_validation. TNC certs also appeared in cert choice dropdowns across apps, directory services, system general UI and system advanced syslog.

Filter TNC certs out of all cert choices methods and add the missing validation hooks so that new users cannot attach a TNC cert to any non-TNC consumer. For directory services LDAP_MTLS the validation is a narrow TNC-prefix check to preserve compatibility with legacy client certs.

Original PR: https://github.com/truenas/middleware/pull/18945
