### PR TITLE
NAS-140933 / 26.0.0-RC.1 / krb5.conf: tolerate legacy unsupported libdefaults_aux (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf.py
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.py
@@ -110,8 +110,8 @@ def generate_krb5_conf(
     if default_realm:
         libdefaults[str(KRB_LibDefaults.DEFAULT_REALM)] = default_realm
 
-    krbconf.add_libdefaults(libdefaults, krb_config['libdefaults_aux'])
-    krbconf.add_appdefaults(appdefaults, krb_config['appdefaults_aux'])
+    krbconf.add_libdefaults(libdefaults, krb_config['libdefaults_aux'], strict=False)
+    krbconf.add_appdefaults(appdefaults, krb_config['appdefaults_aux'], strict=False)
 
     return krbconf.generate()
 

--- a/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
@@ -214,6 +214,9 @@ class KRB5Conf():
         auxiliary_parameters: Optional[list] = None,
         strict: bool = True,
     ):
+        # `strict` only loosens auxiliary_parameters validation. `config`
+        # comes from middleware code (not persisted user input) and is
+        # always validated strictly.
         for param, value in config.items():
             validate_krb5_parameter(section, param, value)
 

--- a/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
@@ -26,6 +26,11 @@ APPDEFAULTS_SUPPORTED_OPTIONS = set(i.value[0] for i in KRB_AppDefaults)
 LIBDEFAULTS_SUPPORTED_OPTIONS = set(i.value[0] for i in KRB_LibDefaults)
 SUPPORTED_ETYPES = set(e.value for e in KRB_ETYPE)
 
+# Dedupe key (section_name, param, value) of lenient-mode skips already logged
+# in this process, so the renderer doesn't re-emit the same warning on every
+# etc.generate call against a legacy auxiliary_parameters value.
+_LOGGED_UNSUPPORTED_AUX: set[tuple[str, str, str]] = set()
+
 
 def format_server(address: str | None) -> str | None:
     """
@@ -110,7 +115,8 @@ def validate_krb5_parameter(section, param, value):
 def parse_krb_aux_params(
     section: KRB5ConfSection,
     section_conf: dict,
-    aux_params: str
+    aux_params: str,
+    strict: bool = True
 ):
     """
     Parse auxiliary parameters and write them to the specified `section_conf`
@@ -121,6 +127,14 @@ def parse_krb_aux_params(
     updated with configuration specified in the `aux_params`
 
     `aux_params` - auxiliary parameters text blob to be parsed and used to update `section_conf`.
+
+    `strict` - when True (default), raise ValueError on any line that fails
+    `validate_krb5_parameter`. When False (used by the etc.generate renderer),
+    log a warning once per (section, param, value) and skip the offending line.
+    Lenient mode exists to keep krb5.conf regeneration working when a
+    previously-supported option (e.g. `allow_weak_crypto`) has been removed
+    from `KRB_LibDefaults` / `KRB_AppDefaults` and is still present in
+    persisted user-supplied text.
     """
     target = section_conf
     is_subsection = False
@@ -166,7 +180,24 @@ def parse_krb_aux_params(
             continue
 
         value = entry[1].strip()
-        validate_krb5_parameter(section, param, value)
+        try:
+            validate_krb5_parameter(section, param, value)
+        except ValueError:
+            if strict:
+                raise
+
+            key = (section.name, param, value)
+            if key not in _LOGGED_UNSUPPORTED_AUX:
+                _LOGGED_UNSUPPORTED_AUX.add(key)
+                logger.warning(
+                    'Dropping unsupported krb5.conf [%s] auxiliary parameter '
+                    '%r=%r from rendered configuration. Run kerberos.update '
+                    'with a cleaned libdefaults_aux/appdefaults_aux value to '
+                    'remove the legacy line from the database.',
+                    section.name.lower(), param, value,
+                )
+            continue
+
         target[param] = value
 
 
@@ -176,14 +207,20 @@ class KRB5Conf():
         self.appdefaults = {}  # settings used by some KRB5 applications
         self.realms = {}  # realm-specific settings
 
-    def __add_parameters(self, section: str, config: dict, auxiliary_parameters: Optional[list] = None):
+    def __add_parameters(
+        self,
+        section: str,
+        config: dict,
+        auxiliary_parameters: Optional[list] = None,
+        strict: bool = True,
+    ):
         for param, value in config.items():
             validate_krb5_parameter(section, param, value)
 
         data = deepcopy(config)
 
         if auxiliary_parameters:
-            parse_krb_aux_params(section, data, auxiliary_parameters)
+            parse_krb_aux_params(section, data, auxiliary_parameters, strict=strict)
 
         match section:
             case KRB5ConfSection.APPDEFAULTS:
@@ -196,7 +233,8 @@ class KRB5Conf():
     def add_libdefaults(
         self,
         config: dict,
-        auxiliary_parameters: Optional[list] = None
+        auxiliary_parameters: Optional[list] = None,
+        strict: bool = True,
     ):
         """
         Add configuration for the [libdefaults] section of the krb5.conf file, replacing
@@ -225,13 +263,15 @@ class KRB5Conf():
         self.__add_parameters(
             KRB5ConfSection.LIBDEFAULTS,
             config,
-            auxiliary_parameters
+            auxiliary_parameters,
+            strict=strict,
         )
 
     def add_appdefaults(
         self,
         config: dict,
-        auxiliary_parameters: Optional[str] = None
+        auxiliary_parameters: Optional[str] = None,
+        strict: bool = True,
     ):
         """
         Add configuration for the [appdefaults] section of the krb5.conf file, replacing
@@ -260,7 +300,8 @@ class KRB5Conf():
         self.__add_parameters(
             KRB5ConfSection.APPDEFAULTS,
             config,
-            auxiliary_parameters
+            auxiliary_parameters,
+            strict=strict,
         )
 
     def __parse_realm(self, realm_info: dict) -> dict:

--- a/tests/unit/test_krb5.py
+++ b/tests/unit/test_krb5.py
@@ -317,6 +317,50 @@ def test__krb5conf_appdefaults_aux_parser_lenient(_clear_logged_unsupported_aux)
     assert data == {'forwardable': 'true'}
 
 
+def test__krb5conf_add_libdefaults_lenient_call_path(_clear_logged_unsupported_aux):
+    # Exercise the same path the etc.generate renderer uses: invalid aux
+    # lines are dropped, valid config + aux entries reach the rendered output.
+    kconf = krb5_conf.KRB5Conf()
+    kconf.add_libdefaults(
+        {'default_realm': 'EXAMPLE.COM'},
+        'allow_weak_crypto = false\nrdns = false',
+        strict=False,
+    )
+
+    assert kconf.libdefaults == {'default_realm': 'EXAMPLE.COM', 'rdns': 'false'}
+
+    rendered = kconf.generate()
+    assert 'allow_weak_crypto' not in rendered
+    assert 'default_realm = EXAMPLE.COM' in rendered
+    assert 'rdns = false' in rendered
+
+
+def test__krb5conf_add_appdefaults_lenient_call_path(_clear_logged_unsupported_aux):
+    kconf = krb5_conf.KRB5Conf()
+    kconf.add_appdefaults(
+        {'forwardable': 'true'},
+        'canonicalize = true\nrenew_lifetime = 86400',
+        strict=False,
+    )
+
+    assert kconf.appdefaults == {'forwardable': 'true', 'renew_lifetime': '86400'}
+
+    rendered = kconf.generate()
+    assert 'canonicalize' not in rendered
+    assert 'forwardable = true' in rendered
+    assert 'renew_lifetime = 86400' in rendered
+
+
+def test__krb5conf_add_libdefaults_strict_default_call_path():
+    # Sanity: the wrapper preserves strict-by-default behavior.
+    kconf = krb5_conf.KRB5Conf()
+    with pytest.raises(ValueError):
+        kconf.add_libdefaults(
+            {'default_realm': 'EXAMPLE.COM'},
+            'allow_weak_crypto = false',
+        )
+
+
 def validate_realms_section(data):
     """
     data will consist of approximately following:

--- a/tests/unit/test_krb5.py
+++ b/tests/unit/test_krb5.py
@@ -1,5 +1,6 @@
 import base64
 import jsonschema
+import logging
 import os
 import pytest
 
@@ -246,6 +247,74 @@ def test__krb5conf_appdefaults_aux_parser(params, expected, success):
                 data,
                 params
             )
+
+
+@pytest.fixture
+def _clear_logged_unsupported_aux():
+    krb5_conf._LOGGED_UNSUPPORTED_AUX.clear()
+    yield
+    krb5_conf._LOGGED_UNSUPPORTED_AUX.clear()
+
+
+def test__krb5conf_libdefaults_aux_parser_strict_default():
+    # Sanity check: the historical strict behavior is still the default.
+    with pytest.raises(ValueError):
+        krb5_conf.parse_krb_aux_params(
+            krb5_conf.KRB5ConfSection.LIBDEFAULTS,
+            {},
+            'allow_weak_crypto = false',
+        )
+
+
+def test__krb5conf_libdefaults_aux_parser_lenient(_clear_logged_unsupported_aux):
+    data = {}
+    krb5_conf.parse_krb_aux_params(
+        krb5_conf.KRB5ConfSection.LIBDEFAULTS,
+        data,
+        'rdns = false\nallow_weak_crypto = false\ncanonicalize = true',
+        strict=False,
+    )
+    assert data == {'rdns': 'false', 'canonicalize': 'true'}
+
+
+def test__krb5conf_libdefaults_aux_lenient_logs_once(
+    _clear_logged_unsupported_aux, caplog
+):
+    bad = 'allow_weak_crypto = false'
+    with caplog.at_level(logging.WARNING, logger=krb5_conf.logger.name):
+        krb5_conf.parse_krb_aux_params(
+            krb5_conf.KRB5ConfSection.LIBDEFAULTS, {}, bad, strict=False,
+        )
+        krb5_conf.parse_krb_aux_params(
+            krb5_conf.KRB5ConfSection.LIBDEFAULTS, {}, bad, strict=False,
+        )
+
+    matching = [r for r in caplog.records if 'allow_weak_crypto' in r.getMessage()]
+    assert len(matching) == 1, [r.getMessage() for r in matching]
+
+
+def test__krb5conf_libdefaults_aux_lenient_preserves_nested(
+    _clear_logged_unsupported_aux,
+):
+    data = {}
+    krb5_conf.parse_krb_aux_params(
+        krb5_conf.KRB5ConfSection.LIBDEFAULTS,
+        data,
+        'MYDOM.TEST = {\n    rdns = false\n    allow_weak_crypto = false\n}',
+        strict=False,
+    )
+    assert data == {'MYDOM.TEST': {'rdns': 'false'}}
+
+
+def test__krb5conf_appdefaults_aux_parser_lenient(_clear_logged_unsupported_aux):
+    data = {}
+    krb5_conf.parse_krb_aux_params(
+        krb5_conf.KRB5ConfSection.APPDEFAULTS,
+        data,
+        'forwardable = true\ncanonicalize = true',
+        strict=False,
+    )
+    assert data == {'forwardable': 'true'}
 
 
 def validate_realms_section(data):


### PR DESCRIPTION
Historically TrueNAS has allowed krb5.conf auxiliary parameters via libdefaults and appdefaults fields with minimal validation.

Validation is required generally for these fields because a broken krb5.conf can have widely problematict impacts system-wide leading to production down situations for the support team; however, some universities have oddball kerberos domains that require some minor tweaks.

In 25.10 when we transitioned to the new API schema for directory services we removed a lot of parameters that could get through our validator that were heavily labelled by the upstream projects as things no one should *ever* use in production. Among these removed and now invalid parameters was allow_weak_crypto. Unfortunately, this broke a community member who had explicitly set this exact parameter, but not in a nice and fun way, but rather in a way that took many things with it.

This commit modifies our renderer for the krb5.conf so that we skip invalid garbage that past users may have inserted in their config and only render a sane krb5.conf without raising an exception (only logging once per middleware process lifetime). Validation on kerberos.update is kept.

Original PR: https://github.com/truenas/middleware/pull/18953
