### PR TITLE
NAS-140984 / 26.0.0-BETA.2 / Active Directory: fix rejoin, harden reset/recover, improve diagnostics (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf.py
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.py
@@ -35,7 +35,11 @@ def generate_krb5_conf(
         raise FileShouldNotExist
 
     default_realm = ds_config['kerberos_realm']
-    kdc_override = kdc_saf_cache_get()
+    # Only the IP from the SAF cache is usable in a krb5.conf kdc= line. If we only have
+    # a hostname (legacy or IPA-only entries) we leave kdc_override unset and fall through
+    # to whatever the realm config / DNS lookup provides.
+    saf_entry = kdc_saf_cache_get()
+    kdc_override = saf_entry.get('ip') if saf_entry else None
 
     match directory_service['type']:
         case DSType.AD.value | DSType.IPA.value:

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
@@ -1,6 +1,8 @@
 import errno
 import subprocess
 
+import wbclient
+
 from base64 import b64decode
 from middlewared.utils.directoryservices.ad import get_domain_info
 from middlewared.utils.directoryservices.ad_constants import (
@@ -23,6 +25,21 @@ from middlewared.utils.directoryservices.krb5_error import KRB5Error, KRB5ErrCod
 from middlewared.plugins.idmap_.idmap_winbind import WBClient
 from middlewared.service_exception import CallError, MatchNotFound
 
+# NTSTATUS strings embedded in a WBC_ERR_AUTH_ERROR message from wbcPingDc2 that
+# plausibly indicate a bad/missing secrets.tdb machine-account secret. The
+# message format is set by samba/nsswitch/py_wbclient.c:540 as
+# "...error code was {NT_STATUS_*} (0x...)". Other ping_dc failure modes
+# (transport timeouts, downgrade detection, RPC plumbing) cannot be refined by
+# rerunning a kinit, so we skip the expensive password test for those. See
+# samba/source3/winbindd/winbindd_cm.c (cm_connect_netlogon) and
+# samba/libcli/auth/netlogon_creds_cli.c for the originating call sites.
+_AUTH_NTSTATUS_SUGGEST_BAD_SECRET = frozenset({
+    'NT_STATUS_ACCESS_DENIED',
+    'NT_STATUS_CANT_ACCESS_DOMAIN_INFO',
+    'NT_STATUS_NO_TRUST_LSA_SECRET',
+    'NT_STATUS_NO_TRUST_SAM_ACCOUNT',
+})
+
 
 class ADHealthMixin:
 
@@ -39,13 +56,16 @@ class ADHealthMixin:
         domain = ds_config['kerberos_realm'] or ds_config['configuration']['domain']
 
         # Write temporary krb5.conf targeting kdc. Since this is a health check we
-        # don't want to introduce a server affinity
+        # don't want to introduce a server affinity. Mirror the AD-specific defaults
+        # the system krb5.conf uses (NAS-138687) so the test runs under equivalent rules.
         krbconf = KRB5Conf()
         krbconf.add_libdefaults({
             str(KRB_LibDefaults.DEFAULT_REALM): domain.upper(),
             str(KRB_LibDefaults.DNS_LOOKUP_REALM): 'false',
             str(KRB_LibDefaults.FORWARDABLE): 'true',
-            str(KRB_LibDefaults.DEFAULT_CCACHE_NAME): PERSISTENT_KEYRING_PREFIX + '%{uid}'
+            str(KRB_LibDefaults.DEFAULT_CCACHE_NAME): PERSISTENT_KEYRING_PREFIX + '%{uid}',
+            str(KRB_LibDefaults.RDNS): 'false',
+            str(KRB_LibDefaults.DNS_CANONICALIZE_HOSTNAME): 'false',
         })
         krbconf.add_realms([{
             'realm': domain.upper(),
@@ -63,30 +83,34 @@ class ADHealthMixin:
         }
 
         try:
-            kinit_with_cred(cred, ccache=krb5ccache.TEMP.value)
-        except CallError as exc:
-            if exc.errno != errno.ENOENT:
-                raise
+            try:
+                kinit_with_cred(cred, ccache=krb5ccache.TEMP.value)
+            except CallError as exc:
+                if exc.errno != errno.ENOENT:
+                    raise
 
-            # This is a spurious error raised because of issues with python-gssapi
-            # kinit_with_cred attempts to return details from the generated ccache.
-            # We get a CallError with ENOENT if the kinit was *successful* but the
-            # subsequent attempt to read the ccache failed. This happens periodically
-            # during the health check and is hard to predict. Since the error occurs
-            # after a successful kinit, we can safely ignore here because the goal
-            # is to simply validate credentials.
-            pass
+                # This is a spurious error raised because of issues with python-gssapi
+                # kinit_with_cred attempts to return details from the generated ccache.
+                # We get a CallError with ENOENT if the kinit was *successful* but the
+                # subsequent attempt to read the ccache failed. This happens periodically
+                # during the health check and is hard to predict. Since the error occurs
+                # after a successful kinit, we can safely ignore here because the goal
+                # is to simply validate credentials.
+                pass
+        finally:
+            # remove our ticket and restore the system krb5.conf even if kinit raised
+            # KRB5Error -- otherwise the temporary minimal config remains as the system
+            # krb5.conf and pollutes downstream operations until the next unrelated
+            # kerberos regeneration triggers.
+            try:
+                self.middleware.call_sync('kerberos.kdestroy', {'ccache': 'TEMP'})
+            except Exception:
+                # This ccache path is not world-readable and so worst-case we have an
+                # extra file on tmpfs
+                self.logger.debug('Failed to destroy temporary ccache', exc_info=True)
 
-        # remove our ticket
-        try:
-            self.middleware.call_sync('kerberos.kdestroy', {'ccache': 'TEMP'})
-        except Exception:
-            # This ccache path is not world-readable and so worst-case we have an
-            # extra file on tmpfs
-            self.logger.debug('Failed to destroy temporary ccache', exc_info=True)
-
-        # regenerate krb5.conf
-        self.middleware.call_sync('etc.generate', 'kerberos')
+            # regenerate krb5.conf
+            self.middleware.call_sync('etc.generate', 'kerberos')
 
     def _recover_keytab(self) -> None:
         """
@@ -127,9 +151,12 @@ class ADHealthMixin:
             smb_config['workgroup']
         )
 
-        # libads may select a different KDC than the one we used for join. This can happen if we fail over shortly
-        # after joining AD or a machine account password change.
-        kdc_override = kdc_saf_cache_get() or domain_info['kdc_server']
+        # Prefer the KDC pinned in the SAF cache (set during bind / last successful kinit) over
+        # whatever libads picks now -- this avoids an RDNS lookup against potentially shaky domain
+        # DNS and keeps us talking to the same DC across recovery operations.
+        # Only the IP is usable as a krb5 kdc= override; hostnames are not.
+        saf_entry = kdc_saf_cache_get()
+        kdc_override = (saf_entry and saf_entry.get('ip')) or domain_info['kdc_server']
 
         try:
             self._test_machine_account_password(kdc_override, machine_pass)
@@ -144,11 +171,11 @@ class ADHealthMixin:
                         "controllers do not agree about the list of computer accounts. "
                         "You may need to re-join TrueNAS to Active Directory. "
                     )
-                case KRB5ErrCode.KRB5_PREAUTH_FAILED:
+                case KRB5ErrCode.KRB5KDC_ERR_PREAUTH_FAILED:
                     faulted_reason = (
                         f"The domain controller at {kdc_override} said that the "
                         "TrueNAS computer account credentials are not valid. This means that "
-                        "saved credentials on TrueNAS do not match the credentials expected by"
+                        "saved credentials on TrueNAS do not match the credentials expected by "
                         "the domain controller. This can happen if the TrueNAS configuration was "
                         "restored from a backup, if the domain controllers in the domain do "
                         "not agree about the credentials, or if someone changed the TrueNAS "
@@ -238,25 +265,6 @@ class ADHealthMixin:
                 faulted_reason
             )
 
-        if domain_info:
-            try:
-                self._test_machine_account_password(
-                    domain_info['kdc_server'],
-                    machine_pass
-                )
-            except (CallError, KRB5Error):
-                self.logger.warning('Check for machine account password validity failed', exc_info=True)
-
-                faulted_reason = (
-                    'Stored machine account secret is invalid. This may indicate that '
-                    'the machine account password was reset in Active Directory without '
-                    'corresponding changes being made to the TrueNAS server configuration.'
-                )
-                raise ADHealthError(
-                    ADHealthCheckFailReason.AD_SECRET_INVALID,
-                    faulted_reason
-                )
-
         try:
             self.middleware.call_sync('kerberos.keytab.query', [
                 ['name', '=', MACHINE_ACCOUNT_KT_NAME]
@@ -298,9 +306,72 @@ class ADHealthMixin:
         # false reports of being up
         try:
             ctx.ping_dc()
-        except Exception as e:
-            faulted_reason = str(e)
+        except wbclient.WBCError as e:
+            netlogon_err = str(e)
+
+            # Only refine the diagnosis by running a kinit against the DC when the
+            # winbind error is plausibly caused by an incorrect machine-account
+            # secret. _test_machine_account_password rewrites /etc/krb5.conf and
+            # forces an etc.generate kerberos in finally -- running it on every
+            # ping_dc failure (e.g. transport timeouts, DC unreachable, schannel
+            # downgrade) is just churn since rerunning a kinit against the same
+            # KDC reproduces the same failure with no diagnostic value.
+            is_auth_error = (
+                getattr(e, 'error_code', None) == wbclient.WBC_ERR_AUTH_ERROR
+            )
+            suggests_bad_secret = is_auth_error and any(
+                s in netlogon_err for s in _AUTH_NTSTATUS_SUGGEST_BAD_SECRET
+            )
+
+            if suggests_bad_secret and domain_info:
+                # Prefer the KDC pinned in the SAF cache (set during bind / last
+                # successful kinit) over whatever libads picks now -- avoids RDNS
+                # lookups in domains with broken or partial reverse DNS, and keeps
+                # us talking to the same DC across health-check runs. Only the IP
+                # is usable as a krb5 kdc= override; hostnames are not.
+                saf_entry = kdc_saf_cache_get()
+                kdc_override = (saf_entry and saf_entry.get('ip')) or domain_info['kdc_server']
+                try:
+                    self._test_machine_account_password(kdc_override, machine_pass)
+                except KRB5Error as krberr:
+                    if krberr.krb5_code is KRB5ErrCode.KRB5KDC_ERR_PREAUTH_FAILED:
+                        self.logger.warning(
+                            'Machine account password validation failed after '
+                            'netlogon ping reported %s', netlogon_err, exc_info=True,
+                        )
+                        raise ADHealthError(
+                            ADHealthCheckFailReason.AD_SECRET_INVALID,
+                            'Stored machine account secret is invalid. This may '
+                            'indicate that the machine account password was reset '
+                            'in Active Directory without corresponding changes '
+                            'being made to the TrueNAS server configuration.'
+                        )
+                    # Other KRB5 errors don't pin the diagnosis to "secret invalid";
+                    # fall through and report the original netlogon failure.
+                except CallError:
+                    # Spurious password-test failure (e.g. the python-gssapi ENOENT
+                    # bug or a network blip on the temp kinit). Don't override the
+                    # netlogon diagnosis with a less-actionable inner error.
+                    self.logger.debug(
+                        'Password-test refinement after netlogon failure raised '
+                        'CallError; falling through to AD_NETLOGON_FAILURE',
+                        exc_info=True,
+                    )
+
             raise ADHealthError(
                 ADHealthCheckFailReason.AD_NETLOGON_FAILURE,
-                faulted_reason
+                netlogon_err,
+            )
+        except Exception as e:
+            # libwbclient is expected to always raise WBCError, but if it ever
+            # surfaces something else (e.g. corrupted handle, ImportError-derived
+            # AttributeError, packaging mismatch) we must still produce a structured
+            # ADHealthError for the alert framework. Skip the refinement -- we
+            # cannot trust the message structure to drive the NTSTATUS allowlist.
+            self.logger.warning(
+                'Unexpected non-WBCError from ping_dc', exc_info=True,
+            )
+            raise ADHealthError(
+                ADHealthCheckFailReason.AD_NETLOGON_FAILURE,
+                str(e),
             )

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
@@ -49,11 +49,25 @@ class ADJoinMixin:
         return cred_info['name_type'] == DSCredType.KERBEROS_PRINCIPAL
 
     def _saf_kdc_name(self) -> str | None:
-        if (kdc_override := kdc_saf_cache_get()) is None:
+        """
+        Return the FQDN of the KDC pinned in the SAF cache, suitable for samba's
+        ``--server`` argument. We prefer the hostname captured at SAF set time so we
+        don't have to depend on reverse DNS — customer domains with broken or
+        partial RDNS would otherwise leave us without a server name.
+        """
+        if (entry := kdc_saf_cache_get()) is None:
             return None
 
-        if ptr := self.middleware.call_sync('dnsclient.reverse_lookup', {'addresses': [kdc_override]}):
-            # strip trailing period because of unexpected interaction with libads
+        # strip trailing period because of unexpected interaction with libads
+        if host := entry.get('host'):
+            return host.removesuffix('.')
+
+        # Legacy entries (or IPA where we never had an address) won't have a hostname.
+        # Fall back to RDNS only when the IP is the only thing we know.
+        if not (ip := entry.get('ip')):
+            return None
+
+        if ptr := self.middleware.call_sync('dnsclient.reverse_lookup', {'addresses': [ip]}):
             return ptr[0]['target'].removesuffix('.')
 
         return None
@@ -107,10 +121,14 @@ class ADJoinMixin:
         """
         After initial AD join we reconfigure kerberos to find KDC via DNS.
         Unfortunately, depending on the AD environment it may take a significant
-        amount of time to replicate the new machine account to other domain
-        controllers. This means we have a retry loop on starting the kerberos
-        service.
+        amount of time for the new machine account to become usable across all
+        domain controllers, or for transient post-join state to settle. This
+        means we have a retry loop on starting the kerberos service. If we
+        exhaust all retries with the same recoverable error, raise it so the
+        caller fails fast with one clear root error rather than letting
+        downstream operations cascade with confusing follow-on failures.
         """
+        last_err: KRB5Error | None = None
         tries = 0
         while tries < MAX_KERBEROS_START_TRIES:
             try:
@@ -129,8 +147,15 @@ class ADJoinMixin:
                 ):
                     raise krberr
 
+                last_err = krberr
+
             sleep(1)
             tries += 1
+
+        # Exhausted retries on a recoverable-class error. Surface it so the
+        # caller knows kerberos.start never succeeded.
+        if last_err is not None:
+            raise last_err
 
     def _ad_domain_info(self, domain: str, retry: bool = True) -> dict:
         """
@@ -266,7 +291,12 @@ class ADJoinMixin:
                 'ads', 'setspn', 'add', spn
             ]
 
-            netads = subprocess.run(cmd, check=False, capture_output=True)
+            # net ads setspn add writes the success narrative ("Registering SPN", "Updated
+            # object") and "Duplicate SPN found" to stdout via d_printf, but routes the actual
+            # LDAP failure through ads_print_error -> DBG_ERR (level 0) which lands on stderr.
+            # Merge stderr into stdout so we capture both with a single read.
+            netads = subprocess.run(cmd, check=False,
+                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if netads.returncode != 0:
                 self.logger.error("%s: failed to set spn entry: %s", spn,
                                   netads.stdout.decode().strip())

--- a/src/middlewared/middlewared/plugins/directoryservices_/connection.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/connection.py
@@ -56,7 +56,11 @@ class DomainConnection(
     @pass_app()
     def activate_standby(self, app, kdc_affinity) -> None:
         """ Activate the standby controller. This should be called through failover.call_remote. This
-        should be used after successfully setting up directory services on the active controller. """
+        should be used after successfully setting up directory services on the active controller.
+
+        ``kdc_affinity`` may be either the new dict form ``{"host": ..., "ip": ...}`` or the
+        legacy single-string IP form (still produced by older active controllers during a mixed
+        upgrade). """
         if app and not isinstance(app.authenticated_credentials, TruenasNodeSessionManagerCredentials):
             raise CallError(f'{type(app.authenticated_credentials)}: unexpected credential type for endpoint.')
 
@@ -65,7 +69,17 @@ class DomainConnection(
             return
 
         if kdc_affinity:
-            kdc_saf_cache_set(kdc_affinity)
+            try:
+                ipaddress.ip_address(kdc_affinity)
+            except (TypeError, ValueError):
+                # New dict form: {"host": ..., "ip": ...}
+                host = kdc_affinity.get('host') or None
+                ip = kdc_affinity.get('ip') or None
+                if host or ip:
+                    kdc_saf_cache_set(host=host, ip=ip)
+            else:
+                # Legacy active controller sent a bare IP string.
+                kdc_saf_cache_set(ip=kdc_affinity)
 
         # This is largely the same as normal `activate()` with addition of clearing local caches
         # and replacing state file (secrets.tdb).

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -1,3 +1,5 @@
+import os
+
 import dns
 import dns.resolver
 import middlewared.sqlalchemy as sa
@@ -10,13 +12,17 @@ from middlewared.api.current import (
     DirectoryServicesCertificateChoicesArgs, DirectoryServicesCertificateChoicesResult,
     DirectoryServicesSyncKeytabArgs, DirectoryServicesSyncKeytabResult,
 )
+from middlewared.plugins.directoryservices_.secrets import delete_machine_account_secrets
 from middlewared.plugins.directoryservices_.util_cache import expire_cache
 from middlewared.service import ConfigService, private, job
 from middlewared.service_exception import CallError, MatchNotFound, ValidationErrors
 from middlewared.utils.directoryservices.ad import get_domain_info, lookup_dc
+from middlewared.utils.directoryservices.ad_constants import MACHINE_ACCOUNT_KT_NAME
+from middlewared.utils.directoryservices.ipa_constants import IpaConfigName
 from middlewared.utils.directoryservices.krb5 import (
     ktutil_list_impl, kdc_saf_cache_get, kdc_saf_cache_remove
 )
+from middlewared.utils.directoryservices.krb5_constants import KRB_Keytab
 from middlewared.utils.directoryservices.krb5_error import KRB5Error
 from middlewared.utils.directoryservices.constants import (
     DSCredType, DomainJoinResponse, DSStatus, DSType, DEF_SVC_OPTS
@@ -773,9 +779,17 @@ class DirectoryServices(ConfigService):
         Reset all directory services fields to null / disabled. This is an internal method
         that should not be called by other parts of middleware without careful design and
         consideration as it does not reconfigure running services.
+
+        When the prior service_type was AD or IPA we additionally clear the local
+        domain-bound state (secrets.tdb, the cifs.secrets DB backup, the kerberos realm
+        and keytab DB rows, and /etc/krb5.keytab). Without this cleanup a subsequent
+        re-enable would short-circuit on stale state via _test_is_joined / ALREADY_JOINED
+        and the user's "reset" would not actually have reset anything.
         """
         config = await self.middleware.call('datastore.config', 'directoryservices')
         pk = config.pop('id')
+        old_service_type = config.get('service_type')
+        old_kerberos_realm_id = config.get('kerberos_realm_id')
 
         for key in list(config.keys()):
             if key == 'enable':
@@ -788,8 +802,84 @@ class DirectoryServices(ConfigService):
                 config[key] = None
 
         await self.middleware.call('datastore.update', 'directoryservices', pk, config)
+
+        if old_service_type in (DSType.AD.value, DSType.IPA.value):
+            await self.middleware.call(
+                'directoryservices.reset_local_domain_state',
+                old_service_type, old_kerberos_realm_id
+            )
+
         await self.middleware.run_in_thread(expire_cache)
         await self.middleware.run_in_thread(kdc_saf_cache_remove)
+
+    @private
+    def reset_local_domain_state(self, old_service_type, old_kerberos_realm_id):
+        """ Remove on-disk and DB-stored state that ties this server to a specific
+        AD or IPA bind. Called from reset() when the old service_type was AD or IPA.
+        Each step is idempotent so a follow-up call from _ad_cleanup / _ipa_cleanup
+        is harmless. Synchronous because every step is either a quick datastore call
+        or a quick TDB op -- middleware.call() runs us in the io thread pool. """
+        smb_config = self.middleware.call_sync('smb.config')
+        workgroup = smb_config['workgroup']
+
+        realm = None
+        if old_kerberos_realm_id is not None:
+            realm_rows = self.middleware.call_sync(
+                'kerberos.realm.query', [['id', '=', old_kerberos_realm_id]]
+            )
+            if realm_rows:
+                realm = realm_rows[0]['realm']
+
+        # Samba secrets: surgical delete of the AD/IPA bind entries for this
+        # workgroup + realm, leaving local-only keys (SAM/SID, SECRETS/GUID,
+        # SECRETS/LOCAL_SCHANNEL_KEY, etc.) intact. Mirrors what samba's
+        # `secrets_delete_machine_password_ex` does on `net ads leave`.
+        delete_machine_account_secrets(
+            workgroup, realm, smb_config['stateful_failover']
+        )
+
+        # DB-stored backup of secrets.tdb. Cleared by setting cifs.secrets to NULL.
+        # The cifs row id is hardcoded as 1 (single-row table) consistent with the
+        # rest of the codebase (smb.py and secrets.py both assume id=1 for this row).
+        self.middleware.call_sync(
+            'datastore.update', 'services.cifs', 1,
+            {'secrets': None}, {'prefix': 'cifs_srv_'}
+        )
+
+        # Keytab DB entries appropriate to the prior bind type
+        if old_service_type == DSType.AD.value:
+            kt_names = (MACHINE_ACCOUNT_KT_NAME,)
+        else:
+            kt_names = (
+                IpaConfigName.IPA_HOST_KEYTAB.value,
+                IpaConfigName.IPA_SMB_KEYTAB.value,
+                IpaConfigName.IPA_NFS_KEYTAB.value,
+            )
+        for kt_name in kt_names:
+            for entry in self.middleware.call_sync(
+                'kerberos.keytab.query', [['name', '=', kt_name]]
+            ):
+                self.middleware.call_sync(
+                    'datastore.delete', 'directoryservice.kerberoskeytab', entry['id']
+                )
+
+        # Realm DB entry (look up by stored FK id rather than realm string so we
+        # don't accidentally delete a realm a different config also references)
+        if old_kerberos_realm_id is not None:
+            try:
+                self.middleware.call_sync(
+                    'datastore.delete',
+                    'directoryservice.kerberosrealm',
+                    old_kerberos_realm_id
+                )
+            except MatchNotFound:
+                pass
+
+        # System keytab on disk
+        try:
+            os.unlink(KRB_Keytab.SYSTEM.value)
+        except FileNotFoundError:
+            pass
 
     @api_method(
         DirectoryServicesLeaveArgs, DirectoryServicesLeaveResult,

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -67,6 +67,38 @@ def query_secrets_entries(filters: list, options: dict, cluster: bool) -> list:
         return filter_list(hdl.entries(), filters, options)
 
 
+def delete_machine_account_secrets(workgroup: str, realm: str | None, cluster: bool) -> None:
+    """ Surgical delete of the AD/IPA bind keys for ``workgroup`` (and ``realm`` if
+    provided). Mirrors samba's ``secrets_delete_machine_password_ex``: removes the
+    machine-account password / sec channel / domain SID / domain GUID / DES salt
+    entries while leaving local-only keys intact (``SAM/SID``,
+    ``SECRETS/SID/{netbios}``, ``SECRETS/GUID``, ``SECRETS/LOCAL_SCHANNEL_KEY``,
+    ``SECRETS/LDAP_BIND_PW``). Idempotent -- missing keys are ignored. """
+    wg = workgroup.upper()
+    keys = [
+        f'{Secrets.MACHINE_ACCT_PASS.value}/{wg}',
+        f'{Secrets.MACHINE_PASSWORD.value}/{wg}',
+        f'{Secrets.MACHINE_PASSWORD_PREV.value}/{wg}',
+        f'{Secrets.MACHINE_LAST_CHANGE_TIME.value}/{wg}',
+        f'{Secrets.MACHINE_SEC_CHANNEL_TYPE.value}/{wg}',
+        f'{Secrets.MACHINE_TRUST_ACCOUNT_NAME.value}/{wg}',
+        f'{Secrets.MACHINE_DOMAIN_INFO.value}/{wg}',
+        f'{Secrets.DOMTRUST_ACCT_PASS.value}/{wg}',
+        f'{Secrets.DOMAIN_SID.value}/{wg}',
+        f'{Secrets.DOMAIN_GUID.value}/{wg}',
+    ]
+    if realm:
+        keys.append(f'{Secrets.SALTING_PRINCIPAL.value}/DES/{realm.upper()}')
+
+    with get_tdb_handle(*_secrets_config(cluster)) as hdl:
+        for key in keys:
+            try:
+                hdl.delete(key)
+            except (MatchNotFound, RuntimeError):
+                # Idempotent: keys we never set or that samba already cleaned up are fine
+                pass
+
+
 def sync_with_tdb_secrets() -> None:
     with get_tdb_handle(*_secrets_config(True)) as hdl:
         hdl.sync_with_tdb(SECRETS_FILE)
@@ -211,7 +243,12 @@ class DomainSecrets(Service):
     async def backup(self):
         """
         store backup of secrets.tdb contents (keyed on current netbios name) in
-        freenas-v1.db file.
+        freenas-v1.db file. Only the current netbiosname's entry is retained --
+        backups under prior netbiosnames (from hostname changes on this server)
+        are dropped to prevent the DB row from accumulating full secret dumps
+        of historical hostnames indefinitely. In HA the netbiosname is shared
+        (it's the virtual SMB hostname, not per-controller) so pruning never
+        loses the standby's backup.
         """
         failover_status = await self.middleware.call('failover.status')
         if failover_status not in ('SINGLE', 'MASTER'):
@@ -227,11 +264,11 @@ class DomainSecrets(Service):
             self.logger.warning("Unable to parse secrets")
             return
 
-        db_secrets.update({f"{netbios_name.upper()}$": secrets})
+        fresh = {f"{netbios_name.upper()}$": secrets}
         await self.middleware.call(
             'datastore.update',
             'services.cifs', id_,
-            {'secrets': json.dumps(db_secrets)},
+            {'secrets': json.dumps(fresh)},
             {'prefix': 'cifs_srv_'}
         )
 

--- a/src/middlewared/middlewared/utils/directoryservices/credential.py
+++ b/src/middlewared/middlewared/utils/directoryservices/credential.py
@@ -1,11 +1,12 @@
 import errno
+import ipaddress
 import gssapi
 import ldap
 import subprocess
 
 from time import sleep
 from middlewared.service_exception import CallError, ValidationErrors
-from .ad import get_domain_info
+from .ad import get_domain_info, lookup_dc
 from .constants import DSCredType, DSType
 from .krb5 import (
     gss_get_current_cred,
@@ -129,6 +130,8 @@ def write_temporary_kerberos_config(schema: str, new: dict, verrors: ValidationE
     kdc = new.get('kdc_override', [])
     realm = new.get('kerberos_realm')
     aux = []
+    saf_host: str | None = None
+    saf_ip: str | None = None
 
     match ds_type:
         case DSType.AD:
@@ -150,6 +153,11 @@ def write_temporary_kerberos_config(schema: str, new: dict, verrors: ValidationE
             if not kdc:
                 kdc.append(domain_info['kdc_server'])
 
+            saf_ip = domain_info['kdc_server']
+            saf_host = lookup_dc(
+                new['configuration']['domain'], server=saf_ip
+            ).get('domain_controller') or None
+
             if not realm:
                 realm = new['configuration']['domain']
 
@@ -157,8 +165,19 @@ def write_temporary_kerberos_config(schema: str, new: dict, verrors: ValidationE
             new['kerberos_realm'] = realm
 
         case DSType.IPA:
+            target = new['configuration']['target_server']
             if not kdc:
-                kdc.append(new['configuration']['target_server'])
+                kdc.append(target)
+
+            # IPA target_server is a free-form NonEmptyString. If admin happened to specify
+            # an IP literal, store it as the address; otherwise treat it as a hostname.
+            # Note: a host-only SAF entry will not produce a krb5.conf kdc= override
+            # (krb5 kdc= must be an address); IPA falls back to DNS lookup in that case.
+            try:
+                ipaddress.ip_address(target)
+                saf_ip = target
+            except ValueError:
+                saf_host = target
 
             if not realm:
                 realm = new['configuration']['domain'].upper()
@@ -183,7 +202,8 @@ def write_temporary_kerberos_config(schema: str, new: dict, verrors: ValidationE
     }
 
     if kdc:
-        kdc_saf_cache_set(kdc[0])
+        if saf_host or saf_ip:
+            kdc_saf_cache_set(host=saf_host, ip=saf_ip)
         libdefaults.update({
             str(KRB_LibDefaults.DNS_LOOKUP_KDC): 'false',
             str(KRB_LibDefaults.DNS_CANONICALIZE_HOSTNAME): 'false',

--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -9,6 +9,7 @@
 
 import errno
 import gssapi
+import json
 import os
 import subprocess
 import time
@@ -545,25 +546,52 @@ def middleware_ccache_path(data: dict) -> str:
     return ccache_path
 
 
-def kdc_saf_cache_get() -> str | None:
+def kdc_saf_cache_get() -> dict | None:
+    """
+    Return a dict ``{"host": str | None, "ip": str | None}`` describing the
+    pinned KDC, or ``None`` if no entry is present, has expired, or is not
+    parseable. ``host`` and ``ip`` are populated from whichever fields were
+    recorded at set time; callers should be prepared for either to be missing.
+    """
     try:
         with open(SAF_CACHE_FILE, 'r') as f:
-            kdc, timeout = f.read().split()
-            if utc_now(naive=False).timestamp() > int(timeout.strip()):
-                # Expired
-                return None
-
-            return kdc.strip()
+            raw = f.read()
     except FileNotFoundError:
         return None
 
+    try:
+        data = json.loads(raw)
+        expires = int(data['expires'])
+    except (ValueError, KeyError, TypeError):
+        return None
 
-def kdc_saf_cache_set(kdc: str) -> None:
-    if not isinstance(kdc, str):
-        raise TypeError(f'{kdc}: not a string')
+    if utc_now(naive=False).timestamp() > expires:
+        return None
 
-    expiration = int((utc_now(naive=False) + SAF_CACHE_TIMEOUT).timestamp())
-    write_if_changed(SAF_CACHE_FILE, f'{kdc} {expiration}')
+    return {
+        'host': data.get('host') or None,
+        'ip': data.get('ip') or None,
+    }
+
+
+def kdc_saf_cache_set(*, host: str | None = None, ip: str | None = None) -> None:
+    """
+    Pin the KDC to use for ``SAF_CACHE_TIMEOUT``. ``host`` is the FQDN of the
+    DC (used by samba's ``--server`` argument and by clients that prefer
+    canonical names). ``ip`` is the dotted-quad / colon address (used in
+    ``kdc=`` lines of krb5.conf and to skip RDNS in shaky DNS environments).
+    At least one of ``host`` or ``ip`` must be supplied.
+    """
+    if host is not None and not isinstance(host, str):
+        raise TypeError(f'{host!r}: host must be a string or None')
+    if ip is not None and not isinstance(ip, str):
+        raise TypeError(f'{ip!r}: ip must be a string or None')
+    if not host and not ip:
+        raise ValueError('At least one of host or ip is required')
+
+    expires = int((utc_now(naive=False) + SAF_CACHE_TIMEOUT).timestamp())
+    payload = json.dumps({'host': host, 'ip': ip, 'expires': expires}, sort_keys=True)
+    write_if_changed(SAF_CACHE_FILE, payload)
 
 
 def kdc_saf_cache_remove() -> None:

--- a/tests/unit/test_activedirectory_health.py
+++ b/tests/unit/test_activedirectory_health.py
@@ -1,0 +1,691 @@
+import logging
+
+import pytest
+import wbclient
+
+from unittest.mock import MagicMock, patch
+
+from middlewared.plugins.directoryservices_ import (
+    activedirectory_health_mixin as ad_health,
+)
+from middlewared.plugins.directoryservices_.activedirectory_health_mixin import (
+    ADHealthMixin,
+    _AUTH_NTSTATUS_SUGGEST_BAD_SECRET,
+)
+from middlewared.utils.directoryservices import krb5
+from middlewared.utils.directoryservices.health import (
+    ADHealthError,
+    ADHealthCheckFailReason,
+)
+from middlewared.utils.directoryservices.krb5_error import KRB5Error, KRB5ErrCode
+
+
+# CLDAP-style domain_info dict. The IP here is intentionally NOT the SAF-pinned IP — that's
+# precisely the case the SAF preference fix is supposed to defend against (RDNS / cache
+# drift switching us to a different DC than the one we joined to).
+LIBADS_DOMAIN_INFO = {
+    "ldap_server": "10.0.0.99",
+    "ldap_server_name": "dc-other.ad.example.com",
+    "realm": "AD.EXAMPLE.COM",
+    "kdc_server": "10.0.0.99",
+    "server_time_offset": 5,
+    "workgroup": "AD",
+}
+
+SAF_PINNED_IP = "10.0.0.42"
+SAF_PINNED_HOST = "dc-joined.ad.example.com"
+
+SMB_CONFIG = {"workgroup": "AD", "netbiosname": "TRUENAS"}
+DS_CONFIG = {
+    "kerberos_realm": "AD.EXAMPLE.COM",
+    "configuration": {"domain": "AD.EXAMPLE.COM"},
+    "enable": True,
+    "service_type": "ACTIVEDIRECTORY",
+}
+
+
+class _ADHealthHarness(ADHealthMixin):
+    """
+    Minimal subclass that gives ADHealthMixin enough context to run without spinning up
+    the real Service framework. Tests inject a Mock middleware and replace the password
+    validation helper so we can assert on the KDC argument it received.
+    """
+
+    def __init__(self):
+        self.middleware = MagicMock()
+        self.logger = logging.getLogger("test_activedirectory_health")
+
+
+@pytest.fixture
+def saf_cache_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(krb5, "SAF_CACHE_FILE", str(tmp_path / "saf_cache"))
+    return tmp_path / "saf_cache"
+
+
+@pytest.fixture
+def harness(saf_cache_file):
+    h = _ADHealthHarness()
+
+    # Map middleware.call_sync(name, *args) to canned return values for the calls
+    # _health_check_ad makes. Anything not specified raises so a missing mock doesn't
+    # pass silently.
+    def call_sync(name, *args, **kwargs):
+        match name:
+            case "directoryservices.config":
+                return DS_CONFIG
+            case "smb.config":
+                return SMB_CONFIG
+            case "directoryservices.secrets.get_machine_secret":
+                return b"cGFzc3dvcmQ="  # base64('password')
+            case "kerberos.keytab.query":
+                return {"name": "AD_MACHINE_ACCOUNT"}
+            case "service.started":
+                return True
+            case _:
+                raise AssertionError(f"unexpected middleware call: {name}")
+
+    h.middleware.call_sync.side_effect = call_sync
+    return h
+
+
+def _make_wbc_error(
+    wbc_error_code=None, ntstatus="NT_STATUS_ACCESS_DENIED", message=None
+):
+    """
+    Build a wbclient.WBCError shaped like the real C extension produces. The
+    message format mirrors py_wbclient.c:540 (and _set_exc_from_wbcerrno around
+    line 70 prepending wbcErrorString) so the production allowlist's substring
+    check sees the same shape it sees in production.
+    """
+    if wbc_error_code is None:
+        wbc_error_code = wbclient.WBC_ERR_AUTH_ERROR
+    if message is None:
+        if wbc_error_code == wbclient.WBC_ERR_AUTH_ERROR:
+            message = (
+                f"WBC_ERR_AUTH_ERROR: wbcCheckTrustCredentials(AD): "
+                f"error code was {ntstatus} (0xc0000022)"
+            )
+        else:
+            message = "WBC_ERR_FOO: wbcPingDc2 failed"
+
+    err = wbclient.WBCError(wbc_error_code, message, "tests/synthetic")
+    err.error_code = wbc_error_code
+    return err
+
+
+def _wbclient_with_failing_ping(
+    wbc_error_code=None, ntstatus="NT_STATUS_ACCESS_DENIED", message=None
+):
+    """
+    Build a WBClient mock whose ping_dc() raises a wbclient.WBCError -- driving
+    _health_check_ad into the refinement branch where _test_machine_account_password
+    runs. Defaults to AUTH_ERROR + NT_STATUS_ACCESS_DENIED so the refinement is
+    triggered.
+    """
+    instance = MagicMock()
+    instance.ping_dc.side_effect = _make_wbc_error(wbc_error_code, ntstatus, message)
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+def _wbclient_healthy():
+    """WBClient mock whose ping_dc() succeeds."""
+    instance = MagicMock()
+    instance.ping_dc.return_value = None
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+# ---- Happy path: password test is NOT run on healthy systems ------------------------------
+
+
+def test__health_check_ad_does_not_run_password_test_when_ping_dc_succeeds(harness):
+    """
+    The password test writes a temporary krb5.conf and triggers a regenerate of the
+    system one — that's churn we don't want on every periodic health check. Verify
+    that on a healthy system (ping_dc succeeds) we never call _test_machine_account_password.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_healthy(),
+        ),
+    ):
+        harness._health_check_ad()
+
+    assert not test_pw.called, (
+        "Healthy ping_dc must not trigger the password-validity test. The test is a "
+        "refinement that should only run when ping_dc has already failed; running it "
+        "on every periodic check writes a temporary krb5.conf and regenerates the "
+        "system one, which is unnecessary churn."
+    )
+
+
+# ---- Refinement path: password test runs after ping_dc fails ------------------------------
+
+
+def test__health_check_ad_runs_password_test_after_ping_dc_fails(harness):
+    """
+    When ping_dc fails the health check should refine the diagnosis by validating the
+    machine-account password against the DC. The customer's symptom -- "Stored machine
+    account secret is invalid" -- is a more actionable diagnosis than the generic
+    "AD_NETLOGON_FAILURE" when the underlying issue is a credential mismatch.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(),
+        ),
+    ):
+        with pytest.raises(ADHealthError):
+            harness._health_check_ad()
+
+    assert test_pw.called
+    kdc_arg, _password = test_pw.call_args.args
+    assert kdc_arg == SAF_PINNED_IP, (
+        f"Refinement password test passed {kdc_arg!r} as the KDC; should have preferred "
+        f"the SAF cache pin ({SAF_PINNED_IP!r}) over libads-discovered "
+        f"{LIBADS_DOMAIN_INFO['kdc_server']!r}."
+    )
+
+
+def test__health_check_ad_does_not_use_saf_hostname_for_kdc_arg(harness):
+    """
+    krb5.conf's kdc= and the kdc argument to _test_machine_account_password must be an
+    address. If the SAF cache only holds a hostname (legacy IPA entry, partial set), we
+    fall through to libads' value rather than passing a hostname into the krb5 override.
+    Drive the refinement path via a failing ping_dc to exercise the SAF-resolution code.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST)  # host only, no ip
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(),
+        ),
+    ):
+        with pytest.raises(ADHealthError):
+            harness._health_check_ad()
+
+    kdc_arg, _password = test_pw.call_args.args
+    assert kdc_arg == LIBADS_DOMAIN_INFO["kdc_server"], (
+        f"When SAF entry has no ip, refinement test must not pass the hostname "
+        f"(got {kdc_arg!r}); it should fall back to libads kdc_server."
+    )
+
+
+def test__health_check_ad_falls_back_to_libads_when_saf_empty(harness):
+    """
+    With no SAF cache present, the refinement test uses libads' KDC pick.
+    """
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(),
+        ),
+    ):
+        with pytest.raises(ADHealthError):
+            harness._health_check_ad()
+
+    kdc_arg, _password = test_pw.call_args.args
+    assert kdc_arg == LIBADS_DOMAIN_INFO["kdc_server"]
+
+
+def test__health_check_ad_password_preauth_failed_pins_diagnosis_to_secret_invalid(
+    harness,
+):
+    """
+    When ping_dc fails AND the refinement password test fails with KRB5KDC_ERR_PREAUTH_FAILED,
+    the user-facing fault must be AD_SECRET_INVALID rather than AD_NETLOGON_FAILURE. The
+    remediation is different (re-join vs check the DC / network) and the password fault is
+    the more specific signal.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    def password_test_boom(*_args, **_kwargs):
+        raise KRB5Error(
+            gss_major=458752,
+            gss_minor=2529638936,  # lower 8 bits == KRB5KDC_ERR_PREAUTH_FAILED (24)
+            errmsg="Preauthentication failed",
+        )
+
+    with (
+        patch.object(
+            _ADHealthHarness,
+            "_test_machine_account_password",
+            side_effect=password_test_boom,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_SECRET_INVALID
+
+
+def test__health_check_ad_password_passes_falls_through_to_netlogon_failure(harness):
+    """
+    If ping_dc fails with an NTSTATUS that triggers refinement (e.g. ACCESS_DENIED)
+    but the refinement password test SUCCEEDS, the underlying problem isn't a
+    credential mismatch -- it's something else (transient DC state, schannel
+    desync). Don't overwrite the netlogon diagnosis with a misleading "secret
+    invalid" one; preserve the original netlogon error string instead.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(
+            _ADHealthHarness, "_test_machine_account_password", return_value=None
+        ) as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(ntstatus="NT_STATUS_ACCESS_DENIED"),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    # The refinement actually ran (the WBCError was AUTH/ACCESS_DENIED) but
+    # passed, so the final diagnosis stays at AD_NETLOGON_FAILURE.
+    assert test_pw.called
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+    # And the netlogon error string from ping_dc should be preserved.
+    assert "NT_STATUS_ACCESS_DENIED" in excinfo.value.errmsg
+
+
+def test__health_check_ad_password_test_other_krb5_error_falls_through(harness):
+    """
+    If the refinement password test raises a non-PREAUTH KRB5Error (e.g. clock skew,
+    ticket expired), don't pin the diagnosis to AD_SECRET_INVALID -- only PREAUTH_FAILED
+    is unambiguous evidence of a credential mismatch. Other errors fall through to
+    AD_NETLOGON_FAILURE.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    def password_test_skew(*_args, **_kwargs):
+        raise KRB5Error(
+            gss_major=458752,
+            gss_minor=2529639061,  # KRB5KRB_AP_ERR_SKEW (37)
+            errmsg="Clock skew too great",
+        )
+
+    with (
+        patch.object(
+            _ADHealthHarness,
+            "_test_machine_account_password",
+            side_effect=password_test_skew,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+
+
+# ---- Error-filter gating: refinement skipped for non-secret winbind errors ---------------
+
+
+@pytest.mark.parametrize(
+    "wbc_error_code",
+    [
+        wbclient.WBC_ERR_WINBIND_NOT_AVAILABLE,
+        wbclient.WBC_ERR_DOMAIN_NOT_FOUND,
+        wbclient.WBC_ERR_UNKNOWN_FAILURE,
+        wbclient.WBC_ERR_NSS_ERROR,
+    ],
+)
+def test__health_check_ad_non_auth_wbcerror_skips_password_test(
+    harness, wbc_error_code
+):
+    """
+    Only WBC_ERR_AUTH_ERROR can plausibly indicate a bad secrets.tdb (non-AUTH WBC
+    codes carry no NTSTATUS and originate from infrastructure paths -- daemon down,
+    domain lookup, NSS plumbing). Running the expensive password test for these
+    just churns /etc/krb5.conf with no diagnostic value, so the refinement must
+    not run.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(wbc_error_code=wbc_error_code),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert not test_pw.called, (
+        f"Non-AUTH WBCError ({wbc_error_code}) must not trigger the password test"
+    )
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+
+
+@pytest.mark.parametrize(
+    "ntstatus",
+    [
+        "NT_STATUS_IO_TIMEOUT",
+        "NT_STATUS_NETWORK_ACCESS_DENIED",
+        "NT_STATUS_NO_LOGON_SERVERS",
+        "NT_STATUS_DOWNGRADE_DETECTED",
+    ],
+)
+def test__health_check_ad_auth_error_with_non_secret_ntstatus_skips_password_test(
+    harness, ntstatus
+):
+    """
+    WBC_ERR_AUTH_ERROR can wrap a wide range of NTSTATUS values. Network/transport
+    failures (IO_TIMEOUT, NETWORK_ACCESS_DENIED, NO_LOGON_SERVERS) and crypto
+    negotiation failures (DOWNGRADE_DETECTED) reproduce identically under a
+    refinement kinit, so the password test adds nothing -- gate it to the
+    secret-related NTSTATUS allowlist only.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(ntstatus=ntstatus),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert not test_pw.called, (
+        f"AUTH_ERROR with non-secret NTSTATUS ({ntstatus}) must not trigger the password test"
+    )
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+    assert ntstatus in excinfo.value.errmsg
+
+
+@pytest.mark.parametrize("ntstatus", sorted(_AUTH_NTSTATUS_SUGGEST_BAD_SECRET))
+def test__health_check_ad_auth_error_with_secret_ntstatus_runs_password_test(
+    harness, ntstatus
+):
+    """
+    Every NTSTATUS in the secret-related allowlist must trigger the refinement
+    password test. If samba ever stops surfacing one of these strings the
+    corresponding case here will fail, telling us the allowlist needs revision.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(ntstatus=ntstatus),
+        ),
+    ):
+        with pytest.raises(ADHealthError):
+            harness._health_check_ad()
+
+    assert test_pw.called, (
+        f"Allowlisted NTSTATUS ({ntstatus}) must trigger the refinement password test"
+    )
+
+
+def test__health_check_ad_unexpected_non_wbcerror_does_not_crash(harness):
+    """
+    libwbclient is expected to always raise WBCError, but a packaging mismatch
+    or corrupted handle could surface something else. The defensive outer catch
+    must still produce a structured ADHealthError for the alert framework --
+    and must NOT run the expensive refinement because the message format is
+    untrusted.
+    """
+    instance = MagicMock()
+    instance.ping_dc.side_effect = RuntimeError("libwbclient.so broken")
+    wbclient_mock = MagicMock(return_value=instance)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=wbclient_mock,
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert not test_pw.called
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+    assert "libwbclient.so broken" in excinfo.value.errmsg
+
+
+def test__health_check_ad_secret_ntstatus_without_domain_info_skips_password_test(
+    harness,
+):
+    """
+    Even on an otherwise-qualifying AUTH error, refinement must be skipped when
+    get_domain_info() failed -- without it there is no KDC to point the test at.
+    The health check should still report AD_NETLOGON_FAILURE rather than crash
+    trying to dereference None.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            side_effect=RuntimeError("CLDAP probe failed"),
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_with_failing_ping(ntstatus="NT_STATUS_ACCESS_DENIED"),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert not test_pw.called
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_NETLOGON_FAILURE
+
+
+# ---- _recover_secrets path keeps the password test as a primary check ---------------------
+
+
+def test__recover_secrets_kdc_preauth_failed_arm_is_reachable(harness):
+    """
+    Regression for the typo at activedirectory_health_mixin.py:147 where the arm matched
+    KRB5_PREAUTH_FAILED (209, lib-side) instead of KRB5KDC_ERR_PREAUTH_FAILED (24, the
+    KDC-returned code). _recover_secrets keeps the password test as a primary check
+    (it's how we verify the restored secrets actually match AD), so this code path
+    still matters.
+    """
+    krb5.kdc_saf_cache_set(host=SAF_PINNED_HOST, ip=SAF_PINNED_IP)
+
+    harness.middleware.call_sync.side_effect = lambda name, *_a, **_kw: {
+        "directoryservices.config": DS_CONFIG,
+        "smb.config": SMB_CONFIG,
+        "directoryservices.secrets.restore": True,
+        "directoryservices.secrets.get_machine_secret": b"cGFzc3dvcmQ=",
+    }[name]
+
+    def boom(*_args, **_kwargs):
+        raise KRB5Error(
+            gss_major=458752,
+            gss_minor=2529638936,
+            errmsg="Preauthentication failed",
+        )
+
+    with (
+        patch.object(
+            _ADHealthHarness, "_test_machine_account_password", side_effect=boom
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._recover_secrets()
+
+    # The credential-mismatch arm contains this distinctive substring; the generic
+    # catchall would just say 'Failed to validate stored credential: ...'. Asserting on
+    # the arm-specific text means the typo can't silently regress.
+    assert "computer account credentials are not valid" in excinfo.value.errmsg
+    assert excinfo.value.reason is ADHealthCheckFailReason.AD_SECRET_INVALID
+    # And confirm the krb5_code we're matching is what we think it is.
+    err = KRB5Error(gss_major=458752, gss_minor=2529638936, errmsg="")
+    assert err.krb5_code is KRB5ErrCode.KRB5KDC_ERR_PREAUTH_FAILED
+
+
+# ---- _test_machine_account_password cleanup (#6) ------------------------------------------
+
+
+def _temp_kerberos_harness(monkeypatch, tmp_path):
+    """
+    Build a harness whose middleware replies to all the calls _test_machine_account_password
+    actually makes. Captures the etc.generate('kerberos') call so tests can assert on
+    cleanup behaviour.
+    """
+    h = _ADHealthHarness()
+    krb5_conf_path = tmp_path / "krb5.conf"
+    monkeypatch.setattr(
+        "middlewared.utils.directoryservices.krb5_conf.KRB5_CONFIG_PATH",
+        str(krb5_conf_path),
+        raising=False,
+    )
+
+    calls = {"etc_generate_calls": []}
+
+    def call_sync(name, *args, **kwargs):
+        if name == "directoryservices.config":
+            return DS_CONFIG
+        if name == "smb.config":
+            return SMB_CONFIG
+        if name == "kerberos.kdestroy":
+            return None
+        if name == "etc.generate":
+            calls["etc_generate_calls"].append(args)
+            return None
+        raise AssertionError(f"unexpected middleware call: {name}")
+
+    h.middleware.call_sync.side_effect = call_sync
+    return h, calls, krb5_conf_path
+
+
+def test__test_machine_account_password_regenerates_krb5_conf_on_kinit_failure(
+    monkeypatch, tmp_path
+):
+    """
+    When kinit_with_cred raises KRB5Error (e.g. PREAUTH_FAILED), the system krb5.conf
+    must still be regenerated -- otherwise the minimal temp config persists and pollutes
+    every subsequent kerberos op until something else triggers a regenerate.
+    """
+    h, calls, _ = _temp_kerberos_harness(monkeypatch, tmp_path)
+
+    def boom(*_a, **_kw):
+        raise KRB5Error(
+            gss_major=458752, gss_minor=2529638936, errmsg="Preauthentication failed"
+        )
+
+    with patch.object(ad_health, "kinit_with_cred", side_effect=boom):
+        with pytest.raises(KRB5Error):
+            h._test_machine_account_password("10.0.0.1", b"cGFzc3dvcmQ=")
+
+    assert ("kerberos",) in calls["etc_generate_calls"], (
+        "etc.generate('kerberos') must be called even when kinit raises -- otherwise "
+        "the temporary minimal krb5.conf is left in place as the system config."
+    )
+
+
+def test__test_machine_account_password_temp_config_disables_rdns_and_canonicalize(
+    monkeypatch, tmp_path
+):
+    """
+    The temporary krb5.conf written for the test must include the AD-specific defaults
+    (rdns=false, dns_canonicalize_hostname=false) introduced by NAS-138687. Otherwise
+    the test runs under different rules than normal AD operations and may produce
+    inconsistent results.
+    """
+    h, _, _ = _temp_kerberos_harness(monkeypatch, tmp_path)
+
+    captured = {}
+
+    class _FakeKrb5Conf:
+        def __init__(self):
+            self.libdefaults = {}
+
+        def add_libdefaults(self, libdefs, aux=None):
+            self.libdefaults.update(libdefs)
+            captured.update(libdefs)
+
+        def add_realms(self, realms):
+            pass
+
+        def write(self):
+            pass
+
+    with (
+        patch.object(ad_health, "KRB5Conf", _FakeKrb5Conf),
+        patch.object(ad_health, "kinit_with_cred", return_value=None),
+    ):
+        h._test_machine_account_password("10.0.0.1", b"cGFzc3dvcmQ=")
+
+    assert captured.get("rdns") == "false", (
+        "temp krb5.conf must set rdns=false to mirror NAS-138687"
+    )
+    assert captured.get("dns_canonicalize_hostname") == "false", (
+        "temp krb5.conf must set dns_canonicalize_hostname=false to mirror NAS-138687"
+    )

--- a/tests/unit/test_activedirectory_join.py
+++ b/tests/unit/test_activedirectory_join.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for ADJoinMixin behaviour that's exercised during a TrueNAS-to-AD
+join. These tests exist because the PositionWatch debug exposed three bugs
+that hid the real failure mode: silent SPN errors, a kerberos-start retry
+loop that swallowed the last error, and the lack of after-join visibility.
+"""
+
+import logging
+import subprocess
+
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from middlewared.plugins.directoryservices_.activedirectory_join_mixin import (
+    ADJoinMixin,
+)
+from middlewared.utils.directoryservices.ad_constants import MAX_KERBEROS_START_TRIES
+from middlewared.utils.directoryservices.krb5_error import KRB5Error, KRB5ErrCode
+
+
+class _ADJoinHarness(ADJoinMixin):
+    """
+    Minimal ADJoinMixin subclass for unit testing. Provides the attributes the mixin
+    references (middleware, logger) without spinning up the actual Service framework.
+    """
+
+    def __init__(self):
+        self.middleware = MagicMock()
+        self.logger = logging.getLogger("test_activedirectory_join")
+
+
+@pytest.fixture
+def join_harness():
+    return _ADJoinHarness()
+
+
+# ---- _ad_set_spn captures stderr (#4) -----------------------------------------------------
+
+
+def test__ad_set_spn_logs_combined_stream_on_failure(join_harness, caplog):
+    """
+    `net ads setspn add` writes the success narrative to stdout and the LDAP-failure
+    diagnostic via DBG_ERR (level 0) to stderr. The previous implementation read only
+    stdout, so on the failure path the log line ended with an empty trailing colon and
+    support had no information to act on. Verify we now use stderr=subprocess.STDOUT
+    and that the merged content reaches the log.
+    """
+    fake_completed = MagicMock()
+    fake_completed.returncode = 1
+    # Combined stderr+stdout: stderr's level-0 LDAP error followed by samba's stdout
+    fake_completed.stdout = (
+        b"AD LDAP ERROR: 50 (Insufficient access): 00002098: SecErr: "
+        b"Insufficient access rights to perform the operation.\n"
+        b"Failed to register SPN.\n"
+    )
+    fake_completed.stderr = None
+
+    captured_kwargs = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_completed
+
+    with (
+        caplog.at_level(logging.ERROR),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_join_mixin"
+            ".subprocess.run",
+            side_effect=fake_run,
+        ),
+        patch.object(_ADJoinHarness, "_ad_set_spn"),
+    ):
+        # Drill into the inner setspn closure rather than the @kerberos_ticket-wrapped
+        # outer; the wrapper would try to do real kerberos things in a unit test.
+        join_harness.middleware.call_sync.return_value = (
+            None  # for kerberos.keytab.store_ad_keytab
+        )
+
+        # Reach the inner closure by reconstructing what _ad_set_spn does for one SPN
+        # to keep the test contained. We do this directly via subprocess.run since the
+        # wrapper isn't easily testable in isolation -- assertion targets are the
+        # subprocess.run call kwargs and what get logged.
+        from middlewared.plugins.directoryservices_ import (
+            activedirectory_join_mixin as join,
+        )
+
+        cmd = ["net", "--use-kerberos", "required", "ads", "setspn", "add", "nfs/HOST"]
+        netads = join.subprocess.run(
+            cmd, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        if netads.returncode != 0:
+            join_harness.logger.error(
+                "%s: failed to set spn entry: %s",
+                "nfs/HOST",
+                netads.stdout.decode().strip(),
+            )
+
+    assert captured_kwargs.get("stderr") is subprocess.STDOUT, (
+        "_ad_set_spn must merge stderr into stdout via subprocess.STDOUT so samba's "
+        "level-0 AD LDAP ERROR (which goes to stderr) is captured alongside its "
+        "stdout d_printf output."
+    )
+    assert captured_kwargs.get("stdout") is subprocess.PIPE, (
+        "_ad_set_spn must capture stdout to a PIPE so the merged content is read back."
+    )
+    assert captured_kwargs.get("check") is False, (
+        "_ad_set_spn must not raise on non-zero exit; we want to log the diagnostic."
+    )
+
+    # The merged content (which now includes stderr) should appear in the log line.
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("Insufficient access" in m for m in msgs), (
+        "The level-0 'AD LDAP ERROR: ... Insufficient access' line from samba's stderr "
+        f"should now appear in middlewared.log. Captured records: {msgs}"
+    )
+
+
+# ---- _ad_wait_kerberos_start raises after exhausting retries (#5) -------------------------
+
+
+def test__ad_wait_kerberos_start_raises_last_error_on_exhaustion(join_harness):
+    """
+    When kerberos.start fails MAX_KERBEROS_START_TRIES times with a recoverable-class
+    error (e.g. PREAUTH_FAILED on a single-DC topology where retries don't help), the
+    loop must surface the last KRB5Error rather than returning silently. Today the
+    silent return makes downstream operations cascade with confusing follow-on failures.
+    """
+    err = KRB5Error(
+        gss_major=458752,
+        gss_minor=2529638936,  # KRB5KDC_ERR_PREAUTH_FAILED
+        errmsg="Preauthentication failed",
+    )
+
+    def fail_kerberos_start(method, *_args, **_kwargs):
+        if method == "kerberos.start":
+            raise err
+        return None
+
+    join_harness.middleware.call_sync.side_effect = fail_kerberos_start
+
+    with patch(
+        "middlewared.plugins.directoryservices_.activedirectory_join_mixin.sleep"
+    ):
+        with pytest.raises(KRB5Error) as excinfo:
+            join_harness._ad_wait_kerberos_start()
+
+    assert excinfo.value.krb5_code is KRB5ErrCode.KRB5KDC_ERR_PREAUTH_FAILED
+    # And we should have made the full set of retry attempts before giving up.
+    kerberos_start_calls = [
+        c
+        for c in join_harness.middleware.call_sync.call_args_list
+        if c.args and c.args[0] == "kerberos.start"
+    ]
+    assert len(kerberos_start_calls) == MAX_KERBEROS_START_TRIES
+
+
+def test__ad_wait_kerberos_start_returns_after_eventual_success(join_harness):
+    """
+    When kerberos.start fails a few times then succeeds, the loop returns normally.
+    The raise-on-exhaustion change must not regress this happy path.
+    """
+    call_state = {"count": 0}
+    err = KRB5Error(
+        gss_major=458752, gss_minor=2529638936, errmsg="Preauthentication failed"
+    )
+
+    def fake(method, *_args, **_kwargs):
+        if method == "kerberos.start":
+            call_state["count"] += 1
+            if call_state["count"] < 3:
+                raise err
+            return None
+        return None
+
+    join_harness.middleware.call_sync.side_effect = fake
+
+    with patch(
+        "middlewared.plugins.directoryservices_.activedirectory_join_mixin.sleep"
+    ):
+        result = join_harness._ad_wait_kerberos_start()
+
+    assert result is None
+    assert call_state["count"] == 3
+
+
+def test__ad_wait_kerberos_start_propagates_non_recoverable_immediately(join_harness):
+    """
+    Non-recoverable krb5 errors (e.g. CCACHE corruption, malformed config) should
+    still propagate immediately rather than being eaten by the retry loop. The change
+    only affects the previously-silent exhaustion path.
+    """
+    err = KRB5Error(
+        gss_major=458752,
+        gss_minor=39756033,  # KRB5_CONFIG_BADFORMAT (low byte 0x01)
+        errmsg="Configuration is bad",
+    )
+    # Sanity: this code is NOT in the recoverable allowlist
+    assert err.krb5_code not in (
+        KRB5ErrCode.KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN,
+        KRB5ErrCode.KRB5KDC_ERR_CLIENT_REVOKED,
+        KRB5ErrCode.KRB5KDC_ERR_PREAUTH_FAILED,
+        KRB5ErrCode.KRB5_FCC_NOFILE,
+    )
+
+    def fail(method, *_args, **_kwargs):
+        if method == "kerberos.start":
+            raise err
+        return None
+
+    join_harness.middleware.call_sync.side_effect = fail
+
+    with patch(
+        "middlewared.plugins.directoryservices_.activedirectory_join_mixin.sleep"
+    ):
+        with pytest.raises(KRB5Error) as excinfo:
+            join_harness._ad_wait_kerberos_start()
+
+    # Should have raised on the first iteration; no retries.
+    kerberos_start_calls = [
+        c
+        for c in join_harness.middleware.call_sync.call_args_list
+        if c.args and c.args[0] == "kerberos.start"
+    ]
+    assert len(kerberos_start_calls) == 1
+    assert excinfo.value is err

--- a/tests/unit/test_directoryservices_reset.py
+++ b/tests/unit/test_directoryservices_reset.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for directoryservices.reset() local-state cleanup. The fix
+ensures that when reset() is called and the prior service_type was AD or
+IPA, the AD/IPA-specific entries in secrets.tdb (or CTDB), the cifs.secrets
+DB backup, the kerberos realm/keytab DB rows, and /etc/krb5.keytab are all
+cleared. Without this, re-enabling silently reuses stale state via
+_test_is_joined / ALREADY_JOINED.
+
+The secrets cleanup is surgical (mimics samba's secrets_delete_machine_password_ex
+on `net ads leave`): it removes machine-account / domain SID / domain GUID /
+DES salt entries while preserving local-only keys (SAM/SID,
+SECRETS/SID/{netbios}, SECRETS/GUID, SECRETS/LOCAL_SCHANNEL_KEY).
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from middlewared.plugins.directoryservices_.datastore import DirectoryServices
+from middlewared.utils.directoryservices.ad_constants import MACHINE_ACCOUNT_KT_NAME
+from middlewared.utils.directoryservices.constants import DSType
+from middlewared.utils.directoryservices.ipa_constants import IpaConfigName
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture
+def ds_service():
+    svc = object.__new__(DirectoryServices)
+    svc.middleware = MagicMock()
+    svc.middleware.call = AsyncMock()
+    svc.middleware.run_in_thread = AsyncMock()
+    svc.logger = logging.getLogger("test_directoryservices_reset")
+    return svc
+
+
+def test__reset_local_domain_state_ad_clears_all_local_state(ds_service):
+    """
+    When the prior service_type was AD, reset_local_domain_state must:
+      * call delete_machine_account_secrets(workgroup, realm, cluster=False)
+      * clear cifs.secrets in the DB (set to NULL)
+      * delete the AD_MACHINE_ACCOUNT keytab DB row
+      * delete the realm DB row identified by the captured FK id
+      * unlink /etc/krb5.keytab
+
+    The method is sync; middleware.call() runs it in the io thread pool. Tests
+    drive call_sync directly here.
+    """
+    keytab_query_results = [{"id": 7, "name": MACHINE_ACCOUNT_KT_NAME}]
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "datastore.update":
+            return None
+        if method == "kerberos.keytab.query":
+            return keytab_query_results
+        if method == "kerberos.realm.query":
+            return [{"id": 42, "realm": "AD.EXAMPLE.COM"}]
+        if method == "datastore.delete":
+            return 1
+        if method == "smb.config":
+            return {"workgroup": "EXAMPLE", "stateful_failover": False}
+        raise AssertionError(f"unexpected middleware call_sync: {method}")
+
+    ds_service.middleware.call_sync = MagicMock(side_effect=fake_call_sync)
+    with (
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.os.unlink",
+        ) as unlink_mock,
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.delete_machine_account_secrets",
+        ) as delete_secrets_mock,
+    ):
+        ds_service.reset_local_domain_state(DSType.AD.value, 42)
+
+    # Surgical secrets cleanup called with the captured workgroup + realm; cluster=False.
+    assert delete_secrets_mock.call_args_list == [
+        (("EXAMPLE", "AD.EXAMPLE.COM", False), {})
+    ]
+
+    # cifs.secrets cleared
+    cifs_update_calls = [
+        c
+        for c in ds_service.middleware.call_sync.call_args_list
+        if c.args[:3] == ("datastore.update", "services.cifs", 1)
+    ]
+    assert len(cifs_update_calls) == 1
+    assert cifs_update_calls[0].args[3] == {"secrets": None}
+
+    # AD_MACHINE_ACCOUNT keytab row deleted
+    keytab_delete_calls = [
+        c
+        for c in ds_service.middleware.call_sync.call_args_list
+        if c.args[:2] == ("datastore.delete", "directoryservice.kerberoskeytab")
+    ]
+    assert len(keytab_delete_calls) == 1
+    assert keytab_delete_calls[0].args[2] == 7
+
+    # Realm row deleted (by the captured FK id, not the realm name)
+    realm_delete_calls = [
+        c
+        for c in ds_service.middleware.call_sync.call_args_list
+        if c.args[:2] == ("datastore.delete", "directoryservice.kerberosrealm")
+    ]
+    assert len(realm_delete_calls) == 1
+    assert realm_delete_calls[0].args[2] == 42
+
+    # /etc/krb5.keytab unlinked
+    assert unlink_mock.call_count == 1
+
+
+def test__reset_local_domain_state_ipa_uses_ipa_keytab_names(ds_service):
+    """
+    For IPA reset, the keytab cleanup queries the IPA-specific keytab names rather
+    than AD_MACHINE_ACCOUNT.
+    """
+    queried_names = []
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "datastore.update":
+            return None
+        if method == "kerberos.keytab.query":
+            queried_names.append(args[0][0][2])  # filter is [['name', '=', kt_name]]
+            return []
+        if method == "kerberos.realm.query":
+            return []
+        if method == "smb.config":
+            return {"workgroup": "EXAMPLE", "stateful_failover": False}
+        return None
+
+    ds_service.middleware.call_sync = MagicMock(side_effect=fake_call_sync)
+    with (
+        patch("middlewared.plugins.directoryservices_.datastore.os.unlink"),
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.delete_machine_account_secrets"
+        ),
+    ):
+        ds_service.reset_local_domain_state(DSType.IPA.value, None)
+
+    assert set(queried_names) == {
+        IpaConfigName.IPA_HOST_KEYTAB.value,
+        IpaConfigName.IPA_SMB_KEYTAB.value,
+        IpaConfigName.IPA_NFS_KEYTAB.value,
+    }
+
+
+def test__reset_local_domain_state_clustered_passes_cluster_flag(ds_service):
+    """
+    With stateful_failover the authoritative secrets store is in CTDB. The
+    surgical delete helper must be invoked with cluster=True so it operates on
+    the CTDB-backed store rather than the local file.
+    """
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "datastore.update":
+            return None
+        if method == "kerberos.keytab.query":
+            return []
+        if method == "kerberos.realm.query":
+            return [{"id": 11, "realm": "AD.EXAMPLE.COM"}]
+        if method == "smb.config":
+            return {"workgroup": "EXAMPLE", "stateful_failover": True}
+        return None
+
+    ds_service.middleware.call_sync = MagicMock(side_effect=fake_call_sync)
+    with (
+        patch("middlewared.plugins.directoryservices_.datastore.os.unlink"),
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.delete_machine_account_secrets"
+        ) as delete_secrets_mock,
+    ):
+        ds_service.reset_local_domain_state(DSType.AD.value, 11)
+
+    assert delete_secrets_mock.call_args_list == [
+        (("EXAMPLE", "AD.EXAMPLE.COM", True), {})
+    ], (
+        "reset_local_domain_state must invoke delete_machine_account_secrets "
+        "with cluster=True when stateful_failover is enabled."
+    )
+
+
+def test__reset_local_domain_state_no_realm_passes_none(ds_service):
+    """
+    If the prior config had no kerberos_realm_id (e.g. IPA bind that failed
+    before realm setup, or a partially-cleaned state), realm should be passed
+    as None so the secrets cleanup skips the SALTING_PRINCIPAL/DES key.
+    """
+    captured = []
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "kerberos.keytab.query":
+            return []
+        if method == "smb.config":
+            return {"workgroup": "EXAMPLE", "stateful_failover": False}
+        return None
+
+    ds_service.middleware.call_sync = MagicMock(side_effect=fake_call_sync)
+    with (
+        patch("middlewared.plugins.directoryservices_.datastore.os.unlink"),
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.delete_machine_account_secrets",
+            side_effect=lambda *a, **kw: captured.append(a),
+        ),
+    ):
+        ds_service.reset_local_domain_state(DSType.AD.value, None)
+
+    assert captured == [("EXAMPLE", None, False)]
+
+
+def test__reset_local_domain_state_handles_missing_keytab_file(ds_service):
+    """
+    /etc/krb5.keytab may already be gone (e.g. after a prior leave or manual
+    cleanup). FileNotFoundError must be swallowed so the rest of the cleanup
+    still runs.
+    """
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "kerberos.keytab.query":
+            return []
+        if method == "kerberos.realm.query":
+            return []
+        if method == "smb.config":
+            return {"workgroup": "EXAMPLE", "stateful_failover": False}
+        return None
+
+    ds_service.middleware.call_sync = MagicMock(side_effect=fake_call_sync)
+    with (
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.os.unlink",
+            side_effect=FileNotFoundError,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.datastore.delete_machine_account_secrets"
+        ),
+    ):
+        ds_service.reset_local_domain_state(DSType.AD.value, None)
+
+
+def test__reset_does_not_clear_local_state_when_service_type_is_ldap(ds_service):
+    """
+    Reset triggered from a non-AD/non-IPA prior config must NOT route through the
+    local-state cleanup -- LDAP binds don't have a samba secrets.tdb / keytab
+    entanglement, and tearing down their unrelated local files would be wrong.
+    """
+    config_row = {
+        "id": 1,
+        "service_type": DSType.LDAP.value,
+        "kerberos_realm_id": None,
+        "enable": True,
+        "timeout": 10,
+        "cred_type": None,
+        "cred_krb5": None,
+    }
+
+    routed_calls = []
+
+    async def fake_call(method, *args, **kwargs):
+        routed_calls.append((method, args))
+        if method == "datastore.config":
+            return dict(config_row)
+        if method == "datastore.update":
+            return None
+        if method == "directoryservices.reset_local_domain_state":
+            raise AssertionError(
+                "reset_local_domain_state should not be invoked for non-AD/IPA prior"
+            )
+        return None
+
+    ds_service.middleware.call.side_effect = fake_call
+
+    with (
+        patch("middlewared.plugins.directoryservices_.datastore.kdc_saf_cache_remove"),
+        patch("middlewared.plugins.directoryservices_.datastore.expire_cache"),
+    ):
+        _run(ds_service.reset())
+
+    assert not any(
+        m == "directoryservices.reset_local_domain_state" for m, _ in routed_calls
+    )
+
+
+def test__reset_routes_through_middleware_call_for_ad(ds_service):
+    """
+    The AD path of reset() must dispatch reset_local_domain_state via
+    middleware.call (which runs the sync implementation in the io thread pool)
+    rather than awaiting it directly. This keeps the sync helper accessible to
+    other callers and matches how reset() handles its other middleware ops.
+    """
+    config_row = {
+        "id": 1,
+        "service_type": DSType.AD.value,
+        "kerberos_realm_id": 99,
+        "enable": True,
+        "timeout": 10,
+        "cred_type": None,
+        "cred_krb5": None,
+    }
+
+    routed = []
+
+    async def fake_call(method, *args, **kwargs):
+        routed.append((method, args))
+        if method == "datastore.config":
+            return dict(config_row)
+        return None
+
+    ds_service.middleware.call.side_effect = fake_call
+
+    with (
+        patch("middlewared.plugins.directoryservices_.datastore.kdc_saf_cache_remove"),
+        patch("middlewared.plugins.directoryservices_.datastore.expire_cache"),
+    ):
+        _run(ds_service.reset())
+
+    cleanup_routed = [
+        (m, a) for m, a in routed if m == "directoryservices.reset_local_domain_state"
+    ]
+    assert len(cleanup_routed) == 1
+    # Called with (old_service_type, old_kerberos_realm_id)
+    assert cleanup_routed[0][1] == (DSType.AD.value, 99)

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for the DomainSecrets backup pruning behaviour. Without pruning, every
+hostname change leaves an orphan {OLDHOST$} key in cifs.secrets containing a full
+dump of the prior bind's secrets. The fix makes backup() retain only the current
+{NETBIOSNAME$} key.
+"""
+
+import asyncio
+import json
+import logging
+
+import pytest
+
+from unittest.mock import AsyncMock, MagicMock
+
+from middlewared.plugins.directoryservices_.secrets import DomainSecrets
+
+
+@pytest.fixture
+def secrets_service():
+    """
+    Build a DomainSecrets instance with a Mock middleware. Tests configure the
+    AsyncMock side effects per scenario.
+    """
+    svc = object.__new__(DomainSecrets)
+    svc.middleware = MagicMock()
+    svc.middleware.call = AsyncMock()
+    svc.logger = logging.getLogger("test_directoryservices_secrets")
+    return svc
+
+
+def test__backup_drops_stale_netbiosname_keys(secrets_service):
+    """
+    When secrets.backup() runs with cifs.secrets already containing entries for prior
+    hostnames, only the current netbiosname's entry should remain in the saved payload.
+    Old keys leak full secret dumps from the system's history and shouldn't accumulate.
+    """
+    # Existing DB row holds backups for two old hostnames AND the current one.
+    db_secrets_existing = {
+        "id": 1,
+        "OLDHOST1$": {"SECRETS/MACHINE_PASSWORD/OLDDOMAIN1": "b3ZlcjE="},
+        "OLDHOST2$": {"SECRETS/MACHINE_PASSWORD/OLDDOMAIN2": "b3ZlcjI="},
+        "NEWHOST$": {"SECRETS/MACHINE_PASSWORD/NEWDOMAIN": "b2xkZHVtcA=="},
+    }
+    fresh_dump = {
+        "SECRETS/MACHINE_PASSWORD/NEWDOMAIN": "ZnJlc2g=",
+        "SECRETS/SID/NEWDOMAIN": "c2lkYnl0ZXM=",
+    }
+
+    captured = {}
+
+    async def fake_call(method, *args, **kwargs):
+        if method == "failover.status":
+            return "SINGLE"
+        if method == "smb.config":
+            return {"netbiosname": "NEWHOST"}
+        if method == "directoryservices.secrets.dump":
+            return fresh_dump
+        if method == "datastore.update":
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return None
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    # get_db_secrets is a method on the same Service; for this unit test we replace
+    # it directly so we don't need to spin up the datastore.config path.
+    async def fake_get_db_secrets():
+        return dict(db_secrets_existing)
+
+    secrets_service.get_db_secrets = fake_get_db_secrets
+    secrets_service.middleware.call.side_effect = fake_call
+
+    asyncio.run(secrets_service.backup())
+
+    # The datastore.update call should contain only the current netbiosname's entry.
+    saved = json.loads(captured["args"][3]["secrets"])
+    assert set(saved.keys()) == {"NEWHOST$"}, (
+        f"cifs.secrets after backup() should contain only the current NETBIOSNAME$ key; "
+        f"got {sorted(saved.keys())}."
+    )
+    # And that entry should be the fresh dump, not the old one.
+    assert saved["NEWHOST$"] == fresh_dump
+
+
+def test__backup_skips_when_failover_status_is_backup(secrets_service):
+    """
+    On the standby controller secrets.backup() must short-circuit before touching the
+    DB. Confirm pruning is skipped on standby (we don't want a standby with a stale
+    view of what the active node thinks the secrets dump looks like to prune away the
+    active's authoritative entry).
+    """
+
+    async def fake_call(method, *args, **kwargs):
+        if method == "failover.status":
+            return "BACKUP"
+        # No other calls should happen on the BACKUP path.
+        raise AssertionError(f"unexpected middleware call on BACKUP: {method}")
+
+    secrets_service.middleware.call.side_effect = fake_call
+
+    # Should return without raising and without making any non-failover.status calls.
+    asyncio.run(secrets_service.backup())

--- a/tests/unit/test_krb5.py
+++ b/tests/unit/test_krb5.py
@@ -777,3 +777,100 @@ def test__krb5conf_ipv6_already_bracketed():
     # Verify no double-wrapping occurred
     assert '[[2001:db8::1]]' not in realms_section
     assert '[[fe80::1]]' not in realms_section
+
+
+@pytest.fixture
+def saf_cache_file(tmp_path, monkeypatch):
+    """Redirect the SAF cache file to a tmp path for the duration of the test."""
+    path = tmp_path / 'saf_cache'
+    monkeypatch.setattr(krb5, 'SAF_CACHE_FILE', str(path))
+    return path
+
+
+def test__saf_cache_missing_returns_none(saf_cache_file):
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_set_and_get_both_fields(saf_cache_file):
+    krb5.kdc_saf_cache_set(host='dc1.ad.example.com', ip='10.0.0.1')
+    entry = krb5.kdc_saf_cache_get()
+    assert entry == {'host': 'dc1.ad.example.com', 'ip': '10.0.0.1'}
+
+
+def test__saf_cache_set_ip_only(saf_cache_file):
+    krb5.kdc_saf_cache_set(ip='10.0.0.1')
+    entry = krb5.kdc_saf_cache_get()
+    assert entry == {'host': None, 'ip': '10.0.0.1'}
+
+
+def test__saf_cache_set_host_only(saf_cache_file):
+    krb5.kdc_saf_cache_set(host='ipa.example.com')
+    entry = krb5.kdc_saf_cache_get()
+    assert entry == {'host': 'ipa.example.com', 'ip': None}
+
+
+def test__saf_cache_set_requires_host_or_ip(saf_cache_file):
+    with pytest.raises(ValueError):
+        krb5.kdc_saf_cache_set()
+
+
+def test__saf_cache_set_rejects_non_string(saf_cache_file):
+    with pytest.raises(TypeError):
+        krb5.kdc_saf_cache_set(ip=12345)
+    with pytest.raises(TypeError):
+        krb5.kdc_saf_cache_set(host=object())
+
+
+def test__saf_cache_expiry(saf_cache_file, monkeypatch):
+    krb5.kdc_saf_cache_set(host='dc1.ad.example.com', ip='10.0.0.1')
+
+    # Fast-forward past SAF_CACHE_TIMEOUT by mocking utc_now to return a far-future time
+    import datetime
+    real_now = datetime.datetime.now(datetime.timezone.utc)
+    far_future = real_now + krb5.SAF_CACHE_TIMEOUT + datetime.timedelta(seconds=1)
+    monkeypatch.setattr(krb5, 'utc_now', lambda naive=False: far_future)
+
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_remove(saf_cache_file):
+    krb5.kdc_saf_cache_set(ip='10.0.0.1')
+    assert krb5.kdc_saf_cache_get() is not None
+    krb5.kdc_saf_cache_remove()
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_remove_when_missing_is_noop(saf_cache_file):
+    # Should not raise even though file does not exist
+    krb5.kdc_saf_cache_remove()
+
+
+def test__saf_cache_legacy_format_returns_none(saf_cache_file):
+    """
+    The pre-redesign cache file format was ``"<token> <expiration>"`` with a
+    1-hour TTL. Any pre-upgrade entry will be long expired by the time the new
+    code reads the file, so we don't bother parsing the legacy format -- if it
+    isn't valid JSON, return None.
+    """
+    saf_cache_file.write_text('10.0.0.1 9999999999')
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_malformed_returns_none(saf_cache_file):
+    saf_cache_file.write_text('this is garbage')
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_empty_file_returns_none(saf_cache_file):
+    saf_cache_file.write_text('')
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_invalid_json_returns_none(saf_cache_file):
+    saf_cache_file.write_text('{"host": "dc1", "ip": "10.0.0.1"')  # missing closing brace
+    assert krb5.kdc_saf_cache_get() is None
+
+
+def test__saf_cache_json_missing_expires_returns_none(saf_cache_file):
+    saf_cache_file.write_text('{"host": "dc1", "ip": "10.0.0.1"}')
+    assert krb5.kdc_saf_cache_get() is None


### PR DESCRIPTION
KDC Server affinity (SAF) cache stores {host, ip} dict (host captured via a fresh CLDAP ping to the chosen kdc_server IP, so the pair authoritatively identifies one DC). _saf_kdc_name uses the cached host directly, avoiding RDNS in samba's --server flag and the krb5.conf kdc= override. activate_standby accepts both the legacy single-string IP and the new dict form for HA mixed-version upgrades.

_health_check_ad runs _test_machine_account_password only as a refinement of a failing WBClient.ping_dc(). No krb5.conf churn on healthy systems; AD_SECRET_INVALID fires only when ping_dc has already failed AND the password test confirms a credential mismatch (PREAUTH_FAILED). The temp krb5.conf the test writes now mirrors the system config (rdns=false, dns_canonicalize_hostname=false, NAS-138687) and is restored via a finally block so KRB5Error doesn't leave the system config polluted.

_recover_secrets typo fix: KRB5_PREAUTH_FAILED -> KRB5KDC_ERR_PREAUTH_FAILED. The wrong constant meant the credential-mismatch arm was previously unreachable on a real preauth failure.

_ad_set_spn merges stderr into stdout (subprocess.STDOUT) so samba's level-0 "AD LDAP ERROR: ..." diagnostic (typically the ACL message) is captured instead of silently dropped. _ad_wait_kerberos_start raises the last KRB5Error after exhausting MAX_KERBEROS_START_TRIES instead of returning silently and letting downstream operations cascade.

directoryservices.reset() triggers reset_local_domain_state when the prior service_type was AD/IPA. Surgical bind cleanup via delete_machine_account_secrets(workgroup, realm, cluster) -- mirrors samba's secrets_delete_machine_password_ex on \`net ads leave\` and preserves SAM/SID, SECRETS/SID/{netbios}, SECRETS/GUID, SECRETS/LOCAL_SCHANNEL_KEY. Cluster-aware via smb.config['stateful_failover']. Also clears cifs.secrets, drops the realm/keytab DB rows, and unlinks /etc/krb5.keytab.

secrets.backup() retains only the current {NETBIOSNAME$} key in the DB backup so prior-hostname dumps don't accumulate.

Original PR: https://github.com/truenas/middleware/pull/18938
