### PR TITLE
NAS-141068 / 26.0.0-RC.1 / Properly handle VM feature flag (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/system_product.py
+++ b/src/middlewared/middlewared/api/v26_0_0/system_product.py
@@ -20,8 +20,14 @@ __all__ = (
 
 
 class SystemFeatureEnabledArgs(BaseModel):
-    feature: Literal["APPS", "DEDUP", "FIBRECHANNEL", "SED", "SUPPORT", "VM", "ZFSTIER"]
+    feature: Literal["APPS", "DEDUP", "FIBRECHANNEL", "SED", "SUPPORT", "VMS", "ZFSTIER"]
     """Feature to check for availability on this system."""
+
+    @classmethod
+    def from_previous(cls, value):
+        if value.get("feature") == "VM":
+            value["feature"] = "VMS"
+        return value
 
 
 class SystemFeatureEnabledResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/truenas/license_legacy_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas/license_legacy_utils.py
@@ -5,7 +5,7 @@ from types import MappingProxyType
 
 from licenselib.license import Features, License
 from licenselib.utils import proactive_support_allowed
-from truenas_pylicensed import LicenseType
+from truenas_pylicensed import FEATURE_NAME_MAP, LicenseType
 
 from .license_utils import FeatureInfo, LicenseInfo
 
@@ -57,8 +57,7 @@ def parse_legacy_license(text: str) -> LicenseInfo:
         if Features.dedup in lic.features and Features.jails in lic.features:
             features.append(Features.fibrechannel)
 
-    feature_name_map = {"JAILS": "APPS"}
-    feature_names = [feature_name_map.get(f.name.upper(), f.name.upper()) for f in features]
+    feature_names = [FEATURE_NAME_MAP.get(f.name.upper(), f.name.upper()) for f in features]
     if proactive_support_allowed(lic.contract_type.name):
         feature_names.append("SUPPORT")
 

--- a/src/middlewared/middlewared/plugins/truenas/license_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas/license_utils.py
@@ -12,7 +12,7 @@ import time
 import typing
 
 from truenas_os_pyutils.io import atomic_write
-from truenas_pylicensed import LicenseStatus, LicenseType, get_fingerprint, verify
+from truenas_pylicensed import FEATURE_NAME_MAP, LicenseStatus, LicenseType, get_fingerprint, verify
 
 from middlewared.service import CallError, ValidationError
 
@@ -211,7 +211,7 @@ def get_license_info(lic: LicenseStatus | None = None) -> LicenseInfo | None:
         expires_at=expires_at,
         features=[
             FeatureInfo(
-                name=name,
+                name=FEATURE_NAME_MAP.get(name, name),
                 start_date=date.fromisoformat(f.start_date) if f.start_date else None,
                 expires_at=date.fromisoformat(f.expires_at) if f.expires_at else None,
             )

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -36,7 +36,7 @@ class VMService(Service):
         """
         can_run_vms = True
         if await self.middleware.call('system.is_ha_capable'):
-            can_run_vms = await self.middleware.call('system.feature_enabled', 'VM')
+            can_run_vms = await self.middleware.call('system.feature_enabled', 'VMS')
 
         return can_run_vms
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_legacy_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_legacy_utils.py
@@ -19,7 +19,7 @@ from middlewared.plugins.truenas.license_utils import FeatureInfo, LicenseInfo
             expires_at=date(2026, 4, 30),
             features=[
                 FeatureInfo(name="FIBRECHANNEL", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
-                FeatureInfo(name="VM", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
+                FeatureInfo(name="VMS", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
                 FeatureInfo(name="SUPPORT", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30))],
             serials=["TEST-000001", "TEST-000002"],
             enclosures={"E24": 3, "E16": 2},

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_utils.py
@@ -1,0 +1,77 @@
+from datetime import date
+
+import pytest
+from truenas_pylicensed import FeatureEntry, LicenseError, LicenseStatus, LicenseType
+
+from middlewared.plugins.truenas.license_utils import FeatureInfo, LicenseInfo, get_license_info
+
+
+def _make_status(features: dict[str, FeatureEntry]) -> LicenseStatus:
+    return LicenseStatus(
+        valid=True,
+        code=LicenseError.OK,
+        id="test-id",
+        version=1,
+        type=LicenseType.ENTERPRISE_HA,
+        model="H10",
+        expires_at=None,
+        features=features,
+        system_id={"serials": ["TEST-000001", "TEST-000002"]},
+        enclosures={"E24": {"count": 3}},
+    )
+
+
+def test__get_license_info__renames_vm_to_vms():
+    status = _make_status(
+        {
+            "VM": FeatureEntry(name="VM", source="enterprise", start_date="2026-04-08", expires_at="2026-04-30"),
+            "SUPPORT": FeatureEntry(
+                name="SUPPORT",
+                source="enterprise",
+                start_date="2026-04-08",
+                expires_at="2026-04-30",
+                type="GOLD",
+            ),
+        }
+    )
+
+    info = get_license_info(status)
+
+    assert info == LicenseInfo(
+        id="test-id",
+        type=LicenseType.ENTERPRISE_HA,
+        model="H10",
+        expires_at=date(2026, 4, 30),
+        features=[
+            FeatureInfo(name="VMS", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
+            FeatureInfo(name="SUPPORT", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
+        ],
+        serials=["TEST-000001", "TEST-000002"],
+        enclosures={"E24": 3},
+        contract_type="GOLD",
+    )
+
+
+def test__get_license_info__passes_through_unrelated_feature_names():
+    status = _make_status(
+        {
+            "APPS": FeatureEntry(name="APPS", source="enterprise"),
+            "DEDUP": FeatureEntry(name="DEDUP", source="enterprise"),
+        }
+    )
+
+    info = get_license_info(status)
+
+    assert info is not None
+    assert {f.name for f in info.features} == {"APPS", "DEDUP"}
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        LicenseStatus(valid=False, code=LicenseError.NO_LICENSE),
+        LicenseStatus(valid=False, code=LicenseError.DAEMON_UNAVAILABLE),
+    ],
+)
+def test__get_license_info__returns_none_for_invalid_license(status):
+    assert get_license_info(status) is None


### PR DESCRIPTION
## Context

Middleware should expose the VM entitlement as "VMS" at the API boundary and to any consumer that inspects license features. The signed license PEM and signing daemon continue to carry "VM" as the JSON key, and existing customer PEMs can't be re-keyed without re-signing, so the translation has to happen middleware-side.

## Solution

A single `FEATURE_NAME_MAP` in license_utils.py translates "VM" → "VMS" for both the daemon-signed and legacy parsers (the legacy-only JAILS → APPS entry sits in the same map; it's a no-op on the modern path since the daemon never emits "JAILS"). v26 and v27 SystemFeatureEnabledArgs both accept "VMS" and carry from_previous / to_previous adapters so v25 / v26 clients passing "VM" are translated transparently.


Original PR: https://github.com/truenas/middleware/pull/19027
