### PR TITLE
NAS-141091 / 27.0.0-BETA.1 / Remove duplicate grub render at boot

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -275,7 +275,7 @@ class EtcService(Service):
             EtcEntry(renderer_type=RendererType.MAKO, path='cron.d/middlewared', checkpoint=Checkpoint.POOL_IMPORT),
         )),
         'grub': EtcGroup(entries=(
-            EtcEntry(renderer_type=RendererType.PY, path='grub', checkpoint=Checkpoint.POST_INIT),
+            EtcEntry(renderer_type=RendererType.PY, path='grub', checkpoint=None),
         )),
         'fips': EtcGroup(entries=(
             EtcEntry(renderer_type=RendererType.PY, path='fips', checkpoint=None),


### PR DESCRIPTION
This commit fixes an issue where on boot two listeners on the `system.ready` event both rendered grub: `etc.generate_checkpoint(POST_INIT)` (via `etc.py`) and `grub_config._reconcile`. Both invoked `write_grub_config` and `grub-mkconfig` concurrently, racing on `/boot/grub/grub.cfg.tmp(.new)` and occasionally producing the "grub-mkconfig error: Generating grub configuration file ..." failure with no diagnostic stderr.

The grub entry is now registered with `checkpoint=None`, so it is skipped during checkpoint-driven boot generation. `_reconcile` becomes the sole boot-time path and only invokes `grub-mkconfig` when `truenas.cfg` content actually changes. Runtime triggers in `system_advanced/serial.py` and `system_vendor/vendor.py` (which call `etc.generate('grub')` directly, without a checkpoint) are unaffected, as is HA propagation via `failover.call_remote('etc.generate', ['grub'])`.