### PR TITLE
NAS-141004 / 27.0.0-BETA.1 / add zpool.query events (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
@@ -14,6 +14,9 @@ __all__ = (
     "ZPoolQuery",
     "ZPoolQueryArgs",
     "ZPoolQueryResult",
+    "ZPoolQueryAddedEvent",
+    "ZPoolQueryChangedEvent",
+    "ZPoolQueryRemovedEvent",
 )
 
 
@@ -173,6 +176,8 @@ class ZPoolFeature(BaseModel):
 
 
 class ZPoolEntry(BaseModel):
+    id: int | None = None
+    """Database id from `storage.volume`. `null` for the boot pool and for any pool not present in the database."""
     name: str
     """Name of the zpool."""
     guid: int
@@ -187,6 +192,8 @@ class ZPoolEntry(BaseModel):
     """Detailed status code (e.g., OK, ERRATA, FEAT_DISABLED, LOCKED_SED_DISKS)."""
     status_detail: str | None
     """Human-readable status description."""
+    is_upgraded: bool | None = None
+    """Whether every ZFS feature flag on the pool is enabled. `null` for OFFLINE pools."""
     properties: dict[str, ZPoolPropertyValue] | None = None
     """Pool properties, keyed by property name."""
     topology: ZPoolTopology | None = None
@@ -221,3 +228,22 @@ class ZPoolQueryArgs(BaseModel):
 
 class ZPoolQueryResult(BaseModel):
     result: list[ZPoolEntry]
+
+
+class ZPoolQueryAddedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""
+    fields: ZPoolEntry
+    """Event fields."""
+
+
+class ZPoolQueryChangedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""
+    fields: ZPoolEntry
+    """Event fields."""
+
+
+class ZPoolQueryRemovedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""

--- a/src/middlewared/middlewared/api/v27_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v27_0_0/zpool_query.py
@@ -14,6 +14,9 @@ __all__ = (
     "ZPoolQuery",
     "ZPoolQueryArgs",
     "ZPoolQueryResult",
+    "ZPoolQueryAddedEvent",
+    "ZPoolQueryChangedEvent",
+    "ZPoolQueryRemovedEvent",
 )
 
 
@@ -173,6 +176,8 @@ class ZPoolFeature(BaseModel):
 
 
 class ZPoolEntry(BaseModel):
+    id: int | None = None
+    """Database id from `storage.volume`. `null` for the boot pool and for any pool not present in the database."""
     name: str
     """Name of the zpool."""
     guid: int
@@ -187,6 +192,8 @@ class ZPoolEntry(BaseModel):
     """Detailed status code (e.g., OK, ERRATA, FEAT_DISABLED, LOCKED_SED_DISKS)."""
     status_detail: str | None
     """Human-readable status description."""
+    is_upgraded: bool | None = None
+    """Whether every ZFS feature flag on the pool is enabled. `null` for OFFLINE pools."""
     properties: dict[str, ZPoolPropertyValue] | None = None
     """Pool properties, keyed by property name."""
     topology: ZPoolTopology | None = None
@@ -221,3 +228,22 @@ class ZPoolQueryArgs(BaseModel):
 
 class ZPoolQueryResult(BaseModel):
     result: list[ZPoolEntry]
+
+
+class ZPoolQueryAddedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""
+    fields: ZPoolEntry
+    """Event fields."""
+
+
+class ZPoolQueryChangedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""
+    fields: ZPoolEntry
+    """Event fields."""
+
+
+class ZPoolQueryRemovedEvent(BaseModel):
+    id: int
+    """Database id of the pool."""

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -189,3 +189,4 @@ class PoolService(Service):
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
         self.middleware.send_event('pool.query', 'REMOVED', id=oid)
+        await self.middleware.call('zpool.send_removed_event', oid)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -345,6 +345,7 @@ class PoolService(Service):
                 pass
 
         self.middleware.send_event('pool.query', event_type, id=pool['id'], fields=pool)
+        await self.middleware.call('zpool.send_change_event', pool['name'], event_type)
 
     @private
     def recursive_mount(self, name):

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -16,8 +16,8 @@ from middlewared.api.current import (
     PoolProcessesResult,
     ZFSResourceQuery,
 )
-from middlewared.service import Service, ValidationError, private
 from middlewared.plugins.zpool import get_zpool_disks_impl, get_zpool_features_impl, is_upgraded_impl
+from middlewared.service import Service, ValidationError, private
 
 
 class PoolService(Service):

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -16,8 +16,8 @@ from middlewared.api.current import (
     PoolProcessesResult,
     ZFSResourceQuery,
 )
-from middlewared.plugins.zpool import get_zpool_disks_impl, get_zpool_features_impl
 from middlewared.service import Service, ValidationError, private
+from middlewared.plugins.zpool import get_zpool_disks_impl, get_zpool_features_impl, is_upgraded_impl
 
 
 class PoolService(Service):
@@ -163,8 +163,4 @@ class PoolService(Service):
             )
 
         pname = pool[0]['vol_name']
-        for feat, info in get_zpool_features_impl(tls.lzh, pname).items():
-            if info.state not in ('ENABLED', 'ACTIVE'):
-                return False
-
-        return True
+        return is_upgraded_impl(get_zpool_features_impl(tls.lzh, pname))

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -602,6 +602,7 @@ class PoolService(CRUDService):
             'dataset.post_create', {'encrypted': bool(encryption_dict), **encrypted_dataset_data}
         )
         self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)
+        await self.middleware.call('zpool.send_change_event', pool['name'], 'ADDED')
         return pool
 
     @private

--- a/src/middlewared/middlewared/plugins/pool_/pool_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool_operations.py
@@ -130,4 +130,5 @@ class PoolService(Service):
             raise
         else:
             self.call_sync2(self.s.alert.oneshot_delete, 'PoolUpgraded', pname)
+            self.middleware.call_sync('zpool.send_change_event', pname, 'CHANGED')
             return True

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -196,6 +196,7 @@ async def zfs_events(middleware, event: ZfsEvent):
                         # endpoints because there are other operations related to create/delete
                         # which when done, we consider the create/delete operation as complete
                         middleware.send_event('pool.query', 'CHANGED', id=pool['id'], fields=pool)
+                        await middleware.call('zpool.send_change_event', pool_name, 'CHANGED')
 
                     await middleware.call2(middleware.services.alert.oneshot_delete, 'PoolUpgraded', pool_name)
                     await create_pool_upgraded_alert(middleware, pool_name)

--- a/src/middlewared/middlewared/plugins/zpool/__init__.py
+++ b/src/middlewared/middlewared/plugins/zpool/__init__.py
@@ -1,11 +1,13 @@
 from .get_zpool_disks_impl import get_zpool_disks_impl
 from .get_zpool_features_impl import get_zpool_features_impl
+from .is_upgraded_impl import is_upgraded_impl
 from .query_impl import query_impl
 from .upgrade_zpool_impl import upgrade_zpool_impl
 
 __all__ = (
     "get_zpool_disks_impl",
     "get_zpool_features_impl",
+    "is_upgraded_impl",
     "query_impl",
     "upgrade_zpool_impl",
 )

--- a/src/middlewared/middlewared/plugins/zpool/crud.py
+++ b/src/middlewared/middlewared/plugins/zpool/crud.py
@@ -1,10 +1,13 @@
 import threading
 
-from middlewared.api import api_method
+from middlewared.api import api_method, Event
 from middlewared.api.current import (
     ZPoolEntry,
     ZPoolQueryArgs,
     ZPoolQueryResult,
+    ZPoolQueryAddedEvent,
+    ZPoolQueryChangedEvent,
+    ZPoolQueryRemovedEvent,
 )
 from middlewared.service import Service, private
 from middlewared.service.decorators import pass_thread_local_storage
@@ -12,17 +15,42 @@ from middlewared.service.decorators import pass_thread_local_storage
 from .query_impl import query_impl
 
 
+# Properties baked into every emitted `zpool.query` event so that subscribers
+# receive a Pool-shaped payload without having to round-trip another call.
+EVENT_PROPERTIES = (
+    "class_normal_used",
+    "class_normal_available",
+    "class_normal_usable",
+    "class_special_used",
+    "class_special_available",
+    "class_special_usable",
+    "autotrim",
+    "dedup_table_size",
+    "dedup_table_quota",
+)
+
+
 class ZPoolService(Service):
     class Config:
         namespace = "zpool"
         cli_private = True
         entry = ZPoolEntry
+        events = [
+            Event(
+                name="zpool.query",
+                description="Sent on zpool changes.",
+                roles=["POOL_READ"],
+                models={
+                    "ADDED": ZPoolQueryAddedEvent,
+                    "CHANGED": ZPoolQueryChangedEvent,
+                    "REMOVED": ZPoolQueryRemovedEvent,
+                },
+            )
+        ]
 
     @private
     @pass_thread_local_storage
-    def query_impl(
-        self, tls: threading.local, data: dict | None = None
-    ) -> list[ZPoolEntry]:
+    def query_impl(self, tls: threading.local, data: dict | None = None) -> list[ZPoolEntry]:
         if data is None:
             data = dict()
         return query_impl(tls.lzh, data)
@@ -70,6 +98,7 @@ class ZPoolService(Service):
 
             entries.append(
                 {
+                    "id": pool_info["id"] if pool_info else None,
                     "name": name,
                     "guid": int(pool_info["guid"]) if pool_info else 0,
                     "status": "OFFLINE",
@@ -77,6 +106,7 @@ class ZPoolService(Service):
                     "warning": False,
                     "status_code": status_code,
                     "status_detail": status_detail,
+                    "is_upgraded": None,
                 }
             )
         return entries
@@ -131,9 +161,7 @@ class ZPoolService(Service):
 
         db_pools = {}
         pool_names = []
-        for p in self.middleware.call_sync(
-            "datastore.query", "storage.volume", [], {"prefix": "vol_"}
-        ):
+        for p in self.middleware.call_sync("datastore.query", "storage.volume", [], {"prefix": "vol_"}):
             if requested_names is None or p["name"] in requested_names:
                 db_pools[p["name"]] = p
                 pool_names.append(p["name"])
@@ -142,9 +170,10 @@ class ZPoolService(Service):
         if requested_names is not None and boot_pool_name in requested_names:
             pool_names.append(boot_pool_name)
 
-        results = self.middleware.call_sync(
-            "zpool.query_impl", data | {"pool_names": pool_names}
-        )
+        results = self.middleware.call_sync("zpool.query_impl", data | {"pool_names": pool_names})
+        for entry in results:
+            entry["id"] = db_pools[entry["name"]]["id"] if entry["name"] in db_pools else None
+
         imported_names = {p["name"] for p in results}
         offline_names = [name for name in pool_names if name not in imported_names]
         results.extend(self.offline_entries(db_pools, offline_names))
@@ -153,3 +182,34 @@ class ZPoolService(Service):
         for pool in results:
             rv.append(ZPoolEntry(**pool))
         return rv
+
+    @private
+    def send_change_event(self, pool_name: str, event_type: str = "CHANGED"):
+        """Emit a ``zpool.query`` event with a Pool-shaped payload.
+
+        Re-queries ``zpool.query`` with topology, scan, and the standard
+        property set so subscribers receive the same fields they would
+        from a direct call. No-ops when the pool is not in the database
+        (boot pool, or a pool that has been exported between the trigger
+        and the emit).
+        """
+        pools = self.middleware.call_sync(
+            "zpool.query",
+            {
+                "pool_names": [pool_name],
+                "topology": True,
+                "scan": True,
+                "properties": list(EVENT_PROPERTIES),
+            },
+        )
+        if not pools:
+            return
+        pool = pools[0].model_dump()
+        if pool["id"] is None:
+            return
+        self.middleware.send_event("zpool.query", event_type, id=pool["id"], fields=pool)
+
+    @private
+    def send_removed_event(self, pool_id: int):
+        """Emit a ``zpool.query`` REMOVED event for the given database id."""
+        self.middleware.send_event("zpool.query", "REMOVED", id=pool_id)

--- a/src/middlewared/middlewared/plugins/zpool/crud.py
+++ b/src/middlewared/middlewared/plugins/zpool/crud.py
@@ -3,13 +3,13 @@ import threading
 from middlewared.api import api_method, Event
 from middlewared.api.current import (
     ZPoolEntry,
-    ZPoolQueryArgs,
-    ZPoolQueryResult,
     ZPoolQueryAddedEvent,
+    ZPoolQueryArgs,
     ZPoolQueryChangedEvent,
     ZPoolQueryRemovedEvent,
+    ZPoolQueryResult,
 )
-from middlewared.service import Service, private
+from middlewared.service import private, Service
 from middlewared.service.decorators import pass_thread_local_storage
 
 from .query_impl import query_impl

--- a/src/middlewared/middlewared/plugins/zpool/crud.py
+++ b/src/middlewared/middlewared/plugins/zpool/crud.py
@@ -1,6 +1,6 @@
 import threading
 
-from middlewared.api import api_method, Event
+from middlewared.api import Event, api_method
 from middlewared.api.current import (
     ZPoolEntry,
     ZPoolQueryAddedEvent,
@@ -9,11 +9,10 @@ from middlewared.api.current import (
     ZPoolQueryRemovedEvent,
     ZPoolQueryResult,
 )
-from middlewared.service import private, Service
+from middlewared.service import Service, private
 from middlewared.service.decorators import pass_thread_local_storage
 
 from .query_impl import query_impl
-
 
 # Properties baked into every emitted `zpool.query` event so that subscribers
 # receive a Pool-shaped payload without having to round-trip another call.

--- a/src/middlewared/middlewared/plugins/zpool/is_upgraded_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/is_upgraded_impl.py
@@ -1,0 +1,15 @@
+from truenas_pylibzfs import libzfs_types
+
+__all__ = ("is_upgraded_impl",)
+
+
+def is_upgraded_impl(features: dict[str, libzfs_types.struct_zpool_feature]) -> bool:
+    """Return whether every ZFS feature flag on a pool is enabled.
+
+    Takes the mapping produced by ``get_zpool_features_impl`` and reports
+    ``True`` only when each feature's state is ``ENABLED`` or ``ACTIVE``.
+    """
+    for info in features.values():
+        if info.state not in ("ENABLED", "ACTIVE"):
+            return False
+    return True

--- a/src/middlewared/middlewared/plugins/zpool/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/query_impl.py
@@ -7,6 +7,7 @@ from middlewared.utils import BOOT_POOL_NAME_VALID
 
 from .exceptions import ZpoolNotFoundException
 from .get_zpool_features_impl import get_zpool_features_impl
+from .is_upgraded_impl import is_upgraded_impl
 
 __all__ = ("query_impl",)
 
@@ -243,9 +244,11 @@ def _build_pool_dict(pool: libzfs_types.ZFSPool, lzh: libzfs_types.ZFS, data: di
     if data.get("expand"):
         result["expand"] = _format_expand(pool.expand_info())
 
+    features = get_zpool_features_impl(lzh, pool.name)
+    result["is_upgraded"] = is_upgraded_impl(features)
     result["features"] = None
     if data.get("features"):
-        result["features"] = _format_features(get_zpool_features_impl(lzh, pool.name))
+        result["features"] = _format_features(features)
 
     return result
 


### PR DESCRIPTION
UX team is switching to `zpool.query` in 26-RC.1 for a new feature and they need events for this endpoint. This adds said events based on a discussion with them and understanding the specific fields they need. This sends the events along-side the other `pool.query` events to keep it simple.

Original PR: https://github.com/truenas/middleware/pull/18962
