### PR TITLE
NAS-141113 / 27.0.0-BETA.1 / Expose all_sed property on zpool.query

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
@@ -194,6 +194,9 @@ class ZPoolEntry(BaseModel):
     """Human-readable status description."""
     is_upgraded: bool | None = None
     """Whether every ZFS feature flag on the pool is enabled. `null` for OFFLINE pools."""
+    all_sed: bool | None = None
+    """`true` when every disk backing the pool is a Self-Encrypting Drive, `false` when at least one is not. \
+    `null` when the SED status of the pool has not yet been determined or does not apply."""
     properties: dict[str, ZPoolPropertyValue] | None = None
     """Pool properties, keyed by property name."""
     topology: ZPoolTopology | None = None

--- a/src/middlewared/middlewared/api/v27_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v27_0_0/zpool_query.py
@@ -194,6 +194,9 @@ class ZPoolEntry(BaseModel):
     """Human-readable status description."""
     is_upgraded: bool | None = None
     """Whether every ZFS feature flag on the pool is enabled. `null` for OFFLINE pools."""
+    all_sed: bool | None = None
+    """`true` when every disk backing the pool is a Self-Encrypting Drive, `false` when at least one is not. \
+    `null` when the SED status of the pool has not yet been determined or does not apply."""
     properties: dict[str, ZPoolPropertyValue] | None = None
     """Pool properties, keyed by property name."""
     topology: ZPoolTopology | None = None

--- a/src/middlewared/middlewared/plugins/zpool/crud.py
+++ b/src/middlewared/middlewared/plugins/zpool/crud.py
@@ -172,16 +172,10 @@ class ZPoolService(Service):
 
         results = self.middleware.call_sync("zpool.query_impl", data | {"pool_names": pool_names})
         for entry in results:
-            entry.update({
-                "id": None,
-                "all_sed": None,
-            })
+            entry.update({"id": None, "all_sed": None})
             db_entry = db_pools.get(entry["name"])
             if db_entry is not None:
-                entry.update({
-                    "id": db_entry["id"],
-                    "all_sed": db_entry["all_sed"],
-                })
+                entry.update({"id": db_entry["id"], "all_sed": db_entry["all_sed"]})
 
         imported_names = {p["name"] for p in results}
         offline_names = [name for name in pool_names if name not in imported_names]

--- a/src/middlewared/middlewared/plugins/zpool/crud.py
+++ b/src/middlewared/middlewared/plugins/zpool/crud.py
@@ -106,6 +106,7 @@ class ZPoolService(Service):
                     "status_code": status_code,
                     "status_detail": status_detail,
                     "is_upgraded": None,
+                    "all_sed": pool_info.get("all_sed"),
                 }
             )
         return entries
@@ -171,7 +172,16 @@ class ZPoolService(Service):
 
         results = self.middleware.call_sync("zpool.query_impl", data | {"pool_names": pool_names})
         for entry in results:
-            entry["id"] = db_pools[entry["name"]]["id"] if entry["name"] in db_pools else None
+            entry.update({
+                "id": None,
+                "all_sed": None,
+            })
+            db_entry = db_pools.get(entry["name"])
+            if db_entry is not None:
+                entry.update({
+                    "id": db_entry["id"],
+                    "all_sed": db_entry["all_sed"],
+                })
 
         imported_names = {p["name"] for p in results}
         offline_names = [name for name in pool_names if name not in imported_names]


### PR DESCRIPTION
This PR adds changes to surface the all_sed flag on zpool.query entries so callers can identify pools made up entirely of Self-Encrypting Drives without going through pool.query.