### PR TITLE
NAS-141142 / 27.0.0-BETA.1 / VM/container: parallelize shutdown and fix force_after_timeout

### DIFF
--- a/src/middlewared/middlewared/plugins/container/__init__.py
+++ b/src/middlewared/middlewared/plugins/container/__init__.py
@@ -145,8 +145,8 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
         start_on_boot(self.context)
 
     @private
-    def handle_shutdown(self) -> None:
-        handle_shutdown(self.context)
+    async def handle_shutdown(self) -> None:
+        await handle_shutdown(self.context)
 
     @private
     async def nsenter(self, id_: int) -> list[str]:

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 import errno
 import os
 import typing
@@ -96,9 +97,19 @@ def start_on_boot(context: ServiceContext) -> None:
             context.logger.error(f"Failed to start {container.name!r} container: {e}")
 
 
-def handle_shutdown(context: ServiceContext) -> None:
-    for container in context.call_sync2(context.s.container.query, [("status.state", "=", "RUNNING")]):
-        stop(context, container.id, ContainerStopOptions(force_after_timeout=True))
+async def _stop_one_container(context: ServiceContext, container: typing.Any) -> None:
+    try:
+        job = await context.call2(
+            context.s.container.stop, container.id, ContainerStopOptions(force_after_timeout=True),
+        )
+        await job.wait(raise_error=True)
+    except Exception:
+        context.logger.error('Failed to stop %r container', container.name, exc_info=True)
+
+
+async def handle_shutdown(context: ServiceContext) -> None:
+    running = await context.call2(context.s.container.query, [("status.state", "=", "RUNNING")])
+    await asyncio.gather(*(_stop_one_container(context, c) for c in running))
 
 
 def start(context: ServiceContext, id_: int) -> None:

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import typing
 
@@ -51,8 +52,14 @@ def stop_vm(context: ServiceContext, id_: int, options: VMStopOptions) -> None:
     libvirt_domain = pylibvirt_vm(context, vm.model_dump(by_alias=True, context={'expose_secrets': True}))
     if options.force:
         context.middleware.libvirt_domains_manager.vms.destroy(libvirt_domain)
-    else:
-        context.middleware.libvirt_domains_manager.vms.shutdown(libvirt_domain, vm.shutdown_timeout)
+        return
+
+    context.middleware.libvirt_domains_manager.vms.shutdown(libvirt_domain, vm.shutdown_timeout)
+    if (
+        options.force_after_timeout
+        and context.call_sync2(context.s.vm.get_instance, id_).status.state == 'RUNNING'
+    ):
+        context.middleware.libvirt_domains_manager.vms.destroy(libvirt_domain)
 
 
 def poweroff_vm(context: ServiceContext, id_: int) -> None:
@@ -142,12 +149,17 @@ async def start_on_boot(context: ServiceContext) -> None:
             context.logger.error(f'Failed to start VM {vm.name}: {e}')
 
 
-async def handle_shutdown(context: ServiceContext) -> None:
-    for vm in await context.call2(context.s.vm.query, [('status.state', 'in', ACTIVE_STATES)]):
+async def _stop_one_vm(context: ServiceContext, vm: typing.Any) -> None:
+    try:
         if vm.status.state == 'RUNNING':
-            await context.call2(context.s.vm.stop, vm.id, VMStopOptions(force_after_timeout=True))
+            job = await context.call2(context.s.vm.stop, vm.id, VMStopOptions(force_after_timeout=True))
+            await job.wait(raise_error=True)
         else:
-            try:
-                await context.to_thread(poweroff_vm, context, vm.id)
-            except Exception:
-                context.logger.error('Powering off %r VM failed', vm.name, exc_info=True)
+            await context.to_thread(poweroff_vm, context, vm.id)
+    except Exception:
+        context.logger.error('Failed to stop %r VM', vm.name, exc_info=True)
+
+
+async def handle_shutdown(context: ServiceContext) -> None:
+    active = await context.call2(context.s.vm.query, [('status.state', 'in', ACTIVE_STATES)])
+    await asyncio.gather(*(_stop_one_vm(context, vm) for vm in active))


### PR DESCRIPTION
## Problem

When middleware itself stops VMs and containers — on system shutdown/reboot via the `system.shutdown` event, or during HA failover — it loops through guests one at a time, waiting up to the per-guest shutdown timeout (90s by default) for each. With many guests this serializes into a long wait, even though stopping different guests has no dependency on one another.

Separately, `vm.stop(force_after_timeout=True)` was silently ignored — `stop_vm` only checked `options.force`. A VM that didn't respond to ACPI within its `shutdown_timeout` was left running, contradicting the API docstring and behaving inconsistently with the container path which honored the flag correctly.

## Solution

Parallelize `vm.handle_shutdown` and `container.handle_shutdown` using `asyncio.gather`, so all guests receive shutdown concurrently. Per-id job locks are unchanged, and `truenas_pylibvirt` releases the GIL during libvirt RPCs, so concurrent stops genuinely run in parallel at libvirtd.

Fix `stop_vm` to honor `force_after_timeout`: after the ACPI wait, if the VM is still RUNNING, call `destroy()` — mirroring the existing container behavior.
