### PR TITLE
Harden default dataset config for NAS storage

### DIFF
--- a/src/middlewared/middlewared/plugins/container/dataset.py
+++ b/src/middlewared/middlewared/plugins/container/dataset.py
@@ -5,7 +5,7 @@ from middlewared.plugins.pool_.utils import CreateImplArgs
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.filesystem.perms import enforce_dir_perms
 
-from .utils import CONTAINER_DS_NAME, container_dataset, container_dataset_mountpoint
+from .utils import CONTAINER_DS_MOUNT_PROPS, CONTAINER_DS_NAME, container_dataset, container_dataset_mountpoint
 
 CONTAINER_DS_PARENT_DIR = f"/mnt/{CONTAINER_DS_NAME}"
 
@@ -44,6 +44,7 @@ async def ensure_datasets(context: ServiceContext, pool: str) -> None:
                     "acltype": "posix",
                     "aclmode": "discard",
                     "snapdir": "hidden",
+                    **CONTAINER_DS_MOUNT_PROPS,
                 },
             ),
         )

--- a/src/middlewared/middlewared/plugins/container/utils.py
+++ b/src/middlewared/middlewared/plugins/container/utils.py
@@ -3,6 +3,7 @@ import os
 from truenas_os_pyutils.io import atomic_write
 
 __all__ = (
+    "CONTAINER_DS_MOUNT_PROPS",
     "CONTAINER_DS_NAME",
     "container_dataset",
     "container_dataset_mountpoint",
@@ -12,6 +13,15 @@ __all__ = (
 )
 
 CONTAINER_DS_NAME = ".truenas_containers"
+
+# Pinned LOCAL on the <pool>/.truenas_containers root to break the pool-root
+# default of exec/devices/setuid=off so container runtimes can execute
+# binaries, honor setuid bits, and access /dev nodes. Children inherit.
+CONTAINER_DS_MOUNT_PROPS = {
+    "exec": "on",
+    "devices": "on",
+    "setuid": "on",
+}
 
 
 def container_dataset(pool: str) -> str:

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -25,6 +25,7 @@ class DatasetDefaults:
     casesensitivity: DatasetProp = DatasetProp('sensitive', True)
     canmount: DatasetProp = DatasetProp('noauto', False)
     dedup: DatasetProp = DatasetProp('off', False)
+    devices: DatasetProp = DatasetProp('on', False, DOCKER_DATASET_NAME)
     encryption: DatasetProp = DatasetProp('off', True, DOCKER_DATASET_NAME)
     exec: DatasetProp = DatasetProp('on', False)
     mountpoint: DatasetProp = DatasetProp(f'/{IX_APPS_DIR_NAME}', True, DOCKER_DATASET_NAME)

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -470,6 +470,11 @@ class PoolDatasetService(CRUDService):
         """
         Creates a dataset/zvol.
 
+        For `FILESYSTEM` datasets, this method forces `devices=off` and `setuid=off`, and
+        defaults `exec=off`, to limit the blast radius of user-supplied data. `exec` may be
+        overridden at create time by passing an explicit `ON` value; `devices` and `setuid`
+        are not exposed via the API.
+
         .. examples(websocket)::
 
           Create a dataset within tank pool.
@@ -523,7 +528,13 @@ class PoolDatasetService(CRUDService):
                     data['casesensitivity'] = 'INSENSITIVE'
                     data['acltype'] = 'NFSV4'
                     data['aclmode'] = 'RESTRICTED'
-                case 'APPS' | 'MULTIPROTOCOL' | 'NFS':
+                case 'APPS':
+                    data['casesensitivity'] = 'SENSITIVE'
+                    data['atime'] = 'OFF'
+                    data['acltype'] = 'NFSV4'
+                    data['aclmode'] = 'PASSTHROUGH'
+                    data['exec'] = 'ON'
+                case 'MULTIPROTOCOL' | 'NFS':
                     data['casesensitivity'] = 'SENSITIVE'
                     data['atime'] = 'OFF'
                     data['acltype'] = 'NFSV4'
@@ -725,6 +736,11 @@ class PoolDatasetService(CRUDService):
                 uprops[i.real_name] = transformed
             else:
                 zprops[i.real_name] = transformed
+
+        if data['type'] == 'FILESYSTEM':
+            zprops.setdefault('exec', 'off')
+            zprops['devices'] = 'off'
+            zprops['setuid'] = 'off'
 
         await self.middleware.call(
             'pool.dataset.create_impl',

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -508,6 +508,9 @@ class PoolService(CRUDService):
             'aclmode': 'discard',
             'compression': 'lz4',
             'xattr': 'sa',
+            'exec': 'off',
+            'devices': 'off',
+            'setuid': 'off',
             'mountpoint': f'/{data["name"]}',
             **encryption_dict
         }

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -113,6 +113,20 @@ def test_002_create_permanent_zpool(request, ws_client):
         fail(f'System dataset move failed: {sysdataset_update["error"]}')
 
 
+def test_002a_pool_root_has_hardened_mount_options(request, ws_client):
+    # Newly-created pools pin exec/devices/setuid=off LOCAL on the root dataset
+    # so the hardened defaults cascade to any child that doesn't explicitly
+    # override them (system datasets, external zfs tools, etc.).
+    depends(request, ['SYSDS'])
+    props = ws_client.call(
+        'zfs.resource.query',
+        {'paths': [pool_name], 'properties': ['exec', 'devices', 'setuid']},
+    )[0]['properties']
+    for p in ('exec', 'devices', 'setuid'):
+        assert props[p]['value'] == 'off', (p, props[p])
+        assert props[p]['source']['type'] == 'LOCAL', (p, props[p])
+
+
 @pytest.mark.dependency(name='POOL_FUNCTIONALITY1')
 def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(ws_client, pool_data):
     """

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -332,3 +332,32 @@ def test_drift_repair_ix_apps(docker_pool):
     # runs the drift-repair enforce_mountpoint_perms call.
     call("docker.start_service")
     assert _chokepoint_perms(IX_APPS_CHOKEPOINT) == (0o700, 0, 0)
+
+
+def test_ix_apps_tree_keeps_exec_devices_setuid_on(docker_pool):
+    # The pool-root defaults of exec/devices/setuid=off would otherwise be
+    # inherited by ix-apps and break apps that need to execute binaries,
+    # honor setuid bits, or open device nodes. The ix-apps root pins all
+    # three LOCAL; every child inherits.
+    ix_apps_root = f"{docker_pool['pool']}/ix-apps"
+    children = {
+        f"{ix_apps_root}/{child}"
+        for child in ("truenas_catalog", "app_configs", "app_mounts", "docker")
+    }
+    results = {
+        r["name"]: r["properties"]
+        for r in call(
+            "zfs.resource.query",
+            {"paths": sorted({ix_apps_root} | children), "properties": ["exec", "devices", "setuid"]},
+        )
+    }
+    assert set(results) == {ix_apps_root} | children
+
+    for p in ("exec", "devices", "setuid"):
+        root_prop = results[ix_apps_root][p]
+        assert root_prop["value"] == "on", (p, root_prop)
+        assert root_prop["source"]["type"] == "LOCAL", (p, root_prop)
+
+    for child in children:
+        for p in ("exec", "devices", "setuid"):
+            assert results[child][p]["value"] == "on", (child, p, results[child][p])

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -536,6 +536,39 @@ def test_drift_repair_containers(started_ubuntu_container):
     assert _chokepoint_perms(CONTAINERS_CHOKEPOINT) == (0o700, 0, 0)
 
 
+def test_container_tree_keeps_exec_devices_setuid_on(started_ubuntu_container):
+    # Pool-root defaults of exec/devices/setuid=off would break container
+    # runtimes (binaries can't run, setuid bits are dropped, /dev nodes
+    # disabled). The .truenas_containers root pins all three LOCAL;
+    # containers/images and per-container clones inherit from it.
+    container_dataset = started_ubuntu_container["dataset"]
+    root = container_dataset.split("/.truenas_containers/", 1)[0] + "/.truenas_containers"
+    children = [
+        f"{root}/containers",
+        f"{root}/images",
+        container_dataset,
+    ]
+    results = {
+        r["name"]: r["properties"]
+        for r in call(
+            "zfs.resource.query",
+            {"paths": [root] + children, "properties": ["exec", "devices", "setuid"]},
+        )
+    }
+    assert set(results) == {root, *children}
+
+    for p in ("exec", "devices", "setuid"):
+        root_prop = results[root][p]
+        assert root_prop["value"] == "on", (p, root_prop)
+        assert root_prop["source"]["type"] == "LOCAL", (p, root_prop)
+
+    for child in children:
+        for p in ("exec", "devices", "setuid"):
+            child_prop = results[child][p]
+            assert child_prop["value"] == "on", (child, p, child_prop)
+            assert child_prop["source"]["type"] == "INHERITED", (child, p, child_prop)
+
+
 # /run/truenas_containers/root/ is the idmapped-bind-mount parent. libvirt_lxc
 # switches to mapped-root (host uid CONTAINER_ROOT_UID + slice * IDMAP_COUNT)
 # *before* the pivot_root setup that creates <UUID>/.oldroot, so it needs

--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -53,3 +53,45 @@ def test_pool_dataset_query():
         first = next(results)
         for next_ds in results:
             assert next_ds == first
+
+
+def _mount_opt_props(ds_name):
+    return call(
+        "zfs.resource.query",
+        {"paths": [ds_name], "properties": ["exec", "devices", "setuid"]},
+    )[0]["properties"]
+
+
+def test_filesystem_default_mount_options_locked_off():
+    with dataset("mount_opts_default") as ds:
+        props = _mount_opt_props(ds)
+        for p in ("exec", "devices", "setuid"):
+            assert props[p]["value"] == "off", (p, props[p])
+            assert props[p]["source"]["type"] == "LOCAL", (p, props[p])
+
+
+def test_filesystem_exec_explicit_on_is_respected():
+    with dataset("mount_opts_exec_on", {"exec": "ON"}) as ds:
+        props = _mount_opt_props(ds)
+        assert props["exec"]["value"] == "on"
+        assert props["devices"]["value"] == "off"
+        assert props["setuid"]["value"] == "off"
+
+
+def test_volume_create_unaffected_by_filesystem_mount_opts():
+    # exec/devices/setuid are filesystem-only ZFS properties; regression guard
+    # that the injection doesn't fire for VOLUME type (ZFS would reject the create).
+    with dataset("mount_opts_zvol", {"type": "VOLUME", "volsize": 1024 ** 3, "sparse": True}):
+        pass
+
+
+def test_apps_share_type_forces_exec_on():
+    # APPS share_type hard-codes exec=ON (like SMB hard-codes acltype/aclmode),
+    # overriding both the FILESYSTEM-default exec=off and any caller-provided
+    # exec value.
+    with dataset("mount_opts_apps", {"share_type": "APPS", "exec": "OFF"}) as ds:
+        props = _mount_opt_props(ds)
+        assert props["exec"]["value"] == "on"
+        assert props["exec"]["source"]["type"] == "LOCAL"
+        assert props["devices"]["value"] == "off"
+        assert props["setuid"]["value"] == "off"


### PR DESCRIPTION
This commit changes our defaults for newly created filesystems that are outside of namespaces for root filesystems for apps and containers. Specifically, we're now setting noexec, nosuid, and nodev by default to more closely align with storage industry best practices. No migration is one for existing data.

The noexec property is exposed to users because there is prior precedence for allowing users to toggle on/off (apps may want to execute scripts provided on generic NAS storage), but other options are not exposed directly to users in the pool.dataset.create API.