### PR TITLE
NAS-141235 / 27.0.0-BETA.1 / Fix ZFS tiering event subscription

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_tier.py
@@ -149,15 +149,15 @@ class ZfsTierRewriteJobQueryEventSourceEvent(BaseModel):
 
 
 class ZfsTierRewriteJobStatusEventSourceArgs(BaseModel):
-    dataset_name: NonEmptyString
-    """ZFS dataset to subscribe to (e.g. `tank/data`). Receives updates whenever the job \
-    status or statistics change."""
+    tier_job_id: NonEmptyString
+    """Rewrite job to subscribe to, in `dataset_name@job_uuid` format. Receives updates \
+    whenever the job status or statistics change."""
 
 
 @single_argument_result
 class ZfsTierRewriteJobStatusEventSourceEvent(BaseModel):
     fields: ZfsTierRewriteJobStatusEntry
-    """Current status and statistics for the dataset's active rewrite job."""
+    """Current status and statistics for the requested rewrite job."""
 
 
 @single_argument_args("zfs_tier_rewrite_job_create")

--- a/src/middlewared/middlewared/api/v27_0_0/zfs_tier.py
+++ b/src/middlewared/middlewared/api/v27_0_0/zfs_tier.py
@@ -149,15 +149,15 @@ class ZfsTierRewriteJobQueryEventSourceEvent(BaseModel):
 
 
 class ZfsTierRewriteJobStatusEventSourceArgs(BaseModel):
-    dataset_name: NonEmptyString
-    """ZFS dataset to subscribe to (e.g. `tank/data`). Receives updates whenever the job \
-    status or statistics change."""
+    tier_job_id: NonEmptyString
+    """Rewrite job to subscribe to, in `dataset_name@job_uuid` format. Receives updates \
+    whenever the job status or statistics change."""
 
 
 @single_argument_result
 class ZfsTierRewriteJobStatusEventSourceEvent(BaseModel):
     fields: ZfsTierRewriteJobStatusEntry
-    """Current status and statistics for the dataset's active rewrite job."""
+    """Current status and statistics for the requested rewrite job."""
 
 
 @single_argument_args("zfs_tier_rewrite_job_create")

--- a/src/middlewared/middlewared/plugins/zfs/tier.py
+++ b/src/middlewared/middlewared/plugins/zfs/tier.py
@@ -111,6 +111,14 @@ def _raise_client_error(e: RewriteClientException, field: str) -> None:
     raise CallError(str(e))
 
 
+def _parse_tier_job_id(tier_job_id: str) -> tuple[str, str]:
+    """Split a ``dataset_name@job_uuid`` tier job id into its two parts."""
+    dataset_name, _, job_uuid = tier_job_id.partition("@")
+    if not dataset_name or not job_uuid:
+        raise CallError(f"Invalid tier_job_id: {tier_job_id!r}")
+    return dataset_name, job_uuid
+
+
 class ZfsTierModel(sa.Model):
     __tablename__ = "zfs_tier"
 
@@ -238,30 +246,31 @@ def get_dataset_tier_info_cached(
 
 class ZfsTierRewriteJobStatusEventSource(TypedEventSource[ZfsTierRewriteJobStatusEventSourceArgs]):
     """
-    Subscribe to real-time status updates for a ZFS rewrite job on the specified dataset.
-    Polls every 2 seconds and emits a CHANGED event when status or statistics change.
+    Subscribe to real-time status updates for a specific ZFS rewrite job, identified by
+    its ``dataset_name@job_uuid`` tier job id. Polls every 2 seconds and emits a CHANGED
+    event when status or statistics change.
     """
 
     args = ZfsTierRewriteJobStatusEventSourceArgs
     event = ZfsTierRewriteJobStatusEventSourceEvent
     roles = ["DATASET_READ"]
 
-    def _poll_job_info(self, dataset_name: str) -> dict[str, typing.Any] | None:
-        """Return a status entry for the given dataset's active job, or None if not found."""
+    def _poll_job_info(self, tier_job_id: str) -> dict[str, typing.Any] | None:
+        """Return a status entry for the given tier job id, or None if it no longer exists."""
+        dataset_name, job_uuid = _parse_tier_job_id(tier_job_id)
         try:
-            last = get_last_job(dataset_name)
-        except KeyError:
+            info = get_info(dataset_name, job_uuid)
+        except ValueError:
             return None
-        info = get_info(last.dataset_name, last.job_uuid)
         return _map_info_result(info)
 
     def run_sync(self) -> None:
-        dataset_name = self.typed_arg.dataset_name
+        tier_job_id = self.typed_arg.tier_job_id
         last_info = None
 
         while not self._cancel_sync.is_set():
             try:
-                current_info = self._poll_job_info(dataset_name)
+                current_info = self._poll_job_info(tier_job_id)
 
                 if current_info != last_info:
                     if current_info is not None:
@@ -269,7 +278,7 @@ class ZfsTierRewriteJobStatusEventSource(TypedEventSource[ZfsTierRewriteJobStatu
 
                     last_info = current_info
             except Exception:
-                self.middleware.logger.debug("Error polling tier job status for %r", dataset_name, exc_info=True)
+                self.middleware.logger.debug("Error polling tier job status for %r", tier_job_id, exc_info=True)
 
             self._cancel_sync.wait(2)
 
@@ -439,7 +448,7 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def rewrite_job_status(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """Get detailed status and statistics for a specific rewrite job."""
-        dataset_name, job_uuid = self._parse_tier_job_id(data["tier_job_id"])
+        dataset_name, job_uuid = _parse_tier_job_id(data["tier_job_id"])
         try:
             info = get_info(dataset_name, job_uuid)
         except Exception as e:
@@ -453,7 +462,7 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def rewrite_job_failures(self, data: dict[str, typing.Any]) -> typing.Any:
         """List files that failed to be rewritten during a rewrite job."""
-        dataset_name, job_uuid = self._parse_tier_job_id(data["tier_job_id"])
+        dataset_name, job_uuid = _parse_tier_job_id(data["tier_job_id"])
         try:
             resolved = await self.middleware.run_in_thread(get_resolved_failures, dataset_name, job_uuid)
         except Exception as e:
@@ -480,7 +489,7 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def rewrite_job_cancel(self, data: dict[str, typing.Any]) -> None:
         """Cancel a running or queued rewrite job."""
-        dataset_name, job_uuid = self._parse_tier_job_id(data["tier_job_id"])
+        dataset_name, job_uuid = _parse_tier_job_id(data["tier_job_id"])
         async with RewriteClient() as client:
             try:
                 await client.abort_job(dataset_name, job_uuid)
@@ -496,7 +505,7 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def rewrite_job_recover(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """Recover a rewrite job in ERROR state by reissuing failed rewrites."""
-        dataset_name, job_uuid = self._parse_tier_job_id(data["tier_job_id"])
+        dataset_name, job_uuid = _parse_tier_job_id(data["tier_job_id"])
         await self._validate_dataset_writable(dataset_name, "zfs_tier_rewrite_job_recover.tier_job_id")
         async with RewriteClient() as client:
             try:
@@ -559,13 +568,6 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
                         f"normal class utilization to {projected_pct:.1f}%, exceeding the 80% threshold",
                         errno.ENOSPC,
                     )
-
-    @private
-    def _parse_tier_job_id(self, tier_job_id: str) -> tuple[str, str]:
-        dataset_name, _, job_uuid = tier_job_id.partition("@")
-        if not dataset_name or not job_uuid:
-            raise CallError(f"Invalid tier_job_id: {tier_job_id!r}")
-        return dataset_name, job_uuid
 
     @api_method(
         ZfsTierDatasetSetTierArgs,

--- a/tests/api2/zfs_tier/test_jobs_extended.py
+++ b/tests/api2/zfs_tier/test_jobs_extended.py
@@ -203,14 +203,14 @@ def test_rewrite_job_query_pagination_via_query_options(tier_pool, wait_for_job_
 
 
 # ----------------------------------------------------------------------------
-# rewrite_job_status event source (per-dataset, polls every 2s)
+# rewrite_job_status event source (per-job, polls every 2s)
 # ----------------------------------------------------------------------------
 
 
 def test_status_event_source_no_events_for_dataset_without_job(tier_ds):
-    """Subscribing to the per-dataset event source for a dataset with no job
-    should not emit any events within 5s (poll interval is 2s)."""
-    arg = json.dumps({"dataset_name": tier_ds})
+    """Subscribing to the per-job event source with a valid-shape tier_job_id that
+    has no backing job should not emit any events within 5s (poll interval is 2s)."""
+    arg = json.dumps({"tier_job_id": f"{tier_ds}@00000000-0000-0000-0000-000000000000"})
     with client() as c:
         events = []
         c.subscribe(

--- a/tests/api2/zfs_tier/test_smoke.py
+++ b/tests/api2/zfs_tier/test_smoke.py
@@ -321,9 +321,9 @@ def test_rewrite_job_abort_nonexistent_raises(tier_pool):
 
 def test_rewrite_job_status_event_source(tier_ds_with_work):
     """The polling event source emits CHANGED events while a job is active."""
-    call("zfs.tier.rewrite_job_create", {"dataset_name": tier_ds_with_work})
+    entry = call("zfs.tier.rewrite_job_create", {"dataset_name": tier_ds_with_work})
 
-    arg = json.dumps({"dataset_name": tier_ds_with_work})
+    arg = json.dumps({"tier_job_id": entry["tier_job_id"]})
     with client() as c:
         events = []
         c.subscribe(
@@ -335,5 +335,6 @@ def test_rewrite_job_status_event_source(tier_ds_with_work):
 
     assert events, "No events received from rewrite_job_status event source"
     assert events[0][0] == "CHANGED"
+    assert events[0][1]["fields"]["tier_job_id"] == entry["tier_job_id"]
     assert events[0][1]["fields"]["dataset_name"] == tier_ds_with_work
     assert "status" in events[0][1]["fields"]

--- a/tests/unit/test_zfs_tier_api_models.py
+++ b/tests/unit/test_zfs_tier_api_models.py
@@ -17,6 +17,7 @@ from middlewared.api.v27_0_0.zfs_tier import (
     ZfsTierRewriteJobQueryArgs,
     ZfsTierRewriteJobStats,
     ZfsTierRewriteJobStatusEntry,
+    ZfsTierRewriteJobStatusEventSourceArgs,
     ZfsTierUpdateArgs,
 )
 from middlewared.api.v27_0_0.smb import SharingSMBUpdateArgs
@@ -206,6 +207,21 @@ def test_rewrite_job_entry_rejects_empty_dataset_name():
             job_uuid="uuid",
             status="RUNNING",
         )
+
+
+# ----------------------------------------------------------------------------
+# ZfsTierRewriteJobStatusEventSourceArgs: subscribe by tier_job_id
+# ----------------------------------------------------------------------------
+
+
+def test_status_event_source_args_valid_tier_job_id():
+    args = ZfsTierRewriteJobStatusEventSourceArgs(tier_job_id="tank/data@uuid")
+    assert args.tier_job_id == "tank/data@uuid"
+
+
+def test_status_event_source_args_rejects_empty_tier_job_id():
+    with pytest.raises(ValidationError):
+        ZfsTierRewriteJobStatusEventSourceArgs(tier_job_id="")
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
During the course of development in our design documents subscriptions shifted from being locked into dataset names to being locked into the tier job id, which is dataset_name@uuid.