### PR TITLE
NAS-141011 / 26.0.0-BETA.2 / webshell: replace sudo gating with per-shell-type RBAC + audit (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import contextlib
+import errno
 import fcntl
 import os
 import queue
@@ -10,17 +11,18 @@ import termios
 import threading
 import time
 
+from truenas_api_client import json
+
+from middlewared.api.base.server.app import App
 from middlewared.api.base.server.ws_handler.base import BaseWebSocketHandler
+from middlewared.plugins.account_.constants import DEFAULT_HOME_PATH
 from middlewared.service_exception import (
     CallError,
     ErrnoMixin,
-    MatchNotFound,
 )
-from middlewared.utils.crypto import ssl_uuid4
+from middlewared.utils.auth import ShellAppType, ShellTokenAuthError
 from middlewared.utils.os import close_fds, terminate_pid
 from middlewared.utils.threading import run_coro_threadsafe
-from middlewared.plugins.account_.constants import DEFAULT_HOME_PATH
-from truenas_api_client import json
 
 __all__ = ("ShellApplication",)
 
@@ -33,64 +35,59 @@ ShellResize = collections.namedtuple("ShellResize", ["cols", "rows"])
 BASH_FALLBACK_SCRIPT = "if command -v bash >/dev/null 2>&1; then exec bash -l; else exec sh; fi"
 
 
+def _audit_target(shell_type, options):
+    if shell_type is ShellAppType.VM:
+        return {"vm_id": options["vm_id"]}
+    if shell_type is ShellAppType.APP:
+        return {"app_name": options["app_name"], "container_id": options["container_id"]}
+    if shell_type is ShellAppType.CONTAINER:
+        return {"container_id": options["container_id"]}
+    return None
+
+
 class ShellWorkerThread(threading.Thread):
     """
     Worker thread responsible for forking and running the shell
     and spawning the reader and writer threads.
     """
 
-    def __init__(self, middleware, ws, input_queue, loop, username, as_root, options, homedir):
+    def __init__(self, middleware, ws, input_queue, loop, username, options, homedir):
         self.middleware = middleware
         self.ws = ws
         self.input_queue = input_queue
         self.loop = loop
         self.shell_pid = None
         self.master_fd = None
-        self.command, self.sudo_warning = self.get_command(username, as_root, options)
+        self.command = self.get_command(username, options)
         self.homedir = homedir
         self.username = username
         self._die = False
         super(ShellWorkerThread, self).__init__(daemon=True)
 
-    def get_command(self, username, as_root, options):
-        allowed_options = ("vm_id", "app_name", "container_id")
-        if all(options.get(k) for k in allowed_options):
-            raise CallError(
-                f'Only one option is supported from {", ".join(allowed_options)}'
-            )
-
+    def get_command(self, username, options):
         if options.get("vm_id"):
-            command = [
+            return [
                 "/usr/bin/virsh",
                 "-c",
                 "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock",
                 "console",
                 f'{options["vm_data"]["uuid"]}',
             ]
-            if not as_root:
-                command = ["/usr/bin/sudo", "-H", "-u", username] + command
-            return command, not as_root
         elif options.get("app_name"):
-            command = [
+            return [
                 "/usr/bin/docker",
                 "exec",
                 "-it",
                 options["container_id"],
                 "/bin/sh", "-c", self._shell_script(options),
             ]
-            if not as_root:
-                command = ["/usr/bin/sudo", "-H", "-u", username] + command
-            return command, not as_root
         elif options.get("container_id"):
             # nsenter argv already terminates with `/bin/sh -c`; append the
             # script as the single trailing argument so it is what `sh -c`
             # actually executes (rather than being interpreted as $0/$1).
-            command = options["nsenter"] + [self._shell_script(options)]
-            if not as_root:
-                command = ["/usr/bin/sudo", "-H", "-u", username] + command
-            return command, not as_root
+            return options["nsenter"] + [self._shell_script(options)]
         else:
-            return ["/usr/bin/login", "-p", "-f", username], False
+            return ["/usr/bin/login", "-p", "-f", username]
 
     def _shell_script(self, options):
         # Callers (currently only integration tests) may override the script
@@ -133,17 +130,6 @@ class ShellWorkerThread(threading.Thread):
         attr = termios.tcgetattr(self.master_fd)
         attr[4] = attr[5] = termios.B921600
         termios.tcsetattr(self.master_fd, termios.TCSANOW, attr)
-
-        if self.sudo_warning:
-            asyncio.run_coroutine_threadsafe(
-                self.ws.send_bytes(
-                    (
-                        f"WARNING: Your user does not have sudo privileges so {self.command[4]} command will run\r\n"
-                        f"on your behalf. This might cause permission issues.\r\n\r\n"
-                    ).encode("utf-8")
-                ),
-                loop=self.loop,
-            ).result()
 
         def reader():
             """
@@ -293,11 +279,14 @@ class ShellApplication:
         if not await self.middleware.ws_can_access(ws, origin):
             return ws
 
+        app = App(origin)
+        app.websocket = True
+
         conndata = ShellConnectionData()
-        conndata.id = str(ssl_uuid4())
+        conndata.id = app.session_id
 
         try:
-            await self.run(ws, origin, conndata)
+            await self.run(ws, app, conndata)
         except Exception:
             if conndata.t_worker:
                 await self.worker_kill(conndata.t_worker)
@@ -306,128 +295,198 @@ class ShellApplication:
             self.shells.pop(conndata.id, None)
             return ws
 
-    async def run(self, ws, origin, conndata):
+    async def run(self, ws, app, conndata):
+        origin = app.origin
         # Each connection will have its own input queue
         input_queue = queue.Queue()
         authenticated = False
+        session_audit_info = None
 
-        async for msg in ws:
-            if authenticated:
-                # Add content of every message received in input queue
-                input_queue.put(msg.data)
-            else:
-                try:
-                    data = json.loads(msg.data)
-                except json.decoder.JSONDecodeError:
-                    continue
+        try:
+            async for msg in ws:
+                if authenticated:
+                    # Add content of every message received in input queue
+                    input_queue.put(msg.data)
+                else:
+                    try:
+                        data = json.loads(msg.data)
+                    except json.decoder.JSONDecodeError:
+                        continue
 
-                token = data.get("token")
-                if not token:
-                    continue
+                    token_id = data.get("token")
+                    if not token_id:
+                        continue
 
-                token = await self.middleware.call(
-                    "auth.get_token_for_shell_application", token, origin
-                )
-                if not token:
+                    options = data.get("options", {})
+
+                    # vm_id selects a VM shell and is mutually exclusive with
+                    # the app/container options. APP shells legitimately
+                    # specify both app_name and container_id, so those two are
+                    # not in conflict with each other.
+                    if options.get("vm_id") and (
+                        options.get("app_name") or options.get("container_id")
+                    ):
+                        raise CallError(
+                            "vm_id cannot be combined with app_name or container_id"
+                        )
+
+                    if options.get("vm_id"):
+                        shell_type = ShellAppType.VM
+                    elif options.get("app_name"):
+                        shell_type = ShellAppType.APP
+                    elif options.get("container_id"):
+                        shell_type = ShellAppType.CONTAINER
+                    else:
+                        shell_type = ShellAppType.HOST
+
+                    audit_target = _audit_target(shell_type, options)
+
+                    token = await self.middleware.call(
+                        "auth.get_token_for_shell_application", token_id, origin, shell_type
+                    )
+                    if not token:
+                        await self.middleware.log_audit_message(app, "WEBSHELL_AUTHENTICATION", {
+                            "shell_type": shell_type.value,
+                            "target": audit_target,
+                            "username": None,
+                            "error": "invalid token",
+                        }, False)
+                        await ws.send_json(
+                            {
+                                "msg": "failed",
+                                "error": {
+                                    "error": ErrnoMixin.ENOTAUTHENTICATED,
+                                    "reason": "Invalid token",
+                                },
+                            }
+                        )
+                        continue
+                    if token.get("error") == ShellTokenAuthError.WEB_SHELL_DENIED:
+                        app.authenticated_credentials = token["credentials"]
+                        await self.middleware.log_audit_message(app, "WEBSHELL_AUTHENTICATION", {
+                            "shell_type": shell_type.value,
+                            "target": audit_target,
+                            "username": token["username"],
+                            "error": "web_shell privilege not granted",
+                        }, False)
+                        await ws.send_json(
+                            {
+                                "msg": "failed",
+                                "error": {
+                                    "error": errno.EACCES,
+                                    "reason": "Web shell privilege not granted for this account",
+                                },
+                            }
+                        )
+                        continue
+                    if token.get("error") == ShellTokenAuthError.MISSING_ROLE:
+                        app.authenticated_credentials = token["credentials"]
+                        await self.middleware.log_audit_message(app, "WEBSHELL_AUTHENTICATION", {
+                            "shell_type": shell_type.value,
+                            "target": audit_target,
+                            "username": token["username"],
+                            "error": f"missing required role: {token['required_role']}",
+                        }, False)
+                        await ws.send_json(
+                            {
+                                "msg": "failed",
+                                "error": {
+                                    "error": errno.EACCES,
+                                    "reason": (
+                                        f"Missing required role for {shell_type.value} shell: "
+                                        f"{token['required_role']}"
+                                    ),
+                                },
+                            }
+                        )
+                        continue
+
+                    app.authenticated_credentials = token["credentials"]
+
+                    if shell_type is ShellAppType.CONTAINER:
+                        # Enrich audit target with the friendly container name
+                        # so admins reviewing logs don't have to cross-reference
+                        # numeric ids. Done only on the auth-success path because
+                        # the lookup would otherwise leak existence to failed
+                        # attempts.
+                        container = await self.middleware.call(
+                            "container.get_instance", options["container_id"]
+                        )
+                        audit_target = {
+                            **audit_target,
+                            "container_name": container["name"],
+                        }
+
+                    session_audit_info = {
+                        "shell_type": shell_type.value,
+                        "target": audit_target,
+                        "username": token["username"],
+                    }
+                    await self.middleware.log_audit_message(app, "WEBSHELL_AUTHENTICATION", {
+                        **session_audit_info,
+                        "error": None,
+                    }, True)
+
+                    authenticated = True
+
+                    if shell_type is ShellAppType.VM:
+                        options["vm_data"] = await self.middleware.call(
+                            "vm.get_instance", options["vm_id"]
+                        )
+                    elif shell_type is ShellAppType.APP:
+                        if not options.get("container_id"):
+                            raise CallError("Container id must be specified")
+                        choices = await self.middleware.call(
+                            "app.container_console_choices", options["app_name"]
+                        )
+                        if options["container_id"] not in choices:
+                            raise CallError("Provided container id is not valid")
+                    elif shell_type is ShellAppType.CONTAINER:
+                        # container.nsenter takes the full container dict
+                        # (it reads container["status"]["pid"], ["uuid"],
+                        # ...), not the id — reuse the lookup from above.
+                        options["nsenter"] = await self.middleware.call(
+                            "container.nsenter", container,
+                        )
+
+                    try:
+                        user_obj = await self.middleware.call("user.get_user_obj", {"username": token["username"]})
+                    except KeyError:
+                        raise CallError(f'{token["username"]}: user does not exist')
+
+                    conndata.t_worker = ShellWorkerThread(
+                        middleware=self.middleware,
+                        ws=ws,
+                        input_queue=input_queue,
+                        loop=asyncio.get_event_loop(),
+                        username=token["username"],
+                        homedir=user_obj["pw_dir"],
+                        options=options,
+                    )
+                    conndata.t_worker.start()
+
+                    self.shells[conndata.id] = conndata.t_worker
+
                     await ws.send_json(
                         {
-                            "msg": "failed",
-                            "error": {
-                                "error": ErrnoMixin.ENOTAUTHENTICATED,
-                                "reason": "Invalid token",
-                            },
+                            "msg": "connected",
+                            "id": conndata.id,
                         }
                     )
-                    continue
 
-                authenticated = True
+            # If connection was not authenticated, return earlier
+            if not authenticated:
+                return ws
 
-                options = data.get("options", {})
-                if options.get("vm_id"):
-                    options["vm_data"] = await self.middleware.call(
-                        "vm.get_instance", options["vm_id"]
-                    )
+            if conndata.t_worker:
+                self.middleware.create_task(self.worker_kill(conndata.t_worker))
 
-                if options.get("app_name"):
-                    if not options.get("container_id"):
-                        raise CallError("Container id must be specified")
-                    if options["container_id"] not in await self.middleware.call(
-                        "app.container_console_choices", options["app_name"]
-                    ):
-                        raise CallError("Provided container id is not valid")
-                elif options.get("container_id"):
-                    options["nsenter"] = await self.middleware.call(
-                        "container.nsenter",
-                        await self.middleware.call("container.get_instance", options["container_id"]),
-                    )
-
-                # By default we want to run virsh with user's privileges and assume all "permission denied"
-                # errors this can cause, unless the user has a sudo permission for all commands; in that case, let's
-                # run them straight with root privileges.
-                as_root = False
-                try:
-                    user = await self.middleware.call(
-                        "user.query",
-                        [["username", "=", token["username"]], ["local", "=", True]],
-                        {"get": True},
-                    )
-                except MatchNotFound:
-                    # Currently only local users can be sudoers
-                    pass
-                else:
-                    if user["uid"] == 0:
-                        as_root = True
-                    elif (
-                        "ALL" in user["sudo_commands"]
-                        or "ALL" in user["sudo_commands_nopasswd"]
-                    ):
-                        as_root = True
-                    else:
-                        for group in await self.middleware.call(
-                            "group.query",
-                            [["id", "in", user["groups"]], ["local", "=", True]],
-                        ):
-                            if (
-                                "ALL" in group["sudo_commands"]
-                                or "ALL" in group["sudo_commands_nopasswd"]
-                            ):
-                                as_root = True
-                                break
-
-                try:
-                    user_obj = await self.middleware.call("user.get_user_obj", {"username": token["username"]})
-                except KeyError:
-                    raise CallError(f'{token["username"]}: user does not exist')
-
-                conndata.t_worker = ShellWorkerThread(
-                    middleware=self.middleware,
-                    ws=ws,
-                    input_queue=input_queue,
-                    loop=asyncio.get_event_loop(),
-                    username=token["username"],
-                    homedir=user_obj["pw_dir"],
-                    as_root=as_root,
-                    options=options,
-                )
-                conndata.t_worker.start()
-
-                self.shells[conndata.id] = conndata.t_worker
-
-                await ws.send_json(
-                    {
-                        "msg": "connected",
-                        "id": conndata.id,
-                    }
-                )
-
-        # If connection was not authenticated, return earlier
-        if not authenticated:
             return ws
-
-        if conndata.t_worker:
-            self.middleware.create_task(self.worker_kill(conndata.t_worker))
-
-        return ws
+        finally:
+            if session_audit_info is not None:
+                await self.middleware.log_audit_message(
+                    app, "WEBSHELL_LOGOUT", session_audit_info, True,
+                )
 
     async def worker_kill(self, t_worker):
         await self.middleware.run_in_thread(t_worker.abort)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -201,6 +201,12 @@ class ServiceContainer(BaseServiceContainer):
             method.__func__.__method_name__ = method_name
 
 
+_AuditEvent = typing.Literal[
+    'METHOD_CALL', 'AUTHENTICATION', 'REBOOT', 'SHUTDOWN', 'LOGOUT',
+    'WEBSHELL_AUTHENTICATION', 'WEBSHELL_LOGOUT',
+]
+
+
 class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
 
     CONSOLE_ONCE_PATH = f'{MIDDLEWARE_RUN_DIR}/.middlewared-console-once'
@@ -1140,7 +1146,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
     def _build_audit_message_sync(
         self,
         app: App,
-        event: typing.Literal['METHOD_CALL', 'AUTHENTICATION', 'REBOOT', 'SHUTDOWN', 'LOGOUT'],
+        event: _AuditEvent,
         event_data: dict,
         success: bool,
     ) -> str:
@@ -1190,7 +1196,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
     def log_audit_message_sync(
         self,
         app: App,
-        event: typing.Literal['METHOD_CALL', 'AUTHENTICATION', 'REBOOT', 'SHUTDOWN', 'LOGOUT'],
+        event: _AuditEvent,
         event_data: dict,
         success: bool,
     ) -> None:
@@ -1206,7 +1212,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
     async def log_audit_message(
         self,
         app: App,
-        event: typing.Literal['METHOD_CALL', 'AUTHENTICATION', 'REBOOT', 'SHUTDOWN', 'LOGOUT'],
+        event: _AuditEvent,
         event_data: dict,
         success: bool,
     ) -> None:

--- a/src/middlewared/middlewared/plugins/audit/schema/middleware.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/middleware.py
@@ -30,6 +30,21 @@ class AuditEventMiddlewareRebootShutdownEventData(BaseModel):
     reason: str | None
 
 
+class AuditEventMiddlewareWebshellAuthenticationEventData(BaseModel):
+    shell_type: Literal['HOST', 'VM', 'CONTAINER', 'APP']
+    target: dict | None
+    username: str | None
+    error: str | None
+    vers: AuditEventVersion
+
+
+class AuditEventMiddlewareWebshellLogoutEventData(BaseModel):
+    shell_type: Literal['HOST', 'VM', 'CONTAINER', 'APP']
+    target: dict | None
+    username: str
+    vers: AuditEventVersion
+
+
 class AuditEventMiddlewareServiceData(BaseModel):
     vers: AuditEventVersion
     origin: str | None
@@ -38,11 +53,13 @@ class AuditEventMiddlewareServiceData(BaseModel):
 
 
 class AuditEventMiddleware(AuditEvent):
-    event: Literal['AUTHENTICATION', 'METHOD_CALL', 'REBOOT', 'SHUTDOWN']
+    event: Literal['AUTHENTICATION', 'METHOD_CALL', 'REBOOT', 'SHUTDOWN', 'WEBSHELL_AUTHENTICATION', 'WEBSHELL_LOGOUT']
     event_data: (
         AuditEventMiddlewareAuthenticationEventData |
         AuditEventMiddlewareMethodCallEventData |
-        AuditEventMiddlewareRebootShutdownEventData
+        AuditEventMiddlewareRebootShutdownEventData |
+        AuditEventMiddlewareWebshellAuthenticationEventData |
+        AuditEventMiddlewareWebshellLogoutEventData
     )
     service: Literal['MIDDLEWARE']
     service_data: AuditEventMiddlewareServiceData
@@ -63,12 +80,24 @@ class AuditEventMiddlewareRebootShutdownCall(AuditEventMiddleware):
     event_data: AuditEventMiddlewareRebootShutdownEventData
 
 
+class AuditEventMiddlewareWebshellAuthentication(AuditEventMiddleware):
+    event: Literal['WEBSHELL_AUTHENTICATION']
+    event_data: AuditEventMiddlewareWebshellAuthenticationEventData
+
+
+class AuditEventMiddlewareWebshellLogout(AuditEventMiddleware):
+    event: Literal['WEBSHELL_LOGOUT']
+    event_data: AuditEventMiddlewareWebshellLogoutEventData
+
+
 AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS = [
     add_attrs(replace_refs(model_json_schema(event_model)))
     for event_model in (
         AuditEventMiddlewareAuthentication,
         AuditEventMiddlewareMethodCall,
         AuditEventMiddlewareRebootShutdownCall,
+        AuditEventMiddlewareWebshellAuthentication,
+        AuditEventMiddlewareWebshellLogout,
     )
 ]
 

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -46,8 +46,18 @@ from middlewared.service_exception import MatchNotFound, ValidationError, Valida
 import middlewared.sqlalchemy as sa
 from middlewared.utils.account.authenticator import TokenPamAuthenticator, UnixPamAuthenticator
 from middlewared.utils.auth import (
-    aal_auth_mechanism_check, AuthMech, AuthResp, AuthenticatorAssuranceLevel, AA_LEVEL1,
-    AA_LEVEL2, AA_LEVEL3, CURRENT_AAL, OTPW_MANAGER,
+    AA_LEVEL1,
+    AA_LEVEL2,
+    AA_LEVEL3,
+    CURRENT_AAL,
+    OTPW_MANAGER,
+    SHELL_APP_REQUIRED_ROLE,
+    AuthenticatorAssuranceLevel,
+    AuthMech,
+    AuthResp,
+    ShellAppType,
+    ShellTokenAuthError,
+    aal_auth_mechanism_check,
 )
 from middlewared.utils.crypto import generate_token
 from middlewared.utils.time_utils import utc_now
@@ -535,7 +545,9 @@ class AuthService(Service):
         return cred
 
     @private
-    def get_token_for_shell_application(self, token_id, origin):
+    def get_token_for_shell_application(self, token_id, origin, shell_type=ShellAppType.HOST):
+        shell_type = ShellAppType(shell_type)
+
         if (token := self.token_manager.get(token_id, origin)) is None:
             return None
 
@@ -547,13 +559,27 @@ class AuthService(Service):
             return None
 
         if not root_credentials.user['privilege']['web_shell']:
-            return None
+            return {
+                'error': ShellTokenAuthError.WEB_SHELL_DENIED,
+                'username': root_credentials.user['username'],
+                'credentials': root_credentials,
+            }
+
+        required_role = SHELL_APP_REQUIRED_ROLE[shell_type]
+        if required_role is not None and required_role not in root_credentials.user['privilege']['roles']:
+            return {
+                'error': ShellTokenAuthError.MISSING_ROLE,
+                'required_role': required_role,
+                'username': root_credentials.user['username'],
+                'credentials': root_credentials,
+            }
 
         if token.single_use:
             self.token_manager.destroy(token)
 
         return {
             'username': root_credentials.user['username'],
+            'credentials': root_credentials,
         }
 
     @api_method(AuthLoginArgs, AuthLoginResult, cli_private=True, authentication_required=False, pass_app=True)

--- a/src/middlewared/middlewared/utils/auth.py
+++ b/src/middlewared/middlewared/utils/auth.py
@@ -3,6 +3,7 @@ import threading
 from dataclasses import dataclass, asdict
 from random import uniform
 from time import monotonic
+from types import MappingProxyType
 from typing import Any
 from .crypto import generate_string, sha512_crypt, check_unixhash
 
@@ -27,6 +28,26 @@ class AuthResp(enum.StrEnum):
     REDIRECT = 'REDIRECT'
     SCRAM_RESPONSE = 'SCRAM_RESPONSE'
     DENIED = 'DENIED'
+
+
+class ShellAppType(enum.StrEnum):
+    HOST = 'HOST'
+    VM = 'VM'
+    CONTAINER = 'CONTAINER'
+    APP = 'APP'
+
+
+class ShellTokenAuthError(enum.StrEnum):
+    WEB_SHELL_DENIED = 'WEB_SHELL_DENIED'
+    MISSING_ROLE = 'MISSING_ROLE'
+
+
+SHELL_APP_REQUIRED_ROLE = MappingProxyType({
+    ShellAppType.HOST:      None,
+    ShellAppType.VM:        'VM_WRITE',
+    ShellAppType.CONTAINER: 'CONTAINER_WRITE',
+    ShellAppType.APP:       'APPS_WRITE',
+})
 
 
 # NIST SP 800-63B provides documentation Authenticator Assurance Levels (AAL)

--- a/tests/api2/test_account_privilege_authentication.py
+++ b/tests/api2/test_account_privilege_authentication.py
@@ -9,6 +9,7 @@ from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.account import user, unprivileged_user as unprivileged_user_template
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, client, ssh, websocket_url
+from middlewared.test.integration.utils.audit import expect_audit_log
 from middlewared.test.integration.utils.shell import assert_shell_works
 
 logger = logging.getLogger(__name__)
@@ -178,16 +179,47 @@ def test_drop_privileges(unprivileged_user_token):
         assert ve.value.errno == errno.EACCES
 
 
-def test_token_auth_working_not_working_web_shell(unprivileged_user_token):
-    ws = websocket.create_connection(websocket_url() + "/websocket/shell")
-    try:
-        ws.send(json.dumps({"token": unprivileged_user_token}))
-        resp_opcode, msg = ws.recv_data()
-        assert json.loads(msg.decode())["msg"] == "failed"
-    finally:
-        ws.close()
+def test_token_auth_working_not_working_web_shell(unprivileged_user, unprivileged_user_token):
+    with expect_audit_log([{
+        "event": "WEBSHELL_AUTHENTICATION",
+        "event_data": {
+            "shell_type": "HOST",
+            "target": None,
+            "username": unprivileged_user.username,
+            "error": "web_shell privilege not granted",
+        },
+        "success": False,
+    }]):
+        ws = websocket.create_connection(websocket_url() + "/websocket/shell")
+        try:
+            ws.send(json.dumps({"token": unprivileged_user_token}))
+            resp_opcode, msg = ws.recv_data()
+            assert json.loads(msg.decode())["msg"] == "failed"
+        finally:
+            ws.close()
 
 
 @pytest.mark.timeout(30)
-def test_token_auth_working_web_shell(unprivileged_user_with_web_shell_token):
-    assert_shell_works(unprivileged_user_with_web_shell_token, "unprivilegedws")
+def test_token_auth_working_web_shell(unprivileged_user_with_web_shell, unprivileged_user_with_web_shell_token):
+    with expect_audit_log([
+        {
+            "event": "WEBSHELL_AUTHENTICATION",
+            "event_data": {
+                "shell_type": "HOST",
+                "target": None,
+                "username": unprivileged_user_with_web_shell.username,
+                "error": None,
+            },
+            "success": True,
+        },
+        {
+            "event": "WEBSHELL_LOGOUT",
+            "event_data": {
+                "shell_type": "HOST",
+                "target": None,
+                "username": unprivileged_user_with_web_shell.username,
+            },
+            "success": True,
+        },
+    ]):
+        assert_shell_works(unprivileged_user_with_web_shell_token, "unprivilegedws")

--- a/tests/api2/test_webshell_audit.py
+++ b/tests/api2/test_webshell_audit.py
@@ -1,0 +1,145 @@
+import json
+
+import pytest
+import websocket
+
+from middlewared.test.integration.assets.account import (
+    unprivileged_user as unprivileged_user_template,
+)
+from middlewared.test.integration.utils import client, websocket_url
+from middlewared.test.integration.utils.audit import expect_audit_log
+
+
+def _attempt_shell_connect(token, options=None):
+    payload = {"token": token}
+    if options is not None:
+        payload["options"] = options
+    ws = websocket.create_connection(websocket_url() + "/websocket/shell")
+    try:
+        ws.send(json.dumps(payload))
+        _, msg = ws.recv_data()
+        return json.loads(msg.decode())
+    finally:
+        ws.close()
+
+
+def _make_token(user):
+    with client(auth=(user.username, user.password)) as c:
+        return c.call("auth.generate_token", 300, {}, True)
+
+
+@pytest.fixture(scope="module")
+def shell_user_no_vm_role():
+    with unprivileged_user_template(
+        username="ws_no_vm",
+        group_name="ws_no_vm_grp",
+        privilege_name="Webshell no VM role",
+        web_shell=True,
+        roles=[],
+    ) as t:
+        yield t
+
+
+@pytest.fixture(scope="module")
+def shell_user_no_container_role():
+    with unprivileged_user_template(
+        username="ws_no_ct",
+        group_name="ws_no_ct_grp",
+        privilege_name="Webshell no container role",
+        web_shell=True,
+        roles=[],
+    ) as t:
+        yield t
+
+
+@pytest.fixture(scope="module")
+def shell_user_no_apps_role():
+    with unprivileged_user_template(
+        username="ws_no_app",
+        group_name="ws_no_app_grp",
+        privilege_name="Webshell no apps role",
+        web_shell=True,
+        roles=[],
+    ) as t:
+        yield t
+
+
+def test_invalid_token_audited():
+    with expect_audit_log(
+        [
+            {
+                "event": "WEBSHELL_AUTHENTICATION",
+                "event_data": {
+                    "shell_type": "HOST",
+                    "target": None,
+                    "username": None,
+                    "error": "invalid token",
+                },
+                "success": False,
+            }
+        ]
+    ):
+        resp = _attempt_shell_connect("nonexistent-token-string")
+        assert resp["msg"] == "failed"
+
+
+def test_missing_vm_role_audited(shell_user_no_vm_role):
+    token = _make_token(shell_user_no_vm_role)
+    with expect_audit_log(
+        [
+            {
+                "event": "WEBSHELL_AUTHENTICATION",
+                "event_data": {
+                    "shell_type": "VM",
+                    "target": {"vm_id": 1},
+                    "username": shell_user_no_vm_role.username,
+                    "error": "missing required role: VM_WRITE",
+                },
+                "success": False,
+            }
+        ]
+    ):
+        resp = _attempt_shell_connect(token, options={"vm_id": 1})
+        assert resp["msg"] == "failed"
+
+
+def test_missing_container_role_audited(shell_user_no_container_role):
+    token = _make_token(shell_user_no_container_role)
+    with expect_audit_log(
+        [
+            {
+                "event": "WEBSHELL_AUTHENTICATION",
+                "event_data": {
+                    "shell_type": "CONTAINER",
+                    "target": {"container_id": 1},
+                    "username": shell_user_no_container_role.username,
+                    "error": "missing required role: CONTAINER_WRITE",
+                },
+                "success": False,
+            }
+        ]
+    ):
+        resp = _attempt_shell_connect(token, options={"container_id": 1})
+        assert resp["msg"] == "failed"
+
+
+def test_missing_apps_role_audited(shell_user_no_apps_role):
+    token = _make_token(shell_user_no_apps_role)
+    with expect_audit_log(
+        [
+            {
+                "event": "WEBSHELL_AUTHENTICATION",
+                "event_data": {
+                    "shell_type": "APP",
+                    "target": {"app_name": "x", "container_id": "y"},
+                    "username": shell_user_no_apps_role.username,
+                    "error": "missing required role: APPS_WRITE",
+                },
+                "success": False,
+            }
+        ]
+    ):
+        resp = _attempt_shell_connect(
+            token, options={"app_name": "x", "container_id": "y"}
+        )
+        assert resp["msg"] == "failed"


### PR DESCRIPTION
The shell websocket handler used to wrap VM/APP/CONTAINER commands in `sudo -H -u <user>` for users without ALL-sudo, then run unwrapped otherwise. In practice the wrapped form failed at root-owned libvirt/ docker sockets, so authorization was effectively "do you have unrestricted sudo?" — coarse, surprising, and not auditable. The reason why we did this historically was because the shell feature here was added before we actually had RBAC.

Replace it with an explicit role gate keyed on the requested shell type:

  HOST       -> web_shell privilege only (unchanged) -- login as user
  VM         -> web_shell + VM_WRITE
  CONTAINER  -> web_shell + CONTAINER_WRITE
  APP        -> web_shell + APPS_WRITE

`auth.get_token_for_shell_application` now takes the shell_type and returns structured errors (WEB_SHELL_DENIED, MISSING_ROLE) along with the credentials, so the handler can attribute the failure to a user and emit a precise denial reason. Commands always run as middleware (root) once the role check passes — equivalent to what these roles already grant via VM/container/app create paths.

Emit two new audit events for the connection lifecycle:
  WEBSHELL_AUTHENTICATION  - success and every failure mode
  WEBSHELL_LOGOUT          - on disconnect of an authenticated session

Tests cover the success path, web_shell-denied path, and each missing-role path, asserting the corresponding audit records.

Original PR: https://github.com/truenas/middleware/pull/18950
