### PR TITLE
NAS-140925 / 26.0.0-BETA.2 / fix HA validation error (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1226,7 +1226,7 @@ class InterfaceService(CRUDService):
         await self._common_validation(
             verrors, 'interface_update', new, iface['type'], update=iface
         )
-        if await self.middleware.call('failover.licensed') and (new.get('ipv4_dhcp') or new.get('ipv6_auto')):
+        if await self.middleware.call('failover.licensed') and (data.get('ipv4_dhcp') or data.get('ipv6_auto')):
             verrors.add('interface_update.dhcp', 'Enabling DHCPv4/v6 on HA systems is unsupported.')
 
         # Validate fec_mode field


### PR DESCRIPTION
## Fix DHCP/IPv6-auto validation misfire on fresh HA installs

The HA validation in `interface.update` (network.py line 1253) was reading
`new.get('ipv4_dhcp')` and `new.get('ipv6_auto')`. Because `iface_extend`
synthesises `True` for these fields when no interface has a datastore
config yet (the first interface configured on a fresh install), the
merged `new` dict carries that synthetic True forward and fires the
"Enabling DHCPv4/v6 on HA systems is unsupported" error even when the
API caller never touched those keys.

Switched the check to `data.get(...)` so it only fires when the caller
is explicitly setting either field to a truthy value, which matches the
wording of the error message.

### Behavioral change

Small. An HA system with `ipv4_dhcp=true` or `ipv6_auto=true` already
persisted in the database, being updated for an unrelated field without
those keys in the payload, will no longer be forced to disable them as
part of that unrelated update. That database state should not exist on
any healthy HA system today because the same validation should have
prevented it from being persisted in the first place, so this only
affects legacy or tampered installs that shouldn't be around in the
world.

Original PR: https://github.com/truenas/middleware/pull/19010
