### PR TITLE
NAS-140766 / 26.0.0-RC.1 / Apply account userns_idmap in container DEFAULT mode (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -72,8 +72,8 @@ from middlewared.utils.security import (
 from middlewared.utils.sid import db_id_to_rid, DomainRid
 from middlewared.utils.time_utils import utc_now, UTC
 from middlewared.plugins.account_.constants import (
-    ADMIN_UID, ADMIN_GID, SKEL_PATH, DEFAULT_HOME_PATH,
-    USERNS_IDMAP_DIRECT, USERNS_IDMAP_NONE, ALLOWED_BUILTIN_GIDS,
+    ADMIN_UID, ADMIN_GID, CONTAINER_ROOT_UID, SKEL_PATH, DEFAULT_HOME_PATH,
+    IDMAP_COUNT, USERNS_IDMAP_DIRECT, USERNS_IDMAP_NONE, ALLOWED_BUILTIN_GIDS,
     SYNTHETIC_CONTAINER_ROOT, NO_LOGIN_SHELL, MIN_AUTO_XID
 )
 from middlewared.plugins.smb_.constants import SMBBuiltin
@@ -687,6 +687,20 @@ class UserService(CRUDService):
 
         if data['uid'] is None:
             data['uid'] = self.get_next_uid()
+
+            # common_validation could not resolve a DIRECT mapping without a uid;
+            # now that one was auto-assigned, recheck against existing idmap claims.
+            idmap_verrors = ValidationErrors()
+            self.middleware.call_sync(
+                'user.validate_userns_idmap_conflict',
+                idmap_verrors, 'user_create', data.get('userns_idmap'), data['uid'], None,
+            )
+            if idmap_verrors:
+                with SYNC_NEXT_UID_LOCK:
+                    self.ReservedUids.remove_entry(data['uid'])
+                if group_created:
+                    self.middleware.call_sync('group.delete', data['group'])
+                idmap_verrors.check()
 
         new_homedir = False
         home_mode = data.pop('home_mode')
@@ -1443,6 +1457,45 @@ class UserService(CRUDService):
                     )
 
     @private
+    async def validate_userns_idmap_conflict(
+        self,
+        verrors: ValidationErrors,
+        schema: str,
+        userns_idmap,
+        uid: int | None,
+        exclude_id: int | None = None,
+    ) -> None:
+        """Verify the proposed userns_idmap doesn't collide with another local user's mapping.
+
+        `uid` is the user's host UID; it may be None during creation if not yet auto-assigned,
+        in which case a DIRECT mapping cannot be resolved and the check is deferred. Callers
+        that auto-assign the UID must re-invoke this check after assignment.
+        """
+        if not userns_idmap:
+            return
+        proposed = uid if userns_idmap == 'DIRECT' else userns_idmap
+        if proposed is None:
+            return
+        conflict_filters = [
+            ['local', '=', True],
+            ['userns_idmap', 'nin', [None, 0]],
+        ]
+        if exclude_id is not None:
+            conflict_filters.append(['id', '!=', exclude_id])
+        for other in await self.middleware.call('user.query', conflict_filters):
+            other_target = (
+                other['uid'] if other['userns_idmap'] == 'DIRECT'
+                else other['userns_idmap']
+            )
+            if other_target == proposed:
+                verrors.add(
+                    f'{schema}.userns_idmap',
+                    f'User {other["username"]!r} already maps to '
+                    f'container UID {proposed}.'
+                )
+                return
+
+    @private
     async def common_validation(
         self, verrors: ValidationErrors, data: dict, schema: str, group_ids: list[int], old: dict | None = None
     ) -> None:
@@ -1457,7 +1510,11 @@ class UserService(CRUDService):
             {'prefix': 'bsdusr_'}
         )
 
-        if data.get('userns_idmap'):
+        # Privileged-roles conflict can be introduced by either changing userns_idmap or
+        # changing the user's group membership, so the check needs to run on both paths.
+        if combined.get('userns_idmap') and (
+            'userns_idmap' in data or 'group' in data or 'groups' in data
+        ):
             if await self.middleware.call('group.query', [
                 ['local', '=', True],
                 ['roles', '!=', []],
@@ -1467,6 +1524,27 @@ class UserService(CRUDService):
                     f'{schema}.userns_idmap',
                     'User namespace idmaps may not be configured for privileged accounts.'
                 )
+
+        if data.get('userns_idmap'):
+            if old and old['builtin']:
+                verrors.add(
+                    f'{schema}.userns_idmap',
+                    'User namespace idmaps may not be configured for builtin accounts.'
+                )
+
+            combined_uid = combined.get('uid')
+            if combined_uid is not None and CONTAINER_ROOT_UID <= combined_uid < CONTAINER_ROOT_UID + IDMAP_COUNT:
+                verrors.add(
+                    f'{schema}.userns_idmap',
+                    f'User UID {combined_uid} falls within the host-side range reserved for '
+                    f'container userns mappings [{CONTAINER_ROOT_UID}, {CONTAINER_ROOT_UID + IDMAP_COUNT}); '
+                    'a user namespace idmap cannot be configured for it.'
+                )
+
+            await self.validate_userns_idmap_conflict(
+                verrors, schema, data['userns_idmap'], combined_uid,
+                exclude_id=old['id'] if old else None,
+            )
 
         if data.get('random_password'):
             if data.get('password'):
@@ -2084,6 +2162,17 @@ class GroupService(CRUDService):
         if data.get('gid') is None:
             data['gid'] = await self.get_next_gid()
 
+            # __common_validation could not resolve a DIRECT mapping without a gid;
+            # now that one was auto-assigned, recheck against existing idmap claims.
+            idmap_verrors = ValidationErrors()
+            await self.validate_userns_idmap_conflict(
+                idmap_verrors, 'group_create', data.get('userns_idmap'), data['gid'], None,
+            )
+            if idmap_verrors:
+                async with ASYNC_NEXT_GID_LOCK:
+                    self.ReservedGids.remove_entry(data['gid'])
+                idmap_verrors.check()
+
         group = data.copy()
         group['group'] = group.pop('name')
 
@@ -2371,6 +2460,45 @@ class GroupService(CRUDService):
 
         return grp_obj
 
+    @private
+    async def validate_userns_idmap_conflict(
+        self,
+        verrors: ValidationErrors,
+        schema: str,
+        userns_idmap,
+        gid: int | None,
+        exclude_id: int | None = None,
+    ) -> None:
+        """Verify the proposed userns_idmap doesn't collide with another local group's mapping.
+
+        `gid` is the group's host GID; it may be None during creation if not yet auto-assigned,
+        in which case a DIRECT mapping cannot be resolved and the check is deferred. Callers
+        that auto-assign the GID must re-invoke this check after assignment.
+        """
+        if not userns_idmap:
+            return
+        proposed = gid if userns_idmap == 'DIRECT' else userns_idmap
+        if proposed is None:
+            return
+        conflict_filters = [
+            ['local', '=', True],
+            ['userns_idmap', 'nin', [None, 0]],
+        ]
+        if exclude_id is not None:
+            conflict_filters.append(['id', '!=', exclude_id])
+        for other in await self.middleware.call('group.query', conflict_filters):
+            other_target = (
+                other['gid'] if other['userns_idmap'] == 'DIRECT'
+                else other['userns_idmap']
+            )
+            if other_target == proposed:
+                verrors.add(
+                    f'{schema}.userns_idmap',
+                    f'Group {other["name"]!r} already maps to '
+                    f'container GID {proposed}.'
+                )
+                return
+
     async def __common_validation(self, verrors, data, schema, pk=None):
 
         exclude_filter = [('id', '!=', pk)] if pk else []
@@ -2380,7 +2508,8 @@ class GroupService(CRUDService):
                 f'{schema}.smb', 'SMB groups may not be configured while SMB service backend is unitialized.'
             )
 
-        if 'userns_idmap' in data and pk:
+        entry = None
+        if pk and 'userns_idmap' in data:
             entry = await self.query([['local', '=', True], ['id', '=', pk]], {'get': True})
             if entry['roles']:
                 verrors.add(
@@ -2393,6 +2522,23 @@ class GroupService(CRUDService):
                     f'{schema}.userns_idmap',
                     'User namespace idmaps may not be configured for builtin accounts.'
                 )
+
+        effective_gid = entry['gid'] if entry else data.get('gid')
+        if (
+            data.get('userns_idmap')
+            and effective_gid is not None
+            and CONTAINER_ROOT_UID <= effective_gid < CONTAINER_ROOT_UID + IDMAP_COUNT
+        ):
+            verrors.add(
+                f'{schema}.userns_idmap',
+                f'Group GID {effective_gid} falls within the host-side range reserved for '
+                f'container userns mappings [{CONTAINER_ROOT_UID}, {CONTAINER_ROOT_UID + IDMAP_COUNT}); '
+                'a user namespace idmap cannot be configured for it.'
+            )
+
+        await self.validate_userns_idmap_conflict(
+            verrors, schema, data.get('userns_idmap'), effective_gid, exclude_id=pk,
+        )
 
         if 'name' in data:
             if data.get('smb'):

--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -34,6 +34,11 @@ ALLOWED_BUILTIN_GIDS = frozenset({
 })
 
 CONTAINER_ROOT_UID = 2147000001
+# Number of UIDs/GIDs the container userns subuid block covers. Together with
+# CONTAINER_ROOT_UID this defines [CONTAINER_ROOT_UID, CONTAINER_ROOT_UID +
+# IDMAP_COUNT) as a host-side range reserved for the container filler — no
+# local user/group may have an id in this range.
+IDMAP_COUNT = 65536
 
 SYNTHETIC_CONTAINER_ROOT = {
     'pw_name': 'truenas_container_unpriv_root',

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -11,14 +11,11 @@ from middlewared.api.current import (
     ContainerStopArgs, ContainerStopResult,
     ZFSResourceQuery
 )
-from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID
+from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID, IDMAP_COUNT
 from middlewared.service import CallError, job, private, Service
 
 from .bridge import container_bridge_name, configure_container_bridge
 from .utils import container_instance_dataset_mountpoint, update_etc_hosts, write_etc_hostname
-
-
-IDMAP_COUNT = 65536
 
 
 class ContainerService(Service):
@@ -119,19 +116,18 @@ class ContainerService(Service):
         if container["idmap"]:
             match container["idmap"]["type"]:
                 case "DEFAULT":
-                    item = ContainerIdmapConfigurationItem(
-                        target=CONTAINER_ROOT_UID,
-                        count=IDMAP_COUNT,
-                    )
+                    uid_items, gid_items = self._build_default_idmap_items()
                 case "ISOLATED":
-                    item = ContainerIdmapConfigurationItem(
-                        target=CONTAINER_ROOT_UID + container["idmap"]["slice"] * IDMAP_COUNT,
-                        count=IDMAP_COUNT,
-                    )
+                    base_target = CONTAINER_ROOT_UID + container["idmap"]["slice"] * IDMAP_COUNT
+                    single = ContainerIdmapConfigurationItem(start=0, target=base_target, count=IDMAP_COUNT)
+                    uid_items, gid_items = [single], [single]
                 case _:
                     raise CallError(f"Unsupported idmap type {container['idmap']['type']!r}")
 
-            container["idmap"] = ContainerIdmapConfiguration(uid=item, gid=item)
+            try:
+                container["idmap"] = ContainerIdmapConfiguration(uid=uid_items, gid=gid_items)
+            except ValueError as e:
+                raise CallError(f"Invalid idmap configuration: {e}")
 
         if container["capabilities_policy"]:
             container["capabilities_policy"] = ContainerCapabilitiesPolicy[container["capabilities_policy"]]
@@ -147,6 +143,93 @@ class ContainerService(Service):
         })
 
         return ContainerDomain(ContainerDomainConfiguration(**container))
+
+    @private
+    def _build_default_idmap_items(self):
+        idmap_filters = [
+            ['local', '=', True],
+            ['userns_idmap', 'nin', [0, None]],
+            ['roles', '=', []],
+        ]
+        users = self.middleware.call_sync('user.query', idmap_filters)
+        groups = self.middleware.call_sync('group.query', idmap_filters)
+
+        uid_passthroughs = [_resolve_target(u['uid'], u['userns_idmap']) for u in users]
+        gid_passthroughs = [_resolve_target(g['gid'], g['userns_idmap']) for g in groups]
+
+        return _build_idmap_items(uid_passthroughs), _build_idmap_items(gid_passthroughs)
+
+
+def _resolve_target(account_id, userns_idmap):
+    """Resolve an account's userns_idmap setting to a (container_id, host_id) pair.
+
+    'DIRECT' means the host UID/GID is exposed inside the container with the same
+    numeric value (container_id == host_id). Any other value is the explicit
+    container-side ID that should map to the host's UID/GID.
+    """
+    container_id = account_id if userns_idmap == 'DIRECT' else userns_idmap
+    return container_id, account_id
+
+
+def _build_idmap_items(passthroughs):
+    """Build a complete idmap table around per-account passthroughs.
+
+    For each passthrough whose container-side ID falls in [0, IDMAP_COUNT), emit
+    a single-ID entry mapping that slot to the account's host ID. Slots not
+    covered by any passthrough are filled with mappings into the shifted
+    CONTAINER_ROOT_UID range so the container has a complete unprivileged
+    UID/GID space. Passthroughs whose container-side ID falls outside
+    [0, IDMAP_COUNT) are appended verbatim as individual one-ID entries.
+
+    Account-level validation rejects duplicate container-side IDs before
+    persistence; the deduplication check here is a safety net for stale or
+    corrupt account state. Host-side overlaps are caught downstream by
+    ContainerIdmapConfiguration validation.
+    """
+    seen = set()
+    for container_id, _ in passthroughs:
+        if container_id in seen:
+            raise CallError(
+                f'Duplicate container-side id {container_id} in account idmap configuration'
+            )
+        seen.add(container_id)
+
+    in_range = []
+    out_of_range = []
+    for c, h in passthroughs:
+        if 0 <= c < IDMAP_COUNT:
+            in_range.append((c, h))
+        else:
+            out_of_range.append((c, h))
+    in_range.sort()
+
+    items = []
+    cursor = 0
+    for container_id, host_id in in_range:
+        if container_id > cursor:
+            items.append(ContainerIdmapConfigurationItem(
+                start=cursor,
+                target=CONTAINER_ROOT_UID + cursor,
+                count=container_id - cursor,
+            ))
+        items.append(ContainerIdmapConfigurationItem(
+            start=container_id, target=host_id, count=1,
+        ))
+        cursor = container_id + 1
+
+    if cursor < IDMAP_COUNT:
+        items.append(ContainerIdmapConfigurationItem(
+            start=cursor,
+            target=CONTAINER_ROOT_UID + cursor,
+            count=IDMAP_COUNT - cursor,
+        ))
+
+    for container_id, host_id in out_of_range:
+        items.append(ContainerIdmapConfigurationItem(
+            start=container_id, target=host_id, count=1,
+        ))
+
+    return items
 
 
 async def __migrate_and_start(middleware):

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -11,6 +11,10 @@ import pytest
 import websocket
 
 from truenas_api_client import ValidationErrors
+from middlewared.test.integration.assets.account import (
+    group as account_group,
+    user as account_user,
+)
 from middlewared.test.integration.assets.pool import another_pool, pool
 from middlewared.test.integration.utils import call, host, ssh, websocket_url
 
@@ -183,6 +187,23 @@ def test_container_update(started_ubuntu_container):
     assert "sleep infinity" in ssh(nsenter(container, "ps -p 1 -o args"))
 
 
+def test_container_rename(ubuntu_container):
+    old_dataset = ubuntu_container["dataset"]
+    new_name = "renamed-container"
+
+    call("container.update", ubuntu_container["id"], {"name": new_name})
+
+    updated = call("container.get_instance", ubuntu_container["id"])
+    assert updated["name"] == new_name
+    expected_dataset = old_dataset[: old_dataset.rfind("/") + 1] + new_name
+    assert updated["dataset"] == expected_dataset
+    result = call(
+        "zfs.resource.query",
+        {"paths": [expected_dataset], "properties": ["mountpoint"]},
+    )
+    assert result, f"ZFS dataset {expected_dataset!r} does not exist after rename"
+
+
 def test_container_stop_force_after_timeout(ubuntu_container):
     container = ubuntu_container
 
@@ -288,6 +309,126 @@ def test_idmap(ubuntu_image, idmap_slice_1_container, target, config):
         ssh(f"mkdir {mountpoint}/playground")
         ssh(nsenter(c, "touch /playground/canary"))
         assert ssh(f"stat -c '%u %g' {mountpoint}/playground/canary").strip().split() == ["0", "0"]
+
+
+def _stat_inside(container_dict, path):
+    return ssh(nsenter(container_dict, f"stat -c '%u %g' {path}")).strip()
+
+
+@contextlib.contextmanager
+def bind_share_with_file(uid, gid, fname="file"):
+    # idmap passthroughs only take effect for mounts that DON'T have a mount
+    # idmap of their own (FilesystemDevice bind-mounts). The rootfs gets a
+    # matched X-mount.idmap, which forces an identity round-trip and hides
+    # the userns mapping. So tests that verify non-DIRECT / ISOLATED behavior
+    # must use a bind-mount source, not files written into the rootfs dataset.
+    share = f"/mnt/{pool}/idmap_share_{uid}_{gid}"
+    try:
+        ssh(f"rm -rf {share}")
+        ssh(f"mkdir -p {share}")
+        ssh(f": > {share}/{fname} && chown {uid}:{gid} {share}/{fname}")
+        yield share
+    finally:
+        ssh(f"rm -rf {share}")
+
+
+def test_default_idmap_passes_apps_user_through(ubuntu_image):
+    # By default builtin sync sets userns_idmap='DIRECT' on the apps user (568)
+    # and apps group (568). DEFAULT idmap should honor those passthroughs so
+    # host UID/GID 568 is visible as the same 568 inside the container via a
+    # FilesystemDevice bind-mount (where the userns extent actually decides
+    # the visible UID, not the rootfs's identity round-trip).
+    with bind_share_with_file(568, 568, fname="apps_file") as share:
+        with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
+            call("container.device.create", {
+                "container": c["id"],
+                "attributes": {
+                    "dtype": "FILESYSTEM",
+                    "source": share,
+                    "target": "/share",
+                },
+            })
+            call("container.start", c["id"])
+            c = call("container.get_instance", c["id"])
+            assert c["status"]["state"] == "RUNNING"
+            assert _stat_inside(c, "/share/apps_file") == "568 568"
+
+
+def test_default_idmap_picks_up_custom_user_direct(ubuntu_image):
+    with account_group({"name": "idmap_grp"}) as g:
+        with account_user({
+            "username": "idmap_user",
+            "full_name": "idmap user",
+            "group": g["id"],
+            "random_password": True,
+        }) as u:
+            uid, gid = u["uid"], g["gid"]
+            call("user.update", u["id"], {"userns_idmap": "DIRECT"})
+            call("group.update", g["id"], {"userns_idmap": "DIRECT"})
+
+            with bind_share_with_file(uid, gid) as share:
+                with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
+                    call("container.device.create", {
+                        "container": c["id"],
+                        "attributes": {
+                            "dtype": "FILESYSTEM",
+                            "source": share,
+                            "target": "/share",
+                        },
+                    })
+                    call("container.start", c["id"])
+                    c = call("container.get_instance", c["id"])
+                    assert c["status"]["state"] == "RUNNING"
+                    assert _stat_inside(c, "/share/file") == f"{uid} {gid}"
+
+
+def test_default_idmap_picks_up_custom_user_numeric(ubuntu_image):
+    target = 8675309
+    with account_user({
+        "username": "idmap_numeric",
+        "full_name": "idmap numeric",
+        "group_create": True,
+        "random_password": True,
+    }) as u:
+        uid = u["uid"]
+        call("user.update", u["id"], {"userns_idmap": target})
+
+        with bind_share_with_file(uid, 0) as share:
+            with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
+                call("container.device.create", {
+                    "container": c["id"],
+                    "attributes": {
+                        "dtype": "FILESYSTEM",
+                        "source": share,
+                        "target": "/share",
+                    },
+                })
+                call("container.start", c["id"])
+                c = call("container.get_instance", c["id"])
+                assert c["status"]["state"] == "RUNNING"
+                assert _stat_inside(c, "/share/file").split()[0] == str(target)
+
+
+def test_isolated_idmap_ignores_account_passthrough(ubuntu_image):
+    # ISOLATED's userns has no extent covering host kuid/kgid 568, so a
+    # bind-mounted file at 568:568 must not show as 568:568 inside.
+    with bind_share_with_file(568, 568, fname="apps_file") as share:
+        with container(ubuntu_image, {"idmap": {"type": "ISOLATED", "slice": 1}}) as c:
+            call("container.device.create", {
+                "container": c["id"],
+                "attributes": {
+                    "dtype": "FILESYSTEM",
+                    "source": share,
+                    "target": "/share",
+                },
+            })
+            call("container.start", c["id"])
+            c = call("container.get_instance", c["id"])
+            assert c["status"]["state"] == "RUNNING"
+            inside = _stat_inside(c, "/share/apps_file")
+            assert inside != "568 568", (
+                f"ISOLATED container leaked apps passthrough: {inside}"
+            )
 
 
 @pytest.mark.parametrize("configuration,has", [

--- a/tests/api2/test_container_acl.py
+++ b/tests/api2/test_container_acl.py
@@ -1,0 +1,290 @@
+import contextlib
+import shlex
+from copy import deepcopy
+
+import pytest
+
+from middlewared.test.integration.assets.account import (
+    group as account_group,
+    user as account_user,
+)
+from middlewared.test.integration.assets.pool import dataset, pool
+from middlewared.test.integration.utils import call, ssh
+
+UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    call(
+        "lxc.update",
+        {
+            "v4_network": "10.47.214.0/24",
+            "v6_network": "fd42:3656:7be9:e46c::0/64",
+        },
+    )
+
+
+@pytest.fixture(scope="module")
+def ubuntu_image():
+    images = call("container.image.query_registry")
+    version = [
+        image["versions"][-1]["version"]
+        for image in images
+        if image["name"] == UBUNTU_IMAGE_NAME
+    ][0]
+    yield {"name": UBUNTU_IMAGE_NAME, "version": version}
+
+
+def nsenter(container, command):
+    return shlex.join(call("container.nsenter", container) + [command])
+
+
+@contextlib.contextmanager
+def _container(image, name="acltest", **options):
+    c = call(
+        "container.create",
+        {
+            "name": name,
+            "pool": pool,
+            "image": image,
+            **options,
+        },
+        job=True,
+    )
+    try:
+        yield c
+    finally:
+        if call("container.get_instance", c["id"])["status"]["state"] == "RUNNING":
+            call("container.stop", c["id"], {"force": True}, job=True)
+        call("container.delete", c["id"])
+
+
+@pytest.fixture(scope="module")
+def instance(ubuntu_image):
+    with _container(ubuntu_image, name="acltest") as c:
+        yield c
+
+
+@pytest.fixture(scope="function")
+def nfs4acl_dataset(instance):
+    with account_group({"name": "testgrp"}) as g:
+        with account_user(
+            {
+                "username": "testusr",
+                "full_name": "testusr",
+                "group": g["id"],
+                "random_password": True,
+            }
+        ) as u:
+            call("user.update", u["id"], {"userns_idmap": "DIRECT"})
+            call("group.update", g["id"], {"userns_idmap": "DIRECT"})
+
+            with dataset("virtnfsshare", {"share_type": "SMB"}) as ds:
+                fs_device = call(
+                    "container.device.create",
+                    {
+                        "container": instance["id"],
+                        "attributes": {
+                            "dtype": "FILESYSTEM",
+                            "source": f"/mnt/{ds}",
+                            "target": "/nfs4acl",
+                        },
+                    },
+                )
+                try:
+                    call("container.start", instance["id"])
+                    try:
+                        yield {
+                            "instance": call("container.get_instance", instance["id"]),
+                            "user": u,
+                            "group": g,
+                            "dataset": ds,
+                            "dev": "/nfs4acl",
+                        }
+                    finally:
+                        call(
+                            "container.stop", instance["id"], {"force": True}, job=True
+                        )
+                finally:
+                    call("container.device.delete", fs_device["id"])
+
+
+def create_container_users(c, uid, gid):
+    """
+    Create three test users inside the container.
+    * `larry` has the specified UID.
+    * `curly` has the specified GID as primary group.
+    * `moe` has the specified GID as an auxiliary group.
+
+    These all get evaluated differently based on ACL.
+
+    NOTE: useradd -g <gid> requires the group to exist inside the container,
+    so we groupadd it first.
+    """
+    ssh(nsenter(c, f"groupadd -g {gid} testgrp"))
+    ssh(nsenter(c, f"useradd -u {uid} larry"))
+    ssh(nsenter(c, f"useradd -g {gid} curly"))
+    ssh(nsenter(c, f"useradd -G {gid} moe"))
+
+
+def check_access(c, path, username, expected_access):
+    account_string = f"sudo -i -u {username}"
+
+    # READ and MODIFY should be able to list
+    match expected_access:
+        case "READ":
+            ssh(nsenter(c, f"{account_string} ls {path}"))
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} mkdir {path}/testdir"))
+
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} chown {username} {path}"))
+
+        case "MODIFY":
+            ssh(nsenter(c, f"{account_string} ls {path}"))
+            ssh(nsenter(c, f"{account_string} mkdir {path}/testdir"))
+            ssh(nsenter(c, f"{account_string} rmdir {path}/testdir"))
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} chown {username} {path}"))
+
+        case "FULL_CONTROL":
+            ssh(nsenter(c, f"{account_string} chown {username} {path}"))
+
+        case None:
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} ls {path}"))
+
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} mkdir {path}/testdir"))
+
+            with pytest.raises(AssertionError, match="Operation not permitted"):
+                ssh(nsenter(c, f"{account_string} chown {username} {path}"))
+        case _:
+            raise ValueError(f"{expected_access}: unexpected access string")
+
+
+def test_container_nfs4acl_functional(nfs4acl_dataset):
+    c = nfs4acl_dataset["instance"]
+    create_container_users(
+        c,
+        nfs4acl_dataset["user"]["uid"],
+        nfs4acl_dataset["group"]["gid"],
+    )
+
+    path = f"/mnt/{nfs4acl_dataset['dataset']}"
+    acl_info = call("filesystem.getacl", path)
+    assert acl_info["acltype"] == "NFS4"
+    acl = deepcopy(acl_info["acl"])
+    acl.extend(
+        [
+            {
+                "tag": "GROUP",
+                "type": "ALLOW",
+                "perms": {"BASIC": "READ"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["group"]["gid"],
+            },
+            {
+                "tag": "USER",
+                "type": "ALLOW",
+                "perms": {"BASIC": "READ"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["user"]["uid"],
+            },
+        ]
+    )
+
+    for username in ("larry", "curly", "moe"):
+        check_access(c, nfs4acl_dataset["dev"], username, None)
+
+    # set READ ACL
+    call("filesystem.setacl", {"path": path, "dacl": acl}, job=True)
+
+    ssh(f"cp /bin/nfs4xdr_getfacl {path}/nfs4xdr_getfacl")
+    ssh(f"cp /bin/nfs4xdr_setfacl {path}/nfs4xdr_setfacl")
+
+    # FIXME - NAS-134466
+    """
+    ssh(f'cp /bin/nfs4xdr_getfacl /mnt/{ds}/nfs4xdr_getfacl')
+
+    cmd = [
+        'incus', 'exec', '-T', instance['name'],
+        '-- bash -c "/host/nfs4xdr_getfacl -j /host"'
+    ]
+    instance_acl = json.loads(ssh(' '.join(cmd)))
+
+    # Check that the ids in the ACL have been mapped
+    check_nfs4_acl_entry(
+        instance_acl['acl'],
+        nfs4acl_dataset['group']['gid'],
+        'ALLOW',
+        'GROUP',
+        {'BASIC': 'READ'},
+        {'BASIC': 'INHERIT'}
+    )
+
+    check_nfs4_acl_entry(
+        instance_acl['acl'],
+        instance['user']['uid'],
+        'ALLOW',
+        'USER',
+        {'BASIC': 'READ'},
+        {'BASIC': 'INHERIT'}
+    )
+    """
+
+    for username in ("larry", "curly", "moe"):
+        check_access(c, nfs4acl_dataset["dev"], username, "READ")
+
+    acl = deepcopy(acl_info["acl"])
+    acl.extend(
+        [
+            {
+                "tag": "GROUP",
+                "type": "ALLOW",
+                "perms": {"BASIC": "MODIFY"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["group"]["gid"],
+            },
+            {
+                "tag": "USER",
+                "type": "ALLOW",
+                "perms": {"BASIC": "MODIFY"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["user"]["uid"],
+            },
+        ]
+    )
+
+    # set MODIFY ACL
+    call("filesystem.setacl", {"path": path, "dacl": acl}, job=True)
+
+    for username in ("larry", "curly", "moe"):
+        check_access(c, nfs4acl_dataset["dev"], username, "MODIFY")
+
+    acl = deepcopy(acl_info["acl"])
+    acl.extend(
+        [
+            {
+                "tag": "GROUP",
+                "type": "ALLOW",
+                "perms": {"BASIC": "FULL_CONTROL"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["group"]["gid"],
+            },
+            {
+                "tag": "USER",
+                "type": "ALLOW",
+                "perms": {"BASIC": "FULL_CONTROL"},
+                "flags": {"BASIC": "INHERIT"},
+                "id": nfs4acl_dataset["user"]["uid"],
+            },
+        ]
+    )
+
+    # set FULL_CONTROL ACL
+    call("filesystem.setacl", {"path": path, "dacl": acl}, job=True)
+
+    for username in ("larry", "curly", "moe"):
+        check_access(c, nfs4acl_dataset["dev"], username, "FULL_CONTROL")

--- a/tests/unit/test_account_userns.py
+++ b/tests/unit/test_account_userns.py
@@ -82,6 +82,19 @@ def test__privileged_user_idmap_namespace_deny(privileged_user):
             c.call('user.update', privileged_user['id'], {'userns_idmap': 'DIRECT'})
 
 
+def test__idmap_user_join_privileged_group_deny(user, privileged_group):
+    _, grp = privileged_group
+    with Client() as c:
+        c.call('user.update', user['id'], {'userns_idmap': 'DIRECT'})
+        try:
+            with pytest.raises(ClientException, match='privileged account'):
+                c.call('user.update', user['id'], {
+                    'groups': user['groups'] + [grp['id']],
+                })
+        finally:
+            c.call('user.update', user['id'], {'userns_idmap': None})
+
+
 def test__privileged_group_idmap_namespace_deny(privileged_group):
     with pytest.raises(ClientException, match='privileged account'):
         with Client() as c:
@@ -129,3 +142,163 @@ def test__update_privilege_with_idmap_group_deny(group):
                     c.call('privilege.update', priv['id'], {'local_groups': [group['gid']]})
             finally:
                 c.call('privilege.delete', priv['id'])
+
+
+def test__user_duplicate_explicit_idmap_deny():
+    with create_user('idmap_dup_a') as u1, create_user('idmap_dup_b') as u2:
+        with Client() as c:
+            c.call('user.update', u1['id'], {'userns_idmap': 12345})
+            try:
+                with pytest.raises(ClientException, match='already maps to container UID 12345'):
+                    c.call('user.update', u2['id'], {'userns_idmap': 12345})
+            finally:
+                c.call('user.update', u1['id'], {'userns_idmap': None})
+
+
+def test__user_duplicate_direct_vs_explicit_deny():
+    with create_user('idmap_dup_a') as u1, create_user('idmap_dup_b') as u2:
+        with Client() as c:
+            c.call('user.update', u1['id'], {'userns_idmap': 'DIRECT'})
+            try:
+                with pytest.raises(ClientException, match=f'already maps to container UID {u1["uid"]}'):
+                    c.call('user.update', u2['id'], {'userns_idmap': u1['uid']})
+            finally:
+                c.call('user.update', u1['id'], {'userns_idmap': None})
+
+
+def test__user_duplicate_explicit_vs_direct_deny():
+    with create_user('idmap_dup_a') as u1, create_user('idmap_dup_b') as u2:
+        with Client() as c:
+            c.call('user.update', u1['id'], {'userns_idmap': u2['uid']})
+            try:
+                with pytest.raises(ClientException, match=f'already maps to container UID {u2["uid"]}'):
+                    c.call('user.update', u2['id'], {'userns_idmap': 'DIRECT'})
+            finally:
+                c.call('user.update', u1['id'], {'userns_idmap': None})
+
+
+def test__group_duplicate_explicit_idmap_deny():
+    with Client() as c:
+        g1_id = c.call('group.create', {'name': 'idmap_dup_grp_a'})
+        try:
+            g2_id = c.call('group.create', {'name': 'idmap_dup_grp_b'})
+            try:
+                c.call('group.update', g1_id, {'userns_idmap': 23456})
+                try:
+                    with pytest.raises(ClientException, match='already maps to container GID 23456'):
+                        c.call('group.update', g2_id, {'userns_idmap': 23456})
+                finally:
+                    c.call('group.update', g1_id, {'userns_idmap': None})
+            finally:
+                c.call('group.delete', g2_id)
+        finally:
+            c.call('group.delete', g1_id)
+
+
+def test__group_duplicate_direct_vs_explicit_deny():
+    with Client() as c:
+        g1_id = c.call('group.create', {'name': 'idmap_dup_grp_a'})
+        try:
+            g1 = c.call('group.query', [['id', '=', g1_id]], {'get': True})
+            g2_id = c.call('group.create', {'name': 'idmap_dup_grp_b'})
+            try:
+                c.call('group.update', g1_id, {'userns_idmap': 'DIRECT'})
+                try:
+                    with pytest.raises(ClientException, match=f'already maps to container GID {g1["gid"]}'):
+                        c.call('group.update', g2_id, {'userns_idmap': g1['gid']})
+                finally:
+                    c.call('group.update', g1_id, {'userns_idmap': None})
+            finally:
+                c.call('group.delete', g2_id)
+        finally:
+            c.call('group.delete', g1_id)
+
+
+def test__user_self_update_keeps_idmap():
+    with create_user('idmap_self') as u:
+        with Client() as c:
+            c.call('user.update', u['id'], {'userns_idmap': 'DIRECT'})
+            try:
+                # Re-asserting the same idmap should not flag self-collision.
+                c.call('user.update', u['id'], {'userns_idmap': 'DIRECT'})
+            finally:
+                c.call('user.update', u['id'], {'userns_idmap': None})
+
+
+def test__user_create_autoassigned_uid_idmap_conflict_deny():
+    with Client() as c:
+        placeholder = c.call('user.create', {
+            'username': 'idmap_auto_placeholder', 'full_name': 'placeholder',
+            'random_password': True, 'group_create': True,
+        })
+        target_uid = placeholder['uid']
+        user_a = c.call('user.create', {
+            'username': 'idmap_auto_a', 'full_name': 'a',
+            'random_password': True, 'group_create': True,
+            'userns_idmap': target_uid,
+        })
+        # Free target_uid so the next auto-assignment returns it (smallest gap).
+        c.call('user.delete', placeholder['id'])
+        try:
+            user_b_id = None
+            try:
+                with pytest.raises(ClientException, match=f'already maps to container UID {target_uid}'):
+                    user_b_id = c.call('user.create', {
+                        'username': 'idmap_auto_b', 'full_name': 'b',
+                        'random_password': True, 'group_create': True,
+                        'userns_idmap': 'DIRECT',
+                    })
+            finally:
+                if user_b_id is not None:
+                    c.call('user.delete', user_b_id)
+        finally:
+            c.call('user.delete', user_a['id'])
+
+
+def test__group_create_autoassigned_gid_idmap_conflict_deny():
+    with Client() as c:
+        placeholder_id = c.call('group.create', {'name': 'idmap_auto_grp_placeholder'})
+        placeholder = c.call('group.query', [['id', '=', placeholder_id]], {'get': True})
+        target_gid = placeholder['gid']
+        g_a_id = c.call('group.create', {
+            'name': 'idmap_auto_grp_a', 'userns_idmap': target_gid,
+        })
+        c.call('group.delete', placeholder_id)
+        try:
+            g_b_id = None
+            try:
+                with pytest.raises(ClientException, match=f'already maps to container GID {target_gid}'):
+                    g_b_id = c.call('group.create', {
+                        'name': 'idmap_auto_grp_b',
+                        'userns_idmap': 'DIRECT',
+                    })
+            finally:
+                if g_b_id is not None:
+                    c.call('group.delete', g_b_id)
+        finally:
+            c.call('group.delete', g_a_id)
+
+
+# Host-side range [CONTAINER_ROOT_UID, CONTAINER_ROOT_UID + IDMAP_COUNT) is reserved
+# for the container userns filler. A local account with an id in that range cannot
+# also be passed through, because its (start=N, target=uid, count=1) entry would
+# host-side-overlap the filler at slot uid - CONTAINER_ROOT_UID.
+RESERVED_HOST_UID = 2147005000  # inside [2147000001, 2147065537)
+
+
+def test__user_idmap_in_reserved_host_range_deny():
+    with create_user('idmap_reserved', uid=RESERVED_HOST_UID) as u:
+        with Client() as c:
+            with pytest.raises(ClientException, match='reserved for container userns mappings'):
+                c.call('user.update', u['id'], {'userns_idmap': 'DIRECT'})
+
+
+def test__group_idmap_in_reserved_host_range_deny():
+    with Client() as c:
+        gid = RESERVED_HOST_UID
+        g_id = c.call('group.create', {'name': 'idmap_reserved_grp', 'gid': gid})
+        try:
+            with pytest.raises(ClientException, match='reserved for container userns mappings'):
+                c.call('group.update', g_id, {'userns_idmap': 'DIRECT'})
+        finally:
+            c.call('group.delete', g_id)

--- a/tests/unit/test_container_idmap.py
+++ b/tests/unit/test_container_idmap.py
@@ -1,0 +1,91 @@
+import pytest
+
+from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID, IDMAP_COUNT
+from middlewared.plugins.container.lifecycle import _build_idmap_items, _resolve_target
+from middlewared.service_exception import CallError
+
+
+def _as_tuples(items):
+    return [(i.start, i.target, i.count) for i in items]
+
+
+def test__resolve_target_direct():
+    assert _resolve_target(3000, "DIRECT") == (3000, 3000)
+
+
+def test__resolve_target_explicit():
+    assert _resolve_target(3000, 5) == (5, 3000)
+
+
+def test__build_idmap_items_empty():
+    # No passthroughs: one filler covers the entire in-range space.
+    items = _build_idmap_items([])
+    assert _as_tuples(items) == [(0, CONTAINER_ROOT_UID, IDMAP_COUNT)]
+
+
+def test__build_idmap_items_single_in_range_middle():
+    items = _build_idmap_items([(100, 3000)])
+    assert _as_tuples(items) == [
+        (0, CONTAINER_ROOT_UID, 100),
+        (100, 3000, 1),
+        (101, CONTAINER_ROOT_UID + 101, IDMAP_COUNT - 101),
+    ]
+
+
+def test__build_idmap_items_at_slot_zero():
+    items = _build_idmap_items([(0, 4000)])
+    assert _as_tuples(items) == [
+        (0, 4000, 1),
+        (1, CONTAINER_ROOT_UID + 1, IDMAP_COUNT - 1),
+    ]
+
+
+def test__build_idmap_items_at_last_in_range_slot():
+    last = IDMAP_COUNT - 1
+    items = _build_idmap_items([(last, 5000)])
+    assert _as_tuples(items) == [
+        (0, CONTAINER_ROOT_UID, last),
+        (last, 5000, 1),
+    ]
+
+
+def test__build_idmap_items_multiple_in_range_sorts_and_fills_gaps():
+    items = _build_idmap_items([(50, 7000), (10, 6000)])
+    assert _as_tuples(items) == [
+        (0, CONTAINER_ROOT_UID, 10),
+        (10, 6000, 1),
+        (11, CONTAINER_ROOT_UID + 11, 39),
+        (50, 7000, 1),
+        (51, CONTAINER_ROOT_UID + 51, IDMAP_COUNT - 51),
+    ]
+
+
+def test__build_idmap_items_out_of_range_appended():
+    high = IDMAP_COUNT + 5
+    items = _build_idmap_items([(high, 9000)])
+    assert _as_tuples(items) == [
+        (0, CONTAINER_ROOT_UID, IDMAP_COUNT),
+        (high, 9000, 1),
+    ]
+
+
+def test__build_idmap_items_mixed_in_and_out_of_range():
+    high = IDMAP_COUNT + 100
+    items = _build_idmap_items([(high, 9000), (5, 4000)])
+    assert _as_tuples(items) == [
+        (0, CONTAINER_ROOT_UID, 5),
+        (5, 4000, 1),
+        (6, CONTAINER_ROOT_UID + 6, IDMAP_COUNT - 6),
+        (high, 9000, 1),
+    ]
+
+
+def test__build_idmap_items_duplicate_in_range_rejected():
+    with pytest.raises(CallError, match="Duplicate container-side id 42"):
+        _build_idmap_items([(42, 3000), (42, 4000)])
+
+
+def test__build_idmap_items_duplicate_out_of_range_rejected():
+    high = IDMAP_COUNT + 1
+    with pytest.raises(CallError, match=f"Duplicate container-side id {high}"):
+        _build_idmap_items([(high, 3000), (high, 4000)])


### PR DESCRIPTION
DEFAULT idmap now consults local users/groups with userns_idmap set and emits passthrough segments alongside the shifted base range, restoring the 25.10 behavior where apps user (568) and other configured accounts keep their host UID/GID inside the container. ISOLATED mode unchanged.

Adds idmap functional tests to test_container.py and ports the NFS4 ACL functional test from 25.10 (deleted with the virt plugin) as test_container_acl.py.

NOTE: Requires truenas_pylibvirt with multi-entry idmap support.

Original PR: https://github.com/truenas/middleware/pull/18940
