### PR TITLE
NAS-141094 / 27.0.0-BETA.1 / mark auth.login and auth.login_with_api_key removed_in v27

### DIFF
--- a/docs/source/accounts/scram_authentication.rst
+++ b/docs/source/accounts/scram_authentication.rst
@@ -61,7 +61,7 @@ Creating an API Key (TrueNAS 26+)
 
     # Authenticate with username/password or existing credentials
     with Client() as c:
-        c.call('auth.login', 'root', 'password')
+        c.login_with_password('root', 'password')
 
         # Create new API key
         api_key_data = c.call('api_key.create', {
@@ -752,7 +752,10 @@ Common error responses:
   Server signature verification failed - possible man-in-the-middle attack.
 
 **Method does not exist:**
-  Server doesn't support ``auth.login_ex`` (pre-SCRAM version). Use legacy ``auth.login_with_api_key`` method.
+  Server doesn't support ``auth.login_ex`` (pre-SCRAM version). The legacy ``auth.login_with_api_key``
+  method may still be available on those older servers (it was removed from the v27 API). Custom
+  clients that need to support older servers can use ``auth.login_with_api_key`` as a fallback for
+  pre-25.04 versions while preferring ``auth.login_ex`` for modern servers.
 
 **Invalid nonce:**
   Server nonce doesn't start with client nonce - protocol violation.

--- a/src/middlewared/middlewared/docs/index.rst
+++ b/src/middlewared/middlewared/docs/index.rst
@@ -91,15 +91,20 @@ Server answers with either `connected` or `failed`.
 Authentication
 ~~~~~~~~~~~~~~
 
-Authentication happens by calling the `auth.login` method.
+Authentication happens by calling the `auth.login_ex` method with the appropriate
+``mechanism`` (e.g. ``PASSWORD_PLAIN``, ``API_KEY_PLAIN``, ``TOKEN_PLAIN``, ``SCRAM``).
 
 Request:
 
     {
       "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
       "msg": "method",
-      "method": "auth.login",
-      "params": ["username", "password"]
+      "method": "auth.login_ex",
+      "params": [{
+        "mechanism": "PASSWORD_PLAIN",
+        "username": "username",
+        "password": "password"
+      }]
     }
 
 Response:
@@ -107,5 +112,5 @@ Response:
     {
       "id": "d8e715be-6bc7-11e6-8c28-00e04d680384",
       "msg": "result",
-      "result": true,
+      "result": {"response_type": "SUCCESS", ...}
     }

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -605,11 +605,15 @@ class AuthService(Service):
             'credentials': root_credentials,
         }
 
-    @api_method(AuthLoginArgs, AuthLoginResult, cli_private=True, authentication_required=False, pass_app=True)
+    @api_method(AuthLoginArgs, AuthLoginResult, cli_private=True, authentication_required=False, pass_app=True,
+                removed_in='v27')
     async def login(self, app, username, password, otp_token):
         """
         Authenticate session using username and password.
         `otp_token` must be specified if two factor authentication is enabled.
+
+        Deprecated and removed in v27. Use `auth.login_ex` with `mechanism="PASSWORD_PLAIN"`
+        (and `auth.login_ex_continue` with `mechanism="OTP_TOKEN"` for the second factor).
         """
 
         resp = await self.login_ex(app, {
@@ -1060,10 +1064,13 @@ class AuthService(Service):
         return response
 
     @api_method(AuthLoginWithApiKeyArgs, AuthLoginWithApiKeyResult, cli_private=True, authentication_required=False,
-                pass_app=True)
+                pass_app=True, removed_in='v27')
     async def login_with_api_key(self, app, api_key):
         """
         Authenticate session using API Key.
+
+        Deprecated and removed in v27. Use `auth.login_ex` with `mechanism="API_KEY_PLAIN"`
+        (or `mechanism="SCRAM"` for SCRAM-based authentication).
         """
         try:
             key_id = int(api_key.split('-')[0])

--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -192,7 +192,12 @@ def test_fields_are_visible_if_has_write_access():
 def test_fields_are_visible_for_api_key():
     with api_key() as key:
         with client(auth=None) as c:
-            assert c.call("auth.login_with_api_key", key)
+            resp = c.call("auth.login_ex", {
+                "mechanism": "API_KEY_PLAIN",
+                "username": "root",
+                "api_key": key,
+            })
+            assert resp["response_type"] == "SUCCESS"
             result = c.call("user.get_instance", 1)
 
     assert result["unixhash"] != REDACTED

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -97,7 +97,16 @@ def test_api_key_info(sharing_admin_user):
 @pytest.mark.parametrize('endpoint', ['LEGACY', 'CURRENT'])
 def test_api_key_session(sharing_admin_user, endpoint):
     with api_key(sharing_admin_user.username) as key:
-        with client(auth=None) as c:
+        match endpoint:
+            case 'LEGACY':
+                # auth.login_with_api_key was removed in v27; exercise it via an older API version.
+                client_kwargs = {'auth': None, 'version': 'v26.0.0'}
+            case 'CURRENT':
+                client_kwargs = {'auth': None}
+            case _:
+                raise ValueError(f'{endpoint}: unknown endpoint')
+
+        with client(**client_kwargs) as c:
             match endpoint:
                 case 'LEGACY':
                     assert c.call('auth.login_with_api_key', key)
@@ -108,8 +117,6 @@ def test_api_key_session(sharing_admin_user, endpoint):
                         'api_key': key
                     })
                     assert resp['response_type'] == 'SUCCESS'
-                case _:
-                    raise ValueError(f'{endpoint}: unknown endpoint')
 
             session = c.call('auth.sessions', [['current', '=', True]], {'get': True})
             assert session['credentials'] == 'API_KEY'

--- a/tests/api2/test_audit_websocket.py
+++ b/tests/api2/test_audit_websocket.py
@@ -497,7 +497,12 @@ def test_api_key_login():
                     "success": True,
                 }
             ], include_logins=True):
-                assert c.call("auth.login_with_api_key", key)
+                resp = c.call("auth.login_ex", {
+                    "mechanism": "API_KEY_PLAIN",
+                    "username": "root",
+                    "api_key": key,
+                })
+                assert resp["response_type"] == "SUCCESS"
 
 
 def test_api_key_login_failed():
@@ -509,16 +514,21 @@ def test_api_key_login_failed():
                     "credentials": {
                         "credentials": "API_KEY",
                         "credentials_data": {
-                            "api_key": "invalid_api_key",
-                            "username": None
+                            "api_key": "<INVALID>",
+                            "username": "root",
                         },
                     },
-                    "error": "Invalid API key",
+                    "error": "[PAM_AUTH_ERR]: pam_authenticate() failed",
                 },
                 "success": False,
             }
         ], include_logins=True):
-            c.call("auth.login_with_api_key", "invalid_api_key")
+            resp = c.call("auth.login_ex", {
+                "mechanism": "API_KEY_PLAIN",
+                "username": "root",
+                "api_key": "invalid_api_key",
+            })
+            assert resp["response_type"] == "AUTH_ERR"
 
 
 def test_2fa_login(sharing_admin_user):


### PR DESCRIPTION
Both methods are thin wrappers around auth.login_ex. Add removed_in='v27' to their @api_method decorators so they're invisible on v27 sessions while remaining reachable for v25/v26 callers via LegacyAPIMethod. Docstrings updated to point at auth.login_ex with the appropriate mechanism.

The primary motivation for this is to encourage users to switch to more secure authentication mechanisms for API key authentication. The deprecated endpoint is incapable of a challenge-response flow.