### PR TITLE
NAS-141187 / 26.0.0-RC.1 / Fix intermittent HA failover stall in "Configuring system dataset" (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/dbus_router.py
+++ b/src/middlewared/middlewared/plugins/service_/services/dbus_router.py
@@ -393,7 +393,12 @@ class CachedSystemDBusRouter:
         # the initial Stop call, but once we're inside filter() we're committed
         # to this connection for signal delivery.
         router = await self._ensure_router()
-        with router.filter(_JOB_REMOVED_FILTER_RULE) as job_queue:
+        # bufsize=0 (unbounded): jeepney's _dispatch silently drops via
+        # put_nowait/QueueFull when the queue is full. During failover, systemd
+        # batches many JobRemoved signals into single socket reads, and the
+        # receiver task processes them without yielding — a bounded queue loses
+        # our target signal and the wait then times out spuriously.
+        with router.filter(_JOB_REMOVED_FILTER_RULE, queue=asyncio.Queue()) as job_queue:
             # Issue the stop action
             unit = DBusAddress(
                 unit_path,
@@ -749,7 +754,9 @@ class CachedSystemDBusRouter:
             )
         else:
             # For non-Stop actions, use original flow
-            with router.filter(_JOB_REMOVED_FILTER_RULE) as queue:
+            # See note above _stop_unit_and_wait_for_exit: bounded queue races
+            # with JobRemoved bursts during failover.
+            with router.filter(_JOB_REMOVED_FILTER_RULE, queue=asyncio.Queue()) as queue:
                 # Issue the action
                 unit = DBusAddress(
                     unit_path,


### PR DESCRIPTION
When a node becomes MASTER with the sysdataset previously parked on boot-pool (after a BACKUP transition), setup_impl takes the "Abandoning ... in favor of <data pool>" branch and enters release_system_dataset(), which stops and restarts netdata/ truenas_zfstierd/nfs/open-vm-tools around the umount+remount. The restart of netdata was hanging until the dbus wait timed out (~95s), blocking vrrp_master.

The unit was actually starting in <1s - middleware just never saw the JobRemoved signal. Root cause: call_unit_action_and_wait and _stop_unit_and_wait_for_exit used jeepney's default size-1 filter queue. jeepney silently drops overflow (asyncio.QueueFull -> pass), and the receiver task dispatches batched JobRemoved signals without yielding - so during a failover's signal burst the target signal is lost and the wait times out.

Pass an unbounded asyncio.Queue() to router.filter() at both call sites.

----
Manually tested with 15 HA failovers.

Original PR: https://github.com/truenas/middleware/pull/19029
