### PR TITLE
NAS-141231 / 26.0.0-RC.1 / Fix dlm remote down (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -323,9 +323,10 @@ class DistributedLockManagerService(Service):
         """
         Handle the HA remote node going down.
 
-        Four guards before calling reset_active:
+        Five guards before calling reset_active:
         - Only act as MASTER (STANDBY and SINGLE are no-ops).
         - Only act if ALUA is being used by iSCSI.  (Otherwise don't care.)
+        - Only act if iSCSI is running.
         - If the peer's DLM port is still reachable, only remote middleware
           restarted; skip to avoid unnecessarily tearing down iSCSI sessions.
         - If we have logged-in extents, we are in standby or mid-transition to
@@ -335,6 +336,9 @@ class DistributedLockManagerService(Service):
             return
 
         if not await self.middleware.call('iscsi.global.using_dlm'):
+            return
+
+        if not await self.middleware.call('service.started', 'iscsitarget'):
             return
 
         peer_ip = self.nodes.get(self.peernodeID, {}).get('ip')

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -224,9 +224,13 @@ class ISCSIGlobalService(SystemServiceService):
 
         if licensed and old['alua'] != new['alua']:
             if new['alua']:
-                await self.middleware.call(
-                    'failover.call_remote', 'service.control', ['START', 'iscsitarget'], {'job': True},
-                )
+                if await self.middleware.call('service.started', 'iscsitarget'):
+                    await self.middleware.call(
+                        'failover.call_remote',
+                        'service.control',
+                        ['START', 'iscsitarget'],
+                        {'job': True},
+                    )
 
         # If we have just turned off iSNS then work around a short-coming in scstadmin reload
         if old['isns_servers'] != new['isns_servers'] and not servers:


### PR DESCRIPTION
In dlm.remote_down do not act if iSCSI is not running.

Also, when enabling ALUA, only start iscsitarget on the STANDBY if it is already running on the ACTIVE node.

Original PR: https://github.com/truenas/middleware/pull/19050
