### PR TITLE
NAS-141114 / 26.0.0-RC.1 / `zpool.query`: remove `stripe` topology key, fold single-disk vdevs into `data`

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
@@ -110,8 +110,6 @@ class ZPoolTopology(BaseModel):
     """Array of L2ARC cache vdev configurations."""
     spares: list[ZPoolVdev]
     """Array of spare disk configurations."""
-    stripe: list[ZPoolVdev]
-    """Array of stripe (single-disk) vdev configurations."""
     special: list[ZPoolVdev]
     """Array of special vdev configurations for metadata."""
     dedup: list[ZPoolVdev]

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -124,12 +124,7 @@ class BootService(Service):
         await self.middleware.call('boot.format', dev, format_opts)
 
         pool = (await self.middleware.call('zpool.query_impl', {'pool_names': [BOOT_POOL_NAME], 'topology': True}))[0]
-
-        # Mirrored boot pools have their vdev in 'data', single-disk boot
-        # pools have it in 'stripe' (no children = no grouping vdev).
-        top = pool['topology']
-        boot_vdev = (top['data'] or top['stripe'])[0]
-
+        boot_vdev = pool['topology']['data'][0]
         zfs_dev_part = await self.middleware.call('disk.get_partition', dev)
         extend_pool_job = await self.middleware.call(
             'zfs.pool.extend', BOOT_POOL_NAME, None, [{

--- a/src/middlewared/middlewared/plugins/pool_/topology.py
+++ b/src/middlewared/middlewared/plugins/pool_/topology.py
@@ -76,10 +76,6 @@ class PoolService(Service):
             # Remove internal fields
             x.pop('top_guid', None)
 
-            # Merge stripe vdevs into data for legacy format
-            if 'stripe' in x:
-                x['data'].extend(x.pop('stripe'))
-
             # Convert vdev stats to legacy format
             if 'stats' in x and isinstance(x['stats'], dict):
                 x['stats'] = _transform_stats(x['stats'])

--- a/src/middlewared/middlewared/plugins/zpool/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/query_impl.py
@@ -26,8 +26,7 @@ def _convert_vdev_state(vdev: dict) -> None:
 def _format_topology(status_dict: dict) -> dict:
     """Organize vdevs from a pylibzfs status dict into a topology dict.
 
-    Separates storage vdevs into 'data' (groups with children) and 'stripe'
-    (single-disk vdevs without children), and places support vdevs (cache,
+    Separates storage vdevs into 'data' and places support vdevs (cache,
     dedup, log, special) and spares into their respective keys.
 
     Also converts VDevState enums to strings and children tuples to lists
@@ -38,7 +37,7 @@ def _format_topology(status_dict: dict) -> dict:
             'storage_vdevs', 'support_vdevs', and 'spares' keys.
 
     Returns:
-        dict with keys: cache, data, dedup, log, spares, special, stripe.
+        dict with keys: cache, data, dedup, log, spares, special.
         Each value is a list of vdev dicts.
     """
     top = {
@@ -48,14 +47,10 @@ def _format_topology(status_dict: dict) -> dict:
         "log": [],
         "spares": [],
         "special": [],
-        "stripe": [],
     }
     for vdev in status_dict["storage_vdevs"]:
         _convert_vdev_state(vdev)
-        if vdev["children"]:
-            top["data"].append(vdev)
-        else:
-            top["stripe"].append(vdev)
+        top["data"].append(vdev)
 
     for key in ("cache", "dedup", "log", "special"):
         for vdev in status_dict["support_vdevs"][key]:

--- a/src/middlewared/middlewared/plugins/zpool/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zpool/query_impl.py
@@ -26,7 +26,7 @@ def _convert_vdev_state(vdev: dict) -> None:
 def _format_topology(status_dict: dict) -> dict:
     """Organize vdevs from a pylibzfs status dict into a topology dict.
 
-    Separates storage vdevs into 'data' and places support vdevs (cache,
+    Places storage vdevs into 'data' and support vdevs (cache,
     dedup, log, special) and spares into their respective keys.
 
     Also converts VDevState enums to strings and children tuples to lists

--- a/tests/api2/test_zpool_query.py
+++ b/tests/api2/test_zpool_query.py
@@ -80,7 +80,7 @@ class TestZpoolQueryFull:
             assert isinstance(topology[key], list)
 
     def test_topology_data_vdev(self, zpool_full):
-        """At least one data or stripe vdev should exist."""
+        """At least one data vdev should exist."""
         vdevs = zpool_full["topology"]["data"]
         assert len(vdevs) > 0
         vdev = vdevs[0]

--- a/tests/api2/test_zpool_query.py
+++ b/tests/api2/test_zpool_query.py
@@ -75,14 +75,13 @@ class TestZpoolQueryFull:
     def test_topology(self, zpool_full):
         topology = zpool_full["topology"]
         assert isinstance(topology, dict)
-        for key in ("data", "log", "cache", "spares", "stripe", "special", "dedup"):
+        for key in ("data", "log", "cache", "spares", "special", "dedup"):
             assert key in topology
             assert isinstance(topology[key], list)
 
     def test_topology_data_vdev(self, zpool_full):
         """At least one data or stripe vdev should exist."""
-        topology = zpool_full["topology"]
-        vdevs = topology["data"] + topology["stripe"]
+        vdevs = zpool_full["topology"]["data"]
         assert len(vdevs) > 0
         vdev = vdevs[0]
         assert "name" in vdev


### PR DESCRIPTION
## Summary

Removes the `stripe` key from the `zpool.query` topology output and folds single-disk (childless) top-level vdevs into the existing `data` key, so all storage vdevs are reported in one place.

## Background

`query_impl._format_topology()` was splitting top-level storage vdevs into two buckets:

- `data`   — vdevs that have children (mirror, raidz, etc.)
- `stripe` — single-disk vdevs with no children

This split was a middleware-only invention. ZFS itself has no separate "stripe" vdev type — a lone disk is simply a top-level data vdev. The distinction added nothing the caller couldn't derive from `vdev['children']`, and it forced every consumer to special-case two keys instead of one.

## Compatibility note

`zpool.query` is new in 26.0.0 and has shipped only in pre-release builds, so removing the `stripe` key carries no stable-API compatibility burden. `pool.query` output is unchanged (it never exposed `stripe`).

http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/207/