### PR TITLE
NAS-141171 / 26.0.0-RC.1 / During become_active activate FILE extents (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -117,11 +117,11 @@ class iSCSITargetAluaService(Service):
         iqn_basename = config['basename']
         thisnode = await self.middleware.call('failover.node')
 
-        # extents: dict[id] : {id, name, type, serial}
+        # extents: dict[id] : {id, name, path, type, serial}
         extents = {ext['id']: ext for ext in await self.middleware.call(
             'iscsi.extent.query',
             [['enabled', '=', True], ['locked', '=', False]],
-            {'select': ['name', 'id', 'type', 'serial']},
+            {'select': ['name', 'id', 'path', 'type', 'serial']},
         )}
 
         # targets: dict[id]: {'name': name, 'mode': mode}
@@ -161,6 +161,17 @@ class iSCSITargetAluaService(Service):
                     target_name = targets[target_id]['name']
                     target_mode = targets[target_id]['mode']
                     extent_name = extents[extent_id]['name']
+                    extent_type = extents[extent_id]['type']
+                    # If the extent is FILE, then call activate_extent
+                    # (bind_alua_state not set by default)
+                    if extent_type == 'FILE':
+                        if not await self.middleware.call(
+                            'iscsi.scst.activate_extent',
+                            extent_name,
+                            extent_type,
+                            extents[extent_id]['path']
+                        ):
+                            self.logger.warning('become_active: failed to activate FILE extent %r', extent_name)
                     if target_mode in ['ISCSI', 'BOTH']:
                         iqn = f'{iqn_basename}:{target_name}'
                         await self.middleware.call('iscsi.scst.replace_iscsi_lun',


### PR DESCRIPTION
A previous PR (#18576) removed the `activate_extents` method, and extents were instead activated via SCST's `bind_alua_state`.

This was fine for ZVOL based extents, but until recently FILE based extents were not supported by this mechanism.  Even though they now are, the default value of `bind_alua_state` for FILE based extents is off.  We could turn it on, but because of how our ALUA is implemented we would encounter some SCST log spamming.  So, instead active the FILE based extents explicitly in `become_active`.

(Caveat: FILE based extents + ALUA is an unexpected combination, so this change is mostly for correctness.)

Original PR: https://github.com/truenas/middleware/pull/19011
