### PR TITLE
NAS-141020 / 27.0.0-BETA.1 / Restrict on-disk perms of internal container/apps dataset roots

### DIFF
--- a/src/middlewared/middlewared/etc_files/libvirt.py
+++ b/src/middlewared/middlewared/etc_files/libvirt.py
@@ -1,5 +1,6 @@
 import os
 
+from middlewared.plugins.container.lifecycle import apply_idmapped_root_acl
 from middlewared.utils.io import write_if_changed
 
 LIBVIRTD_CONF_PATH = "/etc/libvirt/libvirtd.conf"
@@ -7,4 +8,5 @@ LIBVIRTD_CONF_PATH = "/etc/libvirt/libvirtd.conf"
 
 def render(service, middleware):
     os.makedirs("/run/truenas_libvirt", exist_ok=True)
+    apply_idmapped_root_acl()
     write_if_changed(LIBVIRTD_CONF_PATH, 'unix_sock_dir = "/run/truenas_libvirt"')

--- a/src/middlewared/middlewared/etc_files/libvirt.py
+++ b/src/middlewared/middlewared/etc_files/libvirt.py
@@ -1,10 +1,16 @@
 import os
 
+from middlewared.utils.filesystem.perms import enforce_dir_perms
 from middlewared.utils.io import write_if_changed
 
-LIBVIRTD_CONF_PATH = '/etc/libvirt/libvirtd.conf'
+LIBVIRTD_CONF_PATH = "/etc/libvirt/libvirtd.conf"
+IDMAPPED_ROOT_DIR = "/run/truenas_containers/root"
 
 
 def render(service, middleware):
-    os.makedirs('/run/truenas_libvirt', exist_ok=True)
+    os.makedirs("/run/truenas_libvirt", exist_ok=True)
+    # makedirs(exist_ok=True) does NOT chmod a pre-existing dir, so follow
+    # with enforce_dir_perms to make perms idempotent across reboots.
+    os.makedirs(IDMAPPED_ROOT_DIR, mode=0o700, exist_ok=True)
+    enforce_dir_perms(IDMAPPED_ROOT_DIR)
     write_if_changed(LIBVIRTD_CONF_PATH, 'unix_sock_dir = "/run/truenas_libvirt"')

--- a/src/middlewared/middlewared/etc_files/libvirt.py
+++ b/src/middlewared/middlewared/etc_files/libvirt.py
@@ -1,16 +1,10 @@
 import os
 
-from middlewared.utils.filesystem.perms import enforce_dir_perms
 from middlewared.utils.io import write_if_changed
 
 LIBVIRTD_CONF_PATH = "/etc/libvirt/libvirtd.conf"
-IDMAPPED_ROOT_DIR = "/run/truenas_containers/root"
 
 
 def render(service, middleware):
     os.makedirs("/run/truenas_libvirt", exist_ok=True)
-    # makedirs(exist_ok=True) does NOT chmod a pre-existing dir, so follow
-    # with enforce_dir_perms to make perms idempotent across reboots.
-    os.makedirs(IDMAPPED_ROOT_DIR, mode=0o700, exist_ok=True)
-    enforce_dir_perms(IDMAPPED_ROOT_DIR)
     write_if_changed(LIBVIRTD_CONF_PATH, 'unix_sock_dir = "/run/truenas_libvirt"')

--- a/src/middlewared/middlewared/plugins/container/dataset.py
+++ b/src/middlewared/middlewared/plugins/container/dataset.py
@@ -3,49 +3,60 @@ import os
 from middlewared.api.current import ZFSResourceQuery
 from middlewared.plugins.pool_.utils import CreateImplArgs
 from middlewared.service import CallError, ServiceContext
+from middlewared.utils.filesystem.perms import enforce_dir_perms
 
-from .utils import container_dataset, container_dataset_mountpoint
+from .utils import CONTAINER_DS_NAME, container_dataset, container_dataset_mountpoint
+
+CONTAINER_DS_PARENT_DIR = f"/mnt/{CONTAINER_DS_NAME}"
 
 
 async def ensure_datasets(context: ServiceContext, pool: str) -> None:
     main_dataset = container_dataset(pool)
     main_dataset_mountpoint = container_dataset_mountpoint(pool)
 
-    datasets = [f'{main_dataset}/containers', f'{main_dataset}/images']
+    datasets = [f"{main_dataset}/containers", f"{main_dataset}/images"]
 
     existing_datasets = set()
     for dataset in await context.call2(
-        context.s.zfs.resource.query_impl,
-        ZFSResourceQuery(paths=[main_dataset] + datasets, properties=['mountpoint'])
+        context.s.zfs.resource.query_impl, ZFSResourceQuery(paths=[main_dataset] + datasets, properties=["mountpoint"])
     ):
-        if dataset['type'] != 'FILESYSTEM':
-            raise CallError(f'Expected dataset {dataset["name"]!r} to be FILESYSTEM, but it is {dataset["type"]}')
+        if dataset["type"] != "FILESYSTEM":
+            raise CallError(f"Expected dataset {dataset['name']!r} to be FILESYSTEM, but it is {dataset['type']}")
 
-        if dataset['name'] == main_dataset:
-            main_dataset_mountpoint_value = f'/mnt{main_dataset_mountpoint}'
-            if dataset['properties']['mountpoint']['value'] != main_dataset_mountpoint_value:
+        if dataset["name"] == main_dataset:
+            main_dataset_mountpoint_value = f"/mnt{main_dataset_mountpoint}"
+            if dataset["properties"]["mountpoint"]["value"] != main_dataset_mountpoint_value:
                 raise CallError(
-                    f'Expected dataset {dataset["name"]} to have mountpoint of {main_dataset_mountpoint_value!r}, '
-                    f'but it is {dataset["properties"]["mountpoint"]["value"]!r}.'
+                    f"Expected dataset {dataset['name']} to have mountpoint of {main_dataset_mountpoint_value!r}, "
+                    f"but it is {dataset['properties']['mountpoint']['value']!r}."
                 )
 
-        existing_datasets.add(dataset['name'])
+        existing_datasets.add(dataset["name"])
 
     if main_dataset not in existing_datasets:
         await context.middleware.call(
-            'pool.dataset.create_impl',
+            "pool.dataset.create_impl",
             CreateImplArgs(
-                name=main_dataset, ztype='FILESYSTEM', zprops={'mountpoint': main_dataset_mountpoint},
-            )
+                name=main_dataset,
+                ztype="FILESYSTEM",
+                zprops={
+                    "mountpoint": main_dataset_mountpoint,
+                    "acltype": "posix",
+                    "aclmode": "discard",
+                    "snapdir": "hidden",
+                },
+            ),
         )
 
-    if not await context.to_thread(os.path.exists, main_dataset_mountpoint):
+    if not await context.to_thread(os.path.ismount, f"/mnt{main_dataset_mountpoint}"):
         await context.call2(context.s.zfs.resource.mount, main_dataset)
 
     for ds_name in datasets:
         if ds_name not in existing_datasets:
-            await context.middleware.call(
-                'pool.dataset.create_impl',
-                CreateImplArgs(name=ds_name, ztype='FILESYSTEM')
-            )
+            await context.middleware.call("pool.dataset.create_impl", CreateImplArgs(name=ds_name, ztype="FILESYSTEM"))
         await context.call2(context.s.zfs.resource.mount, ds_name)
+
+    # ZFS auto-creates CONTAINER_DS_PARENT_DIR as a side effect of mounting the
+    # per-pool dataset. Restrict it so non-root host users can't traverse to
+    # any container's on-disk rootfs (UID-collision exposure for apps user etc.).
+    await context.to_thread(enforce_dir_perms, CONTAINER_DS_PARENT_DIR)

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -21,8 +21,6 @@ from .bridge import configure_container_bridge, container_bridge_name
 from .dataset import CONTAINER_DS_PARENT_DIR
 from .utils import container_instance_dataset_mountpoint, update_etc_hosts, write_etc_hostname
 
-IDMAPPED_ROOT_DIR = "/run/truenas_containers/root"
-
 
 def start_on_boot(context: ServiceContext) -> None:
     for container in context.call_sync2(
@@ -41,7 +39,6 @@ def handle_shutdown(context: ServiceContext) -> None:
 
 def start(context: ServiceContext, id_: int) -> None:
     enforce_dir_perms(CONTAINER_DS_PARENT_DIR)
-    enforce_dir_perms(IDMAPPED_ROOT_DIR)
 
     container = context.run_coroutine(context.call2(context.s.container.get_instance, id_))
     configure_container_bridge(context)

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -15,27 +15,34 @@ from truenas_pylibvirt import (
 from middlewared.api.current import ContainerStopOptions, QueryOptions, ZFSResourceQuery
 from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID, IDMAP_COUNT
 from middlewared.service import CallError, ServiceContext
+from middlewared.utils.filesystem.perms import enforce_dir_perms
 
 from .bridge import configure_container_bridge, container_bridge_name
+from .dataset import CONTAINER_DS_PARENT_DIR
 from .utils import container_instance_dataset_mountpoint, update_etc_hosts, write_etc_hostname
+
+IDMAPPED_ROOT_DIR = "/run/truenas_containers/root"
 
 
 def start_on_boot(context: ServiceContext) -> None:
     for container in context.call_sync2(
-        context.s.container.query, [('autostart', '=', True)], QueryOptions(force_sql_filters=True)
+        context.s.container.query, [("autostart", "=", True)], QueryOptions(force_sql_filters=True)
     ):
         try:
             start(context, container.id)
         except Exception as e:
-            context.logger.error(f'Failed to start {container.name!r} container: {e}')
+            context.logger.error(f"Failed to start {container.name!r} container: {e}")
 
 
 def handle_shutdown(context: ServiceContext) -> None:
-    for container in context.call_sync2(context.s.container.query, [('status.state', '=', 'RUNNING')]):
+    for container in context.call_sync2(context.s.container.query, [("status.state", "=", "RUNNING")]):
         stop(context, container.id, ContainerStopOptions(force_after_timeout=True))
 
 
 def start(context: ServiceContext, id_: int) -> None:
+    enforce_dir_perms(CONTAINER_DS_PARENT_DIR)
+    enforce_dir_perms(IDMAPPED_ROOT_DIR)
+
     container = context.run_coroutine(context.call2(context.s.container.get_instance, id_))
     configure_container_bridge(context)
 
@@ -46,7 +53,7 @@ def start(context: ServiceContext, id_: int) -> None:
         write_etc_hostname(pylibvirt_obj.configuration.root, container.name)
         update_etc_hosts(pylibvirt_obj.configuration.root, container.name)
     except Exception:
-        context.logger.warning('Failed to configure hostname for container %r', container.name, exc_info=True)
+        context.logger.warning("Failed to configure hostname for container %r", container.name, exc_info=True)
 
     context.middleware.libvirt_domains_manager.containers.start(pylibvirt_obj)
 
@@ -59,9 +66,10 @@ def stop(context: ServiceContext, id_: int, options: ContainerStopOptions) -> No
         return
 
     context.middleware.libvirt_domains_manager.containers.shutdown(pylibvirt_container_obj)
-    if options.force_after_timeout and context.run_coroutine(
-        context.call2(context.s.container.get_instance, id_)
-    ).status.state == 'RUNNING':
+    if (
+        options.force_after_timeout
+        and context.run_coroutine(context.call2(context.s.container.get_instance, id_)).status.state == "RUNNING"
+    ):
         context.middleware.libvirt_domains_manager.containers.destroy(pylibvirt_container_obj)
 
 
@@ -69,28 +77,28 @@ def pylibvirt_container(
     context: ServiceContext, container: dict[str, typing.Any], check_ds: bool = False
 ) -> ContainerDomain:
     container = container.copy()
-    container.pop('id', None)
-    container.pop('status', None)
-    container.pop('autostart', None)
-    container.pop('default_network', None)
+    container.pop("id", None)
+    container.pop("status", None)
+    container.pop("autostart", None)
+    container.pop("default_network", None)
 
-    dataset = container.pop('dataset')
-    pool = dataset.split('/')[0]
-    container['root'] = f"/mnt/{container_instance_dataset_mountpoint(pool, container['name'])}"
+    dataset = container.pop("dataset")
+    pool = dataset.split("/")[0]
+    container["root"] = f"/mnt/{container_instance_dataset_mountpoint(pool, container['name'])}"
     if check_ds:
         datasets = context.call_sync2(
             context.s.zfs.resource.query_impl,
             ZFSResourceQuery(paths=[dataset], properties=None),
         )
         if not datasets:
-            raise CallError(f'Dataset {dataset!r} not found', errno.ENOTDIR)
+            raise CallError(f"Dataset {dataset!r} not found", errno.ENOTDIR)
 
-    container['time'] = Time(container['time'])
+    container["time"] = Time(container["time"])
     device_factory = context.middleware.services.container.device.device_factory
     devices = []
     has_nic_device = False
-    for device in container.get('devices', []):
-        if device['attributes']['dtype'] == 'NIC':
+    for device in container.get("devices", []):
+        if device["attributes"]["dtype"] == "NIC":
             has_nic_device = True
 
         devices.append(device_factory.get_device(device))
@@ -108,7 +116,7 @@ def pylibvirt_container(
             )
         )
 
-    container['devices'] = devices
+    container["devices"] = devices
 
     if container['idmap']:
         match container['idmap']['type']:
@@ -126,18 +134,20 @@ def pylibvirt_container(
         except ValueError as e:
             raise CallError(f'Invalid idmap configuration: {e}')
 
-    if container['capabilities_policy']:
-        container['capabilities_policy'] = ContainerCapabilitiesPolicy[container['capabilities_policy']]
+    if container["capabilities_policy"]:
+        container["capabilities_policy"] = ContainerCapabilitiesPolicy[container["capabilities_policy"]]
 
     # We add this to configuration because for cpu related attrs, we need them if cpuset on
     # container is actually set
     # For memory, lxc does not respect it but libvirt requires it in the xml to be defined
-    container.update({
-        'vcpus': None,
-        'cores': None,
-        'threads': None,
-        'memory': None,
-    })
+    container.update(
+        {
+            "vcpus": None,
+            "cores": None,
+            "threads": None,
+            "memory": None,
+        }
+    )
 
     return ContainerDomain(ContainerDomainConfiguration(**container))
 

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -1,6 +1,8 @@
 import errno
+import os
 import typing
 
+import truenas_os
 from truenas_pylibvirt import (
     ContainerCapabilitiesPolicy,
     ContainerDomain,
@@ -21,6 +23,60 @@ from .bridge import configure_container_bridge, container_bridge_name
 from .dataset import CONTAINER_DS_PARENT_DIR
 from .utils import container_instance_dataset_mountpoint, update_etc_hosts, write_etc_hostname
 
+IDMAPPED_ROOT_DIR = "/run/truenas_containers/root"
+
+# The full enumeration of host UIDs any container's container-uid-0 ever
+# maps to: CONTAINER_ROOT_UID + slice*IDMAP_COUNT for slice in range(1000).
+# - slice 0 is the DEFAULT-idmap row (stored internally; not user-settable).
+# - slice [1, 999] is the ISOLATED range per api/v27_0_0/container.py
+#   (PositiveInt with lt=1000).
+# - ContainerXID is `ge=1` in api/base/types/user.py, so no local account
+#   can ever claim container-uid 0; container 0 therefore always maps to
+#   CONTAINER_ROOT_UID + slice*IDMAP_COUNT for some slice in this range.
+# Static set -> no per-container ACL bookkeeping at all.
+_IDMAPPED_ROOT_ALLOWED_UIDS = frozenset(
+    CONTAINER_ROOT_UID + n * IDMAP_COUNT for n in range(1000)
+)
+
+
+def apply_idmapped_root_acl() -> None:
+    """Pin IDMAPPED_ROOT_DIR to root:root with a POSIX1E ACL granting `--x`
+    (search only) to every possible container-uid-0 host UID. Idempotent;
+    called from etc-render at boot and from container.start as drift repair.
+
+    fsetacl writes UGO/MASK through to the legacy mode bits, so a single
+    fsetacl is sole source of truth for both the ACL and the mode (visible
+    as 0o710 because MASK ends up in the group triad).
+    """
+    os.makedirs(IDMAPPED_ROOT_DIR, mode=0o700, exist_ok=True)
+    fd = truenas_os.openat2(
+        IDMAPPED_ROOT_DIR,
+        flags=os.O_DIRECTORY,
+        resolve=truenas_os.RESOLVE_NO_SYMLINKS,
+    )
+    try:
+        st = os.fstat(fd)
+        if st.st_uid != 0 or st.st_gid != 0:
+            os.fchown(fd, 0, 0)
+        truenas_os.fsetacl(fd, _build_idmapped_root_acl())
+    finally:
+        os.close(fd)
+
+
+def _build_idmapped_root_acl() -> "truenas_os.POSIXACL":
+    P, T = truenas_os.POSIXPerm, truenas_os.POSIXTag
+    rwx = P.READ | P.WRITE | P.EXECUTE
+    nothing = P(0)
+    aces = [
+        truenas_os.POSIXAce(T.USER_OBJ, rwx),
+        truenas_os.POSIXAce(T.GROUP_OBJ, nothing),
+    ]
+    for uid in sorted(_IDMAPPED_ROOT_ALLOWED_UIDS):
+        aces.append(truenas_os.POSIXAce(T.USER, P.EXECUTE, id=uid))
+    aces.append(truenas_os.POSIXAce(T.MASK, P.EXECUTE))
+    aces.append(truenas_os.POSIXAce(T.OTHER, nothing))
+    return truenas_os.POSIXACL.from_aces(aces)
+
 
 def start_on_boot(context: ServiceContext) -> None:
     for container in context.call_sync2(
@@ -39,6 +95,7 @@ def handle_shutdown(context: ServiceContext) -> None:
 
 def start(context: ServiceContext, id_: int) -> None:
     enforce_dir_perms(CONTAINER_DS_PARENT_DIR)
+    apply_idmapped_root_acl()
 
     container = context.run_coroutine(context.call2(context.s.container.get_instance, id_))
     configure_container_bridge(context)

--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -6,6 +6,7 @@ import typing
 from middlewared.api.current import ZFSResourceQuery
 from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.service import CallError, ServiceContext, ValidationError
+from middlewared.utils.filesystem.perms import enforce_mountpoint_perms
 
 from .state_utils import IX_APPS_MOUNT_PATH, Status, docker_dataset_custom_props
 
@@ -24,18 +25,16 @@ async def ensure_ix_apps_mount_point(context: ServiceContext, docker_ds: str) ->
     properly.
     """
     ds = await context.call2(
-        context.s.zfs.resource.query_impl,
-        ZFSResourceQuery(paths=[docker_ds], properties=['mountpoint'])
+        context.s.zfs.resource.query_impl, ZFSResourceQuery(paths=[docker_ds], properties=["mountpoint"])
     )
     if not ds:
         return
 
     # If the mount point is not at the expected location, fix it
-    if ds[0]['properties']['mountpoint']['value'] != IX_APPS_MOUNT_PATH:
-        mp = docker_dataset_custom_props(docker_ds.split('/')[-1])['mountpoint']
+    if ds[0]["properties"]["mountpoint"]["value"] != IX_APPS_MOUNT_PATH:
+        mp = docker_dataset_custom_props(docker_ds.split("/")[-1])["mountpoint"]
         await context.middleware.call(
-            'pool.dataset.update_impl',
-            UpdateImplArgs(name=docker_ds, zprops={'mountpoint': mp})
+            "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, zprops={"mountpoint": mp})
         )
 
 
@@ -44,17 +43,17 @@ async def ix_apps_is_mounted(context: ServiceContext, dataset_to_check: str | No
     This will tell us if some dataset is mounted on /mnt/.ix-apps or not.
     """
     try:
-        fs_details = await context.middleware.call('filesystem.statfs', IX_APPS_MOUNT_PATH)
+        fs_details = await context.middleware.call("filesystem.statfs", IX_APPS_MOUNT_PATH)
     except CallError as e:
         if e.errno == errno.ENOENT:
             return False
         raise
 
-    if fs_details['source'].startswith('boot-pool/'):
+    if fs_details["source"].startswith("boot-pool/"):
         return False
 
     if dataset_to_check:
-        return bool(fs_details['source'] == dataset_to_check)
+        return bool(fs_details["source"] == dataset_to_check)
 
     return True
 
@@ -74,14 +73,13 @@ async def common_func(context: ServiceContext, mount: bool) -> Job | None:
                 recursive=True,
                 force=True,
             )
+            # Restrict the apps chokepoint so non-root host users can't traverse
+            # into Docker overlay layers or ix_volume datasets (UID-collision
+            # exposure for apps user etc.).
+            await context.to_thread(enforce_mountpoint_perms, IX_APPS_MOUNT_PATH)
         else:
             try:
-                await context.call2(
-                    context.s.zfs.resource.unmount,
-                    docker_ds,
-                    recursive=True,
-                    force=True
-                )
+                await context.call2(context.s.zfs.resource.unmount, docker_ds, recursive=True, force=True)
             except ValidationError as e:
                 if e.errno == errno.ENOENT:
                     # who cares, failing here is not ideal
@@ -94,23 +92,23 @@ async def common_func(context: ServiceContext, mount: bool) -> Job | None:
                 raise
 
             await context.middleware.call(
-                'pool.dataset.update_impl',
-                UpdateImplArgs(name=docker_ds, iprops={'mountpoint'})
+                "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, iprops={"mountpoint"})
             )
         try:
-            return await context.middleware.call('catalog.sync')  # type: ignore[no-any-return]
+            return await context.middleware.call("catalog.sync")  # type: ignore[no-any-return]
         except CallError as e:
             if e.errno != errno.EBUSY:
                 raise
             # A sync is already running - return that job so callers can wait on it
             if jobs := await context.middleware.call(
-                'core.get_jobs', [['method', '=', 'catalog.sync'], ['state', '=', 'RUNNING']]
+                "core.get_jobs", [["method", "=", "catalog.sync"], ["state", "=", "RUNNING"]]
             ):
-                return await context.middleware.call('core.job_wait', jobs[0]['id'])  # type: ignore[no-any-return]
+                return await context.middleware.call("core.job_wait", jobs[0]["id"])  # type: ignore[no-any-return]
     except Exception as e:
         await context.call2(
-            context.s.docker.set_status, Status.FAILED.value,
-            f'Failed to {"mount" if mount else "umount"} {docker_ds!r}: {e}',
+            context.s.docker.set_status,
+            Status.FAILED.value,
+            f"Failed to {'mount' if mount else 'umount'} {docker_ds!r}: {e}",
         )
         raise
 
@@ -127,8 +125,8 @@ async def umount_docker_ds(context: ServiceContext) -> Job | None:
     # while mounted, it writes to /mnt/.ix-apps/truenas_catalog. Unmounting
     # while sync is active would cause writes to an invalid path.
     for job in await context.middleware.call(
-        'core.get_jobs', [['method', '=', 'catalog.sync'], ['state', '=', 'RUNNING']]
+        "core.get_jobs", [["method", "=", "catalog.sync"], ["state", "=", "RUNNING"]]
     ):
-        await (await context.middleware.call('core.job_wait', job['id'])).wait()
+        await (await context.middleware.call("core.job_wait", job["id"])).wait()
 
     return await common_func(context, False)

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -3,6 +3,7 @@ import errno
 from middlewared.alert.source.applications import ApplicationsConfigurationFailedAlert, ApplicationsStartFailedAlert
 from middlewared.api.current import DockerStatusInfo
 from middlewared.service import CallError, ServiceContext
+from middlewared.utils.filesystem.perms import enforce_mountpoint_perms
 
 from .fs_manage import ix_apps_is_mounted, mount_docker_ds
 from .service_utils import license_active
@@ -26,15 +27,15 @@ async def set_status(context: ServiceContext, new_status: str, extra: str | None
     status = Status(new_status)
     STATUS = APPS_STATUS(
         status,
-        f'{STATUS_DESCRIPTIONS[status]}:\n{extra}' if extra else STATUS_DESCRIPTIONS[status],
+        f"{STATUS_DESCRIPTIONS[status]}:\n{extra}" if extra else STATUS_DESCRIPTIONS[status],
     )
-    context.middleware.send_event('docker.state', 'CHANGED', fields=get_status().model_dump())
+    context.middleware.send_event("docker.state", "CHANGED", fields=get_status().model_dump())
 
 
 async def before_start_check(context: ServiceContext) -> None:
     try:
         if not await license_active(context):
-            raise CallError('System is not licensed to use Applications')
+            raise CallError("System is not licensed to use Applications")
 
         await docker_validate_fs(context)
     except CallError as e:
@@ -44,21 +45,21 @@ async def before_start_check(context: ServiceContext) -> None:
                 ApplicationsConfigurationFailedAlert(error=e.errmsg),
             )
 
-        await set_status(context, Status.FAILED.value, f'Could not validate applications setup ({e.errmsg})')
+        await set_status(context, Status.FAILED.value, f"Could not validate applications setup ({e.errmsg})")
         raise
 
-    await context.call2(context.s.alert.oneshot_delete, 'ApplicationsConfigurationFailed', None)
+    await context.call2(context.s.alert.oneshot_delete, "ApplicationsConfigurationFailed", None)
 
 
 async def after_start_check(context: ServiceContext) -> None:
-    if await context.middleware.call('service.started', 'docker'):
+    if await context.middleware.call("service.started", "docker"):
         await set_status(context, Status.RUNNING.value)
-        await context.call2(context.s.alert.oneshot_delete, 'ApplicationsStartFailed', None)
+        await context.call2(context.s.alert.oneshot_delete, "ApplicationsStartFailed", None)
     else:
-        await set_status(context, Status.FAILED.value, 'Failed to start docker service')
+        await set_status(context, Status.FAILED.value, "Failed to start docker service")
         await context.call2(
             context.s.alert.oneshot_create,
-            ApplicationsStartFailedAlert(error='Docker service could not be started'),
+            ApplicationsStartFailedAlert(error="Docker service could not be started"),
         )
 
 
@@ -73,29 +74,32 @@ async def start_service(context: ServiceContext, mount_datasets: bool = False) -
         config = await context.call2(context.s.docker.config)
         # Make sure correct ix-apps dataset is mounted
         if not await ix_apps_is_mounted(context, config.dataset):
-            raise CallError(f'{config.dataset!r} dataset is not mounted on {IX_APPS_MOUNT_PATH!r}')
+            raise CallError(f"{config.dataset!r} dataset is not mounted on {IX_APPS_MOUNT_PATH!r}")
+        # Drift repair: re-tighten perms on the apps chokepoint in case an
+        # admin chmod'd it between mounts.
+        await context.to_thread(enforce_mountpoint_perms, IX_APPS_MOUNT_PATH)
         await (
-            await context.middleware.call('service.control', 'START', 'docker', {'timeout': DOCKER_START_TIMEOUT})
+            await context.middleware.call("service.control", "START", "docker", {"timeout": DOCKER_START_TIMEOUT})
         ).wait(raise_error=True)
     except Exception as e:
         await set_status(context, Status.FAILED.value, str(e))
         raise
     else:
-        await context.middleware.call('app.certificate.redeploy_apps_consuming_outdated_certs')
+        await context.middleware.call("app.certificate.redeploy_apps_consuming_outdated_certs")
     finally:
         if catalog_sync_job:
             await catalog_sync_job.wait()
 
 
 async def initialize_state(context: ServiceContext) -> None:
-    if not await context.middleware.call('system.ready'):
+    if not await context.middleware.call("system.ready"):
         # Status will be automatically updated when system is ready
         return
 
     if not (await context.call2(context.s.docker.config)).pool:
         await set_status(context, Status.UNCONFIGURED.value)
     else:
-        if await context.middleware.call('service.started', 'docker'):
+        if await context.middleware.call("service.started", "docker"):
             await set_status(context, Status.RUNNING.value)
         else:
             await set_status(context, Status.FAILED.value)
@@ -103,13 +107,13 @@ async def initialize_state(context: ServiceContext) -> None:
 
 async def validate_state(context: ServiceContext, raise_error: bool = True) -> bool:
     # When `raise_error` is unset, we return boolean true if there was no issue with the state
-    error_str = ''
+    error_str = ""
     if not (await context.call2(context.s.docker.config)).pool:
-        error_str = 'No pool configured for Docker'
-    if not error_str and not await context.middleware.call('service.started', 'docker'):
-        error_str = 'Docker service is not running'
+        error_str = "No pool configured for Docker"
+    if not error_str and not await context.middleware.call("service.started", "docker"):
+        error_str = "Docker service is not running"
     if not await license_active(context):
-        error_str = 'System is not licensed to use Applications'
+        error_str = "System is not licensed to use Applications"
 
     if error_str and raise_error:
         raise CallError(error_str)
@@ -146,11 +150,13 @@ async def terminate(context: ServiceContext) -> None:
     Only applies to single node systems (not HA).
     Waits up to DOCKER_SHUTDOWN_TIMEOUT seconds for Docker to stop gracefully.
     """
-    if not await context.middleware.call('failover.licensed') and await context.middleware.call(
-        'system.state'
-    ) == 'SHUTTING_DOWN' and await context.middleware.call('service.started', 'docker'):
+    if (
+        not await context.middleware.call("failover.licensed")
+        and await context.middleware.call("system.state") == "SHUTTING_DOWN"
+        and await context.middleware.call("service.started", "docker")
+    ):
         try:
-            job_id = await context.middleware.call('service.control', 'STOP', 'docker')
+            job_id = await context.middleware.call("service.control", "STOP", "docker")
             await job_id.wait(DOCKER_SHUTDOWN_TIMEOUT)
         except Exception as e:
-            context.logger.warning('Failed to gracefully stop Docker service: %s', e)
+            context.logger.warning("Failed to gracefully stop Docker service: %s", e)

--- a/src/middlewared/middlewared/utils/filesystem/perms.py
+++ b/src/middlewared/middlewared/utils/filesystem/perms.py
@@ -1,0 +1,53 @@
+import errno
+import os
+
+import truenas_os
+
+
+def _open_dir_no_symlinks(fs_path: str) -> int:
+    return truenas_os.openat2(fs_path, os.O_DIRECTORY, resolve=truenas_os.RESOLVE_NO_SYMLINKS)
+
+
+def _apply_perms(fd: int, mode: int, uid: int, gid: int) -> None:
+    st = os.fstat(fd)
+    if st.st_uid != uid or st.st_gid != gid:
+        os.fchown(fd, uid, gid)
+    if (st.st_mode & 0o7777) != mode:
+        os.fchmod(fd, mode)
+
+
+def enforce_dir_perms(fs_path: str, mode: int = 0o700, uid: int = 0, gid: int = 0) -> None:
+    """
+    Symlink-safe ownership + mode enforcement for a directory.
+
+    Opens `fs_path` with openat2(O_DIRECTORY, RESOLVE_NO_SYMLINKS) so subsequent
+    fd-based syscalls cannot be redirected by a concurrent symlink swap.
+    Stat-first: a steady-state call (already-correct dir) issues no chown/chmod.
+    """
+    fd = _open_dir_no_symlinks(fs_path)
+    try:
+        _apply_perms(fd, mode, uid, gid)
+    finally:
+        os.close(fd)
+
+
+def enforce_mountpoint_perms(fs_path: str, mode: int = 0o700, uid: int = 0, gid: int = 0) -> None:
+    """
+    Same as enforce_dir_perms plus a mountpoint guard via STATX_ATTR_MOUNT_ROOT.
+
+    If the target is not a mount root, raises OSError(ENOTDIR). Setting perms
+    on a stale dir whose mode vanishes on remount is worse than failing loudly.
+    """
+    fd = _open_dir_no_symlinks(fs_path)
+    try:
+        st = truenas_os.statx(
+            "",
+            dir_fd=fd,
+            flags=truenas_os.AT_EMPTY_PATH,
+            mask=truenas_os.STATX_BASIC_STATS,
+        )
+        if not (st.stx_attributes & truenas_os.STATX_ATTR_MOUNT_ROOT):
+            raise OSError(errno.ENOTDIR, f"{fs_path!r} is not a mountpoint")
+        _apply_perms(fd, mode, uid, gid)
+    finally:
+        os.close(fd)

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.test.integration.utils import call, client
+from middlewared.test.integration.utils import call, client, ssh
 from middlewared.test.integration.assets.apps import app
 from middlewared.test.integration.assets.docker import docker
 from middlewared.test.integration.assets.pool import another_pool
@@ -8,66 +8,57 @@ from truenas_api_client import ValidationErrors
 
 
 CUSTOM_CONFIG = {
-    'services': {
-        'actual_budget': {
-            'user': '568:568',
-            'image': 'actualbudget/actual-server:24.10.1',
-            'restart': 'unless-stopped',
-            'deploy': {
-                'resources': {
-                    'limits': {
-                        'cpus': '2',
-                        'memory': '4096M'
-                    }
-                }
+    "services": {
+        "actual_budget": {
+            "user": "568:568",
+            "image": "actualbudget/actual-server:24.10.1",
+            "restart": "unless-stopped",
+            "deploy": {"resources": {"limits": {"cpus": "2", "memory": "4096M"}}},
+            "devices": [],
+            "depends_on": {
+                "permissions": {"condition": "service_completed_successfully"}
             },
-            'devices': [],
-            'depends_on': {
-                'permissions': {
-                    'condition': 'service_completed_successfully'
-                }
-            },
-            'cap_drop': ['ALL'],
-            'security_opt': ['no-new-privileges'],
-            'healthcheck': {
-                'interval': '10s',
-                'retries': 30,
-                'start_period': '10s',
-                'test': (
+            "cap_drop": ["ALL"],
+            "security_opt": ["no-new-privileges"],
+            "healthcheck": {
+                "interval": "10s",
+                "retries": 30,
+                "start_period": "10s",
+                "test": (
                     "/bin/bash -c 'exec {health_check_fd}< /dev/tcp/127.0.0.1/31012 "
                     "&& echo -e 'GET /health HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n"
                     "Connection: close\\r\\n\\r\\n' >&$$health_check_fd && "
                     "cat <&$$health_check_fd'"
                 ),
-                'timeout': '5s'
+                "timeout": "5s",
             },
-            'environment': {
-                'ACTUAL_HOSTNAME': '0.0.0.0',
-                'ACTUAL_PORT': '31012',
-                'ACTUAL_SERVER_FILES': '/data/server-files',
-                'ACTUAL_USER_FILES': '/data/user-files',
-                'GID': '568',
-                'GROUP_ID': '568',
-                'NODE_ENV': 'production',
-                'PGID': '568',
-                'PUID': '568',
-                'TZ': 'Etc/UTC',
-                'UID': '568',
-                'USER_ID': '568'
+            "environment": {
+                "ACTUAL_HOSTNAME": "0.0.0.0",
+                "ACTUAL_PORT": "31012",
+                "ACTUAL_SERVER_FILES": "/data/server-files",
+                "ACTUAL_USER_FILES": "/data/user-files",
+                "GID": "568",
+                "GROUP_ID": "568",
+                "NODE_ENV": "production",
+                "PGID": "568",
+                "PUID": "568",
+                "TZ": "Etc/UTC",
+                "UID": "568",
+                "USER_ID": "568",
             },
-            'ports': [
+            "ports": [
                 {
-                    'host_ip': '0.0.0.0',
-                    'mode': 'ingress',
-                    'protocol': 'tcp',
-                    'published': 31012,
-                    'target': 31012
+                    "host_ip": "0.0.0.0",
+                    "mode": "ingress",
+                    "protocol": "tcp",
+                    "published": 31012,
+                    "target": 31012,
                 }
-            ]
+            ],
         },
-        'permissions': {
-            'command': [
-                '''
+        "permissions": {
+            "command": [
+                """
                 function process_dir() {
                     local dir=$$1
                     local mode=$$2
@@ -78,31 +69,24 @@ CUSTOM_CONFIG = {
                     # Process directory logic here...
                 }
                 process_dir /mnt/actual_budget/config check 568 568 false false
-                '''
+                """
             ],
-            'deploy': {
-                'resources': {
-                    'limits': {
-                        'cpus': '1.0',
-                        'memory': '512m'
-                    }
-                }
-            },
-            'entrypoint': ['bash', '-c'],
-            'image': 'bash',
-            'user': 'root'
-        }
+            "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "512m"}}},
+            "entrypoint": ["bash", "-c"],
+            "image": "bash",
+            "user": "root",
+        },
     },
-    'x-portals': [
+    "x-portals": [
         {
-            'host': '0.0.0.0',
-            'name': 'Web UI',
-            'path': '/',
-            'port': 31012,
-            'scheme': 'http'
+            "host": "0.0.0.0",
+            "name": "Web UI",
+            "path": "/",
+            "port": 31012,
+            "scheme": "http",
         }
     ],
-    'x-notes': '''# Welcome to TrueNAS SCALE
+    "x-notes": """# Welcome to TrueNAS SCALE
 
     Thank you for installing Actual Budget!
 
@@ -116,10 +100,10 @@ CUSTOM_CONFIG = {
     ## Feature requests or improvements
     If you find a feature request for this app, please file an issue at
     https://ixsystems.atlassian.net or https://github.com/truenas/apps.
-    '''
+    """,
 }
 
-INVALID_YAML = '''
+INVALID_YAML = """
 services:
   actual_budget
     user: 568:568
@@ -133,10 +117,10 @@ services:
         condition: service_completed_successfully
     cap_drop: ['ALL']
     security_opt: ['no-new-privileges']
-'''
+"""
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def docker_pool():
     with another_pool() as pool:
         with docker(pool) as docker_config:
@@ -144,100 +128,125 @@ def docker_pool():
 
 
 def test_create_catalog_app(docker_pool):
-    with app('actual-budget', {
-        'train': 'community',
-        'catalog_app': 'actual-budget',
-    }, {'remove_images': False}) as app_info:
-        assert app_info['name'] == 'actual-budget', app_info
-        assert app_info['state'] == 'DEPLOYING', app_info
-        volume_ds = call('app.get_app_volume_ds', 'actual-budget')
+    with app(
+        "actual-budget",
+        {
+            "train": "community",
+            "catalog_app": "actual-budget",
+        },
+        {"remove_images": False},
+    ) as app_info:
+        assert app_info["name"] == "actual-budget", app_info
+        assert app_info["state"] == "DEPLOYING", app_info
+        volume_ds = call("app.get_app_volume_ds", "actual-budget")
         assert volume_ds is not None, volume_ds
 
 
 def test_create_custom_app(docker_pool):
-    with app('custom-budget', {
-        'custom_app': True,
-        'custom_compose_config': CUSTOM_CONFIG,
-    }, {'remove_images': False}) as app_info:
-        assert app_info['name'] == 'custom-budget'
-        assert app_info['state'] == 'DEPLOYING'
+    with app(
+        "custom-budget",
+        {
+            "custom_app": True,
+            "custom_compose_config": CUSTOM_CONFIG,
+        },
+        {"remove_images": False},
+    ) as app_info:
+        assert app_info["name"] == "custom-budget"
+        assert app_info["state"] == "DEPLOYING"
 
 
 def test_create_custom_app_validation_error(docker_pool):
     with pytest.raises(ValidationErrors):
-        with app('custom-budget', {
-            'custom_app': False,
-            'custom_compose_config': CUSTOM_CONFIG,
-        }, {'remove_images': False}):
+        with app(
+            "custom-budget",
+            {
+                "custom_app": False,
+                "custom_compose_config": CUSTOM_CONFIG,
+            },
+            {"remove_images": False},
+        ):
             pass
 
 
 def test_create_custom_app_invalid_yaml(docker_pool):
     with pytest.raises(ValidationErrors):
-        with app('custom-budget', {
-            'custom_app': True,
-            'custom_compose_config': INVALID_YAML,
-        }, {'remove_images': False}):
+        with app(
+            "custom-budget",
+            {
+                "custom_app": True,
+                "custom_compose_config": INVALID_YAML,
+            },
+            {"remove_images": False},
+        ):
             pass
 
 
 def test_delete_app_validation_error_for_non_existent_app(docker_pool):
     with pytest.raises(ValidationErrors):
-        call('app.delete', 'actual-budget', {'remove_ix_volumes': True, 'remove_images': True}, job=True)
+        call(
+            "app.delete",
+            "actual-budget",
+            {"remove_ix_volumes": True, "remove_images": True},
+            job=True,
+        )
 
 
 def test_update_app(docker_pool):
     values = {
-        'values': {
-            'network': {
-                'web_port': {
-                    'bind_mode': 'published',
-                    'host_ips': [],
-                    'port_number': 32000
+        "values": {
+            "network": {
+                "web_port": {
+                    "bind_mode": "published",
+                    "host_ips": [],
+                    "port_number": 32000,
                 }
             },
-            'resources': {
-                'limits': {
-                    'memory': 8192
-                }
-            }
+            "resources": {"limits": {"memory": 8192}},
         }
     }
-    with app('actual-budget', {
-        'train': 'community',
-        'catalog_app': 'actual-budget',
-    }, {'remove_images': False}) as app_info:
-        app_info = call('app.update', app_info['name'], values, job=True)
-        assert app_info['active_workloads']['used_ports'][0]['host_ports'][0]['host_port'] == 32000
+    with app(
+        "actual-budget",
+        {
+            "train": "community",
+            "catalog_app": "actual-budget",
+        },
+        {"remove_images": False},
+    ) as app_info:
+        app_info = call("app.update", app_info["name"], values, job=True)
+        assert (
+            app_info["active_workloads"]["used_ports"][0]["host_ports"][0]["host_port"]
+            == 32000
+        )
 
 
 def test_stop_start_app(docker_pool):
-    with app('actual-budget', {
-        'train': 'community',
-        'catalog_app': 'actual-budget'
-    }, {'remove_images': False}):
+    with app(
+        "actual-budget",
+        {"train": "community", "catalog_app": "actual-budget"},
+        {"remove_images": False},
+    ):
         # stop running app
-        call('app.stop', 'actual-budget', job=True)
-        states = call('app.query', [], {'select': ['state']})[0]
-        assert states['state'] == 'STOPPED'
+        call("app.stop", "actual-budget", job=True)
+        states = call("app.query", [], {"select": ["state"]})[0]
+        assert states["state"] == "STOPPED"
 
         # start stopped app
-        call('app.start', 'actual-budget', job=True)
-        states = call('app.query', [], {'select': ['state']})[0]
-        assert states['state'] in ['RUNNING', 'DEPLOYING']
+        call("app.start", "actual-budget", job=True)
+        states = call("app.query", [], {"select": ["state"]})[0]
+        assert states["state"] in ["RUNNING", "DEPLOYING"]
 
 
 def test_event_subscribe(docker_pool):
     with client(py_exceptions=False) as c:
-        expected_event_type_order = ['ADDED', 'CHANGED']
-        expected_event_order = ['STOPPING', 'STOPPED', 'DEPLOYING']
+        expected_event_type_order = ["ADDED", "CHANGED"]
+        expected_event_order = ["STOPPING", "STOPPED", "DEPLOYING"]
         events = []
         event_types = []
         track_states = False
 
         def callback(event_type, **message):
             nonlocal events, event_types, track_states
-            state = message['fields']['state']
+            state = message["fields"]["state"]
             # Always track event types (for the outer assertion)
             if not event_types or event_types[-1] != event_type:
                 event_types.append(event_type)
@@ -245,7 +254,7 @@ def test_event_subscribe(docker_pool):
             # Start tracking states when we see STOPPING.
             # This is deterministic because STOPPING only comes from app.stop,
             # avoiding the race condition of clearing events at the right time.
-            if state == 'STOPPING':
+            if state == "STOPPING":
                 track_states = True
 
             if not track_states:
@@ -254,14 +263,11 @@ def test_event_subscribe(docker_pool):
             if not events or events[-1] != state:
                 events.append(state)
 
-        c.subscribe('app.query', callback, sync=True)
+        c.subscribe("app.query", callback, sync=True)
 
-        with app('ipfs', {
-            'train': 'community',
-            'catalog_app': 'ipfs'
-        }):
-            call('app.stop', 'ipfs', job=True)
-            call('app.start', 'ipfs', job=True)
+        with app("ipfs", {"train": "community", "catalog_app": "ipfs"}):
+            call("app.stop", "ipfs", job=True)
+            call("app.start", "ipfs", job=True)
             assert expected_event_order == events
 
         assert expected_event_type_order == event_types
@@ -269,17 +275,60 @@ def test_event_subscribe(docker_pool):
 
 def test_delete_app_options(docker_pool):
     with app(
-        'custom-budget',
+        "custom-budget",
         {
-            'custom_app': True,
-            'custom_compose_config': CUSTOM_CONFIG,
+            "custom_app": True,
+            "custom_compose_config": CUSTOM_CONFIG,
         },
-        {'remove_ix_volumes': True, 'remove_images': True}
+        {"remove_ix_volumes": True, "remove_images": True},
     ) as app_info:
-        assert app_info['name'] == 'custom-budget'
-        assert app_info['state'] == 'DEPLOYING'
+        assert app_info["name"] == "custom-budget"
+        assert app_info["state"] == "DEPLOYING"
 
-    app_images = call('app.image.query', [['repo_tags', '=', ['actualbudget/actual-server:24.10.1']]])
+    app_images = call(
+        "app.image.query", [["repo_tags", "=", ["actualbudget/actual-server:24.10.1"]]]
+    )
     assert len(app_images) == 0
-    volume_ds = call('app.get_app_volume_ds', 'custom-budget')
+    volume_ds = call("app.get_app_volume_ds", "custom-budget")
     assert volume_ds is None
+
+
+# Chokepoint lockdown — non-root host users (apps UID 568) must not be able
+# to traverse /mnt/.ix-apps. Docker overlay layers and ix_volume datasets
+# contain files owned by colliding UIDs.
+
+IX_APPS_CHOKEPOINT = "/mnt/.ix-apps"
+
+
+def _chokepoint_perms(path):
+    st = call("filesystem.stat", path)
+    return st["mode"] & 0o7777, st["uid"], st["gid"]
+
+
+def test_ix_apps_chokepoint_locked(docker_pool):
+    assert _chokepoint_perms(IX_APPS_CHOKEPOINT) == (0o700, 0, 0)
+
+
+@pytest.mark.parametrize("child", ["", "docker", "app_mounts"])
+def test_apps_user_cannot_traverse_ix_apps(docker_pool, child):
+    target = f"{IX_APPS_CHOKEPOINT}/{child}".rstrip("/")
+    result = ssh(
+        f"runuser -u apps -- ls {target}/",
+        check=False,
+        complete_response=True,
+    )
+    assert result["returncode"] != 0
+    assert "Permission denied" in result["stderr"]
+
+
+def test_root_retains_access_ix_apps(docker_pool):
+    listing = set(ssh(f"ls {IX_APPS_CHOKEPOINT}/").split())
+    assert {"docker", "app_mounts", "app_configs", "truenas_catalog"} <= listing
+
+
+def test_drift_repair_ix_apps(docker_pool):
+    ssh(f"chmod 0755 {IX_APPS_CHOKEPOINT}")
+    # start_service is idempotent if docker is already running, but still
+    # runs the drift-repair enforce_mountpoint_perms call.
+    call("docker.start_service")
+    assert _chokepoint_perms(IX_APPS_CHOKEPOINT) == (0o700, 0, 0)

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -621,7 +621,6 @@ def test_container_device_nic_crud(ubuntu_container):
 # container collide with real host accounts (DEFAULT idmap passthrough).
 
 CONTAINERS_CHOKEPOINT = "/mnt/.truenas_containers"
-IDMAPPED_ROOT_CHOKEPOINT = "/run/truenas_containers/root"
 
 
 def _chokepoint_perms(path):
@@ -633,23 +632,9 @@ def test_truenas_containers_chokepoint_locked(started_ubuntu_container):
     assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
 
 
-def test_idmapped_root_chokepoint_locked(started_ubuntu_container):
-    assert _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT) == (0o700, 0, 0)
-
-
 def test_apps_user_cannot_traverse_containers(started_ubuntu_container):
     result = ssh(
         f"runuser -u apps -- ls {CONTAINERS_CHOKEPOINT}/",
-        check=False,
-        complete_response=True,
-    )
-    assert result["returncode"] != 0
-    assert "Permission denied" in result["stderr"]
-
-
-def test_apps_user_cannot_traverse_idmapped_root(started_ubuntu_container):
-    result = ssh(
-        f"runuser -u apps -- ls {IDMAPPED_ROOT_CHOKEPOINT}/",
         check=False,
         complete_response=True,
     )
@@ -664,13 +649,11 @@ def test_root_retains_access_containers(started_ubuntu_container):
 
 def test_drift_repair_containers(started_ubuntu_container):
     # Simulate an admin loosening perms, then confirm the next container
-    # lifecycle op re-tightens both chokepoints via the drift-repair hooks
+    # lifecycle op re-tightens the chokepoint via the drift-repair hook
     # in lifecycle.py::start().
     ssh(f"chmod 0755 {CONTAINERS_CHOKEPOINT}")
-    ssh(f"chmod 0755 {IDMAPPED_ROOT_CHOKEPOINT}")
 
     call("container.stop", started_ubuntu_container["id"], job=True)
     call("container.start", started_ubuntu_container["id"])
 
     assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
-    assert _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT) == (0o700, 0, 0)

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -657,3 +657,87 @@ def test_drift_repair_containers(started_ubuntu_container):
     call("container.start", started_ubuntu_container["id"])
 
     assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
+
+
+# /run/truenas_containers/root/ is the idmapped-bind-mount parent. libvirt_lxc
+# switches to mapped-root (host uid CONTAINER_ROOT_UID + slice * IDMAP_COUNT)
+# *before* the pivot_root setup that creates <UUID>/.oldroot, so it needs
+# search permission on this parent dir while running as the mapped uid -- not
+# host root. We grant exactly that via a POSIX1E ACL with `user:<uid>:--x`
+# entries for every *possible* container-root host uid (the set is static --
+# slice space is [0, 1000) and ContainerXID ge=1 rules out any other value).
+# The legacy mode bits show 0o710: MASK in the group triad gates the named
+# entries to --x.
+
+IDMAPPED_ROOT_CHOKEPOINT = "/run/truenas_containers/root"
+CONTAINER_ROOT_UID = 2147000001
+IDMAP_COUNT = 65536
+EXPECTED_NAMED_UIDS = frozenset(
+    CONTAINER_ROOT_UID + n * IDMAP_COUNT for n in range(1000)
+)
+
+
+def _named_user_uids_in_acl(path):
+    out = ssh(f"getfacl --absolute-names --omit-header {path}")
+    uids = []
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("user:") and line != "user::rwx":
+            # form: "user:<uid>:--x"
+            uids.append(int(line.split(":")[1]))
+    return uids
+
+
+def test_idmapped_root_chokepoint_locked():
+    # Static ACL: 1000 named-USER `--x` entries + MASK=--x; mode shows 0o710
+    # because MASK occupies the legacy group triad.
+    mode, uid, gid = _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT)
+    assert (uid, gid) == (0, 0)
+    assert mode == 0o710
+    assert frozenset(_named_user_uids_in_acl(IDMAPPED_ROOT_CHOKEPOINT)) == EXPECTED_NAMED_UIDS
+
+
+def test_apps_user_cannot_traverse_idmapped_root():
+    result = ssh(
+        f"runuser -u apps -- ls {IDMAPPED_ROOT_CHOKEPOINT}/",
+        check=False,
+        complete_response=True,
+    )
+    assert result["returncode"] != 0
+    assert "Permission denied" in result["stderr"]
+
+
+def test_apps_user_cannot_plant_in_running_container_tmp(started_ubuntu_container):
+    # The actual threat model: a non-root host user MUST NOT be able to write
+    # into a running container's /tmp (0o1777, world-writable from the idmap
+    # view). Blocked by ACL on the parent denying traversal.
+    uuid = started_ubuntu_container["uuid"]
+    result = ssh(
+        f"runuser -u apps -- touch {IDMAPPED_ROOT_CHOKEPOINT}/{uuid}/tmp/pwned",
+        check=False,
+        complete_response=True,
+    )
+    assert result["returncode"] != 0
+    assert "Permission denied" in result["stderr"]
+
+
+def test_root_retains_access_idmapped_root(started_ubuntu_container):
+    # Real host root has CAP_DAC_OVERRIDE / CAP_DAC_READ_SEARCH so it can
+    # traverse and list regardless of the ACL.
+    listing = ssh(f"ls {IDMAPPED_ROOT_CHOKEPOINT}/")
+    assert started_ubuntu_container["uuid"] in listing.split()
+
+
+def test_drift_repair_idmapped_root(started_ubuntu_container):
+    # Wipe ACL + open mode bits, then bounce the container -- the start path
+    # re-applies the static ACL.
+    ssh(f"setfacl -b {IDMAPPED_ROOT_CHOKEPOINT}")
+    ssh(f"chmod 0755 {IDMAPPED_ROOT_CHOKEPOINT}")
+
+    call("container.stop", started_ubuntu_container["id"], job=True)
+    call("container.start", started_ubuntu_container["id"])
+
+    mode, uid, gid = _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT)
+    assert (uid, gid) == (0, 0)
+    assert mode == 0o710
+    assert frozenset(_named_user_uids_in_acl(IDMAPPED_ROOT_CHOKEPOINT)) == EXPECTED_NAMED_UIDS

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -614,3 +614,63 @@ def test_container_device_nic_crud(ubuntu_container):
         assert device["attributes"]["mac"]  # auto-generated
     finally:
         call("container.device.delete", device["id"])
+
+
+# Chokepoint lockdown — non-root host users (e.g. apps UID 568) must not be
+# able to traverse the on-disk container rootfs paths, since UIDs inside the
+# container collide with real host accounts (DEFAULT idmap passthrough).
+
+CONTAINERS_CHOKEPOINT = "/mnt/.truenas_containers"
+IDMAPPED_ROOT_CHOKEPOINT = "/run/truenas_containers/root"
+
+
+def _chokepoint_perms(path):
+    st = call("filesystem.stat", path)
+    return st["mode"] & 0o7777, st["uid"], st["gid"]
+
+
+def test_truenas_containers_chokepoint_locked(started_ubuntu_container):
+    assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
+
+
+def test_idmapped_root_chokepoint_locked(started_ubuntu_container):
+    assert _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT) == (0o700, 0, 0)
+
+
+def test_apps_user_cannot_traverse_containers(started_ubuntu_container):
+    result = ssh(
+        f"runuser -u apps -- ls {CONTAINERS_CHOKEPOINT}/",
+        check=False,
+        complete_response=True,
+    )
+    assert result["returncode"] != 0
+    assert "Permission denied" in result["stderr"]
+
+
+def test_apps_user_cannot_traverse_idmapped_root(started_ubuntu_container):
+    result = ssh(
+        f"runuser -u apps -- ls {IDMAPPED_ROOT_CHOKEPOINT}/",
+        check=False,
+        complete_response=True,
+    )
+    assert result["returncode"] != 0
+    assert "Permission denied" in result["stderr"]
+
+
+def test_root_retains_access_containers(started_ubuntu_container):
+    listing = ssh(f"ls {CONTAINERS_CHOKEPOINT}/")
+    assert pool in listing.split()
+
+
+def test_drift_repair_containers(started_ubuntu_container):
+    # Simulate an admin loosening perms, then confirm the next container
+    # lifecycle op re-tightens both chokepoints via the drift-repair hooks
+    # in lifecycle.py::start().
+    ssh(f"chmod 0755 {CONTAINERS_CHOKEPOINT}")
+    ssh(f"chmod 0755 {IDMAPPED_ROOT_CHOKEPOINT}")
+
+    call("container.stop", started_ubuntu_container["id"], job=True)
+    call("container.start", started_ubuntu_container["id"])
+
+    assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
+    assert _chokepoint_perms(IDMAPPED_ROOT_CHOKEPOINT) == (0o700, 0, 0)

--- a/tests/unit/test_filesystem_perms.py
+++ b/tests/unit/test_filesystem_perms.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for middlewared.utils.filesystem.perms — enforce_dir_perms and
+enforce_mountpoint_perms.
+
+These helpers wrap openat2(RESOLVE_NO_SYMLINKS) + stat-first conditional
+fchmod/fchown to set a fixed (mode, uid, gid) on a directory in a
+symlink-safe way. enforce_mountpoint_perms additionally gates on
+STATX_ATTR_MOUNT_ROOT.
+
+The tests use pytest's tmp_path; they do not touch ZFS or the data pool.
+"""
+
+import errno
+import os
+from unittest.mock import patch
+
+import pytest
+
+from middlewared.utils.filesystem.perms import (
+    enforce_dir_perms,
+    enforce_mountpoint_perms,
+)
+
+
+def _mode(path):
+    return os.stat(path).st_mode & 0o7777
+
+
+def test_enforce_dir_perms_sets_mode(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    os.chmod(d, 0o755)
+
+    enforce_dir_perms(str(d))
+
+    assert _mode(d) == 0o700
+
+
+def test_enforce_dir_perms_respects_custom_mode(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+
+    enforce_dir_perms(str(d), mode=0o750)
+
+    assert _mode(d) == 0o750
+
+
+def test_enforce_dir_perms_stat_first_is_noop_when_correct(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    os.chmod(d, 0o700)
+    st = os.stat(d)
+
+    # Helper must not call fchmod or fchown when mode + ownership already match.
+    # Pass the dir's actual owner so the no-op path is hit even when the test
+    # runs as non-root.
+    with (
+        patch("os.fchmod", side_effect=AssertionError("fchmod should not be called")),
+        patch("os.fchown", side_effect=AssertionError("fchown should not be called")),
+    ):
+        enforce_dir_perms(str(d), mode=0o700, uid=st.st_uid, gid=st.st_gid)
+
+
+def test_enforce_dir_perms_rejects_symlink_component(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    with pytest.raises(OSError) as ei:
+        enforce_dir_perms(str(link))
+
+    assert ei.value.errno == errno.ELOOP
+
+
+def test_enforce_dir_perms_raises_on_missing(tmp_path):
+    with pytest.raises(OSError) as ei:
+        enforce_dir_perms(str(tmp_path / "does_not_exist"))
+
+    assert ei.value.errno == errno.ENOENT
+
+
+def test_enforce_mountpoint_perms_rejects_regular_dir(tmp_path):
+    # tmp_path is on the same filesystem as its parent — not a mount root.
+    with pytest.raises(OSError) as ei:
+        enforce_mountpoint_perms(str(tmp_path))
+
+    assert ei.value.errno == errno.ENOTDIR
+
+
+def test_enforce_mountpoint_perms_rejects_symlink_component(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    with pytest.raises(OSError) as ei:
+        enforce_mountpoint_perms(str(link))
+
+    assert ei.value.errno == errno.ELOOP


### PR DESCRIPTION
The internal dataset trees that back containers
(/mnt/.truenas_containers/), Docker apps (/mnt/.ix-apps/), and the per-container idmapped bind-mount parent (/run/truenas_containers/root/) are implementation-detail paths that aren't intended to be inspected directly by host users. They currently mount with the default of drwxr-xr-x root:root (or 0755 from os.makedirs for the /run parent), which is looser than necessary.

This PR pins those three directories to 0700 root:root and re-applies the mode at the relevant entry points so the property is idempotent across reboots and manual chmod drift.