### PR TITLE
NAS-141127 / 27.0.0-BETA.1 / smb: disable automatic conversion of adouble files

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -314,6 +314,7 @@ def generate_smb_share_conf_dict(
         'smbd max xattr size': 2097152,
         'fruit:metadata': 'stream',
         'fruit:resource': 'stream',
+        'fruit:convert_adouble': False,
         'comment': share_config[share_field.COMMENT],
         'browseable': share_config[share_field.BROWSEABLE],
         'ea support': False,

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -369,6 +369,56 @@ def test__afp_share(nfsacl_dataset):
     assert conf['streams_xattr:xattr_compat'] is True
 
 
+def test__fruit_convert_adouble_default(nfsacl_dataset):
+    """
+    Stream-mode shares have no ._<base> companions to convert, so eager
+    per-readdir-entry conversion via ad_convert is wasted work. The
+    middleware default flips fruit:convert_adouble to False so vfs_fruit
+    skips the per-entry ENOENT openat. Conversion still happens lazily
+    via fruit_create_file on actual stream access.
+    """
+    conf = generate_smb_share_conf_dict(
+        None, DEFAULT_SHARE | {'path': nfsacl_dataset},
+        BASE_SMB_CONFIG | {'aapl_extensions': True}
+    )
+
+    assert conf['fruit:metadata'] == 'stream'
+    assert conf['fruit:resource'] == 'stream'
+    assert conf['fruit:convert_adouble'] is False
+
+
+def test__fruit_convert_adouble_afp_preserved(nfsacl_dataset):
+    """
+    AFP-compat shares (fruit:resource=file, fruit:metadata=netatalk) hold
+    real Netatalk-written ._<base> files and rely on ad_convert running.
+    The AFP override block must not pick up the stream-mode default.
+    """
+    smb = LEGACY_SHARE | {'path': nfsacl_dataset}
+    smb['options'] = LEGACY_SHARE_OPTS | {'afp': True}
+    conf = generate_smb_share_conf_dict(None, smb, BASE_SMB_CONFIG)
+
+    assert conf['fruit:metadata'] == 'netatalk'
+    assert conf['fruit:resource'] == 'file'
+    assert 'fruit:convert_adouble' not in conf
+
+
+def test__fruit_convert_adouble_aux_override(nfsacl_dataset):
+    """
+    A stream-mode share holding legacy ._<base> artefacts can re-enable
+    eager conversion explicitly via auxsmbconf. Aux params are applied
+    after the defaults, so the override wins.
+    """
+    smb = LEGACY_SHARE | {'path': nfsacl_dataset}
+    smb['options'] = LEGACY_SHARE_OPTS | {
+        'auxsmbconf': 'fruit:convert_adouble = yes'
+    }
+    conf = generate_smb_share_conf_dict(
+        None, smb, BASE_SMB_CONFIG | {'aapl_extensions': True}
+    )
+
+    assert conf['fruit:convert_adouble'] == 'yes'
+
+
 @pytest.mark.parametrize('tmopts', (
     {'auto_snapshot': True},
     {'auto_dataset_creation': True},


### PR DESCRIPTION
This commit disables a relatively new on-by-default feature of vfs_fruit that attempts to detect and auto-migrate file-backed AFP-style metadata. This exists primarily to facilitate data mobility between different vfs_fruit / server configurations. Since we've only had a single supported fruit configuration regarding metadata and resource forks since TrueNAS 9.10 we can safely disable this feature, which requires attempted per-file opens for every directory listing. This significantly harms dir listing performance for macos clients.