### PR TITLE
NAS-141089 / 27.0.0-BETA.1 / Fix FILESYSTEM duplicate-target check for path variants

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/test_libvirt_device_uniqueness.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_libvirt_device_uniqueness.py
@@ -194,6 +194,34 @@ def test_extract_identity_filesystem_target():
     assert _extract_identity(device) == '/media'
 
 
+@pytest.mark.parametrize('target,expected', [
+    ('/mnt/tank/', '/mnt/tank'),
+    ('/mnt/tank', '/mnt/tank'),
+    ('/mnt/tank//', '/mnt/tank'),
+    ('/mnt/tank/./', '/mnt/tank'),
+    ('/mnt//tank', '/mnt/tank'),
+    ('/media/', '/media'),
+])
+def test_extract_identity_filesystem_target_normalized(target, expected):
+    device = {'attributes': {'dtype': 'FILESYSTEM', 'target': target, 'source': '/mnt/tank/shares'}}
+    assert _extract_identity(device) == expected
+
+
+def test_extract_identity_filesystem_target_missing():
+    device = {'attributes': {'dtype': 'FILESYSTEM', 'source': '/mnt/tank/shares'}}
+    assert _extract_identity(device) is None
+
+
+def test_container_filesystem_duplicate_target_trailing_slash():
+    """A FILESYSTEM whose target differs from an existing one only by trailing slash must collide."""
+    new_fs = {'attributes': {
+        'dtype': 'FILESYSTEM', 'source': '/mnt/tank/other', 'target': '/media/',
+    }}
+    assert device_uniqueness_check(
+        new_fs, CONTAINER_INSTANCE, ('DISK', 'RAW', 'CDROM', 'FILESYSTEM'),
+    ) is False
+
+
 def test_extract_identity_usb_device_path_priority():
     """Host device path should take priority over vendor:product."""
     device = {'attributes': {

--- a/src/middlewared/middlewared/utils/libvirt/utils.py
+++ b/src/middlewared/middlewared/utils/libvirt/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 from truenas_pylibvirt.utils.usb import find_usb_device_by_ids
@@ -22,7 +23,9 @@ def _extract_identity(device: dict[str, Any]) -> str | None:
         case 'DISK' | 'RAW' | 'CDROM':
             return translate_device(device)
         case 'FILESYSTEM':
-            return device['attributes'].get('target')
+            if target := device['attributes'].get('target'):
+                return os.path.normpath(target)
+            return None
         case 'PCI':
             return device['attributes'].get('pptdev')
         case 'GPU':


### PR DESCRIPTION
## Problem

The container `FILESYSTEM` device uniqueness check compares the `target` field as a raw string. As a result, paths that differ only by trivial formatting differences—such as trailing slashes, duplicate slashes, or `./` segments—are treated as distinct values.

This allows multiple `FILESYSTEM` devices to be added with effectively the same mount target (e.g. `/mnt/tank` and `/mnt/tank/`), bypassing duplicate-target validation in `FilesystemDelegate.validate_middleware`.

## Solution

Canonicalize filesystem targets using `os.path.normpath` before returning them from `_extract_identity`, ensuring equivalent paths resolve to the same identity.

Also preserve the existing `str | None` contract by guarding against missing or empty target values.
