### PR TITLE
NAS-141204 / 27.0.0-BETA.1 / Process BACKUP in vrrp rapid-succession branch

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/vrrp_events.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events.py
@@ -163,10 +163,40 @@ class VrrpEventThread(Thread):
                     last_event = this_event
                     sleep(self.rapid_event_settle_time)
                 else:
+                    # Settle period already paid. Fire the hook for BACKUP
+                    # (safer state to converge on, idempotent on a fresh
+                    # boot); log+drop MASTER, since acting on an unsettled
+                    # MASTER would kick off fenced + zpool import. If we've
+                    # already successfully run vrrp_backup since this
+                    # process started, the BACKUP event is redundant -
+                    # drop it too.
                     last_event = None
                     backoff = False
                     self.event_queue.pop()
-                    LOGGER.warning('Detected rapid succession of failover events: (%r)', this_event)
+                    if this_event['event'] == 'BACKUP':
+                        last_type = self.middleware.call_sync(
+                            'failover.events.last_event_type'
+                        )
+                        if last_type == 'BACKUP':
+                            LOGGER.warning(
+                                'Rapid succession of failover events; '
+                                'skipping redundant BACKUP after settle '
+                                '(vrrp_backup already ran): (%r)',
+                                this_event,
+                            )
+                        else:
+                            LOGGER.warning(
+                                'Rapid succession of failover events; '
+                                'processing latest BACKUP after settle: (%r)',
+                                this_event,
+                            )
+                            self.middleware.call_hook_sync('vrrp.fifo', data=this_event)
+                    else:
+                        LOGGER.warning(
+                            'Rapid succession of failover events; '
+                            'dropping non-BACKUP latest after settle: (%r)',
+                            this_event,
+                        )
             else:
                 LOGGER.warning('Unhandled failover event. last_event: %r, this_event: %r', last_event, this_event)
                 last_event = None

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -66,6 +66,11 @@ class FailoverEventsService(Service):
     # represents if a failover event was successful or not
     FAILOVER_RESULT = None
 
+    # tracks the type of the last successfully-completed event so the
+    # vrrp event thread can avoid re-firing vrrp_backup when we're
+    # already in BACKUP state. None until the first event completes.
+    LAST_EVENT_TYPE = None
+
     # list of critical services that get restarted first
     # before the other services during a failover event
     CRITICAL_SERVICES = ['iscsitarget', 'nvmet']
@@ -202,6 +207,14 @@ class FailoverEventsService(Service):
                 await self.middleware.call('failover.call_remote', 'failover.status_refresh')
             except Exception:
                 self.logger.warning('Failed to refresh failover status on active node')
+
+    def last_event_type(self):
+        """Return the type ('MASTER' | 'BACKUP') of the last successfully
+        completed failover event on this middlewared process, or None if
+        no event has completed since startup. Used by the vrrp event
+        thread to avoid re-firing a redundant vrrp_backup after a flap.
+        """
+        return self.LAST_EVENT_TYPE
 
     def run_call(self, method, *args, job=False):
         try:
@@ -556,6 +569,7 @@ class FailoverEventsService(Service):
             # there is nothing else to do so just log a warning and return early
             logger.warning('No zpools to import, exiting failover event')
             self.FAILOVER_RESULT = 'INFO'
+            self.LAST_EVENT_TYPE = 'MASTER'
             return self.FAILOVER_RESULT
 
         # unlock SED disks
@@ -845,6 +859,7 @@ class FailoverEventsService(Service):
         job.set_progress(None, description='SUCCESS')
 
         self.FAILOVER_RESULT = 'SUCCESS'
+        self.LAST_EVENT_TYPE = 'MASTER'
 
         return self.FAILOVER_RESULT
 
@@ -1069,6 +1084,7 @@ class FailoverEventsService(Service):
 
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'
+        self.LAST_EVENT_TYPE = 'BACKUP'
 
         return self.FAILOVER_RESULT
 


### PR DESCRIPTION
When VrrpEventThread saw a second rapid event after waiting rapid_event_settle_time, it dropped the latest queued event and logged a warning. On boot-time keepalived flaps where the MASTER->BACKUP gap floors below max_wait, that drop swallowed the only BACKUP signal middleware was going to see, so vrrp_backup never ran.

Fire the hook for BACKUP (skipping if vrrp_backup already ran this process lifetime, tracked via a new LAST_EVENT_TYPE attribute on FailoverEventsService); keep the drop+warn for MASTER, since acting on an unsettled MASTER would kick off fenced + zpool import.