### PR TITLE
NAS-141191 / 26.0.0-RC.1 / fix release_notes_url (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -101,13 +101,8 @@ class SystemService(Service):
         if parsed_version is None:
             raise CallError(f"Invalid version string specified: {version_str}")
 
-        version_split = parsed_version.split(".")
-        major_version = ".".join(version_split[0:2])
-        base_url = f"https://www.truenas.com/docs/scale/{major_version}/gettingstarted/scalereleasenotes"
-        if len(version_split) == 2:
-            return base_url
-        else:
-            return f"{base_url}/#{''.join(version_split)}"
+        major = parsed_version.split(".")[0]
+        return f"https://www.truenas.com/docs/scale/{major}/gettingstarted/versionnotes"
 
     @api_method(
         SystemVersionArgs,


### PR DESCRIPTION
This was broken silently outside our control. Return the new style URL so release note hyperlinks in the TrueNAS UI actually resolve instead of returning a 404 like they do currently.

Original PR: https://github.com/truenas/middleware/pull/19047
