### PR TITLE
NAS-141142 / 26.0.0-RC.1 / VM/container: parallelize shutdown and fix force_after_timeout (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 import errno
 import os
 
@@ -76,6 +77,16 @@ def _build_idmapped_root_acl() -> 'truenas_os.POSIXACL':
     return truenas_os.POSIXACL.from_aces(aces)
 
 
+async def _stop_one_container(middleware, container):
+    try:
+        job = await middleware.call(
+            'container.stop', container['id'], {'force_after_timeout': True},
+        )
+        await job.wait(raise_error=True)
+    except Exception:
+        middleware.logger.error('Failed to stop %r container', container['name'], exc_info=True)
+
+
 class ContainerService(Service):
 
     @private
@@ -102,8 +113,8 @@ class ContainerService(Service):
 
     @private
     async def handle_shutdown(self):
-        for container in await self.middleware.call('container.query', [('status.state', '=', 'RUNNING')]):
-            await self.middleware.call('container.stop', container['id'], {'force_after_timeout': True})
+        running = await self.middleware.call('container.query', [('status.state', '=', 'RUNNING')])
+        await asyncio.gather(*(_stop_one_container(self.middleware, c) for c in running))
 
     @api_method(ContainerStartArgs, ContainerStartResult, roles=["CONTAINER_WRITE"])
     def start(self, id_):

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -1,5 +1,18 @@
+import asyncio
+
 from middlewared.service import private, Service
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
+
+
+async def _stop_one_vm(middleware, vm):
+    try:
+        if vm['status']['state'] == 'RUNNING':
+            job = await middleware.call('vm.stop', vm['id'], {'force_after_timeout': True})
+            await job.wait(raise_error=True)
+        else:
+            await middleware.call('vm.poweroff', vm['id'])
+    except Exception:
+        middleware.logger.error('Failed to stop %r VM', vm['name'], exc_info=True)
 
 
 class VMService(Service):
@@ -14,14 +27,8 @@ class VMService(Service):
 
     @private
     async def handle_shutdown(self):
-        for vm in await self.middleware.call('vm.query', [('status.state', 'in', ACTIVE_STATES)]):
-            if vm['status']['state'] == 'RUNNING':
-                await self.middleware.call('vm.stop', vm['id'], {'force_after_timeout': True})
-            else:
-                try:
-                    await self.middleware.call('vm.poweroff', vm['id'])
-                except Exception:
-                    self.middleware.logger.error('Powering off %r VM failed', vm['name'], exc_info=True)
+        active = await self.middleware.call('vm.query', [('status.state', 'in', ACTIVE_STATES)])
+        await asyncio.gather(*(_stop_one_vm(self.middleware, vm) for vm in active))
 
 
 async def __event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -72,8 +72,14 @@ class VMService(Service):
         libvirt_domain = self.pylibvirt_vm(vm_data)
         if options['force']:
             self.middleware.libvirt_domains_manager.vms.destroy(libvirt_domain)
-        else:
-            self.middleware.libvirt_domains_manager.vms.shutdown(libvirt_domain, vm_data['shutdown_timeout'])
+            return
+
+        self.middleware.libvirt_domains_manager.vms.shutdown(libvirt_domain, vm_data['shutdown_timeout'])
+        if (
+            options['force_after_timeout']
+            and self.middleware.call_sync('vm.get_instance', id_)['status']['state'] == 'RUNNING'
+        ):
+            self.middleware.libvirt_domains_manager.vms.destroy(libvirt_domain)
 
     @api_method(VMPoweroffArgs, VMPoweroffResult, roles=['VM_WRITE'])
     def poweroff(self, id_):


### PR DESCRIPTION
## Problem

When middleware itself stops VMs and containers — on system shutdown/reboot via the `system.shutdown` event, or during HA failover — it loops through guests one at a time, waiting up to the per-guest shutdown timeout (90s by default) for each. With many guests this serializes into a long wait, even though stopping different guests has no dependency on one another.

Separately, `vm.stop(force_after_timeout=True)` was silently ignored — `stop_vm` only checked `options.force`. A VM that didn't respond to ACPI within its `shutdown_timeout` was left running, contradicting the API docstring and behaving inconsistently with the container path which honored the flag correctly.

## Solution

Parallelize `vm.handle_shutdown` and `container.handle_shutdown` using `asyncio.gather`, so all guests receive shutdown concurrently. Per-id job locks are unchanged, and `truenas_pylibvirt` releases the GIL during libvirt RPCs, so concurrent stops genuinely run in parallel at libvirtd.

Fix `stop_vm` to honor `force_after_timeout`: after the ACPI wait, if the VM is still RUNNING, call `destroy()` — mirroring the existing container behavior.


Original PR: https://github.com/truenas/middleware/pull/19000
