### PR TITLE
NAS-141124 / 26.0.0-RC.1 / Prevent VMs being suspended indefinitely after periodic snapshots

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -138,7 +138,7 @@ class VMService(Service):
     def resume_suspended_vms(self, vm_ids):
         vms = {vm['id']: vm for vm in self.middleware.call_sync('vm.query')}
         for vm_id in filter(
-            lambda vm_id: vms.get(vm_id).get('status', {}).get('state') == 'SUSPENDED',
+            lambda vm_id: vms.get(vm_id, {}).get('status', {}).get('state') == 'SUSPENDED',
             map(int, vm_ids)
         ):
             try:

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -122,13 +122,10 @@ class VMService(Service):
     @private
     def suspend_vms(self, vm_ids):
         vms = {vm['id']: vm for vm in self.middleware.call_sync('vm.query')}
-        for vm_id in filter(
-            lambda vm_id: (
-                (vm := vms.get(vm_id, {})).get('status', {}).get('state') == 'RUNNING'
-                and vm.get('suspend_on_snapshot')
-            ),
-            map(int, vm_ids)
-        ):
+        for vm_id in map(int, vm_ids):
+            vm = vms.get(vm_id)
+            if vm is None or vm['status']['state'] != 'RUNNING' or not vm['suspend_on_snapshot']:
+                continue
             try:
                 self.suspend(vm_id)
             except Exception:
@@ -137,10 +134,10 @@ class VMService(Service):
     @private
     def resume_suspended_vms(self, vm_ids):
         vms = {vm['id']: vm for vm in self.middleware.call_sync('vm.query')}
-        for vm_id in filter(
-            lambda vm_id: vms.get(vm_id, {}).get('status', {}).get('state') == 'SUSPENDED',
-            map(int, vm_ids)
-        ):
+        for vm_id in map(int, vm_ids):
+            vm = vms.get(vm_id)
+            if vm is None or vm['status']['state'] != 'SUSPENDED':
+                continue
             try:
                 self.resume(vm_id)
             except Exception:

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -123,7 +123,10 @@ class VMService(Service):
     def suspend_vms(self, vm_ids):
         vms = {vm['id']: vm for vm in self.middleware.call_sync('vm.query')}
         for vm_id in filter(
-            lambda vm_id: vms.get(vm_id).get('status', {}).get('state') == 'RUNNING',
+            lambda vm_id: (
+                (vm := vms.get(vm_id, {})).get('status', {}).get('state') == 'RUNNING'
+                and vm.get('suspend_on_snapshot')
+            ),
             map(int, vm_ids)
         ):
             try:

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -208,11 +208,18 @@ class ZettareplProcess:
                         context = None
                         if begin_context := c.call("vmware.periodic_snapshot_task_begin", task_id):
                             context = c.call("vmware.periodic_snapshot_task_proceed", begin_context, job=True)
+                        self.vmware_contexts[task_id] = context
+
                         if vm_context := c.call("vm.periodic_snapshot_task_begin", task_id):
-                            c.call("vm.suspend_vms", list(vm_context))
+                            try:
+                                c.call("vm.suspend_vms", list(vm_context))
+                            except ClientException as e:
+                                # The server-side suspend completes even if this call times out; swallow the
+                                # error so the VMs are still recorded below (and resumed by the end handler) and
+                                # the vmsynced marking is not skipped.
+                                logger.error("Failed to suspend VMs for snapshot task %r: %r", task_id, e.error)
 
                     self.vm_contexts[task_id] = vm_context
-                    self.vmware_contexts[task_id] = context
 
                     if context and context["vmsynced"]:
                         # If there were no failures and we successfully took some VMWare snapshots
@@ -220,13 +227,19 @@ class ZettareplProcess:
                         # inside it.
                         return message.response(properties={"freenas:vmsynced": "Y"})
 
-                if isinstance(message, (PeriodicSnapshotTaskSuccess, PeriodicSnapshotTaskError)):
+                elif isinstance(message, (PeriodicSnapshotTaskSuccess, PeriodicSnapshotTaskError)):
                     context = self.vmware_contexts.pop(task_id, None)
                     vm_context = self.vm_contexts.pop(task_id, None)
                     if context or vm_context:
                         with Client(private_methods=True) as c:
                             if context:
-                                c.call("vmware.periodic_snapshot_task_end", context, job=True)
+                                # Do not let a VMWare finalization failure prevent the VMs from being resumed.
+                                try:
+                                    c.call("vmware.periodic_snapshot_task_end", context, job=True)
+                                except ClientException:
+                                    logger.error(
+                                        "Failed to finalize VMWare snapshot for task %r", task_id, exc_info=True
+                                    )
                             if vm_context:
                                 c.call("vm.resume_suspended_vms", list(vm_context))
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
@@ -14,29 +14,32 @@ def make_service(vms):
     return service
 
 
-@pytest.mark.parametrize('vms,expected_suspended', [
-    # Running and opted in -> suspended.
-    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': True}], [1]),
-    # Running but opted out -> NOT suspended (the bug being fixed).
-    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': False}], []),
-    # Opted in but not running -> nothing to suspend.
-    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'STOPPED'}, 'suspend_on_snapshot': True}], []),
-    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'SUSPENDED'}, 'suspend_on_snapshot': True}], []),
-    # Mixed: only the running, opted-in VM is suspended.
-    (
-        [
-            {'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': True},
-            {'id': 2, 'name': 'vm2', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': False},
-            {'id': 3, 'name': 'vm3', 'status': {'state': 'SUSPENDED'}, 'suspend_on_snapshot': True},
-            {'id': 4, 'name': 'vm4', 'status': {'state': 'STOPPED'}, 'suspend_on_snapshot': True},
-        ],
-        [1],
-    ),
-])
+@pytest.mark.parametrize(
+    "vms,expected_suspended",
+    [
+        # Running and opted in -> suspended.
+        ([{"id": 1, "name": "vm1", "status": {"state": "RUNNING"}, "suspend_on_snapshot": True}], [1]),
+        # Running but opted out -> NOT suspended (the bug being fixed).
+        ([{"id": 1, "name": "vm1", "status": {"state": "RUNNING"}, "suspend_on_snapshot": False}], []),
+        # Opted in but not running -> nothing to suspend.
+        ([{"id": 1, "name": "vm1", "status": {"state": "STOPPED"}, "suspend_on_snapshot": True}], []),
+        ([{"id": 1, "name": "vm1", "status": {"state": "SUSPENDED"}, "suspend_on_snapshot": True}], []),
+        # Mixed: only the running, opted-in VM is suspended.
+        (
+            [
+                {"id": 1, "name": "vm1", "status": {"state": "RUNNING"}, "suspend_on_snapshot": True},
+                {"id": 2, "name": "vm2", "status": {"state": "RUNNING"}, "suspend_on_snapshot": False},
+                {"id": 3, "name": "vm3", "status": {"state": "SUSPENDED"}, "suspend_on_snapshot": True},
+                {"id": 4, "name": "vm4", "status": {"state": "STOPPED"}, "suspend_on_snapshot": True},
+            ],
+            [1],
+        ),
+    ],
+)
 def test_suspend_vms_only_running_opted_in(vms, expected_suspended):
     service = make_service(vms)
 
-    service.suspend_vms([vm['id'] for vm in vms])
+    service.suspend_vms([vm["id"] for vm in vms])
 
     assert [c.args[0] for c in service.suspend.call_args_list] == expected_suspended
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock
+
+import pytest
+
+from middlewared.plugins.vm.vm_lifecycle import VMService
+
+
+def make_service(vms):
+    service = VMService.__new__(VMService)
+    service.middleware = Mock()
+    service.middleware.call_sync = Mock(return_value=vms)
+    service.logger = Mock()
+    service.suspend = Mock()
+    return service
+
+
+@pytest.mark.parametrize('vms,expected_suspended', [
+    # Running and opted in -> suspended.
+    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': True}], [1]),
+    # Running but opted out -> NOT suspended (the bug being fixed).
+    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': False}], []),
+    # Opted in but not running -> nothing to suspend.
+    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'STOPPED'}, 'suspend_on_snapshot': True}], []),
+    ([{'id': 1, 'name': 'vm1', 'status': {'state': 'SUSPENDED'}, 'suspend_on_snapshot': True}], []),
+    # Mixed: only the running, opted-in VM is suspended.
+    (
+        [
+            {'id': 1, 'name': 'vm1', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': True},
+            {'id': 2, 'name': 'vm2', 'status': {'state': 'RUNNING'}, 'suspend_on_snapshot': False},
+            {'id': 3, 'name': 'vm3', 'status': {'state': 'SUSPENDED'}, 'suspend_on_snapshot': True},
+            {'id': 4, 'name': 'vm4', 'status': {'state': 'STOPPED'}, 'suspend_on_snapshot': True},
+        ],
+        [1],
+    ),
+])
+def test_suspend_vms_only_running_opted_in(vms, expected_suspended):
+    service = make_service(vms)
+
+    service.suspend_vms([vm['id'] for vm in vms])
+
+    assert [c.args[0] for c in service.suspend.call_args_list] == expected_suspended
+
+
+def test_suspend_vms_tolerates_unknown_id():
+    # An id passed in but absent from vm.query must not raise.
+    service = make_service([])
+
+    service.suspend_vms([999])
+
+    service.suspend.assert_not_called()


### PR DESCRIPTION
## Problem

VMs with disks on a dataset covered by a periodic snapshot task could be left indefinitely in the libvirt `PAUSED` (`SUSPENDED`) state, recoverable only via `vm.resume` or a host reboot. Two independent bugs combined to cause this.

## Bug 1: `suspend_on_snapshot` was ignored for running VMs

`vm.suspend_vms` suspended every running VM whose disk was on the snapshotted dataset, regardless of the per-VM `suspend_on_snapshot` setting. The opt-out filter in `query_snapshot_begin` (`status NOT IN active AND suspend_on_snapshot = False`) only ever excluded *stopped* VMs, so it was a no-op for the running VMs that actually get suspended.

Fix: gate suspension in `suspend_vms` on `RUNNING and suspend_on_snapshot`. The filter is left in `suspend_vms` rather than `query_snapshot_begin` because the latter is also used by `cloud_backup.validate_zvol` purely as an attachment-existence check.

## Bug 2: a timed-out observer call orphaned the suspend/resume bracket

In `ZettareplProcess._observer`, `self.vm_contexts[task_id]` was stored *after* the `with Client` block. A client-side `Client.call` timeout during `vm.suspend_vms` does not cancel the server-side suspend, so the VMs were suspended but the context was never recorded; the later `PeriodicSnapshotTaskSuccess`/`Error` handler then popped `None` and never issued the resume.

Fix:
- Record `vm_contexts`/`vmware_contexts` before the calls that can time out.
- In the end handler, isolate VMware finalization in its own `try/except` so it cannot prevent the VM resume.

## Tests

Unit tests for `suspend_vms` covering the opt-in/running matrix and an unknown id.