### PR TITLE
NAS-141183 / 27.0.0-BETA.1 / Replace constructed-filter `filter_list` calls with native Python

### DIFF
--- a/src/middlewared/middlewared/alert/source/security.py
+++ b/src/middlewared/middlewared/alert/source/security.py
@@ -12,7 +12,6 @@ from middlewared.alert.base import (
 )
 from middlewared.alert.schedule import CrontabSchedule
 from middlewared.utils import ProductType, security
-from middlewared.utils.filter_list import filter_list
 
 
 @dataclass(kw_only=True)
@@ -69,11 +68,11 @@ class SecurityLocalUserAccountExpirationAlertSource(AlertSource):
     products = (ProductType.ENTERPRISE,)
 
     async def check(self) -> list[Alert[Any]]:
-        alerts: list[Alert[Any]] = []
         sec = await self.middleware.call("system.security.config")
-        if not sec["max_password_age"]:
+        max_pw_age = sec["max_password_age"]
+        if not max_pw_age:
             # password aging disabled and so we can skip these checks
-            return alerts
+            return []
 
         unlocked_local_accounts = await self.middleware.call("user.query", [
             ["local", "=", True],
@@ -82,22 +81,11 @@ class SecurityLocalUserAccountExpirationAlertSource(AlertSource):
             ["locked", "=", False]
         ])
 
-        expiring = filter_list(unlocked_local_accounts, [
-            ["password_age", ">=", sec["max_password_age"] - security.PASSWORD_PROMPT_AGE],
-            ["password_age", "<", sec["max_password_age"]],
-        ])
-
-        expired = filter_list(unlocked_local_accounts, [
-            ["password_age", ">=", sec["max_password_age"]]
-        ])
-
-        # Generate this alert an extra day early since we don't want to risk admin lockout
-        active_full_admins = filter_list(unlocked_local_accounts, [
-            ["roles", "rin", "FULL_ADMIN"],
-            ["password_age", "<", sec["max_password_age"] - 1],
-        ])
-
-        if not active_full_admins:
+        if not any(
+            # Generate this alert an extra day early since we don't want to risk admin lockout
+            "FULL_ADMIN" in acct["roles"] and acct["password_age"] < max_pw_age - 1
+            for acct in unlocked_local_accounts
+        ):
             # Once per day we check whether we've potentially locked out all
             # admins from accessing the NAS. If that occurs we forcibly regenerate
             # the shadow file, which will have the effect of disabling password aging
@@ -107,18 +95,24 @@ class SecurityLocalUserAccountExpirationAlertSource(AlertSource):
             # updating password.
             await self.middleware.call('etc.generate', 'shadow')
 
-        if expiring:
-            alerts.append(Alert(
-                LocalAccountExpiringAlert(
-                    accounts=", ".join([u["username"] for u in expiring]),
-                )
-            ))
+        alerts: list[Alert[Any]] = []
 
-        if expired:
-            alerts.append(Alert(
-                LocalAccountExpiredAlert(
-                    accounts=", ".join([u["username"] for u in expired]),
-                )
-            ))
+        # Alert for expiring accounts
+        expiring_accounts = ", ".join(
+            acct["username"]
+            for acct in unlocked_local_accounts
+            if max_pw_age - security.PASSWORD_PROMPT_AGE <= acct["password_age"] < max_pw_age
+        )
+        if expiring_accounts:
+            alerts.append(Alert(LocalAccountExpiringAlert(accounts=expiring_accounts)))
+
+        # Alert for expired accounts
+        expired_accounts = ", ".join(
+            acct["username"]
+            for acct in unlocked_local_accounts
+            if acct["password_age"] >= max_pw_age
+        )
+        if expired_accounts:
+            alerts.append(Alert(LocalAccountExpiredAlert(accounts=expired_accounts)))
 
         return alerts

--- a/src/middlewared/middlewared/etc_files/krb5.conf.py
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.py
@@ -1,17 +1,20 @@
 import logging
+from typing import TYPE_CHECKING
 
 from middlewared.plugins.etc import FileShouldNotExist
 from middlewared.utils.directoryservices.constants import DSType
 from middlewared.utils.directoryservices.krb5 import kdc_saf_cache_get
 from middlewared.utils.directoryservices.krb5_conf import KRB5Conf
 from middlewared.utils.directoryservices.krb5_constants import PERSISTENT_KEYRING_PREFIX, KRB_LibDefaults
-from middlewared.utils.filter_list import filter_list
+
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
 logger = logging.getLogger(__name__)
 
 
 def generate_krb5_conf(
-    middleware: object,
+    middleware: 'Middleware',
     directory_service: dict,
     krb_config: dict,
     realms: list
@@ -47,16 +50,21 @@ def generate_krb5_conf(
             # AD / IPA domain has been lost. In almost all circumstances this will match the
             # domainname so we can recover from there
             if not default_realm:
+                ds_config_domain = ds_config['configuration']['domain']
                 logger.error(
                     '%s: no realm configuration found for domain. Attempting to recover.',
-                    ds_config['configuration']['domain']
+                    ds_config_domain
                 )
 
                 # Try looking up again by domain
-                default_realm = filter_list(realms, [['realm', '=', ds_config['configuration']['domain']]])
-                if not default_realm:
+                for r in realms:
+                    if r['realm'] == ds_config_domain:
+                        realm_id = r['id']
+                        default_realm = ds_config_domain
+                        break
+                else:
                     # Try to recover by creating a realm stub
-                    if not ds_config['configuration']['domain']:
+                    if not ds_config_domain:
                         # We have an invalid directory services configuration (no domain, no realm)
                         # log an error message and prevent kerberos config generation
 
@@ -67,13 +75,10 @@ def generate_krb5_conf(
 
                     realm_id = middleware.call_sync(
                         'datastore.insert', 'directoryservice.kerberosrealm',
-                        {'krb_realm': ds_config['configuration']['domain']}
+                        {'krb_realm': ds_config_domain}
                     )
 
                     default_realm = middleware.call_sync('kerberos.realm.get_instance', realm_id)['realm']
-                else:
-                    realm_id = default_realm[0]['id']
-                    default_realm = default_realm[0]['realm']
 
                 middleware.call_sync(
                     'datastore.update', 'directoryservices',
@@ -120,7 +125,7 @@ def generate_krb5_conf(
     return krbconf.generate()
 
 
-def render(service, middleware, render_ctx):
+def render(service, middleware: 'Middleware', render_ctx):
 
     return generate_krb5_conf(
         middleware,

--- a/src/middlewared/middlewared/etc_files/web_ui_root_login_alert.py
+++ b/src/middlewared/middlewared/etc_files/web_ui_root_login_alert.py
@@ -1,9 +1,12 @@
+from typing import TYPE_CHECKING
+
 from middlewared.alert.source.web_ui_root_login import WebUiRootLoginAlert
-from middlewared.utils.filter_list import filter_list
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
 
-async def render(service, middleware, render_ctx):
-    root_user = filter_list(render_ctx['user.query'], [('username', '=', 'root')], {'get': True})
+async def render(service, middleware: 'Middleware', render_ctx):
+    root_user = next(u for u in render_ctx['user.query'] if u['username'] == 'root')
 
     if root_user['password_disabled'] and await middleware.call(
         'privilege.always_has_root_password_enabled',

--- a/src/middlewared/middlewared/etc_files/web_ui_root_login_alert.py
+++ b/src/middlewared/middlewared/etc_files/web_ui_root_login_alert.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from middlewared.alert.source.web_ui_root_login import WebUiRootLoginAlert
+
 if TYPE_CHECKING:
     from middlewared.main import Middleware
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -529,11 +529,11 @@ class UserService(CRUDService):
                     f'{data["home"]}: home directory path is immutable.'
                 )
 
-        in_use = filter_list(users, [('home', '=', data['home'])])
+        in_use = next((u for u in users if u['home'] == data['home']), None)
         if in_use:
             verrors.add(
                 f'{schema}.home',
-                f'{data["home"]}: homedir already used by {in_use[0]["username"]}.',
+                f'{data["home"]}: homedir already used by {in_use["username"]}.',
                 errno.EEXIST
             )
 
@@ -1374,23 +1374,23 @@ class UserService(CRUDService):
             local_users = await self.middleware.call('user.query', [['local', '=', True]])
             local_groups = await self.middleware.call('group.query', [['local', '=', True]])
 
-            if filter_list(local_users, [['uid', '=', ADMIN_UID]]):
+            if any(u['uid'] == ADMIN_UID for u in local_users):
                 raise CallError(
                     f'A user with uid={ADMIN_UID} already exists, setting up local administrator is not possible',
                     errno.EEXIST,
                 )
 
-            if filter_list(local_users, [['username', '=', username]]):
+            if any(u['username'] == username for u in local_users):
                 raise CallError(f'{username!r} user already exists, setting up local administrator is not possible',
                                 errno.EEXIST)
 
-            if filter_list(local_groups, [['gid', '=', ADMIN_GID]]):
+            if any(g['gid'] == ADMIN_GID for g in local_groups):
                 raise CallError(
                     f'A group with gid={ADMIN_GID} already exists, setting up local administrator is not possible',
                     errno.EEXIST,
                 )
 
-            if filter_list(local_groups, [['group', '=', username]]):
+            if any(g['group'] == username for g in local_groups):
                 raise CallError(f'{username!r} group already exists, setting up local administrator is not possible',
                                 errno.EEXIST)
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1614,7 +1614,7 @@ class UserService(CRUDService):
         if 'username' in data:
             pw_checkname(verrors, f'{schema}.username', data['username'])
 
-            if filter_list(users, [('username', '=', data['username'])]):
+            if any(u['username'] == data['username'] for u in users):
                 verrors.add(
                     f'{schema}.username',
                     f'The username "{data["username"]}" already exists.',
@@ -1622,7 +1622,10 @@ class UserService(CRUDService):
                 )
 
             if data.get('smb'):
-                if filter_list(users, [['username', 'C=', data['username']], ['smb', '=', True]]):
+                if any(
+                    u['smb'] and u['username'].casefold() == data['username'].casefold()
+                    for u in users
+                ):
                     verrors.add(
                         f'{schema}.smb',
                         f'Username "{data["username"]}" conflicts with existing SMB user. Note that SMB '
@@ -2575,7 +2578,7 @@ class GroupService(CRUDService):
                                                         [('smb', '=', True)] + exclude_filter,
                                                         {'prefix': 'bsdgrp_'})
 
-                if filter_list(smb_groups, [['group', 'C=', data['name']]]):
+                if any(g['group'].casefold() == data['name'].casefold() for g in smb_groups):
                     verrors.add(
                         f'{schema}.name',
                         f'Group name "{data["name"]}" conflicts with existing groupmap entry. '

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -17,7 +17,7 @@ from middlewared.api.current import (
     UserWebUiLoginDisabledAddedEvent,
 )
 from middlewared.plugins.account import unixhash_is_valid
-from middlewared.service import CallError, CRUDService, ValidationErrors, filter_list, private
+from middlewared.service import CallError, CRUDService, ValidationErrors, private
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils.allowlist import Allowlist
@@ -233,9 +233,8 @@ class PrivilegeService(CRUDService):
         by_gid = {group["gid"]: group for group in groups}
         by_sid = {
             group["sid"]: group
-            for group in filter_list(
-                groups, [["sid", "!=", None], ["local", "=", False]],
-            )
+            for group in groups
+            if group["sid"] is not None and not group["local"]
         }
 
         return {'by_gid': by_gid, 'by_sid': by_sid}
@@ -430,11 +429,7 @@ class PrivilegeService(CRUDService):
         if groups is None:
             groups = await self.middleware.call('group.query', [['local', '=', True]])
 
-        root_user = filter_list(
-            users,
-            [['username', '=', 'root']],
-            {'get': True},
-        )
+        root_user = next(u for u in users if u['username'] == 'root')
         users = await self.local_administrators([root_user['id']], users, groups)
         if not users:
             value = True
@@ -471,11 +466,7 @@ class PrivilegeService(CRUDService):
             groups,
         )
         if not local_administrators:
-            root_user = filter_list(
-                users,
-                [['username', '=', 'root']],
-                {'get': True},
-            )
+            root_user = next(u for u in users if u['username'] == 'root')
             if root_user['id'] not in exclude_user_ids:
                 if unixhash_is_valid(root_user['unixhash']):
                     # This can only be if `always_has_root_password_enabled` is `True`

--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -367,11 +367,10 @@ class FCPortService(CRUDService):
         else:
             fc_host_alias = data['port']
             chan = None
-        try:
-            fc_host_pair = filter_list(context['fc.fc_host.query'], [('alias', '=', fc_host_alias)], {'get': True})
-        except MatchNotFound:
-            pass
-        else:
+        fc_host_pair = next(
+            (h for h in context['fc.fc_host.query'] if h['alias'] == fc_host_alias), None
+        )
+        if fc_host_pair is not None:
             if chan:
                 # NPIV
                 data['wwpn'] = wwpn_to_vport_naa(fc_host_pair.get('wwpn'), int(chan))

--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -198,14 +198,15 @@ class ShareSec(Service):
         shares = await self.middleware.call('datastore.query', 'sharing.cifs_share', [], {'prefix': 'cifs_'})
         for s in shares:
             share_name = s['name'] if not s['home'] else 'homes'
-            if not (share_acl := filter_list(entries, [['key', '=', f'SECDESC/{share_name.lower()}']])):
+            share_acl = next((e for e in entries if e['key'] == f'SECDESC/{share_name.lower()}'), None)
+            if not share_acl:
                 continue
 
-            if share_acl[0]['value'] != s['share_acl']:
+            if share_acl['value'] != s['share_acl']:
                 self.logger.debug('Updating stored copy of SMB share ACL on %s', share_name)
                 await self.middleware.call(
                     'datastore.update',
                     'sharing.cifs_share',
                     s['id'],
-                    {'cifs_share_acl': share_acl[0]['value']}
+                    {'cifs_share_acl': share_acl['value']}
                 )

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -27,7 +27,6 @@ from middlewared.plugins.zfs.utils import get_encryption_info
 from middlewared.service import CallError, ConfigService, ValidationError, ValidationErrors, job, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import BOOT_POOL_NAME_VALID, MIDDLEWARE_RUN_DIR
-from middlewared.utils.filter_list import filter_list
 from middlewared.utils.size import format_size
 from middlewared.utils.tdb import close_sysdataset_tdb_handles
 from middlewared.utils.zfs import query_imported_fast_impl
@@ -310,7 +309,7 @@ class SystemDatasetService(ConfigService):
 
         mntinfo = list(iter_mountinfo())
         if config['pool'] != boot_pool:
-            if not any(filter_list(mntinfo, [['mount_source', '=', config['pool']]])):
+            if not any(mnt['mount_source'] == config['pool'] for mnt in mntinfo):
                 ds = self.call_sync2(
                     self.s.zfs.resource.query_impl,
                     ZFSResourceQuery(paths=[config['basename']], properties=['encryption'])
@@ -340,9 +339,9 @@ class SystemDatasetService(ConfigService):
 
         mounted_pool = mounted = None
 
-        sysds_mntinfo = filter_list(mntinfo, [['mountpoint', '=', '/var/db/system']])
+        sysds_mntinfo = next((mnt for mnt in mntinfo if mnt['mountpoint'] == '/var/db/system'), None)
         if sysds_mntinfo:
-            mounted_pool = sysds_mntinfo[0]['mount_source'].split('/')[0]
+            mounted_pool = sysds_mntinfo['mount_source'].split('/')[0]
 
         if mounted_pool and mounted_pool.split('/')[0] != config['pool']:
             self.logger.debug('Abandoning dataset on %r in favor of %r', mounted_pool, config['pool'])
@@ -364,9 +363,9 @@ class SystemDatasetService(ConfigService):
 
         os.makedirs(SYSDATASET_PATH, mode=0o755, exist_ok=True)
 
-        ds_mntinfo = filter_list(mntinfo, [['mount_source', '=', config['basename']]])
+        ds_mntinfo = next((mnt for mnt in mntinfo if mnt['mount_source'] == config['basename']), None)
         if ds_mntinfo:
-            acl_enabled = 'POSIXACL' in ds_mntinfo[0]['super_opts'] or 'NFSV4ACL' in ds_mntinfo[0]['super_opts']
+            acl_enabled = 'POSIXACL' in ds_mntinfo['super_opts'] or 'NFSV4ACL' in ds_mntinfo['super_opts']
         else:
             ds = self.call_sync2(
                 self.s.zfs.resource.query_impl,

--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -418,15 +418,11 @@ def keytab_services(keytab_file: str) -> list:
 
     `keytab_file` - path to kerberos keytab
     """
-    keytab_data = filter_list(
-        ktutil_list_impl(keytab_file),
-        [['principal', 'rin', '/']]
-    )
-    services = []
-    for entry in keytab_data:
-        services.append(entry['principal'].split('/')[0])
-
-    return services
+    return [
+        entry['principal'].split('/')[0]
+        for entry in ktutil_list_impl(keytab_file)
+        if '/' in entry['principal']
+    ]
 
 
 def extract_from_keytab(


### PR DESCRIPTION
## Summary

`filter_list()` is TrueNAS's query engine: it compiles a filter DSL (`[['field', 'op', value]]`) and options (`get`, `select`, `order_by`, ...) and runs them through the `truenas_pyfilter` C extension. It exists so that **caller-supplied** query-filters arriving from an API method can be applied to an in-memory list.

Over time it has also been used internally with **hardcoded** filters — places where the filter and options are literals written in the source, not values received from a caller. In those cases the DSL buys nothing: it's a less direct, less readable, and slightly more expensive way of writing a predicate that Python already expresses with `any()`, `next()`, or a comprehension.

This branch replaces those constructed-filter calls with the equivalent native Python, while leaving every legitimate use of `filter_list` intact.

## The rule applied

A `filter_list` call is replaced **only if** its filters and/or options are constructed in code rather than received as arguments from an API method.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/9113/