### PR TITLE
NAS-141282 / 27.0.0-BETA.1 / Improve system dataset moves

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -306,8 +306,13 @@ class SystemDatasetService(ConfigService):
     @private
     def sysdataset_path(self, expected_datasetname=None):
         """
-        Returns SYSDATASET_PATH if the expected dataset is mounted there,
-        otherwise None. Called frequently -- single statmount probe.
+        This function returns either None or SYSDATASET_PATH,
+        and is called potentially quite frequently (once per ZFS event
+        or pool.dataset.query, etc).
+
+        `None` indicates that there was an issue with filesystem mounted
+        at SYSDATASET_PATH. Typically this could indicate a failed migration
+        of system dataset or problem importing expected pool for system dataset.
         """
         if expected_datasetname is None:
             db_pool = self.middleware.call_sync(
@@ -394,7 +399,9 @@ class SystemDatasetService(ConfigService):
 
     @api_method(SystemDatasetPoolChoicesArgs, SystemDatasetPoolChoicesResult, roles=['POOL_READ'])
     async def pool_choices(self, include_current_pool):
-        """Retrieve pool choices which can be used for configuring system dataset."""
+        """
+        Retrieve pool choices which can be used for configuring system dataset.
+        """
         boot_pool = await self.middleware.call('boot.pool_name')
         current_pool = (await self.config())['pool']
         valid_pools = await self.middleware.call('systemdataset.query_pools_for_system_dataset')
@@ -410,14 +417,8 @@ class SystemDatasetService(ConfigService):
     async def do_update(self, job, data):
         """Update System Dataset Service Configuration.
 
-        Records the user's pool selection in the datastore, then calls
-        reconcile() with `authority=SysdatasetAuthority.LIVE` so the data the user
-        was just working with travels to the new pool. See the module
-        docstring for the state matrix.
-
-        `job` is forwarded into reconcile() so whichever action ends up
-        running (typically MIGRATE_DATA) reports progress as it quiesces
-        services, copies the dataset, and swaps the mount.
+        Set `pool` to choose which pool hosts the system dataset. Changing the
+        pool moves the system dataset and its contents to the new pool.
         """
         job.set_progress(0, 'Validating system dataset configuration')
         data.setdefault('pool_exclude', None)
@@ -575,17 +576,15 @@ class SystemDatasetService(ConfigService):
             config = self.middleware.call_sync('systemdataset.config')
             authority = SysdatasetAuthority.LIVE
 
-        # 2. Make sure SYSDATASET_PATH exists as a real directory before
-        #    any mount work -- the swap opens it and would happily traverse
-        #    a stray symlink target if we let one slip through.
-        if not os.path.isdir(SYSDATASET_PATH) and os.path.exists(SYSDATASET_PATH):
-            os.unlink(SYSDATASET_PATH)
+        # 2. Make sure SYSDATASET_PATH is a real directory before any mount
+        #    work. Remove whatever's there if it isn't one (stale file or
+        #    symlink), then create it.
+        try:
+            if not stat.S_ISDIR(os.lstat(SYSDATASET_PATH).st_mode):
+                os.unlink(SYSDATASET_PATH)
+        except FileNotFoundError:
+            pass
         os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
-        os.close(truenas_os.openat2(
-            SYSDATASET_PATH,
-            flags=os.O_DIRECTORY | os.O_CLOEXEC,
-            resolve=truenas_os.RESOLVE_NO_SYMLINKS,
-        ))
 
         # 3. Inspect live state and dispatch via the state machine.
         live_pool = self._live_pool()
@@ -626,12 +625,12 @@ class SystemDatasetService(ConfigService):
 
     @private
     def query_pools_for_system_dataset(self, exclude_pool=None):
-        """Pools eligible to host the system dataset.
-
-        Pools with passphrase-locked roots are eligible because ZFS
-        encryption is per-dataset and the system dataset uses a legacy
-        mount; key format is only exposed via libzfs, so reading mountinfo
-        here is insufficient.
+        """
+        Pools with passphrase-locked root level datasets are permitted as system
+        dataset targets. This is because ZFS encryption is at the dataset level
+        rather than pool level, and we use a legacy mount for the system dataset.
+        Key format is only exposed via libzfs and so reading mountinfo here is
+        insufficient.
         """
         rv = []
         for i in query_imported_fast_impl().values():
@@ -982,10 +981,13 @@ class SystemDatasetService(ConfigService):
     @contextmanager
     @private
     def release_system_dataset(self):
-        """Quiesce daemons that hold sysdataset handles.
+        """
+        This context manager is used to toggle system-dataset dependent services and
+        tasks for cases where the dataset is unmounted / remounted.
 
-        sysdataset.update and sysdataset.setup can both reach this via
-        different code paths -- the lock prevents simultaneous releases.
+        The operations are performed under a lock because systemdataset.update() and
+        systemdataset.setup() both can lead to this being called, and we don't want
+        simultaneous releases of system dataset.
         """
         with self.sysdataset_release_lock:
             # TODO: Review these services because /var/log no longer sits on
@@ -1113,7 +1115,9 @@ async def pool_post_create(middleware, pool):
 
 
 async def pool_post_import(middleware, pool):
-    """On pool import we may need to reconfigure the system dataset."""
+    """
+    On pool import we may need to reconfigure system dataset.
+    """
     await middleware.call('systemdataset.setup')
 
 

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -340,12 +340,12 @@ class SystemDatasetService(ConfigService):
 
     @private
     async def config_extend(self, config):
-        # Empty pool is treated as boot pool.
+        # Treat empty system dataset pool as boot pool
         config['pool_set'] = bool(config['pool'])
         config['pool'] = self.force_pool or config['pool'] or await self.middleware.call('boot.pool_name')
         config['basename'] = f'{config["pool"]}/.system'
 
-        # `uuid` always reflects the local node (B uses uuid_b).
+        # Make `uuid` point to the uuid of current node
         uuid_key = 'uuid'
         if await self.middleware.call('failover.node') == 'B':
             uuid_key = 'uuid_b'
@@ -495,8 +495,8 @@ class SystemDatasetService(ConfigService):
 
         used = existing_dataset['properties']['used']['value']
         available = new_dataset['properties']['available']['value']
-        # 1.1x margin: same files don't take exactly the same amount of
-        # space on a different pool.
+        # 1.1 is a safety margin because same files won't
+        # take exactly the same amount of space on a different pool
         used = int(used * 1.1)
         if available < used:
             return (
@@ -734,18 +734,16 @@ class SystemDatasetService(ConfigService):
                 self.s.zfs.resource.query_impl,
                 ZFSResourceQuery(
                     paths=list(datasets),
-                    properties=['encryption', 'quota', 'used', 'overlay'] + list(SystemDatasetZfsProperties)
+                    properties=['encryption', 'quota', 'used'] + list(SystemDatasetZfsProperties)
                 ),
             )
         }
         for dataset, config in datasets.items():
             props = config['props']
-            # Disable encryption on system-managed children of
-            # passphrase-encrypted pools.
+            # Disable encryption for system managed datasets that are
+            # configured on zpools that are passphrase-encrypted.
             if root_dataset_is_passphrase_encrypted:
                 props['encryption'] = 'off'
-            # overlayfs is never used on system dataset paths.
-            props['overlay'] = 'off'
             is_cores_ds = dataset.endswith('/cores')
             if is_cores_ds:
                 # 1G; raw value so the update_props_dict comparison below
@@ -1138,26 +1136,14 @@ async def pool_pre_export(middleware, pool, options, job):
 async def setup(middleware):
     def setup_paths():
         os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
-        # /var/cache/nscd should be a symlink to /var/run/nscd/cache.
-        # Probe via lstat on a /var/cache dir_fd so the check doesn't
-        # traverse a hostile symlink at the final component.
-        cache_fd = os.open('/var/cache', os.O_DIRECTORY | os.O_CLOEXEC)
-        try:
-            try:
-                st = os.lstat('nscd', dir_fd=cache_fd)
-                is_symlink = stat.S_ISLNK(st.st_mode)
-                exists = True
-            except FileNotFoundError:
-                is_symlink = False
-                exists = False
+        if not os.path.exists('/var/cache/nscd') or not os.path.islink('/var/cache/nscd'):
+            if os.path.exists('/var/cache/nscd'):
+                shutil.rmtree('/var/cache/nscd')
 
-            if not is_symlink:
-                if exists:
-                    shutil.rmtree('/var/cache/nscd')
-                os.makedirs('/var/run/nscd/cache', exist_ok=True)
-                os.symlink('/var/run/nscd/cache', 'nscd', dir_fd=cache_fd)
-        finally:
-            os.close(cache_fd)
+            os.makedirs('/var/run/nscd/cache', exist_ok=True)
+
+        if not os.path.islink('/var/cache/nscd'):
+            os.symlink('/var/run/nscd/cache', '/var/cache/nscd')
 
     middleware.register_hook('pool.post_create', pool_post_create)
     # Reconfigure the system dataset first thing after a pool import.

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -1,15 +1,240 @@
+"""System dataset.
+
+The system dataset is a hierarchy of ZFS datasets rooted at <pool>/.system
+
+Mount + replication primitives live in `system_dataset.mount`. This module
+is the orchestrator: pool selection, DB persistence, and the state machine
+that decides what to do when configured pool, on-disk reality, and live
+mount disagree.
+
+
+============================================================================
+Terminology
+============================================================================
+
+    configured_pool   The user's recorded selection
+                      (`system_systemdataset.sys_pool`). Empty string means
+                      "no preference" -- config_extend resolves it to the
+                      boot pool for display, but the field stays empty in
+                      the DB so a real selection can be distinguished from
+                      a default.
+
+    live_pool         The pool whose `<pool>/.system` is currently mounted
+                      at SYSDATASET_PATH (/var/db/system), determined by
+                      statmount. None if nothing is mounted there. May
+                      differ from configured_pool for legitimate reasons
+                      (fallback overlay) or pathological ones (a prior
+                      migration crashed between DB write and mount swap).
+
+    target_pool       The pool reconcile() will leave live at the end of
+                      this call.
+                      - In setup() / pool.post_* flows: selected from
+                        configured_pool via pool-availability fallback
+                        rules (see "Pool selection" below).
+                      - In do_update flow: the user-validated choice
+                        (already known available; no fallback needed).
+
+    authority         When live_pool != target_pool, whose data wins
+                      (the SysdatasetAuthority enum):
+                        LIVE    -> live_pool's contents must be preserved
+                                  (snapshot + send -> target_pool).
+                                  Set by do_update -- the user is moving
+                                  their selection; the data they were
+                                  using has to travel with them.
+                        TARGET  -> target_pool's existing `.system` is the
+                                  truth; live_pool was a transient
+                                  overlay. Set by setup() -- the DB hasn't
+                                  changed, so a live mismatch is the
+                                  thing to discard.
+
+                      reconcile() promotes TARGET -> LIVE when it
+                      itself persists a fresh non-fallback selection
+                      (e.g. pool.post_create chose a data pool against
+                      an empty DB). In that case we are effectively
+                      acting on the user's behalf, and the data they
+                      can currently see at SYSDATASET_PATH must follow
+                      the selection.
+
+    force_pool        Process-local override that makes config_extend
+                      report `target_pool` for the duration of a fallback
+                      overlay without persisting that choice. Cleared at
+                      the start of every reconcile().
+
+
+============================================================================
+Pool selection (setup() path only -- do_update validates upfront)
+============================================================================
+
+select_system_dataset_pool(configured_pool, exclude_pool) resolves the DB
+value against pool reality:
+
+    configured_pool        pool state                       -> result
+    ----------------------------------------------------------------------
+    (unset / empty)        any                              -> first usable
+                                                              non-boot pool,
+                                                              else boot.
+                                                              persisted.
+    configured             importable, not key-locked       -> configured.
+    configured             passphrase-locked root           -> configured.
+                                                              (sysdataset
+                                                              uses legacy
+                                                              mount; per-
+                                                              dataset keys
+                                                              are independent
+                                                              of root state.)
+    configured             root locked-with-key             -> boot,
+                                                              force_pool=boot
+                                                              (overlay; DB
+                                                              unchanged so
+                                                              we revisit
+                                                              when it
+                                                              unlocks).
+    configured             not imported                     -> boot,
+                                                              force_pool=boot
+                                                              (overlay).
+
+`is_fallback` is True in the two overlay rows. The DB is only rewritten in
+the first row.
+
+
+============================================================================
+Reconcile state machine
+============================================================================
+
+Once target_pool and authority are settled, reconcile() inspects live_pool
+and picks one of four actions:
+
+    live_pool   live==target   authority   action
+    ----------------------------------------------------------------------
+    None        any            any         MOUNT_FRESH
+    target      yes            any         RECONCILE_ONLY
+    other       no             LIVE        MIGRATE_DATA
+    other       no             TARGET      ABANDON_AND_REMOUNT
+
+Action semantics:
+
+    MOUNT_FRESH
+        Nothing mounted at SYSDATASET_PATH. Create any missing datasets
+        under <target_pool>/.system per the spec, mount the hierarchy,
+        finalize. Used at first boot and after a `pool_pre_export` cleared
+        the field with no live mount left behind.
+
+    RECONCILE_ONLY
+        Already mounted from the right pool. Re-run setup_datasets
+        (idempotent -- creates anything missing, fixes prop drift) and
+        post-mount fixups (acltype=off, cores->coredump bind). No mount
+        churn, no service quiesce.
+
+    MIGRATE_DATA
+        Snapshot live_pool/.system recursively, send to target_pool/.system
+        via local_replicate with `force=True` (zfs receive -F), then (with
+        daemon quiesce) umount SYSDATASET_PATH and mount target_pool/.system
+        there, and destroy live_pool/.system. Force receive replaces any pre-existing
+        `<target>/.system` atomically as part of the receive -- stale
+        leftovers from prior aborted migrations and child datasets not
+        in the stream get destroyed by the kernel during recv.
+
+        Some destinations the kernel refuses to overwrite even with -F
+        (top-level snapshots, clones). In those cases the receive fails
+        with EZFS_EXISTS; we fall back to an explicit recursive destroy
+        of `<target>/.system` (with hard return-value checking, since
+        destroy_impl reports logical failures via tuple return rather
+        than raising) and retry the receive once.
+
+    ABANDON_AND_REMOUNT
+        With daemon quiesce, umount SYSDATASET_PATH and mount target_pool's
+        existing `.system` there. live_pool's data is discarded (it was an
+        overlay or a stale leftover; the user-visible "real" data lives on
+        target_pool). No destroy of target, no replication.
+
+
+============================================================================
+Caller -> action flowchart
+============================================================================
+
+    setup()  /  pool.post_create  /  pool.post_import  /  failover event
+        |
+        |   exclude_pool=None (or the pool being processed)
+        |   authority=TARGET   <- DB is source of truth
+        v
+    reconcile() --> select target via fallback rules
+                 --> persist target to DB if it's a non-fallback change
+                 --> state machine above
+
+    do_update({pool, pool_exclude})           (job, lock=sysdataset_update)
+        |
+        +-> _validate_and_select_pool   (verrors if pool unavailable)
+        +-> write target to DB
+        +-> reconcile(authority=LIVE)
+        |       target = DB value (just written)
+        |       authority=LIVE -> user-initiated; preserve current data
+        +-> return config
+
+    pool.pre_export(pool_being_exported)
+        |
+        +-> systemdataset.update({pool: None, pool_exclude: <being-exported>})
+              |
+              +-> _validate_and_select_pool picks the next data pool
+                  (or '' for boot fallback) and the rest is do_update.
+
+The two paths converge on reconcile(); the only difference is the
+`authority` parameter -- i.e. who owns the data when they disagree.
+
+
+============================================================================
+HA lifecycle
+============================================================================
+
+In a TrueNAS HA pair the data pool that hosts the sysdataset is shared
+storage imported by exactly one controller at a time. The standby
+controller cannot import that pool, so the sysdataset must live somewhere
+else for the duration. The boot-pool overlay handles this naturally:
+
+    Standby controller, DB says "tank" (the shared pool):
+        select_system_dataset_pool(preferred="tank")
+          -> tank not importable here  -> (boot, is_fallback=True)
+        force_pool = boot (no DB write; the configured choice is unchanged)
+        live = None at boot, or boot from a prior reconcile
+          -> MOUNT_FRESH or RECONCILE_ONLY on the boot overlay.
+
+    Failover: standby takes over and imports tank. pool.post_import
+    fires setup() -> reconcile(authority=TARGET):
+        select_system_dataset_pool(preferred="tank")
+          -> tank now importable  -> (tank, is_fallback=False)
+        force_pool cleared; config['pool'] == DB's "tank"; no drift.
+        live = boot (the overlay), target = tank, authority = TARGET
+          -> ABANDON_AND_REMOUNT mounts tank/.system from the shared pool.
+        The boot-pool overlay is discarded: its contents were standby-
+        local scratch, not real sysdataset state. The "real" sysdataset
+        lives on tank with whatever the previously-active controller
+        wrote into it.
+
+    Failback (planned takeover the other direction) is symmetric: the
+    incoming-active sees pool.post_import on tank, runs the same
+    ABANDON_AND_REMOUNT, and the now-standby falls back to its own boot
+    overlay on the next setup() pass.
+
+The authority=TARGET choice on the failover path is the load-bearing
+piece: copying the standby's boot-pool overlay onto tank would destroy
+the active's working state. That's exactly the "target wins" semantic
+ABANDON_AND_REMOUNT implements.
+
+Per-controller UUID handling (sys_uuid_b column, ensure_standby_uuid)
+sits outside reconcile() -- each controller has its own uuid, synced
+once over `failover.call_remote`.
+"""
 from contextlib import contextmanager, suppress
+import enum
 import errno
-import json
 import os
-from pathlib import Path
 import shutil
-import subprocess
+import stat
 import threading
 import uuid
 
 import truenas_os
 from truenas_os_pyutils.mount import iter_mountinfo, statmount, umount
+import truenas_pylibzfs
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -22,14 +247,38 @@ from middlewared.api.current import (
 )
 from middlewared.plugins.pool_.utils import CreateImplArgs, UpdateImplArgs
 from middlewared.plugins.system_dataset.hierarchy import SystemDatasetZfsProperties, get_system_dataset_spec
+from middlewared.plugins.system_dataset.mount import (
+    mount_hierarchy,
+    replicate,
+)
 from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
+from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
 from middlewared.plugins.zfs.utils import get_encryption_info
 from middlewared.service import CallError, ConfigService, ValidationError, ValidationErrors, job, private
 import middlewared.sqlalchemy as sa
-from middlewared.utils import BOOT_POOL_NAME_VALID, MIDDLEWARE_RUN_DIR
+from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.size import format_size
 from middlewared.utils.tdb import close_sysdataset_tdb_handles
 from middlewared.utils.zfs import query_imported_fast_impl
+
+# systemd writes coredumps here; we bind <SYSDATASET>/cores onto it so
+# coredumps land on persistent storage instead of the boot pool.
+_COREDUMP_PATH = '/var/lib/systemd/coredump'
+
+
+class SysdatasetAuthority(enum.StrEnum):
+    """Whose data wins when the live mount and the target pool disagree.
+
+    LIVE    the data currently visible at SYSDATASET_PATH is authoritative
+            and must travel to the target pool. Set by do_update -- the user
+            is moving their selection and their data has to follow.
+    TARGET  the target pool's existing `.system` is authoritative; whatever
+            is mounted now was a transient overlay and is discarded. Set by
+            setup() -- the DB hasn't changed, so a live mismatch is the thing
+            to throw away.
+    """
+    LIVE = 'LIVE'
+    TARGET = 'TARGET'
 
 
 class SystemDatasetModel(sa.Model):
@@ -57,18 +306,12 @@ class SystemDatasetService(ConfigService):
     @private
     def sysdataset_path(self, expected_datasetname=None):
         """
-        This function returns either None or SYSDATASET_PATH,
-        and is called potentially quite frequently (once per ZFS event
-        or pool.dataset.query, etc).
-
-        `None` indicates that there was an issue with filesystem mounted
-        at SYSDATASET_PATH. Typically this could indicate a failed migration
-        of system dataset or problem importing expected pool for system dataset.
+        Returns SYSDATASET_PATH if the expected dataset is mounted there,
+        otherwise None. Called frequently -- single statmount probe.
         """
         if expected_datasetname is None:
             db_pool = self.middleware.call_sync(
-                'datastore.config',
-                'system.systemdataset'
+                'datastore.config', 'system.systemdataset',
             )['sys_pool']
             pool = self.force_pool or db_pool or self.middleware.call_sync('boot.pool_name')
             ds_name = f'{pool}/.system'
@@ -82,32 +325,33 @@ class SystemDatasetService(ConfigService):
             return None
 
         if mntinfo.sb_source != ds_name:
-            self.logger.warning('Unexpected dataset mounted at %s, %r present, but %r expected.',
-                                SYSDATASET_PATH, mntinfo.sb_source, ds_name)
+            self.logger.warning(
+                'Unexpected dataset mounted at %s, %r present, but %r expected.',
+                SYSDATASET_PATH, mntinfo.sb_source, ds_name,
+            )
             return None
 
         return SYSDATASET_PATH
 
     @private
     async def config_extend(self, config):
-        # Treat empty system dataset pool as boot pool
+        # Empty pool is treated as boot pool.
         config['pool_set'] = bool(config['pool'])
         config['pool'] = self.force_pool or config['pool'] or await self.middleware.call('boot.pool_name')
-
         config['basename'] = f'{config["pool"]}/.system'
 
-        # Make `uuid` point to the uuid of current node
+        # `uuid` always reflects the local node (B uses uuid_b).
         uuid_key = 'uuid'
         if await self.middleware.call('failover.node') == 'B':
             uuid_key = 'uuid_b'
             config['uuid'] = config['uuid_b']
-
         del config['uuid_b']
 
         if not config['uuid']:
             config['uuid'] = uuid.uuid4().hex
             await self.middleware.call(
-                'datastore.update', 'system.systemdataset', config['id'], {uuid_key: config['uuid']}, {'prefix': 'sys_'}
+                'datastore.update', 'system.systemdataset', config['id'],
+                {uuid_key: config['uuid']}, {'prefix': 'sys_'},
             )
 
         config['path'] = await self.middleware.run_in_thread(self.sysdataset_path, config['basename'])
@@ -119,13 +363,16 @@ class SystemDatasetService(ConfigService):
         if await self.middleware.call('failover.node') == 'B':
             remote_uuid_key = 'uuid'
 
-        local_config = await self.middleware.call('datastore.config', 'system.systemdataset', {'prefix': 'sys_'})
+        local_config = await self.middleware.call(
+            'datastore.config', 'system.systemdataset', {'prefix': 'sys_'},
+        )
         if local_config[remote_uuid_key]:
             self.logger.debug('We already know the standby controller system dataset UUID')
             return
 
         remote_config = await self.middleware.call(
-            'failover.call_remote', 'datastore.config', ['system.systemdataset', {'prefix': 'sys_'}],
+            'failover.call_remote', 'datastore.config',
+            ['system.systemdataset', {'prefix': 'sys_'}],
         )
         if not remote_config[remote_uuid_key]:
             self.logger.warning('Standby controller does not yet have the system dataset UUID')
@@ -133,11 +380,8 @@ class SystemDatasetService(ConfigService):
 
         self.logger.info(f'Setting {remote_uuid_key}={remote_config[remote_uuid_key]!r}')
         await self.middleware.call(
-            'datastore.update',
-            'system.systemdataset',
-            local_config['id'],
-            {remote_uuid_key: remote_config[remote_uuid_key]},
-            {'prefix': 'sys_'},
+            'datastore.update', 'system.systemdataset', local_config['id'],
+            {remote_uuid_key: remote_config[remote_uuid_key]}, {'prefix': 'sys_'},
         )
 
     @private
@@ -146,95 +390,97 @@ class SystemDatasetService(ConfigService):
         if not pool:
             raise CallError('System dataset pool is not set. This may prevent '
                             'system services from functioning properly.')
-
         return pool in BOOT_POOL_NAME_VALID
 
     @api_method(SystemDatasetPoolChoicesArgs, SystemDatasetPoolChoicesResult, roles=['POOL_READ'])
     async def pool_choices(self, include_current_pool):
-        """
-        Retrieve pool choices which can be used for configuring system dataset.
-        """
+        """Retrieve pool choices which can be used for configuring system dataset."""
         boot_pool = await self.middleware.call('boot.pool_name')
         current_pool = (await self.config())['pool']
-        valid_pools = await self.middleware.call(
-            'systemdataset.query_pools_for_system_dataset'
-        )
+        valid_pools = await self.middleware.call('systemdataset.query_pools_for_system_dataset')
 
         pools = [boot_pool]
         if include_current_pool:
             pools.append(current_pool)
         pools.extend(valid_pools)
-
-        return {
-            p: p for p in sorted(set(pools))
-        }
+        return {p: p for p in sorted(set(pools))}
 
     @api_method(SystemDatasetUpdateArgs, SystemDatasetUpdateResult)
     @job(lock='sysdataset_update')
     async def do_update(self, job, data):
+        """Update System Dataset Service Configuration.
+
+        Records the user's pool selection in the datastore, then calls
+        reconcile() with `authority=SysdatasetAuthority.LIVE` so the data the user
+        was just working with travels to the new pool. See the module
+        docstring for the state matrix.
+
+        `job` is forwarded into reconcile() so whichever action ends up
+        running (typically MIGRATE_DATA) reports progress as it quiesces
+        services, copies the dataset, and swaps the mount.
         """
-        Update System Dataset Service Configuration.
-        """
+        job.set_progress(0, 'Validating system dataset configuration')
         data.setdefault('pool_exclude', None)
-
         config = await self.config()
+        new_pool = await self._validate_and_select_pool(data, config)
 
-        new = config.copy()
-        new.update(data)
+        await self.middleware.call(
+            'datastore.update', 'system.systemdataset', config['id'],
+            {'pool': new_pool or ''}, {'prefix': 'sys_'},
+        )
 
+        await self.middleware.call(
+            'systemdataset.reconcile', data['pool_exclude'], SysdatasetAuthority.LIVE, job,
+        )
+        job.set_progress(100, 'System dataset configuration complete')
+        return await self.config()
+
+    async def _validate_and_select_pool(self, data, config):
+        """Validate the requested pool and return the pool name to record.
+
+        If the caller explicitly passes pool=None (e.g. pool_pre_export
+        clearing the selection), pick the first usable data pool that
+        isn't excluded. Returning '' lets the DB record the empty value
+        and config_extend fall back to the boot pool.
+        """
         verrors = ValidationErrors()
-        if new['pool'] != config['pool']:
-            if new['pool']:
-                if error := await self.destination_pool_error(new['pool']):
-                    verrors.add('sysdataset_update.pool', error)
+        new_pool = data.get('pool', config['pool'])
 
-        if new['pool']:
-            if new['pool'] not in await self.pool_choices(False):
+        if new_pool and new_pool != config['pool']:
+            if error := await self.destination_pool_error(new_pool):
+                verrors.add('sysdataset_update.pool', error)
+
+        if new_pool:
+            if new_pool not in await self.pool_choices(False):
                 verrors.add(
                     'sysdataset_update.pool',
-                    'The system dataset cannot be placed on this pool.'
+                    'The system dataset cannot be placed on this pool.',
                 )
         else:
+            # Caller passed None -- pick a data pool ourselves so that
+            # do_update has a concrete `new_pool` to migrate to.
             for pool in await self.middleware.call(
-                'systemdataset.query_pools_for_system_dataset', data['pool_exclude']
+                'systemdataset.query_pools_for_system_dataset', data['pool_exclude'],
             ):
                 if await self.destination_pool_error(pool):
                     continue
-
-                new['pool'] = pool
+                new_pool = pool
                 break
             else:
-                # If a data pool could not be found, reset it to blank
-                # Which will eventually mean its back to boot pool (temporarily)
-                new['pool'] = ''
+                # No usable data pool -- clear the field so config_extend
+                # falls back to the boot pool.
+                new_pool = ''
 
         verrors.check()
-
-        update_dict = {k: v for k, v in new.items() if k in ['pool']}
-
-        await self.middleware.call(
-            'datastore.update',
-            'system.systemdataset',
-            config['id'],
-            update_dict,
-            {'prefix': 'sys_'}
-        )
-
-        new = await self.config()
-
-        if config['pool'] != new['pool']:
-            await self.middleware.call('systemdataset.migrate', config['pool'], new['pool'])
-
-        await self.middleware.call('systemdataset.setup', data['pool_exclude'])
-        return await self.config()
+        return new_pool
 
     @private
     async def destination_pool_error(self, new_pool):
         config = await self.config()
-        existing_dataset, new_dataset = None, None
+        existing_dataset = new_dataset = None
         for i in await self.call2(
             self.s.zfs.resource.query_impl,
-            ZFSResourceQuery(paths=[config['basename'], new_pool], properties=['used', 'available'])
+            ZFSResourceQuery(paths=[config['basename'], new_pool], properties=['used', 'available']),
         ):
             if i['name'] == config['basename']:
                 existing_dataset = i
@@ -243,14 +489,13 @@ class SystemDatasetService(ConfigService):
 
         if not existing_dataset:
             return
-        elif not new_dataset:
+        if not new_dataset:
             return f'Dataset {new_pool} does not exist'
-        else:
-            used = existing_dataset['properties']['used']['value']
-            available = new_dataset['properties']['available']['value']
 
-        # 1.1 is a safety margin because same files won't
-        # take exactly the same amount of space on a different pool
+        used = existing_dataset['properties']['used']['value']
+        available = new_dataset['properties']['available']['value']
+        # 1.1x margin: same files don't take exactly the same amount of
+        # space on a different pool.
         used = int(used * 1.1)
         if available < used:
             return (
@@ -260,178 +505,142 @@ class SystemDatasetService(ConfigService):
 
     @private
     def setup(self, exclude_pool: str | None = None):
-        self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': True})
-        try:
-            return self.setup_impl(exclude_pool)
-        finally:
-            self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': False})
+        """Reconcile with DB as the source of truth (SysdatasetAuthority.TARGET).
+
+        Public entry point used by `pool.post_create`, `pool.post_import`,
+        and failover events. do_update goes directly to reconcile().
+        """
+        return self.reconcile(exclude_pool, SysdatasetAuthority.TARGET)
 
     @private
-    def setup_impl(self, exclude_pool):
-        self.force_pool = None
-        config = self.middleware.call_sync('systemdataset.config')
+    def reconcile(self, exclude_pool: str | None, authority: SysdatasetAuthority, job=None):
+        """Bring SYSDATASET_PATH to a known-good state.
 
-        boot_pool = self.middleware.call_sync('boot.pool_name')
+        See the module docstring for the state matrix. This is the single
+        dispatcher used by both `setup` (SysdatasetAuthority.TARGET) and
+        `do_update` (SysdatasetAuthority.LIVE).
 
-        # If the system dataset is configured in a data pool we need to make sure it exists.
-        # In case it does not we need to use another one.
-        pools_in_db = {
-            i['vol_name']: i for i in self.middleware.call_sync(
-                'datastore.query', 'storage_volume'
-            )
-        }
-        if (
-            config['pool'] != boot_pool
-            and config['pool'] not in pools_in_db
-            and not self.call_sync2(
-                self.s.zfs.resource.query_impl, ZFSResourceQuery(paths=[config['pool']], properties=None)
-            )
-        ):
-            # FIXME: this is badddddd. It's a DEADLOCK because this method (setup_impl)
-            # is called by sysdataset.update and sysdataset.update calls this method which
-            # calls sysdataset.update.......yikes
-            self.logger.debug('Pool %r does not exist, moving system dataset to another pool', config['pool'])
-            job = self.middleware.call_sync('systemdataset.update', {'pool': None, 'pool_exclude': exclude_pool})
-            job.wait_sync(raise_error=True)
-            return
+        `job`, when supplied (do_update path), is threaded down to the
+        reconcile action so it can report progress. setup()/failover
+        reconciles pass None and report nothing.
 
-        # If we dont have a pool configured in the database try to find the first data pool
-        # to put it on.
-        if not config['pool_set']:
-            if pools := self.query_pools_for_system_dataset(exclude_pool):
-                self.logger.debug(
-                    'System dataset pool was not set, moving it to first available pool %r',
-                    pools[0]
-                )
-                job = self.middleware.call_sync('systemdataset.update', {'pool': pools[0]})
-                job.wait_sync(raise_error=True)
-                return
-
-        mntinfo = list(iter_mountinfo())
-        if config['pool'] != boot_pool:
-            if not any(mnt['mount_source'] == config['pool'] for mnt in mntinfo):
-                ds = self.call_sync2(
-                    self.s.zfs.resource.query_impl,
-                    ZFSResourceQuery(paths=[config['basename']], properties=['encryption'])
-                )
-                if not ds:
-                    # Pool is not mounted (e.g. HA node B), temporary set up system dataset on the boot pool
-                    msg = 'Root dataset for pool %r is not available, and dataset %r does not exist, '
-                    msg += 'temporarily setting up system dataset on boot pool'
-                    self.logger.debug(msg, config['pool'], config['basename'])
-                    self.force_pool = boot_pool
-                    config = self.middleware.call_sync('systemdataset.config')
-                else:
-                    enc = get_encryption_info(ds[0]['properties'])
-                    if enc.encrypted and enc.locked and enc.encryption_type != 'passphrase':
-                        msg = 'Root dataset for pool %r is not available,'
-                        msg += 'temporarily setting up system dataset on boot pool'
-                        # Pool is encrypted with a key and is locked
-                        self.logger.debug(msg, config['pool'])
-                        self.force_pool = boot_pool
-                        config = self.middleware.call_sync('systemdataset.config')
-                    else:
-                        self.logger.debug(
-                            'Root dataset for pool %r is not available, but system dataset may be manually '
-                            'mounted. Proceeding with normal setup.',
-                            config['pool']
-                        )
-
-        mounted_pool = mounted = None
-
-        sysds_mntinfo = next((mnt for mnt in mntinfo if mnt['mountpoint'] == '/var/db/system'), None)
-        if sysds_mntinfo:
-            mounted_pool = sysds_mntinfo['mount_source'].split('/')[0]
-
-        if mounted_pool and mounted_pool.split('/')[0] != config['pool']:
-            self.logger.debug('Abandoning dataset on %r in favor of %r', mounted_pool, config['pool'])
-            with self.release_system_dataset():
-                self.__umount(mounted_pool, config['uuid'])
-                self.middleware.call_sync('systemdataset.setup_datasets', config['pool'], config['uuid'])
-                mounted = self.__mount(config['pool'], config['uuid'])
-        else:
-            self.middleware.call_sync('systemdataset.setup_datasets', config['pool'], config['uuid'])
-
-        # refresh our mountinfo in case it changed
+        Fires the `sysdataset.setup` hook around the work so subscribers
+        (e.g. failover state UI) see exactly one in_progress=True / =False
+        pair per reconcile.
+        """
         try:
-            sysds_mntinfo = [statmount(path=SYSDATASET_PATH)]
-        except FileNotFoundError:
-            sysds_mntinfo = []
+            authority = SysdatasetAuthority(authority)
+        except ValueError:
+            raise CallError(f'invalid authority: {authority!r}')
 
+        self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': True})
+        try:
+            self._reconcile_impl(exclude_pool, authority, job)
+        finally:
+            self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': False})
+        return self.middleware.call_sync('systemdataset.config')
+
+    def _reconcile_impl(self, exclude_pool, authority, job=None):
+        # 1. Pick target_pool and decide whether the DB needs persistence
+        #    or an overlay. See "Pool selection" in the module docstring.
+        self.force_pool = None
+        preferred = self.middleware.call_sync(
+            'datastore.config', 'system_systemdataset',
+        )['sys_pool']
+        target_pool, is_fallback = self.select_system_dataset_pool(
+            preferred_pool=preferred, exclude_pool=exclude_pool,
+        )
+
+        config = self.middleware.call_sync('systemdataset.config')
+        if is_fallback:
+            self.force_pool = target_pool
+            config = self.middleware.call_sync('systemdataset.config')
+        elif target_pool != config['pool']:
+            # Non-fallback drift: we're making a selection on the user's
+            # behalf (e.g. pool_post_create on a DB that had no pool
+            # picked yet). Persist directly -- we can't re-enter
+            # systemdataset.update from here because do_update holds the
+            # sysdataset_update job lock.
+            #
+            # Promote authority to SysdatasetAuthority.LIVE: the data the user can see
+            # at SYSDATASET_PATH right now (typically the boot-pool
+            # fallback) is the truth and must travel to target_pool.
+            self.logger.debug(
+                'Updating system dataset pool from %r to %r', config['pool'], target_pool,
+            )
+            self.middleware.call_sync(
+                'datastore.update', 'system.systemdataset', config['id'],
+                {'pool': target_pool}, {'prefix': 'sys_'},
+            )
+            config = self.middleware.call_sync('systemdataset.config')
+            authority = SysdatasetAuthority.LIVE
+
+        # 2. Make sure SYSDATASET_PATH exists as a real directory before
+        #    any mount work -- the swap opens it and would happily traverse
+        #    a stray symlink target if we let one slip through.
         if not os.path.isdir(SYSDATASET_PATH) and os.path.exists(SYSDATASET_PATH):
             os.unlink(SYSDATASET_PATH)
-
         os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
+        os.close(truenas_os.openat2(
+            SYSDATASET_PATH,
+            flags=os.O_DIRECTORY | os.O_CLOEXEC,
+            resolve=truenas_os.RESOLVE_NO_SYMLINKS,
+        ))
 
-        ds_mntinfo = next((mnt for mnt in mntinfo if mnt['mount_source'] == config['basename']), None)
-        if ds_mntinfo:
-            acl_enabled = 'POSIXACL' in ds_mntinfo['super_opts'] or 'NFSV4ACL' in ds_mntinfo['super_opts']
+        # 3. Inspect live state and dispatch via the state machine.
+        live_pool = self._live_pool()
+
+        if live_pool is None:
+            self._action_mount_fresh(target_pool, config['uuid'], job)
+        elif live_pool == target_pool:
+            self._action_reconcile_only(target_pool, config['uuid'], job)
+        elif authority == SysdatasetAuthority.LIVE:
+            self.logger.debug(
+                'Migrating system dataset from %r to %r', live_pool, target_pool,
+            )
+            self._action_migrate_data(live_pool, target_pool, config['uuid'], job)
         else:
-            ds = self.call_sync2(
-                self.s.zfs.resource.query_impl,
-                ZFSResourceQuery(paths=[config['basename']], properties=['acltype'])
+            self.logger.info(
+                'Abandoning sysdataset mount on %r in favor of %r (no data copy)',
+                live_pool, target_pool,
             )
-            acl_enabled = ds and ds[0]['properties']['acltype']['raw'] != 'off'
+            self._action_abandon_and_remount(target_pool, config['uuid'], job)
 
-        if acl_enabled:
-            self.middleware.call_sync(
-                'pool.dataset.update_impl',
-                UpdateImplArgs(name=config['basename'], zprops={'acltype': 'off'})
-            )
+    @private
+    def _live_pool(self):
+        """Pool whose `<pool>/.system` is mounted at SYSDATASET_PATH.
 
-        if mounted is None:
-            mounted = self.__mount(config['pool'], config['uuid'])
+        Returns None if nothing is mounted or the mount source doesn't
+        match the `<pool>/.system` pattern (e.g. a tmpfs slipped under
+        the path somehow -- treat as "nothing useful is there").
+        """
+        try:
+            mntinfo = statmount(path=SYSDATASET_PATH)
+        except FileNotFoundError:
+            return None
 
-        corepath = f'{SYSDATASET_PATH}/cores'
-        if os.path.exists(corepath):
-            if self.call_sync2(self.s.keyvalue.get, 'run_migration', False):
-                try:
-                    cores = Path(corepath)
-                    for corefile in cores.iterdir():
-                        corefile.unlink()
-                except Exception:
-                    self.logger.warning("Failed to clear old core files.", exc_info=True)
-
-            # ValueError when /var/lib/systemd/coredump is not a mountpoint.
-            with suppress(OSError, ValueError):
-                umount('/var/lib/systemd/coredump')
-            os.makedirs('/var/lib/systemd/coredump', exist_ok=True)
-            with suppress(OSError):
-                tree_fd = truenas_os.open_tree(
-                    path=corepath,
-                    flags=truenas_os.OPEN_TREE_CLONE | truenas_os.OPEN_TREE_CLOEXEC,
-                )
-                try:
-                    truenas_os.move_mount(
-                        from_path='', from_dirfd=tree_fd,
-                        to_path='/var/lib/systemd/coredump',
-                        flags=truenas_os.MOVE_MOUNT_F_EMPTY_PATH,
-                    )
-                finally:
-                    os.close(tree_fd)
-
-        return self.middleware.call_sync('systemdataset.config')
+        mount_source = mntinfo['mount_source'] or ''
+        if not mount_source.endswith('/.system'):
+            return None
+        return mount_source.split('/', 1)[0]
 
     @private
     def query_pools_for_system_dataset(self, exclude_pool=None):
+        """Pools eligible to host the system dataset.
+
+        Pools with passphrase-locked roots are eligible because ZFS
+        encryption is per-dataset and the system dataset uses a legacy
+        mount; key format is only exposed via libzfs, so reading mountinfo
+        here is insufficient.
         """
-        Pools with passphrase-locked root level datasets are permitted as system
-        dataset targets. This is because ZFS encryption is at the dataset level
-        rather than pool level, and we use a legacy mount for the system dataset.
-        Key format is only exposed via libzfs and so reading mountinfo here is
-        insufficient.
-        """
-        rv = list()
+        rv = []
         for i in query_imported_fast_impl().values():
-            if (
-                exclude_pool and exclude_pool == i['name']
-                or i['name'] in BOOT_POOL_NAME_VALID
-            ):
+            if (exclude_pool and exclude_pool == i['name']) or i['name'] in BOOT_POOL_NAME_VALID:
                 continue
 
             ds = self.call_sync2(
                 self.s.zfs.resource.query_impl,
-                ZFSResourceQuery(paths=[i['name']], properties=['encryption'])
+                ZFSResourceQuery(paths=[i['name']], properties=['encryption']),
             )
             if not ds:
                 continue
@@ -442,16 +651,73 @@ class SystemDatasetService(ConfigService):
         return rv
 
     @private
-    async def setup_datasets(self, pool, uuid):
+    def select_system_dataset_pool(self, preferred_pool=None, exclude_pool=None):
+        """Pick which pool should host the system dataset.
+
+        Returns: (pool_name, is_temporary_fallback)
+
+        Priority:
+          1. preferred_pool, if it's importable and not key-locked
+          2. first available non-boot data pool
+          3. boot pool
+
+        is_temporary_fallback=True when the preferred pool is configured
+        but currently inaccessible (unimported or root-locked-with-key);
+        the caller uses force_pool rather than persisting the fallback.
         """
-        Make sure system datasets for `pool` exist and have the right mountpoint property
+        boot_pool = self.middleware.call_sync('boot.pool_name')
+
+        if preferred_pool and preferred_pool != exclude_pool:
+            if self._pool_is_available(preferred_pool):
+                return (preferred_pool, False)
+            if preferred_pool != boot_pool:
+                self.logger.warning(
+                    'Pool %r unavailable, using boot pool temporarily', preferred_pool,
+                )
+                return (boot_pool, True)
+
+        for pool in self.query_pools_for_system_dataset(exclude_pool):
+            return (pool, False)
+
+        return (boot_pool, False)
+
+    def _pool_is_available(self, pool):
+        """True if `pool`'s root is mounted and the pool is usable for sysdataset."""
+        boot_pool = self.middleware.call_sync('boot.pool_name')
+        if pool == boot_pool:
+            return True
+
+        for mnt in iter_mountinfo():
+            if mnt['mount_source'] == pool:
+                return True
+
+        # Not mounted -- check whether the root is locked-with-key.
+        ds = self.call_sync2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[pool], properties=['encryption']),
+        )
+        if ds:
+            enc = get_encryption_info(ds[0]['properties'])
+            if enc.encrypted and enc.locked and enc.encryption_type != 'passphrase':
+                return False
+        return False
+
+    @private
+    async def setup_datasets(self, pool, uuid):
+        """Make sure the system datasets for `pool` exist with the right props.
+
+        Returns the spec list (suitable for passing to mount_hierarchy /
+        finalize_datasets).
         """
         boot_pool = await self.middleware.call('boot.pool_name')
+        # Empty string falls back to boot pool (handles cases where no
+        # data pool is selectable).
+        pool = pool or boot_pool
         root_dataset_is_passphrase_encrypted = False
         if pool != boot_pool:
             p = await self.call2(
                 self.s.zfs.resource.query_impl,
-                ZFSResourceQuery(paths=[pool], properties=['encryption'])
+                ZFSResourceQuery(paths=[pool], properties=['encryption']),
             )
             if not p:
                 raise ValidationError(
@@ -459,9 +725,8 @@ class SystemDatasetService(ConfigService):
                     f'Pool {pool!r} does not exist.',
                     errno.ENOENT,
                 )
-            else:
-                enc = get_encryption_info(p[0]['properties'])
-                root_dataset_is_passphrase_encrypted = enc.encryption_type == 'passphrase'
+            enc = get_encryption_info(p[0]['properties'])
+            root_dataset_is_passphrase_encrypted = enc.encryption_type == 'passphrase'
 
         datasets = {i['name']: i for i in get_system_dataset_spec(pool, uuid)}
         datasets_prop = {
@@ -470,228 +735,257 @@ class SystemDatasetService(ConfigService):
                 self.s.zfs.resource.query_impl,
                 ZFSResourceQuery(
                     paths=list(datasets),
-                    properties=['encryption', 'quota', 'used'] + list(SystemDatasetZfsProperties)
-                )
+                    properties=['encryption', 'quota', 'used', 'overlay'] + list(SystemDatasetZfsProperties)
+                ),
             )
         }
         for dataset, config in datasets.items():
             props = config['props']
-            # Disable encryption for system managed datasets that are
-            # configured on zpools that are passphrase-encrypted.
+            # Disable encryption on system-managed children of
+            # passphrase-encrypted pools.
             if root_dataset_is_passphrase_encrypted:
                 props['encryption'] = 'off'
+            # overlayfs is never used on system dataset paths.
+            props['overlay'] = 'off'
             is_cores_ds = dataset.endswith('/cores')
             if is_cores_ds:
-                props['quota'] = '1073741824'  # 1G, needs to be raw value for update_props_dict comparison to work
+                # 1G; raw value so the update_props_dict comparison below
+                # works (raw values are strings of bytes for sizes).
+                props['quota'] = '1073741824'
+
             if dataset not in datasets_prop:
                 await self.middleware.call(
-                    'pool.dataset.create_impl', CreateImplArgs(name=dataset, ztype='FILESYSTEM', zprops=props)
+                    'pool.dataset.create_impl',
+                    CreateImplArgs(name=dataset, ztype='FILESYSTEM', zprops=props),
                 )
             elif is_cores_ds and datasets_prop[dataset]['used']['value'] >= 1024 ** 3:
                 try:
-                    await self.call2(self.s.zfs.resource.destroy_impl, dataset, recursive=True)
+                    # bypass=True: <pool>/.system/cores is protected.
+                    await self.call2(
+                        self.s.zfs.resource.destroy_impl, dataset,
+                        recursive=True, bypass=True,
+                    )
                     await self.middleware.call(
-                        'pool.dataset.create_impl', CreateImplArgs(name=dataset, ztype='FILESYSTEM', zprops=props)
+                        'pool.dataset.create_impl',
+                        CreateImplArgs(name=dataset, ztype='FILESYSTEM', zprops=props),
                     )
                 except Exception:
                     self.logger.warning("Failed to replace dataset [%s].", dataset, exc_info=True)
             else:
-                update_props_dict = dict()
-                for k, v in props.items():
-                    if datasets_prop[dataset][k]['raw'] != v:
-                        # use `raw` key instead of `value` since
-                        # the latter will do some fancy translation
-                        # depending on the property.
-                        # (i.e. if raw == "on" value == True)
-                        update_props_dict[k] = v
-
-                if update_props_dict:
+                # Compare via raw values; `value` does some
+                # property-specific translation (e.g. raw "on" -> True).
+                update_props = {
+                    k: v for k, v in props.items() if datasets_prop[dataset][k]['raw'] != v
+                }
+                if update_props:
                     await self.middleware.call(
                         'pool.dataset.update_impl',
-                        UpdateImplArgs(name=dataset, zprops=update_props_dict)
+                        UpdateImplArgs(name=dataset, zprops=update_props),
                     )
 
-    def __create_relevant_paths(self, ds_name, create_paths):
-        for create_path_config in create_paths:
-            try:
-                os.makedirs(create_path_config['path'], exist_ok=True)
-                cpath_stat = os.stat(create_path_config['path'])
-                if all(create_path_config[k] for k in ('uid', 'gid')) and (
-                    cpath_stat.st_uid != create_path_config['uid'] or cpath_stat.st_gid != create_path_config['gid']
-                ):
-                    os.chown(create_path_config['path'], create_path_config['uid'], create_path_config['gid'])
-
-                if (mode := create_path_config.get('mode')) and (cpath_stat.st_mode & 0o777) != mode:
-                    os.chmod(create_path_config['path'], mode)
-            except Exception:
-                self.logger.exception(
-                    'Failed to ensure %r path for %r dataset', create_path_config['path'], ds_name,
-                )
-
-    def __mount(self, pool, uuid, path=SYSDATASET_PATH):
-        """
-        Mount group of datasets associated with our system dataset.
-        `path` will be either  SYSDATASET_PATH or temp dir in the middlewared
-        rundir. The latter occurs when migrating dataset between pools.
-        """
-        mounted = False
-        for ds_config in get_system_dataset_spec(pool, uuid):
-            dataset, name = ds_config['name'], os.path.basename(ds_config['name'])
-
-            mountpoint = ds_config.get('mountpoint', f'{SYSDATASET_PATH}/{name}').replace(SYSDATASET_PATH, path)
-
-            if os.path.ismount(mountpoint):
-                continue
-
-            with suppress(FileExistsError):
-                os.mkdir(mountpoint)
-            subprocess.run(['mount', '-t', 'zfs', dataset, mountpoint], check=True)
-
-            chown_config = ds_config['chown_config']
-            mode_perms = chown_config.pop('mode')
-            mountpoint_stat = os.stat(mountpoint)
-            if mountpoint_stat.st_uid != chown_config['uid'] or mountpoint_stat.st_gid != chown_config['gid']:
-                os.chown(mountpoint, **chown_config)
-
-            if (mountpoint_stat.st_mode & 0o777) != mode_perms:
-                os.chmod(mountpoint, mode_perms)
-
-            mounted = True
-            if path == SYSDATASET_PATH:
-                self.__create_relevant_paths(ds_config['name'], ds_config.get('create_paths', []))
-                self.__post_mount_actions(ds_config['name'], ds_config.get('post_mount_actions', []))
-
-        return mounted
-
-    def __post_mount_actions(self, ds_name, actions):
-        for action in actions:
-            try:
-                self.middleware.call_sync(action['method'], *action.get('args', []))
-            except Exception:
-                self.logger.error(
-                    'Failed to run post mount action %r endpoint for %r dataset',
-                    action['method'], ds_name, exc_info=True,
-                )
-            else:
-                self.logger.info(
-                    'Successfully ran post mount action %r endpoint for %r dataset', action['method'], ds_name
-                )
-
-    def __umount(self, pool, uuid, retry=True):
-        """
-        Umount the group of datasets associated with the system dataset.
-        When migrating between system datasets, `pool` will be filesystem
-        mounted in middleware rundir for one of the umount calls.
-
-        This is why mount info is checked before manipulating sysdataset_path.
-        """
-        # Find mount by source
-        mntinfo = None
-        for mount in iter_mountinfo():
-            if mount['mount_source'] == f'{pool}/.system':
-                mntinfo = mount
-                break
-
-        if not mntinfo:
-            # Pool's system dataset not mounted
-            return
-
-        mp = mntinfo['mountpoint']
-        if retry:
-            flags = '-f' if not self.middleware.call_sync('failover.licensed') else '-l'
-        else:
-            # We're doing a retry and have logged a warning message pointing fingers
-            # at offending processes so that a dev can hopefully fix it later on.
-            flags = '-lf'
-
-        try:
-            subprocess.run(['umount', flags, '--recursive', mp], check=True, capture_output=True)
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr.decode()
-            if 'no mount point specified' in stderr:
-                return
-        else:
-            return
-
-        error = f'Unable to umount {mp}: {stderr}'
-        if 'target is busy' in stderr:
-            # error message is of format "umount: <mountpoint>: target is busy"
-            ds_mp = stderr.split(':')[1].strip()
-            processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [ds_mp], True, True)
-
-            if retry:
-                self.logger.warning("The following processes are using %s: %s",
-                                    ds_mp, json.dumps(processes, indent=2))
-                return self.__umount(pool, uuid, False)
-
-            error += f'\nThe following processes are using {ds_mp!r}: ' + json.dumps(processes, indent=2)
-
-        raise CallError(error) from None
+        return list(datasets.values())
 
     @private
-    def migrate(self, _from, _to):
+    def mount_system_dataset(self, datasets):
+        """Mount the system dataset hierarchy at SYSDATASET_PATH."""
+        target_fd = os.open(SYSDATASET_PATH, os.O_DIRECTORY)
+        try:
+            mount_hierarchy(target_fd=target_fd, datasets=datasets)
+        finally:
+            os.close(target_fd)
+
+    def _finalize_mount(self, datasets):
+        """Post-mount steps shared by every reconcile action: per-dataset
+        create_paths / post_mount_actions, then acltype + cores->coredump bind.
         """
-        Migrate system dataset to a new pool. If it is moving from
-        an existing pool, then the new datasets are mounted in
-        the middleware rundir temprorarily so that data can be
-        rsynced from the old pool.
+        self._finalize_datasets(datasets)
+        self._post_mount_setup()
+
+    @staticmethod
+    def _job_progress(job, percent, description):
+        """Report reconcile progress when a job is driving it.
+
+        do_update forwards its job down here; setup()/failover reconciles
+        pass job=None and report nothing.
         """
-        config = self.middleware.call_sync('systemdataset.config')
+        if job is not None:
+            job.set_progress(percent, description)
 
-        os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
-        self.middleware.call_sync('systemdataset.setup_datasets', _to, config['uuid'])
+    # --- reconcile actions ----------------------------------------------
+    # The four helpers below are the action vocabulary for reconcile().
+    # All are idempotent and assume SYSDATASET_PATH already exists as a
+    # real directory (verified in _reconcile_impl). Each takes an optional
+    # `job` (do_update path) to report progress; setup() passes None.
 
-        if _from:
-            path = f'{MIDDLEWARE_RUN_DIR}/system.new'
-            if not os.path.exists(f'{MIDDLEWARE_RUN_DIR}/system.new'):
-                os.mkdir(f'{MIDDLEWARE_RUN_DIR}/system.new')
-            else:
-                # Make sure we clean up any previous attempts
-                with suppress(OSError, ValueError):
-                    umount(path, recursive=True)
-        else:
-            path = SYSDATASET_PATH
+    def _action_mount_fresh(self, target_pool, uid, job=None):
+        """MOUNT_FRESH: nothing live, mount target_pool from scratch."""
+        self._job_progress(job, 30, f'Configuring system dataset on {target_pool!r}')
+        datasets = self.middleware.call_sync(
+            'systemdataset.setup_datasets', target_pool, uid,
+        )
+        self._job_progress(job, 70, f'Mounting system dataset on {target_pool!r}')
+        self.mount_system_dataset(datasets)
+        self._job_progress(job, 90, 'Finalizing system dataset configuration')
+        self._finalize_mount(datasets)
 
-        self.__mount(_to, config['uuid'], path=path)
+    def _action_reconcile_only(self, target_pool, uid, job=None):
+        """RECONCILE_ONLY: already correctly mounted, just ensure spec
+        and post-mount fixups. No mount churn, no service quiesce.
+        """
+        self._job_progress(job, 40, f'Reconciling system dataset on {target_pool!r}')
+        datasets = self.middleware.call_sync(
+            'systemdataset.setup_datasets', target_pool, uid,
+        )
+        self._job_progress(job, 90, 'Finalizing system dataset configuration')
+        self._finalize_mount(datasets)
 
-        # context manager handles service stop / restart
+    def _action_migrate_data(self, live_pool, target_pool, uid, job=None):
+        """MIGRATE_DATA: send live -> target and swap the mount, then destroy
+        live. The send and the swap run under one quiesce, so the copy is taken
+        from a quiescent source and the umount -> mount window is covered.
+
+        Receive strategy:
+        - Try `force=True` (zfs receive -F) first. For a recursive stream
+          the kernel replaces `{target_pool}/.system` atomically as part
+          of the receive, destroying children and snapshots on dest that
+          aren't in the stream.
+        - libzfs refuses -F when the dest has top-level snapshots or is
+          a clone (EZFS_EXISTS). In that case, recursive-destroy the dest
+          (hard-failing if destroy_impl reports a logical error, since
+          retrying without the dataset gone is pointless) and replicate
+          again.
+        """
+        # Set before entering the CM -- release_system_dataset() stops the
+        # services as its first act, so the message is live while it does.
+        self._job_progress(job, 10, 'Stopping services that use the system dataset')
         with self.release_system_dataset():
-            if _from:
-                cp = subprocess.run(
-                    ['rsync', '-az', f'{SYSDATASET_PATH}/', f'{MIDDLEWARE_RUN_DIR}/system.new'],
-                    check=False,
-                    capture_output=True
+            self._job_progress(job, 25, f'Copying system dataset to {target_pool!r}')
+            try:
+                replicate(live_pool, target_pool)
+            except truenas_pylibzfs.ZFSException as e:
+                if e.code != truenas_pylibzfs.ZFSError.EZFS_EXISTS:
+                    raise
+                self.logger.warning(
+                    '%s/.system: force receive blocked by existing snapshots '
+                    'or clones; falling back to recursive destroy + retry',
+                    target_pool,
                 )
-                # Exit code 24 means "some files vanished before they could be
-                # transferred".  This is expected when rsyncing a live system
-                # directory — lock files (e.g. nfs/.etab.lock) can disappear
-                # between rsync's directory scan and the actual transfer.
-                # The rsync plugin (RsyncReturnCode.nonfatals) treats 24 the
-                # same way: non-fatal.
-                if cp.returncode in (0, 24):
-                    # Let's make sure that we don't have coredump directory mounted
-                    with suppress(OSError, ValueError):
-                        umount('/var/lib/systemd/coredump')
-                    self.__umount(_from, config['uuid'])
-                    self.__umount(_to, config['uuid'])
-                    self.__mount(_to, config['uuid'], SYSDATASET_PATH)
-                    proc = subprocess.Popen(f'zfs list -H -o name {_from}/.system|xargs zfs destroy -r', shell=True)
-                    proc.communicate()
+                self._destroy_sysdataset_root(target_pool, must_succeed=True)
+                replicate(live_pool, target_pool)
 
-                    os.rmdir(f'{MIDDLEWARE_RUN_DIR}/system.new')
-                else:
-                    raise CallError(f'Failed to rsync from {SYSDATASET_PATH}: {cp.stderr.decode()}')
+            self._job_progress(job, 70, f'Configuring system dataset on {target_pool!r}')
+            datasets = self.middleware.call_sync(
+                'systemdataset.setup_datasets', target_pool, uid,
+            )
+            self._job_progress(job, 80, f'Mounting system dataset on {target_pool!r}')
+            self._swap(datasets)
+            # Last act inside the CM: the restart happens on exit, so this
+            # message is what's shown while the services come back up.
+            self._job_progress(job, 85, 'Restarting services')
+
+        self._job_progress(job, 90, 'Finalizing system dataset configuration')
+        self._finalize_mount(datasets)
+
+        # Drop the source. The data has moved to target_pool, so
+        # live_pool/.system has no live consumers. Best-effort: a stuck
+        # destroy here must not undo the migration -- log and leave the orphan.
+        self._job_progress(job, 95, f'Removing previous system dataset from {live_pool!r}')
+        self._destroy_sysdataset_root(live_pool, must_succeed=False)
+
+    def _destroy_sysdataset_root(self, pool, *, must_succeed):
+        """Recursively destroy `<pool>/.system` with explicit status
+        handling.
+
+        destroy_impl reports logical failures via `(failed_msg, errnum)`
+        without raising, so the result has to be checked. `ZFSPathNotFoundException`
+        ("nothing to do") is always benign.
+
+        must_succeed=True raises CallError on any failure -- used by the
+        MIGRATE_DATA fallback where leaving the dataset behind would
+        guarantee the retry hits EZFS_EXISTS again.
+
+        must_succeed=False logs a warning and returns -- used by the
+        post-migration source cleanup, where the migration has already
+        succeeded and a leftover .system on the source pool is
+        recoverable out of band.
+        """
+        path = f'{pool}/.system'
+        try:
+            failed, errnum = self.call_sync2(
+                self.s.zfs.resource.destroy_impl, path,
+                recursive=True, bypass=True,
+            )
+        except ZFSPathNotFoundException:
+            return
+        except Exception:
+            if must_succeed:
+                raise
+            self.logger.warning('%s: destroy raised', path, exc_info=True)
+            return
+
+        if not failed:
+            return
+        msg = f'{path}: recursive destroy failed: {failed} (errno={errnum})'
+        if must_succeed:
+            raise CallError(msg, errno=errnum or errno.EIO)
+        self.logger.warning(msg)
+
+    def _action_abandon_and_remount(self, target_pool, uid, job=None):
+        """ABANDON_AND_REMOUNT: mount target's existing .system over the
+        current live mount. NO destroy of target_pool/.system, NO data
+        copy -- the live mount is treated as an overlay to discard.
+        """
+        self._job_progress(job, 30, f'Configuring system dataset on {target_pool!r}')
+        datasets = self.middleware.call_sync(
+            'systemdataset.setup_datasets', target_pool, uid,
+        )
+        self._job_progress(job, 50, 'Stopping services that use the system dataset')
+        with self.release_system_dataset():
+            self._job_progress(job, 75, f'Mounting system dataset on {target_pool!r}')
+            self._swap(datasets)
+            self._job_progress(job, 85, 'Restarting services')
+        self._job_progress(job, 90, 'Finalizing system dataset configuration')
+        self._finalize_mount(datasets)
+
+    def _swap(self, datasets):
+        """Replace the system dataset mounted at SYSDATASET_PATH with `datasets`:
+        recursively umount the old tree, then mount the new one at the final
+        path. The recursive umount propagates (shared /var) into the mount
+        namespaces of sandboxed services that cloned /var/db/system, releasing
+        their copies so the source datasets are destroyable. Must run inside
+        release_system_dataset() -- the caller quiesces the daemons that hold
+        handles for the umount -> mount window.
+        """
+        # Drop the cores -> coredump bind; _post_mount_setup re-binds it.
+        with suppress(OSError, ValueError):
+            umount(_COREDUMP_PATH)
+        self._umount_sysdataset()
+        self.mount_system_dataset(datasets)
+
+    def _umount_sysdataset(self):
+        """Recursively umount SYSDATASET_PATH. Plain umount first so a real
+        local holder surfaces and is logged; lazy (MNT_DETACH) retry if one is
+        busy so the swap still proceeds.
+        """
+        try:
+            umount(SYSDATASET_PATH, recursive=True)
+        except OSError:
+            procs = self.middleware.call_sync(
+                'pool.dataset.processes_using_paths', [SYSDATASET_PATH], True, True,
+            )
+            self.logger.warning(
+                '%s: busy during swap (%r); falling back to lazy umount',
+                SYSDATASET_PATH, procs,
+            )
+            umount(SYSDATASET_PATH, recursive=True, detach=True)
 
     @contextmanager
     @private
     def release_system_dataset(self):
-        """
-        This context manager is used to toggle system-dataset dependent services and
-        tasks for cases where the dataset is unmounted / remounted.
+        """Quiesce daemons that hold sysdataset handles.
 
-        The operations are performed under a lock because systemdataset.update() and
-        systemdataset.setup() both can lead to this being called, and we don't want
-        simultaneous releases of system dataset.
+        sysdataset.update and sysdataset.setup can both reach this via
+        different code paths -- the lock prevents simultaneous releases.
         """
         with self.sysdataset_release_lock:
             # TODO: Review these services because /var/log no longer sits on
@@ -705,19 +999,112 @@ class SystemDatasetService(ConfigService):
                 restart.append('open-vm-tools')
 
             try:
-                for i in restart:
-                    self.middleware.call_sync('service.control', 'STOP', i).wait_sync(raise_error=True)
-
+                for svc in restart:
+                    self.middleware.call_sync('service.control', 'STOP', svc).wait_sync(raise_error=True)
                 close_sysdataset_tdb_handles()
                 yield
             finally:
-                restart.reverse()
-                for i in restart:
-                    self.middleware.call_sync('service.control', 'START', i).wait_sync(raise_error=True)
+                for svc in reversed(restart):
+                    self.middleware.call_sync('service.control', 'START', svc).wait_sync(raise_error=True)
 
     @private
     def get_system_dataset_spec(self, pool, uid):
         return get_system_dataset_spec(pool, uid)
+
+    # ---- internals ---------------------------------------------------------
+
+    def _finalize_datasets(self, datasets: list[dict]) -> None:
+        """Run create_paths and post_mount_actions for each dataset spec."""
+        for ds in datasets:
+            for cp in ds.get('create_paths', []):
+                try:
+                    os.makedirs(cp['path'], exist_ok=True)
+                    st = os.stat(cp['path'])
+                    uid, gid = cp.get('uid'), cp.get('gid')
+                    if uid is not None and gid is not None and (st.st_uid != uid or st.st_gid != gid):
+                        os.chown(cp['path'], uid, gid)
+                    if (mode := cp.get('mode')) and (st.st_mode & 0o777) != mode:
+                        os.chmod(cp['path'], mode)
+                except Exception:
+                    self.logger.exception(
+                        'Failed to ensure %r path for %r dataset', cp['path'], ds['name'],
+                    )
+            for action in ds.get('post_mount_actions', []):
+                try:
+                    self.middleware.call_sync(action['method'], *action.get('args', []))
+                except Exception:
+                    self.logger.error(
+                        'Failed to run post mount action %r for %r dataset',
+                        action['method'], ds['name'], exc_info=True,
+                    )
+
+    def _post_mount_setup(self) -> None:
+        """Post-mount fixups: enforce acltype=off, (re)bind cores -> coredump.
+
+        Runs after the system dataset is mounted at SYSDATASET_PATH (whether
+        via fresh mount or migration swap). Idempotent.
+        """
+        config = self.middleware.call_sync('systemdataset.config')
+        try:
+            sysds_mntinfo = statmount(path=SYSDATASET_PATH)
+        except FileNotFoundError:
+            raise CallError(f'{SYSDATASET_PATH}: not mounted after setup')
+        if sysds_mntinfo['mount_source'] != config['basename']:
+            raise CallError(
+                f'{SYSDATASET_PATH}: expected {config["basename"]!r}, '
+                f'got {sysds_mntinfo["mount_source"]!r}',
+            )
+
+        # System dataset must be a plain legacy mount -- kill any ACL state.
+        if 'POSIXACL' in sysds_mntinfo['super_opts'] or 'NFSV4ACL' in sysds_mntinfo['super_opts']:
+            self.middleware.call_sync(
+                'pool.dataset.update_impl',
+                UpdateImplArgs(name=config['basename'], zprops={'acltype': 'off'}),
+            )
+
+        self._bind_cores_to_coredump()
+
+    def _bind_cores_to_coredump(self) -> None:
+        """Bind <SYSDATASET>/cores onto /var/lib/systemd/coredump.
+
+        On a `run_migration` boot the cores directory is wiped first
+        (stale coredumps from before an upgrade are uninteresting and can
+        be large).
+
+        If the destination is already a mountpoint, unmount it first so the
+        fresh clone lands on a bare dir.
+        """
+        corepath = f'{SYSDATASET_PATH}/cores'
+        if not os.path.exists(corepath):
+            return
+
+        if self.call_sync2(self.s.keyvalue.get, 'run_migration', False):
+            try:
+                with os.scandir(corepath) as it:
+                    for entry in it:
+                        os.unlink(entry.path)
+            except Exception:
+                self.logger.warning('Failed to clear old core files.', exc_info=True)
+
+        os.makedirs(_COREDUMP_PATH, exist_ok=True)
+        # Drop any prior bind so the fresh clone lands on a bare dir.
+        with suppress(OSError):
+            umount(_COREDUMP_PATH)
+
+        # Clone the cores mount (it stays at corepath) and attach the clone
+        # at coredump_path.
+        tree_fd = truenas_os.open_tree(
+            path=corepath,
+            flags=truenas_os.OPEN_TREE_CLONE | truenas_os.OPEN_TREE_CLOEXEC,
+        )
+        try:
+            truenas_os.move_mount(
+                from_dirfd=tree_fd, from_path='',
+                to_path=_COREDUMP_PATH,
+                flags=truenas_os.MOVE_MOUNT_F_EMPTY_PATH,
+            )
+        finally:
+            os.close(tree_fd)
 
 
 async def pool_post_create(middleware, pool):
@@ -726,9 +1113,7 @@ async def pool_post_create(middleware, pool):
 
 
 async def pool_post_import(middleware, pool):
-    """
-    On pool import we may need to reconfigure system dataset.
-    """
+    """On pool import we may need to reconfigure the system dataset."""
     await middleware.call('systemdataset.setup')
 
 
@@ -741,23 +1126,37 @@ async def pool_pre_export(middleware, pool, options, job):
         })
         await sysds_job.wait()
         if sysds_job.error:
-            raise CallError(f'This pool contains system dataset, but its reconfiguration failed: {sysds_job.error}')
+            raise CallError(
+                f'This pool contains system dataset, but its reconfiguration failed: {sysds_job.error}',
+            )
 
 
 async def setup(middleware):
     def setup_paths():
         os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
-        if not os.path.exists('/var/cache/nscd') or not os.path.islink('/var/cache/nscd'):
-            if os.path.exists('/var/cache/nscd'):
-                shutil.rmtree('/var/cache/nscd')
+        # /var/cache/nscd should be a symlink to /var/run/nscd/cache.
+        # Probe via lstat on a /var/cache dir_fd so the check doesn't
+        # traverse a hostile symlink at the final component.
+        cache_fd = os.open('/var/cache', os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            try:
+                st = os.lstat('nscd', dir_fd=cache_fd)
+                is_symlink = stat.S_ISLNK(st.st_mode)
+                exists = True
+            except FileNotFoundError:
+                is_symlink = False
+                exists = False
 
-            os.makedirs('/var/run/nscd/cache', exist_ok=True)
-
-        if not os.path.islink('/var/cache/nscd'):
-            os.symlink('/var/run/nscd/cache', '/var/cache/nscd')
+            if not is_symlink:
+                if exists:
+                    shutil.rmtree('/var/cache/nscd')
+                os.makedirs('/var/run/nscd/cache', exist_ok=True)
+                os.symlink('/var/run/nscd/cache', 'nscd', dir_fd=cache_fd)
+        finally:
+            os.close(cache_fd)
 
     middleware.register_hook('pool.post_create', pool_post_create)
-    # Reconfigure system dataset first thing after we import a pool.
+    # Reconfigure the system dataset first thing after a pool import.
     middleware.register_hook('pool.post_import', pool_post_import, order=-10000)
     middleware.register_hook('pool.pre_export', pool_pre_export, order=40, raise_error=True)
 

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -301,7 +301,7 @@ class SystemDatasetService(ConfigService):
         entry = SystemDatasetEntry
 
     force_pool = None
-    sysdataset_release_lock = threading.Lock()
+    sysdataset_reconcile_lock = threading.Lock()
 
     @private
     def sysdataset_path(self, expected_datasetname=None):
@@ -528,18 +528,30 @@ class SystemDatasetService(ConfigService):
         Fires the `sysdataset.setup` hook around the work so subscribers
         (e.g. failover state UI) see exactly one in_progress=True / =False
         pair per reconcile.
+
+        Serialized by `sysdataset_reconcile_lock` so concurrent callers
+        (do_update, setup from pool hooks, failover) can never swap the
+        SYSDATASET_PATH mount at the same time.
         """
         try:
             authority = SysdatasetAuthority(authority)
         except ValueError:
             raise CallError(f'invalid authority: {authority!r}')
 
-        self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': True})
-        try:
-            self._reconcile_impl(exclude_pool, authority, job)
-        finally:
-            self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': False})
-        return self.middleware.call_sync('systemdataset.config')
+        # Serialize every reconcile regardless of caller -- do_update holds the
+        # sysdataset_update job lock, but setup() (pool.post_create/post_import,
+        # failover) holds nothing. Without this, two reconciles could swap the
+        # /var/db/system mount concurrently. Plain (non-reentrant) Lock is
+        # deliberate: nothing run under it re-enters reconcile/setup/update, so a
+        # future change that does will deadlock loudly in testing instead of
+        # silently allowing a concurrent mount swap. Do NOT switch to RLock.
+        with self.sysdataset_reconcile_lock:
+            self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': True})
+            try:
+                self._reconcile_impl(exclude_pool, authority, job)
+            finally:
+                self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': False})
+            return self.middleware.call_sync('systemdataset.config')
 
     def _reconcile_impl(self, exclude_pool, authority, job=None):
         # 1. Pick target_pool and decide whether the DB needs persistence
@@ -983,29 +995,27 @@ class SystemDatasetService(ConfigService):
         This context manager is used to toggle system-dataset dependent services and
         tasks for cases where the dataset is unmounted / remounted.
 
-        The operations are performed under a lock because systemdataset.update() and
-        systemdataset.setup() both can lead to this being called, and we don't want
-        simultaneous releases of system dataset.
+        Callers run inside reconcile(), which holds sysdataset_reconcile_lock, so
+        releases are already serialized -- no separate lock is needed here.
         """
-        with self.sysdataset_release_lock:
-            # TODO: Review these services because /var/log no longer sits on
-            # the system dataset so any service that could potentially open
-            # a file descriptor underneath /var/log will no longer need to be
-            # stopped/restarted to allow the system dataset to migrate
-            restart = ['netdata', 'truenas_zfstierd']
-            if self.middleware.call_sync('service.started', 'nfs'):
-                restart.append('nfs')
-            if self.middleware.call_sync('service.started', 'open-vm-tools'):
-                restart.append('open-vm-tools')
+        # TODO: Review these services because /var/log no longer sits on
+        # the system dataset so any service that could potentially open
+        # a file descriptor underneath /var/log will no longer need to be
+        # stopped/restarted to allow the system dataset to migrate
+        restart = ['netdata', 'truenas_zfstierd']
+        if self.middleware.call_sync('service.started', 'nfs'):
+            restart.append('nfs')
+        if self.middleware.call_sync('service.started', 'open-vm-tools'):
+            restart.append('open-vm-tools')
 
-            try:
-                for svc in restart:
-                    self.middleware.call_sync('service.control', 'STOP', svc).wait_sync(raise_error=True)
-                close_sysdataset_tdb_handles()
-                yield
-            finally:
-                for svc in reversed(restart):
-                    self.middleware.call_sync('service.control', 'START', svc).wait_sync(raise_error=True)
+        try:
+            for svc in restart:
+                self.middleware.call_sync('service.control', 'STOP', svc).wait_sync(raise_error=True)
+            close_sysdataset_tdb_handles()
+            yield
+        finally:
+            for svc in reversed(restart):
+                self.middleware.call_sync('service.control', 'START', svc).wait_sync(raise_error=True)
 
     @private
     def get_system_dataset_spec(self, pool, uid):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -693,7 +693,14 @@ class SystemDatasetService(ConfigService):
         return (boot_pool, False)
 
     def _pool_is_available(self, pool):
-        """True if `pool`'s root is mounted and the pool is usable for sysdataset."""
+        """True if `pool` is usable as a system dataset target.
+
+        Usable means the pool is importable and its root is either mounted,
+        unencrypted, or passphrase-locked -- a passphrase-locked root is fine
+        because we create `.system` with encryption=off. A key-locked root, or
+        a pool we can't query at all, is not usable. Mirrors the logic in
+        query_pools_for_system_dataset().
+        """
         boot_pool = self.middleware.call_sync('boot.pool_name')
         if pool == boot_pool:
             return True
@@ -702,16 +709,16 @@ class SystemDatasetService(ConfigService):
             if mnt['mount_source'] == pool:
                 return True
 
-        # Not mounted -- check whether the root is locked-with-key.
         ds = self.call_sync2(
             self.s.zfs.resource.query_impl,
             ZFSResourceQuery(paths=[pool], properties=['encryption']),
         )
-        if ds:
-            enc = get_encryption_info(ds[0]['properties'])
-            if enc.encrypted and enc.locked and enc.encryption_type != 'passphrase':
-                return False
-        return False
+        if not ds:
+            return False
+        enc = get_encryption_info(ds[0]['properties'])
+        if enc.encrypted and enc.locked and enc.encryption_type != 'passphrase':
+            return False
+        return True
 
     @private
     async def setup_datasets(self, pool, uuid):
@@ -1024,8 +1031,28 @@ class SystemDatasetService(ConfigService):
     # ---- internals ---------------------------------------------------------
 
     def _finalize_datasets(self, datasets: list[dict]) -> None:
-        """Run create_paths and post_mount_actions for each dataset spec."""
+        """Apply mountpoint ownership/mode, then run create_paths and
+        post_mount_actions for each dataset spec."""
         for ds in datasets:
+            # mount_hierarchy applies chown_config to the cover dir before the
+            # mount lands over it, so the visible mountpoint keeps ZFS's default
+            # 0o755 root:root. Set the real perms on the mounted dataset root
+            # here -- this also covers RECONCILE_ONLY, which never calls
+            # mount_hierarchy.
+            mountpoint = ds.get('mountpoint') or os.path.join(
+                SYSDATASET_PATH, os.path.basename(ds['name']),
+            )
+            cc = ds['chown_config']
+            try:
+                st = os.stat(mountpoint)
+                if st.st_uid != cc['uid'] or st.st_gid != cc['gid']:
+                    os.chown(mountpoint, cc['uid'], cc['gid'])
+                if (st.st_mode & 0o777) != cc['mode']:
+                    os.chmod(mountpoint, cc['mode'])
+            except Exception:
+                self.logger.exception(
+                    'Failed to apply ownership/mode to %r mountpoint', mountpoint,
+                )
             for cp in ds.get('create_paths', []):
                 try:
                     os.makedirs(cp['path'], exist_ok=True)

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -251,7 +251,7 @@ from middlewared.plugins.system_dataset.mount import (
     mount_hierarchy,
     replicate,
 )
-from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH, dataset_mountpoint
 from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
 from middlewared.plugins.zfs.utils import get_encryption_info
 from middlewared.service import CallError, ConfigService, ValidationError, ValidationErrors, job, private
@@ -1039,9 +1039,7 @@ class SystemDatasetService(ConfigService):
             # 0o755 root:root. Set the real perms on the mounted dataset root
             # here -- this also covers RECONCILE_ONLY, which never calls
             # mount_hierarchy.
-            mountpoint = ds.get('mountpoint') or os.path.join(
-                SYSDATASET_PATH, os.path.basename(ds['name']),
-            )
+            mountpoint = dataset_mountpoint(ds)
             cc = ds['chown_config']
             try:
                 st = os.stat(mountpoint)

--- a/src/middlewared/middlewared/plugins/system_dataset/mount.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/mount.py
@@ -1,0 +1,161 @@
+"""System dataset mount and replication primitives.
+
+Mount mechanics use the new mount API (`fsopen` / `fsconfig` / `fsmount`):
+
+- `create_mount_one` builds a detached ZFS mount object held by an fd
+  (no fork/exec, no PATH lookup -- just syscalls).
+- `mount_hierarchy` mounts the parent .system dataset at a target_fd and
+  nests each child mount inside the parent. Children become nested mounts
+  of the parent, so they follow it when the parent is move_mount'd.
+
+Replication uses the `TAKE_SNAPSHOTS` channel program for an atomic
+recursive snapshot, then `ZFSDataset.local_replicate` to move the tree.
+Cleanup uses the `DESTROY_SNAPSHOTS` zcp on both sides.
+"""
+
+import logging
+import os
+import uuid
+
+import truenas_os
+import truenas_pylibzfs
+
+__all__ = ["create_mount_one", "mount_hierarchy", "replicate"]
+
+logger = logging.getLogger("system_dataset")
+
+
+def create_mount_one(dataset_spec: dict) -> int:
+    """Build a detached ZFS mount via the new mount API; return the mount fd."""
+    fsfd = truenas_os.fsopen(fs_name="zfs", flags=truenas_os.FSOPEN_CLOEXEC)
+    try:
+        truenas_os.fsconfig(
+            fs_fd=fsfd,
+            cmd=truenas_os.FSCONFIG_SET_STRING,
+            key="source",
+            value=dataset_spec["name"],
+        )
+        truenas_os.fsconfig(fs_fd=fsfd, cmd=truenas_os.FSCONFIG_CMD_CREATE)
+        return truenas_os.fsmount(fs_fd=fsfd, flags=truenas_os.FSMOUNT_CLOEXEC)
+    finally:
+        os.close(fsfd)
+
+
+def mount_hierarchy(*, target_fd: int, datasets: list[dict]) -> None:
+    """Mount the system dataset hierarchy under `target_fd`.
+
+    The first spec entry is the parent (e.g. <pool>/.system); its mount
+    lands at target_fd. Subsequent entries are nested mounts inside the
+    parent's mount root, so the whole tree moves as a unit when the parent
+    is later move_mount'd.
+    """
+    child_target_fd = None
+    mntfd = None
+    try:
+        for idx, ds in enumerate(datasets):
+            mntfd = create_mount_one(ds)
+            if idx == 0:
+                truenas_os.move_mount(
+                    from_dirfd=mntfd,
+                    from_path="",
+                    to_dirfd=target_fd,
+                    to_path="",
+                    flags=(truenas_os.MOVE_MOUNT_F_EMPTY_PATH | truenas_os.MOVE_MOUNT_T_EMPTY_PATH),
+                )
+                # target_fd was opened before the mount landed, so it
+                # references the underlying dir entry. Re-open by path so
+                # subsequent lookups traverse INTO the new mount.
+                child_target_fd = os.open(
+                    os.readlink(f"/proc/self/fd/{target_fd}"),
+                    os.O_DIRECTORY,
+                )
+            else:
+                target_path = os.path.basename(ds["name"])
+                chown = dict(ds["chown_config"])
+                mode = chown.pop("mode")
+                try:
+                    os.mkdir(target_path, dir_fd=child_target_fd, mode=mode)
+                except FileExistsError:
+                    os.chmod(target_path, dir_fd=child_target_fd, mode=mode)
+                os.chown(target_path, dir_fd=child_target_fd, **chown)
+                truenas_os.move_mount(
+                    from_dirfd=mntfd,
+                    from_path="",
+                    to_dirfd=child_target_fd,
+                    to_path=target_path,
+                    flags=truenas_os.MOVE_MOUNT_F_EMPTY_PATH,
+                )
+            os.close(mntfd)
+            mntfd = None
+    finally:
+        if child_target_fd is not None:
+            os.close(child_target_fd)
+        if mntfd is not None:
+            os.close(mntfd)
+
+
+def replicate(_from: str, _to: str) -> None:
+    """Replicate the system dataset hierarchy from `_from` to `_to`.
+
+    Source remains live and mounted throughout. Spec datasets that don't
+    exist on the source aren't snapshotted -- the caller's setup_datasets
+    will create them empty afterwards.
+
+    `force=True` (zfs receive -F) lets the receive overwrite anything
+    already at `{_to}/.system`. For a recursive (-R) stream the kernel
+    destroys snapshots and child datasets on the destination that aren't
+    in the stream, atomically with the receive -- so the caller can rely
+    on the destination being a byte-for-byte copy of the source after a
+    successful return, even when `{_to}/.system` was non-empty going in.
+
+    Caveat: libzfs rejects -F up front when the destination has top-level
+    snapshots or is a clone. The receive raises ZFSException(EZFS_EXISTS)
+    in those cases; the caller handles the fallback.
+    """
+    src_root_name = f"{_from}/.system"
+    dst_root_name = f"{_to}/.system"
+    snap_tag = f"sysdataset-migrate-{uuid.uuid4().hex[:12]}"
+
+    lz = truenas_pylibzfs.open_handle()
+    src_root = lz.open_resource(name=src_root_name)
+
+    take_result = truenas_pylibzfs.lzc.run_channel_program(
+        pool_name=_from,
+        script=truenas_pylibzfs.lzc.ChannelProgramEnum.TAKE_SNAPSHOTS,
+        script_arguments=[src_root_name, snap_tag],
+        readonly=False,
+    )
+    try:
+        # lzc wraps the Lua return value under a "return" key, so the
+        # outer dict is always truthy. The Lua program's `failed` table
+        # is empty on full success -- only non-empty inner value means
+        # at least one descendant failed to snapshot.
+        failed_snaps = take_result.get("return") or {}
+        if failed_snaps:
+            raise RuntimeError(
+                f"TAKE_SNAPSHOTS failed on {src_root_name}@{snap_tag}: {failed_snaps!r}",
+            )
+        src_root.local_replicate(tosnap=snap_tag, dest=dst_root_name, force=True)
+    finally:
+        # Best-effort cleanup: log failures rather than raise so we don't
+        # mask any error from the replicate above.
+        for pool, root in ((_from, src_root_name), (_to, dst_root_name)):
+            try:
+                truenas_pylibzfs.lzc.run_channel_program(
+                    pool_name=pool,
+                    script=truenas_pylibzfs.lzc.ChannelProgramEnum.DESTROY_SNAPSHOTS,
+                    script_arguments_dict={
+                        "target": root,
+                        "recursive": True,
+                        "pattern": snap_tag,
+                        "defer": False,
+                    },
+                    readonly=False,
+                )
+            except Exception:
+                logger.warning(
+                    "%s@%s: failed to destroy migration snapshot",
+                    root,
+                    snap_tag,
+                    exc_info=True,
+                )

--- a/src/middlewared/middlewared/plugins/system_dataset/mount.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/mount.py
@@ -20,6 +20,8 @@ import uuid
 import truenas_os
 import truenas_pylibzfs
 
+from .utils import SYSDATASET_PATH, dataset_mountpoint
+
 __all__ = ["create_mount_one", "mount_hierarchy", "replicate"]
 
 logger = logging.getLogger("system_dataset")
@@ -70,7 +72,12 @@ def mount_hierarchy(*, target_fd: int, datasets: list[dict]) -> None:
                     os.O_DIRECTORY,
                 )
             else:
-                target_path = os.path.basename(ds["name"])
+                # child_target_fd already points at SYSDATASET_PATH, so the
+                # mount lands at the dataset's absolute mountpoint reduced to a
+                # path relative to that root. Must be a single component: the
+                # os.mkdir below has no makedirs semantics, so a nested
+                # mountpoint override would fail here.
+                target_path = os.path.relpath(dataset_mountpoint(ds), SYSDATASET_PATH)
                 chown = dict(ds["chown_config"])
                 mode = chown.pop("mode")
                 try:

--- a/src/middlewared/middlewared/plugins/system_dataset/utils.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/utils.py
@@ -1,6 +1,5 @@
 import os
 
-
 SYSDATASET_PATH = '/var/db/system'
 
 

--- a/src/middlewared/middlewared/plugins/system_dataset/utils.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/utils.py
@@ -1,1 +1,17 @@
+import os
+
+
 SYSDATASET_PATH = '/var/db/system'
+
+
+def dataset_mountpoint(ds: dict) -> str:
+    """Absolute path where system-dataset spec entry `ds` is mounted.
+
+    Honors an explicit ``mountpoint`` override -- a UUID-named per-controller
+    dataset (e.g. ``.system/netdata-{uuid}``) pins to a stable well-known path
+    (``/var/db/system/netdata``) that both HA controllers and the dataset's
+    consumers agree on. Otherwise the path is the dataset basename under
+    SYSDATASET_PATH. Single source of truth for mount-path resolution so
+    mount_hierarchy and _finalize_datasets can't drift.
+    """
+    return ds.get('mountpoint') or os.path.join(SYSDATASET_PATH, os.path.basename(ds['name']))

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -102,16 +102,6 @@ def test_002_create_permanent_zpool(request, ws_client):
         assert results['pool'] == pool_name
         assert results['basename'] == f'{pool_name}/.system'
 
-    try:
-        sysdataset_update = ws_client.call('core.get_jobs', [
-            ['method', '=', 'systemdataset.update']
-        ], {'order_by': ['-id'], 'get': True})
-    except Exception:
-        fail('Failed to get status of systemdataset update')
-
-    if sysdataset_update['state'] != 'SUCCESS':
-        fail(f'System dataset move failed: {sysdataset_update["error"]}')
-
 
 @pytest.mark.dependency(name='POOL_FUNCTIONALITY1')
 def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(ws_client, pool_data):


### PR DESCRIPTION
* Use FD-based mount APIs for moving around system datasets
* Use zfs send/recv for shifting system datasets between pools
* Add job progress reporting
* Add some documentation and try to clarify flow of datasets

This fixes some issues. The current bottleneck on system dataset move speed is
netdata, which is horrifically slow to stop / start.