### PR TITLE
NAS-141131 / 26.0.0-RC.1 / Set PARALLEL_SHUTDOWN for faster guest shutdown (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
+++ b/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
@@ -6,14 +6,13 @@
 
     # Using `container.query`/`vm.query` here will result in a deadlock, as these methods retrieve container/VM status,
     # which means ensureing libvirtd is started, which means this file needs to be generated.
-    vm_max_shutdown = max(map(
-        lambda v: v['shutdown_timeout'],
-        (
-            middleware.call_sync('datastore.query', 'container.container') +
-            middleware.call_sync('datastore.query', 'vm.vm')
-        ),
-    ), default=10)
+    containers = middleware.call_sync('datastore.query', 'container.container')
+    vms = middleware.call_sync('datastore.query', 'vm.vm')
+    vm_max_shutdown = max((g['shutdown_timeout'] for g in containers + vms), default=10)
+    # PARALLEL_SHUTDOWN is applied independently per URI (lxc, qemu), so the cap only needs to cover the larger batch.
+    parallel_shutdown = max(len(containers), len(vms), 1)
 %>\
 URIS="${uris}"
 ON_SHUTDOWN=shutdown
 SHUTDOWN_TIMEOUT=${vm_max_shutdown}
+PARALLEL_SHUTDOWN=${parallel_shutdown}


### PR DESCRIPTION
## Problem

On shutdown/reboot, TrueNAS stops containers and VMs one at a time, waiting up to the per-guest shutdown timeout (90s by default) for each. With many guests, this serializes into a long wait — a system with 10 containers and 10 VMs can spend most of its shutdown idle, waiting on guests one after another.

## Solution

Set `PARALLEL_SHUTDOWN` in `/etc/default/libvirt-guests` so all containers shut down concurrently and all VMs shut down concurrently. The per-guest timeout is unchanged; the waits just happen in parallel.

libvirt applies `PARALLEL_SHUTDOWN` independently per URI (lxc, qemu), so the cap only needs to cover the larger batch — hence `max(len(containers), len(vms), 1)`.


Original PR: https://github.com/truenas/middleware/pull/18989
