### PR TITLE
NAS-141095 / 27.0.0-BETA.1 / Sweep orphaned container runtime mounts at startup

### DIFF
--- a/src/middlewared/middlewared/plugins/container/__init__.py
+++ b/src/middlewared/middlewared/plugins/container/__init__.py
@@ -191,3 +191,12 @@ async def setup(middleware: Middleware) -> None:
     middleware.libvirt_domains_manager.containers.connection.register_domain_event_callback(
         functools.partial(domain_event_callback, middleware)
     )
+    if await middleware.call('system.ready'):
+        # Reconcile runtime state on every middleware startup. system.ready is
+        # only fired at first boot, so a `systemctl restart middlewared` would
+        # otherwise skip the boot-path reconcile. Idempotent; safe to run again
+        # from start_on_boot at boot time.
+        try:
+            await middleware.run_in_thread(middleware.libvirt_domains_manager.reconcile_runtime_state)
+        except Exception:
+            middleware.logger.error('Failed to reconcile container runtime state on startup', exc_info=True)

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -21,6 +21,14 @@ from .utils import container_instance_dataset_mountpoint, update_etc_hosts, writ
 
 
 def start_on_boot(context: ServiceContext) -> None:
+    # Reap orphaned runtime state under /run/truenas_containers/ before any
+    # autostart so a fresh start can't collide with a leaked staged path
+    # from a previous unclean shutdown (libvirtd or middlewared crash).
+    try:
+        context.middleware.libvirt_domains_manager.reconcile_runtime_state()
+    except Exception:
+        context.logger.error('Failed to reconcile container runtime state', exc_info=True)
+
     for container in context.call_sync2(
         context.s.container.query, [('autostart', '=', True)], QueryOptions(force_sql_filters=True)
     ):

--- a/src/middlewared/middlewared/test/integration/assets/container.py
+++ b/src/middlewared/middlewared/test/integration/assets/container.py
@@ -1,0 +1,128 @@
+import base64
+import contextlib
+import shlex
+import textwrap
+
+from middlewared.test.integration.utils import call, pool, ssh
+
+UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
+ALPINE_IMAGE_NAME = "alpine:edge:amd64:default"
+VIRSH = "virsh -c 'lxc:///system?socket=/run/truenas_libvirt/libvirt-sock'"
+
+
+def nsenter(container, command):
+    return shlex.join(call("container.nsenter", container["id"]) + [command])
+
+
+def resolve_image(name):
+    images = call("container.image.query_registry")
+    version = [image["versions"][-1]["version"] for image in images if image["name"] == name][0]
+    return {"name": name, "version": version}
+
+
+def configure_bridge():
+    call(
+        "lxc.update",
+        {
+            "v4_network": "10.47.214.0/24",
+            "v6_network": "fd42:3656:7be9:e46c::0/64",
+        },
+    )
+
+
+def get_mountpoint(dataset):
+    rv = call("zfs.resource.query", {"paths": [dataset], "properties": ["mountpoint"]})
+    return rv[0]["properties"]["mountpoint"]["value"]
+
+
+@contextlib.contextmanager
+def container(image, options=None, start=False, startup_script=None, name="test"):
+    options = options or {}
+
+    container = call(
+        "container.create",
+        {
+            "name": name,
+            "pool": pool,
+            "image": image,
+            **options,
+        },
+        job=True,
+    )
+    try:
+        mountpoint = get_mountpoint(container["dataset"])
+        if startup_script is not None:
+            ssh(f"mkdir -p {mountpoint}/var/spool/cron/crontabs")
+
+            call(
+                "filesystem.file_receive",
+                f"{mountpoint}/var/spool/cron/crontabs/root",
+                base64.b64encode(b"@reboot /script-wrapper.sh\n").decode("ascii"),
+                {"mode": 0o600},
+            )
+            call(
+                "filesystem.file_receive",
+                f"{mountpoint}/script-wrapper.sh",
+                base64.b64encode(
+                    textwrap.dedent("""\
+                    #!/bin/sh
+                    /script.sh > /.log 2>&1
+                    mv /.log /log
+                """).encode("ascii")
+                ).decode("ascii"),
+                {"mode": 0o755},
+            )
+            call(
+                "filesystem.file_receive",
+                f"{mountpoint}/script.sh",
+                base64.b64encode(startup_script.encode("ascii")).decode("ascii"),
+                {"mode": 0o755},
+            )
+
+        if start:
+            call("container.start", container["id"])
+
+            container = call("container.get_instance", container["id"])
+            assert container["status"]["state"] == "RUNNING"
+
+        yield container
+    finally:
+        if call("container.get_instance", container["id"])["status"]["state"] == "RUNNING":
+            call("container.stop", container["id"], {"force": True}, job=True)
+        call("container.delete", container["id"])
+
+        #  Id   Name   State
+        # --------------------
+        assert container["uuid"] not in ssh(f"{VIRSH} list --all")
+
+
+@contextlib.contextmanager
+def filesystem_device(container_id, source, target):
+    """Attach a FILESYSTEM device for the lifetime of the block.
+
+    container.device.delete requires the container to be STOPPED, so on exit
+    we force-stop the container (if still present and running) before deleting
+    the device. If the container was deleted by an outer context manager
+    already, we silently skip cleanup.
+    """
+    device = call(
+        "container.device.create",
+        {
+            "container": container_id,
+            "attributes": {
+                "dtype": "FILESYSTEM",
+                "source": source,
+                "target": target,
+            },
+        },
+    )
+    try:
+        yield device
+    finally:
+        try:
+            instance = call("container.get_instance", container_id)
+        except Exception:
+            return
+        if instance["status"]["state"] == "RUNNING":
+            call("container.stop", container_id, {"force": True}, job=True)
+        call("container.device.delete", device["id"])

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -1,9 +1,7 @@
-import base64
 import contextlib
 import itertools
 import json
 import re
-import shlex
 import textwrap
 import time
 
@@ -15,12 +13,19 @@ from middlewared.test.integration.assets.account import (
     group as account_group,
     user as account_user,
 )
+from middlewared.test.integration.assets.container import (
+    ALPINE_IMAGE_NAME,
+    UBUNTU_IMAGE_NAME,
+    configure_bridge,
+    container,
+    filesystem_device,
+    get_mountpoint,
+    nsenter,
+    resolve_image,
+)
 from middlewared.test.integration.assets.pool import another_pool, pool
 from middlewared.test.integration.utils import call, host, ssh, websocket_url
 
-UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
-ALPINE_IMAGE_NAME = "alpine:edge:amd64:default"
-VIRSH = "virsh -c 'lxc:///system?socket=/run/truenas_libvirt/libvirt-sock'"
 # Capabilities necessary to launch a basic LXC container from linuxcontainers.org
 BASIC_CAPABILITIES = {
     # Capabilities enabled in a default docker container
@@ -43,15 +48,6 @@ BASIC_CAPABILITIES = {
 }
 
 
-def get_mountpoint(dataset):
-    rv = call("zfs.resource.query", {"paths": [dataset], "properties": ["mountpoint"]})
-    return rv[0]["properties"]["mountpoint"]["value"]
-
-
-def nsenter(container, command):
-    return shlex.join(call("container.nsenter", container["id"]) + [command])
-
-
 def script_output(container):
     for i in range(30):
         result = ssh(
@@ -71,96 +67,17 @@ def bounding_set(capsh_print):
 
 @pytest.fixture(scope="module", autouse=True)
 def bridge():
-    call(
-        "lxc.update",
-        {
-            "v4_network": "10.47.214.0/24",
-            "v6_network": "fd42:3656:7be9:e46c::0/64",
-        },
-    )
+    configure_bridge()
 
 
 @pytest.fixture(scope="module")
 def ubuntu_image():
-    images = call("container.image.query_registry")
-    version = [
-        image["versions"][-1]["version"]
-        for image in images
-        if image["name"] == UBUNTU_IMAGE_NAME
-    ][0]
-
-    yield {"name": UBUNTU_IMAGE_NAME, "version": version}
+    yield resolve_image(UBUNTU_IMAGE_NAME)
 
 
 @pytest.fixture(scope="module")
 def alpine_image():
-    images = call("container.image.query_registry")
-    version = [
-        image["versions"][-1]["version"]
-        for image in images
-        if image["name"] == ALPINE_IMAGE_NAME
-    ][0]
-
-    yield {"name": ALPINE_IMAGE_NAME, "version": version}
-
-
-@contextlib.contextmanager
-def container(image, options=None, start=False, startup_script=None):
-    options = options or {}
-
-    container = call(
-        "container.create",
-        {
-            "name": "test",
-            "pool": pool,
-            "image": image,
-            **options,
-        },
-        job=True,
-    )
-    try:
-        mountpoint = get_mountpoint(container["dataset"])
-        if startup_script is not None:
-            ssh(f"mkdir -p {mountpoint}/var/spool/cron/crontabs")
-
-            call(
-                "filesystem.file_receive",
-                f"{mountpoint}/var/spool/cron/crontabs/root",
-                base64.b64encode(b"@reboot /script-wrapper.sh\n").decode("ascii"),
-                {"mode": 0o600},
-            )
-            call(
-                "filesystem.file_receive",
-                f"{mountpoint}/script-wrapper.sh",
-                base64.b64encode(
-                    textwrap.dedent("""\
-                    #!/bin/sh
-                    /script.sh > /.log 2>&1
-                    mv /.log /log
-                """).encode("ascii")
-                ).decode("ascii"),
-                {"mode": 0o755},
-            )
-            call(
-                "filesystem.file_receive",
-                f"{mountpoint}/script.sh",
-                base64.b64encode(startup_script.encode("ascii")).decode("ascii"),
-                {"mode": 0o755},
-            )
-
-        if start:
-            call("container.start", container["id"])
-
-            container = call("container.get_instance", container["id"])
-            assert container["status"]["state"] == "RUNNING"
-
-        yield container
-    finally:
-        call("container.delete", container["id"])
-
-        #  Id   Name   State
-        # --------------------
-        assert container["uuid"] not in ssh(f"{VIRSH} list --all")
+    yield resolve_image(ALPINE_IMAGE_NAME)
 
 
 @pytest.fixture(scope="function")
@@ -396,21 +313,11 @@ def test_default_idmap_passes_apps_user_through(ubuntu_image):
     # the visible UID, not the rootfs's identity round-trip).
     with bind_share_with_file(568, 568, fname="apps_file") as share:
         with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
-            call(
-                "container.device.create",
-                {
-                    "container": c["id"],
-                    "attributes": {
-                        "dtype": "FILESYSTEM",
-                        "source": share,
-                        "target": "/share",
-                    },
-                },
-            )
-            call("container.start", c["id"])
-            c = call("container.get_instance", c["id"])
-            assert c["status"]["state"] == "RUNNING"
-            assert _stat_inside(c, "/share/apps_file") == "568 568"
+            with filesystem_device(c["id"], share, "/share"):
+                call("container.start", c["id"])
+                c = call("container.get_instance", c["id"])
+                assert c["status"]["state"] == "RUNNING"
+                assert _stat_inside(c, "/share/apps_file") == "568 568"
 
 
 def test_default_idmap_picks_up_custom_user_direct(ubuntu_image):
@@ -429,21 +336,11 @@ def test_default_idmap_picks_up_custom_user_direct(ubuntu_image):
 
             with bind_share_with_file(uid, gid) as share:
                 with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
-                    call(
-                        "container.device.create",
-                        {
-                            "container": c["id"],
-                            "attributes": {
-                                "dtype": "FILESYSTEM",
-                                "source": share,
-                                "target": "/share",
-                            },
-                        },
-                    )
-                    call("container.start", c["id"])
-                    c = call("container.get_instance", c["id"])
-                    assert c["status"]["state"] == "RUNNING"
-                    assert _stat_inside(c, "/share/file") == f"{uid} {gid}"
+                    with filesystem_device(c["id"], share, "/share"):
+                        call("container.start", c["id"])
+                        c = call("container.get_instance", c["id"])
+                        assert c["status"]["state"] == "RUNNING"
+                        assert _stat_inside(c, "/share/file") == f"{uid} {gid}"
 
 
 def test_default_idmap_picks_up_custom_user_numeric(ubuntu_image):
@@ -461,21 +358,11 @@ def test_default_idmap_picks_up_custom_user_numeric(ubuntu_image):
 
         with bind_share_with_file(uid, 0) as share:
             with container(ubuntu_image, {"idmap": {"type": "DEFAULT"}}) as c:
-                call(
-                    "container.device.create",
-                    {
-                        "container": c["id"],
-                        "attributes": {
-                            "dtype": "FILESYSTEM",
-                            "source": share,
-                            "target": "/share",
-                        },
-                    },
-                )
-                call("container.start", c["id"])
-                c = call("container.get_instance", c["id"])
-                assert c["status"]["state"] == "RUNNING"
-                assert _stat_inside(c, "/share/file").split()[0] == str(target)
+                with filesystem_device(c["id"], share, "/share"):
+                    call("container.start", c["id"])
+                    c = call("container.get_instance", c["id"])
+                    assert c["status"]["state"] == "RUNNING"
+                    assert _stat_inside(c, "/share/file").split()[0] == str(target)
 
 
 def test_isolated_idmap_ignores_account_passthrough(ubuntu_image):
@@ -485,24 +372,14 @@ def test_isolated_idmap_ignores_account_passthrough(ubuntu_image):
         with container(
             ubuntu_image, {"idmap": {"type": "ISOLATED", "slice": 1}}
         ) as c:
-            call(
-                "container.device.create",
-                {
-                    "container": c["id"],
-                    "attributes": {
-                        "dtype": "FILESYSTEM",
-                        "source": share,
-                        "target": "/share",
-                    },
-                },
-            )
-            call("container.start", c["id"])
-            c = call("container.get_instance", c["id"])
-            assert c["status"]["state"] == "RUNNING"
-            inside = _stat_inside(c, "/share/apps_file")
-            assert inside != "568 568", (
-                f"ISOLATED container leaked apps passthrough: {inside}"
-            )
+            with filesystem_device(c["id"], share, "/share"):
+                call("container.start", c["id"])
+                c = call("container.get_instance", c["id"])
+                assert c["status"]["state"] == "RUNNING"
+                inside = _stat_inside(c, "/share/apps_file")
+                assert inside != "568 568", (
+                    f"ISOLATED container leaked apps passthrough: {inside}"
+                )
 
 
 @pytest.mark.parametrize(

--- a/tests/api2/test_container_acl.py
+++ b/tests/api2/test_container_acl.py
@@ -1,5 +1,3 @@
-import contextlib
-import shlex
 from copy import deepcopy
 
 import pytest
@@ -8,61 +6,31 @@ from middlewared.test.integration.assets.account import (
     group as account_group,
     user as account_user,
 )
-from middlewared.test.integration.assets.pool import dataset, pool
+from middlewared.test.integration.assets.container import (
+    UBUNTU_IMAGE_NAME,
+    configure_bridge,
+    container,
+    filesystem_device,
+    nsenter,
+    resolve_image,
+)
+from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, ssh
-
-UBUNTU_IMAGE_NAME = "ubuntu:noble:amd64:default"
 
 
 @pytest.fixture(scope="module", autouse=True)
 def bridge():
-    call(
-        "lxc.update",
-        {
-            "v4_network": "10.47.214.0/24",
-            "v6_network": "fd42:3656:7be9:e46c::0/64",
-        },
-    )
+    configure_bridge()
 
 
 @pytest.fixture(scope="module")
 def ubuntu_image():
-    images = call("container.image.query_registry")
-    version = [
-        image["versions"][-1]["version"]
-        for image in images
-        if image["name"] == UBUNTU_IMAGE_NAME
-    ][0]
-    yield {"name": UBUNTU_IMAGE_NAME, "version": version}
-
-
-def nsenter(container, command):
-    return shlex.join(call("container.nsenter", container["id"]) + [command])
-
-
-@contextlib.contextmanager
-def _container(image, name="acltest", **options):
-    c = call(
-        "container.create",
-        {
-            "name": name,
-            "pool": pool,
-            "image": image,
-            **options,
-        },
-        job=True,
-    )
-    try:
-        yield c
-    finally:
-        if call("container.get_instance", c["id"])["status"]["state"] == "RUNNING":
-            call("container.stop", c["id"], {"force": True}, job=True)
-        call("container.delete", c["id"])
+    yield resolve_image(UBUNTU_IMAGE_NAME)
 
 
 @pytest.fixture(scope="module")
 def instance(ubuntu_image):
-    with _container(ubuntu_image, name="acltest") as c:
+    with container(ubuntu_image, name="acltest") as c:
         yield c
 
 
@@ -81,33 +49,15 @@ def nfs4acl_dataset(instance):
             call("group.update", g["id"], {"userns_idmap": "DIRECT"})
 
             with dataset("virtnfsshare", {"share_type": "SMB"}) as ds:
-                fs_device = call(
-                    "container.device.create",
-                    {
-                        "container": instance["id"],
-                        "attributes": {
-                            "dtype": "FILESYSTEM",
-                            "source": f"/mnt/{ds}",
-                            "target": "/nfs4acl",
-                        },
-                    },
-                )
-                try:
+                with filesystem_device(instance["id"], f"/mnt/{ds}", "/nfs4acl"):
                     call("container.start", instance["id"])
-                    try:
-                        yield {
-                            "instance": call("container.get_instance", instance["id"]),
-                            "user": u,
-                            "group": g,
-                            "dataset": ds,
-                            "dev": "/nfs4acl",
-                        }
-                    finally:
-                        call(
-                            "container.stop", instance["id"], {"force": True}, job=True
-                        )
-                finally:
-                    call("container.device.delete", fs_device["id"])
+                    yield {
+                        "instance": call("container.get_instance", instance["id"]),
+                        "user": u,
+                        "group": g,
+                        "dataset": ds,
+                        "dev": "/nfs4acl",
+                    }
 
 
 def create_container_users(c, uid, gid):

--- a/tests/api2/test_container_filesystem_child_mounts.py
+++ b/tests/api2/test_container_filesystem_child_mounts.py
@@ -1,0 +1,131 @@
+import contextlib
+
+import pytest
+
+from middlewared.test.integration.assets.container import (
+    UBUNTU_IMAGE_NAME,
+    configure_bridge,
+    container,
+    filesystem_device,
+    nsenter,
+    resolve_image,
+)
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    configure_bridge()
+
+
+@pytest.fixture(scope="module")
+def ubuntu_image():
+    yield resolve_image(UBUNTU_IMAGE_NAME)
+
+
+@contextlib.contextmanager
+def parent_with_child_dataset():
+    # Lays down a parent ZFS dataset with one auto-mounted child dataset
+    # underneath, plus a sentinel file on each so callers can distinguish
+    # "parent contents visible" from "child contents leaked".
+    with dataset("childmount_parent", mode="0o777") as parent:
+        parent_path = f"/mnt/{parent}"
+        ssh(
+            f": > {parent_path}/parent_sentinel && "
+            f"chmod 0666 {parent_path}/parent_sentinel"
+        )
+        with dataset("childmount_parent/child", mode="0o777") as child:
+            child_path = f"/mnt/{child}"
+            ssh(
+                f": > {child_path}/child_sentinel && "
+                f"chmod 0666 {child_path}/child_sentinel"
+            )
+            yield {
+                "parent_path": parent_path,
+                "parent_sentinel": "parent_sentinel",
+                "child_subdir": "child",
+                "child_sentinel": "child_sentinel",
+            }
+
+
+@pytest.mark.parametrize(
+    "idmap",
+    [
+        pytest.param({"type": "DEFAULT"}, id="default-idmap"),
+        pytest.param({"type": "ISOLATED", "slice": 1}, id="isolated-idmap"),
+    ],
+)
+def test_container_starts_with_filesystem_source_having_child_mounts(
+    ubuntu_image,
+    idmap,
+):
+    # Regression guard for truenas_pylibvirt fdce747: pre-fix, attaching a
+    # parent ZFS dataset (with auto-mounted child datasets under it) as a
+    # FilesystemDevice to an ISOLATED container failed with EINVAL during
+    # MS_BIND because libvirt-LXC's non-recursive bind hit the locked child
+    # submounts. The fix stages the source via open_tree + MS_SLAVE +
+    # move_mount before libvirt sees it.
+    with parent_with_child_dataset() as ds_info:
+        with container(ubuntu_image, {"idmap": idmap}) as c:
+            with filesystem_device(c["id"], ds_info["parent_path"], "/share"):
+                call("container.start", c["id"])
+                c = call("container.get_instance", c["id"])
+                assert c["status"]["state"] == "RUNNING"
+
+                ls_parent = ssh(nsenter(c, "ls /share")).split()
+                assert ds_info["parent_sentinel"] in ls_parent
+
+                # Documented trade-off: non-recursive bind hides child dataset
+                # contents. The child mountpoint dir may or may not be visible,
+                # but child_sentinel MUST NOT be reachable.
+                ls_child = ssh(
+                    nsenter(c, f"ls /share/{ds_info['child_subdir']}"),
+                    check=False,
+                    complete_response=True,
+                )
+                if ls_child["returncode"] == 0:
+                    assert (
+                        ds_info["child_sentinel"] not in ls_child["stdout"].split()
+                    ), (
+                        "Child dataset leaked into container despite non-recursive "
+                        "bind staging (pylibvirt fdce747 trade-off regressed)"
+                    )
+
+
+def test_filesystem_child_mount_runtime_state_cleaned_on_stop(ubuntu_image):
+    # The fix stages FilesystemDevice sources under /run/truenas_containers/
+    # devices/<uuid>/<slug>. After container stop, pylibvirt's
+    # runtime.cleanup_for_uuid (driven by the libvirt STOPPED event) removes
+    # the staged tree. This test asserts both the "exists while running" and
+    # "gone after stop" invariants on the VM.
+    with parent_with_child_dataset() as ds_info:
+        with container(
+            ubuntu_image,
+            {"idmap": {"type": "ISOLATED", "slice": 1}},
+        ) as c:
+            with filesystem_device(c["id"], ds_info["parent_path"], "/share"):
+                call("container.start", c["id"])
+                c = call("container.get_instance", c["id"])
+                uuid = c["uuid"]
+                staged_root = f"/run/truenas_containers/devices/{uuid}"
+
+                running_check = ssh(
+                    f"test -d {staged_root}",
+                    check=False,
+                    complete_response=True,
+                )
+                assert running_check["returncode"] == 0, (
+                    f"{staged_root} missing while container is running"
+                )
+
+                call("container.stop", c["id"], {"force": True}, job=True)
+
+                gone_check = ssh(
+                    f"test -e {staged_root}",
+                    check=False,
+                    complete_response=True,
+                )
+                assert gone_check["returncode"] != 0, (
+                    f"{staged_root} not cleaned up after container stop"
+                )


### PR DESCRIPTION
## Context

The most recent `truenas_pylibvirt` change ([truenas/truenas_pylibvirt#49](https://github.com/truenas/truenas_pylibvirt/pull/49)) fixed a regression where an unprivileged container (`ISOLATED` idmap) with a `FilesystemDevice` whose source is a parent ZFS dataset with auto-mounted child datasets failed to start with `EINVAL` during `MS_BIND` — libvirt-LXC's hard-coded non-recursive bind hits the locked submounts produced by ZFS auto-mounts in the less-privileged user namespace. The fix stages the source via `open_tree()` → `mount_setattr(MS_SLAVE, AT_RECURSIVE)` → `move_mount()` before libvirt sees it, rewriting the source to `/run/truenas_containers/devices/<uuid>/<slug>`. It also introduces `DomainManagers.reconcile_runtime_state()` for sweeping orphaned runtime state, which the middleware must call once at process startup.

This PR wires that startup hook into middleware and adds end-to-end regression coverage so the bug can't silently come back.
