### PR TITLE
NAS-141135 / 27.0.0-BETA.1 / Fix `pool.snapshottask.run` after type-safe model conversion (by creatorcary)

### DIFF
--- a/tests/api2/test_snapshot_task.py
+++ b/tests/api2/test_snapshot_task.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.service_exception import InstanceNotFound
+from middlewared.service_exception import CallError, InstanceNotFound
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.snapshot_task import snapshot_task
 from middlewared.test.integration.utils import call
@@ -40,6 +40,21 @@ def test_snapshot_task_is_deleted_when_deleting_a_parent_dataset():
 
                 with pytest.raises(InstanceNotFound):
                     assert call("pool.snapshottask.get_instance", t["id"])
+
+
+def test_snapshot_task_run_disabled_task_raises():
+    """Running a disabled periodic snapshot task should raise a CallError, not crash."""
+    with dataset("snap_disabled") as ds:
+        with snapshot_task({
+            "dataset": ds,
+            "recursive": True,
+            "lifetime_value": 1,
+            "lifetime_unit": "DAY",
+            "naming_schema": "%Y%m%d%H%M",
+            "enabled": False,
+        }) as t:
+            with pytest.raises(CallError, match="Task is not enabled"):
+                call("pool.snapshottask.run", t["id"])
 
 
 def test_snapshot_task_can_be_deleted_after_dataset_rename():


### PR DESCRIPTION
#18015 made `CRUDService.get_instance()` return a Pydantic model (`PeriodicSnapshotTaskEntry`) instead of a plain `dict`, and converted the callers to attribute access. The `pool.snapshottask.run` method was missed, so it still used dict subscripting and raised `TypeError` on every call:
```
    File "middlewared/plugins/snapshot.py", line 292, in run
        if not task["enabled"]:
    TypeError: 'PeriodicSnapshotTaskEntry' object is not subscriptable
```

Original PR: https://github.com/truenas/middleware/pull/18994
