### PR TITLE
NAS-140948 / 25.10.4 / Avoid LUN-replace stall and slow HA-session cleanup at failover (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -421,11 +421,6 @@ class DistributedLockManagerService(Service):
                     if await self.middleware.call('dlm.kernel.lockspace_is_stopped', lockspace):
                         self.logger.warning('Starting stopped lockspace %r', lockspace)
                         await self.middleware.call('dlm.kernel.lockspace_start', lockspace)
-
-                self.logger.debug('Logout all HA targets')
-                remote_ip = await self.middleware.call('failover.remote_ip')
-                await self.middleware.call('iscsi.target.logout_all', remote_ip)
-                self.logger.debug('Logged out all HA targets')
             finally:
                 DistributedLockManagerService.resetting = False
         finally:

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -770,5 +770,27 @@ class iSCSITargetAluaService(Service):
     async def reset_active(self, job):
         """Job to be run on the ACTIVE node before the STANDBY node will join."""
         self.standby_starting = False
-        dlm_ra = await self.middleware.call('dlm.reset_active')
-        await job.wrap(dlm_ra)
+        try:
+            dlm_ra = await self.middleware.call('dlm.reset_active')
+            await job.wrap(dlm_ra)
+        finally:
+            # Release any LUN-replace cleanup that was parked by
+            # enable_async_lun_replace. dlm.reset_active does eject_peer
+            # before any of its other steps, so by the time we get here the
+            # peer is already out of the DLM lockspaces -- which is the only
+            # prerequisite the parked work has.
+            await self.middleware.call('iscsi.scst.disable_async_lun_replace')
+
+        # Log out any leftover HA iSCSI sessions to the (former) peer. The
+        # failover event's handle_alua block defers this logout to reset_active
+        # so the ALUA tgt_dev filter stays in place across the LUN replace.
+        # It also keeps dlm.remote_down's logged_in_extents guard from tripping
+        # later: without this, lingering sessions die only when their NOP-out
+        # timer expires, which can keep remote_down skipping reset_active for
+        # minutes. Swallow failures -- the NOP-out timeout is the backstop.
+        try:
+            remote_ip = await self.middleware.call('failover.remote_ip')
+            if remote_ip:
+                await self.middleware.call('iscsi.target.logout_all', remote_ip)
+        except Exception:
+            self.logger.warning('reset_active: logout_all failed', exc_info=True)

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -208,11 +208,30 @@ class iSCSITargetService(Service):
             self.logger.warning('Failed to set ALUA active state')
 
     def enable_async_lun_replace(self):
-        """Enable async LUN replace to avoid blocking failover on tgt_dev drain."""
+        """Enable async LUN replace to avoid blocking failover on tgt_dev drain.
+
+        While enabled, the kernel parks the deferred cleanup of old tgt_devs
+        from each LUN replace instead of running it on a workqueue
+        immediately. The orchestrating layer must call
+        disable_async_lun_replace once any cluster coordination the cleanup
+        depends on (e.g. DLM peer eviction) has completed, to release the
+        parked work."""
         try:
             pathlib.Path(SCST_ASYNC_LUN_REPLACE).write_text('1\n')
         except Exception:
             self.logger.warning('Failed to enable async_lun_replace')
+
+    def disable_async_lun_replace(self):
+        """Disable async LUN replace and release any parked LUN-replace cleanup.
+
+        Should be called after the cluster coordination that the parked
+        cleanup depends on (e.g. DLM peer eviction via dlm.reset_active) has
+        completed, so that scst_free_tgt_dev -> scst_clear_reservation ->
+        scst_dlm_res_lock will not stall."""
+        try:
+            pathlib.Path(SCST_ASYNC_LUN_REPLACE).write_text('0\n')
+        except Exception:
+            self.logger.warning('Failed to disable async_lun_replace')
 
     def copy_manager_devices(self):
         result = []


### PR DESCRIPTION
Release parked async LUN-replace cleanup after DLM peer eviction
scst.async_lun_replace=1 now also tells the kernel to park the deferred
cleanup of old tgt_devs from each LUN replace until the flag is cleared.
This avoids stalling become_active on scst_dlm_lock_wait inside
scst_clear_reservation while the dead peer is still a DLM lockspace
member.

Add iscsi.scst.disable_async_lun_replace and call it from the end of
iscsi.alua.reset_active, after dlm.reset_active (which evicts the peer)
completes.

Original PR: https://github.com/truenas/middleware/pull/18920
