### PR TITLE
NAS-141169 / 27.0.0-BETA.1 / Clean up `plugins.certificate.utils.get_private_key`

### DIFF
--- a/src/middlewared/middlewared/plugins/certificate/create_handlers.py
+++ b/src/middlewared/middlewared/plugins/certificate/create_handlers.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import pydantic
 from truenas_crypto_utils.csr import generate_certificate_signing_request
+from truenas_crypto_utils.key import export_private_key
 
 from middlewared.api.current import CertificateCreate
 from middlewared.service import ServiceContext, ValidationErrors
@@ -14,7 +15,7 @@ from .private_models import (
     CertificateCreateImportedCertificatePayload,
     CertificateCreateImportedCSRPayload,
 )
-from .utils import CERT_TYPE_CSR, CERT_TYPE_EXISTING, get_cert_info_from_data, get_private_key
+from .utils import CERT_TYPE_CSR, CERT_TYPE_EXISTING, get_cert_info_from_data
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -65,7 +66,7 @@ def create_imported_certificate(
     job.set_progress(90, "Finalizing changes")
     return {
         "certificate": payload.certificate,
-        "privatekey": get_private_key(payload.privatekey, payload.passphrase),
+        "privatekey": export_private_key(payload.privatekey, payload.passphrase) if payload.privatekey else None,
         "type": CERT_TYPE_EXISTING,
     }
 
@@ -91,7 +92,7 @@ def create_imported_csr(
     job.set_progress(90, "Finalizing changes")
     return {
         "CSR": payload.CSR,
-        "privatekey": get_private_key(payload.privatekey, payload.passphrase),
+        "privatekey": export_private_key(payload.privatekey, payload.passphrase),
         "type": CERT_TYPE_CSR,
     }
 

--- a/src/middlewared/middlewared/plugins/certificate/create_handlers.py
+++ b/src/middlewared/middlewared/plugins/certificate/create_handlers.py
@@ -65,13 +65,7 @@ def create_imported_certificate(
     job.set_progress(90, "Finalizing changes")
     return {
         "certificate": payload.certificate,
-        "privatekey": get_private_key(
-            {
-                "private_key": payload.privatekey,
-                "privatekey": payload.privatekey,
-                "passphrase": payload.passphrase,
-            }
-        ),
+        "privatekey": get_private_key(payload.privatekey, payload.passphrase),
         "type": CERT_TYPE_EXISTING,
     }
 
@@ -97,13 +91,7 @@ def create_imported_csr(
     job.set_progress(90, "Finalizing changes")
     return {
         "CSR": payload.CSR,
-        "privatekey": get_private_key(
-            {
-                "private_key": payload.privatekey,
-                "privatekey": payload.privatekey,
-                "passphrase": payload.passphrase,
-            }
-        ),
+        "privatekey": get_private_key(payload.privatekey, payload.passphrase),
         "type": CERT_TYPE_CSR,
     }
 

--- a/src/middlewared/middlewared/plugins/certificate/utils.py
+++ b/src/middlewared/middlewared/plugins/certificate/utils.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from truenas_crypto_utils.key import export_private_key
-
 # Cert locations
 CERT_ROOT_PATH = "/etc/certificates"
 DEFAULT_CERT_NAME = "truenas_default"
@@ -30,14 +28,4 @@ def get_cert_info_from_data(data: dict[str, Any]) -> dict[str, Any]:
         "digest_algorithm",
         "organizational_unit",
     ]
-    return {key: data.get(key) for key in cert_info_keys if data.get(key)}
-
-
-def get_private_key(privatekey: str | None = None, passphrase: str | None = None) -> str | None:
-    if passphrase is None:
-        return privatekey
-
-    if privatekey is None:
-        raise ValueError("Must provide privatekey")
-
-    return export_private_key(privatekey, passphrase)
+    return {key: value for key in cert_info_keys if (value := data.get(key))}

--- a/src/middlewared/middlewared/plugins/certificate/utils.py
+++ b/src/middlewared/middlewared/plugins/certificate/utils.py
@@ -33,9 +33,11 @@ def get_cert_info_from_data(data: dict[str, Any]) -> dict[str, Any]:
     return {key: data.get(key) for key in cert_info_keys if data.get(key)}
 
 
-def get_private_key(data: dict[str, Any]) -> str | None:
-    private_key: str | None = data.get("private_key")
-    if "passphrase" in data:
-        private_key = export_private_key(data["privatekey"], data["passphrase"])
+def get_private_key(privatekey: str | None = None, passphrase: str | None = None) -> str | None:
+    if passphrase is None:
+        return privatekey
 
-    return private_key
+    if privatekey is None:
+        raise ValueError("Must provide privatekey")
+
+    return export_private_key(privatekey, passphrase)


### PR DESCRIPTION
Remove `plugins.certificate.utils.get_private_key`. Dead code that was passing private key twice. Preserves behavior.