### PR TITLE
NAS-141232 / 27.0.0-BETA.1 / Fix mail.send NotRequired filter

### DIFF
--- a/src/middlewared/middlewared/plugins/mail/send.py
+++ b/src/middlewared/middlewared/plugins/mail/send.py
@@ -17,7 +17,7 @@ import typing
 
 import html2text
 
-from middlewared.api.base import NotRequired
+from middlewared.api.base.model import _NotRequired
 from middlewared.api.current import MailEntry, MailSendMessage, MailUpdate
 from middlewared.service import CallError, NetworkActivityDisabled, ServiceContext, ValidationError
 from middlewared.utils import BRAND, ProductName
@@ -42,7 +42,7 @@ def send(
     request: MailSendMessage,
     extra_config: MailUpdate,
 ) -> None:
-    message = {k: v for k, v in request.model_dump().items() if v != NotRequired}
+    message = {k: v for k, v in request.model_dump().items() if not isinstance(v, _NotRequired)}
 
     gc = context.middleware.call_sync("datastore.config", "network.globalconfiguration")
     hostname = f"{gc['gc_hostname']}.{gc['gc_domain']}"


### PR DESCRIPTION
The filter introduced in NAS-141218/PR #19045 used `v != NotRequired`, which falls back to identity comparison since `_NotRequired` defines no `__eq__`. Pydantic's serializer can hand back a fresh `_NotRequired` instance rather than the singleton, so the filter let those values through and `timedelta(seconds=interval)` crashed with:

```
  TypeError: unsupported type for timedelta seconds component: _NotRequired
```
Switch to `isinstance(v, _NotRequired)`, matching the pattern already used in api/base/handler/version.py.