### PR TITLE
NAS-141161 / 26.0.0-RC.1 / Switch to truenas_pyos access check function (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/shell.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/shell.py
@@ -49,7 +49,7 @@ class ShellAuthenticator(Authenticator):
 
         try:
             can_access = await middleware.call(
-                'filesystem.can_access_as_user', data['user'], data['script'], {'execute': True}
+                'filesystem.can_access_as_user', data['user'], data['script'], ['EXECUTE']
             )
         except CallError as e:
             verrors.add('script', f'Unable to validate script: {e}')

--- a/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
@@ -1,10 +1,54 @@
 import errno
 import os
 import pathlib
+from types import MappingProxyType
+
+import truenas_os
 
 from middlewared.service import CallError, Service, private
-from middlewared.utils.filesystem.access import check_access, check_acl_execute_impl
-from middlewared.utils.user_context import run_with_user_context
+from middlewared.utils.filesystem.access import get_user_details
+
+_PERM_TOKEN_TO_BIT = MappingProxyType({
+    'READ': os.R_OK,
+    'WRITE': os.W_OK,
+    'EXECUTE': os.X_OK,
+})
+
+
+def _perms_to_mode(perms: list[str]) -> int:
+    """Translate a list of ``"READ"`` / ``"WRITE"`` / ``"EXECUTE"`` tokens into
+    the bitmask that ``truenas_os.check_path_access`` forwards to faccessat2."""
+    mode = 0
+    for token in perms:
+        bit = _PERM_TOKEN_TO_BIT.get(token)
+        if bit is None:
+            raise CallError(
+                f'{token!r}: invalid perm token; must be one of '
+                f'{sorted(_PERM_TOKEN_TO_BIT)}',
+                errno.EINVAL,
+            )
+        mode |= bit
+    return mode
+
+
+def _path_ancestor_components(path: str) -> list[bytes]:
+    """Build the ancestor-component byte list expected by truenas_os.check_path_access.
+
+    For ``/mnt/tank/share/file`` this yields ``[b"/mnt", b"/mnt/tank", b"/mnt/tank/share"]``
+    — every parent directory between the filesystem root and the leaf, exclusive
+    of the leaf itself.
+    """
+    parts = pathlib.Path(path).parts
+    return [('/' + '/'.join(parts[1:i])).encode() for i in range(2, len(parts))]
+
+
+def _cred_from_user_details(user_details: dict) -> truenas_os.CredEntry:
+    return truenas_os.create_cred_entry(
+        user_details['id_name'],
+        user_details['pw_uid'],
+        user_details['pw_gid'],
+        user_details['grouplist'],
+    )
 
 
 class FilesystemService(Service):
@@ -62,21 +106,18 @@ class FilesystemService(Service):
         }
 
     @private
-    def check_as_user_impl(self, user_details, path, perms):
-        return run_with_user_context(check_access, user_details, [path, perms])
+    def can_access_as_user(self, username: str, path: str, perms: list[str]) -> bool:
+        """
+        Check whether `username` is granted every permission in `perms` on `path`.
 
-    @private
-    def can_access_as_user(self, username: str, path: str, perms: dict[str, bool | None] | None = None):
+        `perms` is a list of ``"READ"`` / ``"WRITE"`` / ``"EXECUTE"`` tokens —
+        at least one must be specified.  Returns True iff every requested bit
+        is granted by the filesystem (mode bits + native ACLs).
         """
-        Check if `username` is able to access `path` with specific `permissions`. At least one of `read/write/execute`
-        permission must be specified for checking with each of these defaulting to `null`. `null` for
-        `read/write/execute` represents that the permission should not be checked.
-        """
-        if perms is None:
-            perms = dict()
-        perms.setdefault("read", None)
-        perms.setdefault("write", None)
-        perms.setdefault("execute", None)
+        if not perms:
+            raise CallError('At least one of READ/WRITE/EXECUTE must be set', errno.EINVAL)
+
+        mode = _perms_to_mode(perms)
 
         path_obj = pathlib.Path(path)
         if not path_obj.is_absolute():
@@ -84,15 +125,19 @@ class FilesystemService(Service):
         elif not path_obj.exists():
             raise CallError(f'{path!r} does not exist', errno.EINVAL)
 
-        if all(v is None for v in perms.values()):
-            raise CallError('At least one of read/write/execute flags must be set', errno.EINVAL)
-
         try:
             user_details = self.middleware.call_sync('user.get_user_obj', {'username': username, 'get_groups': True})
         except KeyError:
             raise CallError(f'{username!r} user does not exist', errno=errno.ENOENT)
 
-        return self.check_as_user_impl(user_details, path, perms)
+        user_details['id_name'] = user_details['pw_name']
+        failures = truenas_os.check_path_access(
+            creds=[_cred_from_user_details(user_details)],
+            components=[path.encode()],
+            mode=mode,
+            path_must_exist=True,
+        )
+        return not failures
 
     @private
     def check_path_execute(self, path, id_type, xid, path_must_exist):
@@ -106,29 +151,87 @@ class FilesystemService(Service):
                               id_type.lower(), xid)
             return
 
-        parts = pathlib.Path(path).parts
-        for idx, part in enumerate(parts):
-            if idx < 2:
-                continue
+        components = _path_ancestor_components(path)
+        if not components:
+            return
 
-            path_to_check = f'/{"/".join(parts[1:idx])}'
-            if not os.path.exists(path_to_check):
-                if path_must_exist:
-                    raise CallError(f'{path_to_check}: path component does not exist.', errno.ENOENT)
+        failures = truenas_os.check_path_access(
+            creds=[_cred_from_user_details(user_details)],
+            components=components,
+            path_must_exist=path_must_exist,
+        )
+        if not failures:
+            return
 
-                continue
+        f = failures[0]
+        failing_component = f.failing_component.decode()
+        if f.errnum == errno.ENOENT:
+            raise CallError(f'{failing_component}: path component does not exist.', errno.ENOENT)
 
-            ok = self.check_as_user_impl(user_details, path_to_check, {'read': None, 'write': None, 'execute': True})
-            if not ok:
-                raise CallError(
-                    f'Filesystem permissions on path {path_to_check} prevent access for '
-                    f'{id_type.lower()} "{user_details["id_name"]}" to the path {path}. '
-                    f'This may be fixed by granting the aforementioned {id_type.lower()} '
-                    f'execute permissions on the path: {path_to_check}.', errno.EPERM
-                )
+        raise CallError(
+            f'Filesystem permissions on path {failing_component} prevent access for '
+            f'{id_type.lower()} "{user_details["id_name"]}" to the path {path}. '
+            f'This may be fixed by granting the aforementioned {id_type.lower()} '
+            f'execute permissions on the path: {failing_component}.', errno.EPERM
+        )
 
     @private
     def check_acl_execute(self, path, acl, uid, gid, path_must_exist=False):
-        run_with_user_context(check_acl_execute_impl, {
-            'pw_uid': 0, 'pw_gid': 0, 'pw_dir': '/var/empty', 'pw_name': 'root', 'grouplist': [0, 544]
-        }, [path, acl, uid, gid, path_must_exist])
+        components = _path_ancestor_components(path)
+        if not components:
+            return
+
+        creds: list[truenas_os.CredEntry] = []
+        id_type_by_name: dict[str, str] = {}
+        seen: set[tuple[str, int]] = set()
+
+        for entry in acl:
+            if entry['tag'] in ('everyone@', 'OTHER', 'MASK'):
+                continue
+            if entry.get('type', 'ALLOW') != 'ALLOW':
+                continue
+
+            if entry['tag'] == 'GROUP':
+                id_type, xid = 'GROUP', entry['id']
+            elif entry['tag'] == 'USER':
+                id_type, xid = 'USER', entry['id']
+            elif entry['tag'] in ('owner@', 'USER_OBJ'):
+                id_type, xid = 'USER', uid
+            elif entry['tag'] in ('group@', 'GROUP_OBJ'):
+                id_type, xid = 'GROUP', gid
+            else:
+                continue
+
+            key = (id_type, xid)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            details = get_user_details(id_type, xid)
+            if details is None:
+                continue
+
+            creds.append(_cred_from_user_details(details))
+            id_type_by_name[details['id_name']] = id_type
+
+        if not creds:
+            return
+
+        failures = truenas_os.check_path_access(
+            creds=creds, components=components, path_must_exist=path_must_exist,
+        )
+        if not failures:
+            return
+
+        f = failures[0]
+        failing_component = f.failing_component.decode()
+        if f.errnum == errno.ENOENT:
+            raise CallError(f'{failing_component}: path component does not exist.', errno.ENOENT)
+
+        id_type_lower = id_type_by_name[f.id_name].lower()
+        raise CallError(
+            f'Filesystem permissions on path {failing_component} prevent access for '
+            f'{id_type_lower} "{f.id_name}" to the path {path}. '
+            f'This may be fixed by granting the aforementioned {id_type_lower} '
+            f'execute permissions on the path: {failing_component}.', errno.EPERM
+        )

--- a/src/middlewared/middlewared/utils/filesystem/access.py
+++ b/src/middlewared/middlewared/utils/filesystem/access.py
@@ -1,30 +1,12 @@
-import errno
 import os
-import pathlib
 from typing import Any
 
 from middlewared.service_exception import CallError
-from middlewared.utils.nss import pwd, grp
-from middlewared.utils.user_context import set_user_context
+from middlewared.utils.nss import grp, pwd
 
 # This should be a sufficiently high UID to never be used explicitly
 # We need one for doing access checks based on groups
 SYNTHETIC_UID = 2 ** 32 - 2
-
-
-def check_access(path: str, check_perms: dict[str, bool | None]) -> bool:
-    flag = True
-    for perm, check_flag in filter(
-        lambda v: v[0] is not None, (
-            (check_perms['read'], os.R_OK),
-            (check_perms['write'], os.W_OK),
-            (check_perms['execute'], os.X_OK),
-        )
-    ):
-        perm_check = os.access(path, check_flag)
-        flag &= (perm_check if perm else not perm_check)
-
-    return flag
 
 
 def get_user_details(id_type: str, xid: int) -> dict[str, Any] | None:
@@ -71,71 +53,3 @@ def get_user_details(id_type: str, xid: int) -> dict[str, Any] | None:
         'grouplist': [grp_obj['gr_gid']],
         'id_name': grp_obj['gr_name']
     }
-
-
-def check_acl_execute_impl(path: str, acl: list[dict[str, Any]], uid: int, gid: int, path_must_exist: bool) -> None:
-    """
-    WARNING: The only way this method should be called is within context of `run_with_user_context`
-    """
-    parts = pathlib.Path(path).parts
-
-    if not isinstance(uid, int):
-        raise TypeError(f'{type(uid)}: uid is not int')
-
-    if not isinstance(gid, int):
-        raise TypeError(f'{type(gid)}: gid is not int')
-
-    for entry in acl:
-        if entry['tag'] in ('everyone@', 'OTHER', 'MASK'):
-            continue
-
-        if entry.get('type', 'ALLOW') != 'ALLOW':
-            continue
-
-        # Determine id_type and xid based on the tag
-        id_type: str | None = None
-        xid: int | None = None
-
-        if entry['tag'] == 'GROUP':
-            id_type = 'GROUP'
-            xid = entry['id']
-
-        elif entry['tag'] == 'USER':
-            id_type = 'USER'
-            xid = entry['id']
-
-        elif entry['tag'] in ('owner@', 'USER_OBJ'):
-            id_type = 'USER'
-            xid = uid
-
-        elif entry['tag'] in ('group@', 'GROUP_OBJ'):
-            id_type = 'GROUP'
-            xid = gid
-
-        # Skip if we couldn't determine the type or id
-        if id_type is None or xid is None:
-            continue
-
-        if (user_details := get_user_details(id_type, xid)) is None:
-            # Account does not exist on server. Skip validation
-            continue
-
-        for idx, part in enumerate(parts):
-            if idx < 2:
-                continue
-
-            path_to_check = f'/{"/".join(parts[1:idx])}'
-            if not os.path.exists(path_to_check):
-                if path_must_exist:
-                    raise CallError(f'{path_to_check}: path component does not exist.', errno.ENOENT)
-
-                continue
-
-            set_user_context(user_details)
-            if not check_access(path_to_check, {'read': None, 'write': None, 'execute': True}):
-                raise CallError(
-                    f'Filesystem permissions on path {path_to_check} prevent access for '
-                    f'{id_type.lower()} "{user_details["id_name"]}" to the path {path}. '
-                    f'This may be fixed by granting the aforementioned {id_type.lower()} '
-                    f'execute permissions on the path: {path_to_check}.', errno.EPERM
-                )

--- a/src/middlewared/middlewared/utils/libvirt/cdrom.py
+++ b/src/middlewared/middlewared/utils/libvirt/cdrom.py
@@ -63,7 +63,7 @@ class CDROMDelegate(DeviceDelegate):
         current_owner = os.stat(path)
         is_valid = False
         if current_owner.st_uid != libvirt_user['pw_uid']:
-            if self.middleware.call_sync('filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}):
+            if self.middleware.call_sync('filesystem.can_access_as_user', LIBVIRT_USER, path, ['READ']):
                 is_valid = True
             else:
                 os.chown(path, libvirt_user['pw_uid'], libvirt_user['pw_gid'])
@@ -76,7 +76,7 @@ class CDROMDelegate(DeviceDelegate):
                 verrors.add('attributes.path', e.errmsg)
 
             if not self.middleware.call_sync(
-                    'filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}
+                    'filesystem.can_access_as_user', LIBVIRT_USER, path, ['READ']
             ):
                 verrors.add(
                     'attributes.path',

--- a/src/middlewared/middlewared/utils/user_context.py
+++ b/src/middlewared/middlewared/utils/user_context.py
@@ -1,72 +1,10 @@
-import concurrent.futures
-import functools
 import logging
-import os
 import subprocess
 from typing import Any, Callable
 
-import middlewared.api
-
 logger = logging.getLogger(__name__)
 
-__all__ = ["run_command_with_user_context", "run_with_user_context", "set_user_context"]
-
-
-def set_user_context(user_details: dict[str, Any]) -> None:
-    if os.geteuid() != 0:
-        # We need to reset to UID 0 before setgroups is called
-        os.seteuid(0)
-
-    os.setgroups(user_details['grouplist'])
-
-    # We must preserve the saved uid of zero so that we can call this multiple times
-    # in same child process.
-    gids = (user_details['pw_gid'], user_details['pw_gid'], 0)
-    uids = (user_details['pw_uid'], user_details['pw_uid'], 0)
-
-    os.setresgid(*gids)
-    os.setresuid(*uids)
-
-    new_gids = os.getresgid()
-    new_uids = os.getresuid()
-
-    if new_gids != gids:
-        raise Exception(
-            f'{user_details["pw_name"]}: Unable to set gids for user context'
-            f' received {new_gids}, expected {gids}'
-        )
-
-    if new_uids != uids:
-        raise Exception(
-            f'{user_details["pw_name"]}: Unable to set uids for user context'
-            f' received {new_uids}, expected {uids}'
-        )
-
-    try:
-        os.chdir(user_details['pw_dir'])
-    except Exception:
-        os.chdir('/var/empty')
-
-    os.environ.update({
-        'HOME': user_details['pw_dir'],
-        'PATH': '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin',
-    })
-
-
-def run_with_user_context_initializer(user_details: dict[str, Any]) -> None:
-    middlewared.api.API_LOADING_FORBIDDEN = True
-    set_user_context(user_details)
-
-
-def run_with_user_context[T](
-    func: Callable[..., T], user_details: dict[str, Any], func_args: list[Any] | None = None
-) -> T:
-    assert {'pw_uid', 'pw_gid', 'pw_dir', 'pw_name', 'grouplist'} - set(user_details) == set()
-
-    with concurrent.futures.ProcessPoolExecutor(
-        max_workers=1, initializer=functools.partial(run_with_user_context_initializer, user_details)
-    ) as exc:
-        return exc.submit(func, *(func_args or [])).result()
+__all__ = ["run_command_with_user_context"]
 
 
 def run_command_with_user_context(

--- a/tests/api2/test_can_access_as_user.py
+++ b/tests/api2/test_can_access_as_user.py
@@ -42,40 +42,40 @@ def directory(name, user, group, permissions):
 
 def test_non_authorized_user_access():
     with file('test', 'root', 'root', '700') as file_path:
-        for perm_check in ('read', 'write', 'execute'):
-            assert call('filesystem.can_access_as_user', 'nobody', file_path, {perm_check: True}) is False
+        for perm_check in ('READ', 'WRITE', 'EXECUTE'):
+            assert call('filesystem.can_access_as_user', 'nobody', file_path, [perm_check]) is False
 
 
 def test_authorized_user_access():
     for user, group in (('apps', 'apps'), ('nobody', 'nogroup')):
         with file('test', user, group, '700') as file_path:
-            for perm_check in ('read', 'write', 'execute'):
-                assert call('filesystem.can_access_as_user', user, file_path, {perm_check: True}) is True
+            for perm_check in ('READ', 'WRITE', 'EXECUTE'):
+                assert call('filesystem.can_access_as_user', user, file_path, [perm_check]) is True
 
 
 def test_read_access():
     for user, group in (('apps', 'apps'), ('nobody', 'nogroup')):
         with file('test', user, group, '400') as file_path:
-            for perm_check, value in (('read', True), ('write', False), ('execute', False)):
-                assert call('filesystem.can_access_as_user', user, file_path, {perm_check: True}) is value
+            for perm_check, value in (('READ', True), ('WRITE', False), ('EXECUTE', False)):
+                assert call('filesystem.can_access_as_user', user, file_path, [perm_check]) is value
 
 
 def test_write_access():
     for user, group in (('apps', 'apps'), ('nobody', 'nogroup')):
         with file('test', user, group, '200') as file_path:
-            for perm_check, value in (('read', False), ('write', True), ('execute', False)):
-                assert call('filesystem.can_access_as_user', user, file_path, {perm_check: True}) is value
+            for perm_check, value in (('READ', False), ('WRITE', True), ('EXECUTE', False)):
+                assert call('filesystem.can_access_as_user', user, file_path, [perm_check]) is value
 
 
 def test_execute_access():
     for user, group in (('apps', 'apps'), ('nobody', 'nogroup')):
         with file('test', user, group, '100') as file_path:
-            for perm_check, value in (('read', False), ('write', False), ('execute', True)):
-                assert call('filesystem.can_access_as_user', user, file_path, {perm_check: True}) is value
+            for perm_check, value in (('READ', False), ('WRITE', False), ('EXECUTE', True)):
+                assert call('filesystem.can_access_as_user', user, file_path, [perm_check]) is value
 
 
 def test_nested_perm_execute_check():
     with directory('test_dir', 'root', 'root', '700') as dir_path:
         file_path = os.path.join(dir_path, 'testfile')
         with file_at_path(file_path, 'root', 'root', '777'):
-            assert call('filesystem.can_access_as_user', 'apps', file_path, {'execute': True}) is False
+            assert call('filesystem.can_access_as_user', 'apps', file_path, ['EXECUTE']) is False


### PR DESCRIPTION
This commit switches from using our process-pool based permissions checker with on that's streamlined inside truenas_pyos and executes with GIL dropped. Historically this area has been troublesome to keep good performance and so simplifying middleware design here is worthwhile.

Original PR: https://github.com/truenas/middleware/pull/19003
