### PR TITLE
NAS-141177 / 27.0.0-BETA.1 / Fix `test_snapshot_task_run_disabled_task_raises` API test

### DIFF
--- a/tests/api2/test_snapshot_task.py
+++ b/tests/api2/test_snapshot_task.py
@@ -54,7 +54,7 @@ def test_snapshot_task_run_disabled_task_raises():
             "enabled": False,
         }) as t:
             with pytest.raises(CallError, match="Task is not enabled"):
-                call("pool.snapshottask.run", t["id"])
+                call("pool.snapshottask.run", t["id"], job=True)
 
 
 def test_snapshot_task_can_be_deleted_after_dataset_rename():

--- a/tests/api2/test_snapshot_task.py
+++ b/tests/api2/test_snapshot_task.py
@@ -1,6 +1,7 @@
 import pytest
+from truenas_api_client import ClientException
 
-from middlewared.service_exception import CallError, InstanceNotFound
+from middlewared.service_exception import InstanceNotFound
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.snapshot_task import snapshot_task
 from middlewared.test.integration.utils import call
@@ -53,7 +54,7 @@ def test_snapshot_task_run_disabled_task_raises():
             "naming_schema": "%Y%m%d%H%M",
             "enabled": False,
         }) as t:
-            with pytest.raises(CallError, match="Task is not enabled"):
+            with pytest.raises(ClientException, match="Task is not enabled"):
                 call("pool.snapshottask.run", t["id"], job=True)
 
 


### PR DESCRIPTION
This test should have been changed to wait for the job return when it was ported to v27 in #18996.