### PR TITLE
NAS-141124 / 27.0.0-BETA.1 / Prevent VMs being suspended indefinitely after periodic snapshots (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -119,10 +119,10 @@ def pylibvirt_vm(
 
 def resume_suspended_vms(context: ServiceContext, vm_ids: list[int]) -> None:
     vms = {vm.id: vm for vm in context.call_sync2(context.s.vm.query)}
-    for vm_id in filter(
-        lambda v_id: v_id in vms and vms[v_id].status.state == 'SUSPENDED',
-        vm_ids
-    ):
+    for vm_id in vm_ids:
+        vm = vms.get(vm_id)
+        if vm is None or vm.status.state != 'SUSPENDED':
+            continue
         try:
             resume_vm(context, vm_id)
         except Exception:
@@ -131,10 +131,10 @@ def resume_suspended_vms(context: ServiceContext, vm_ids: list[int]) -> None:
 
 def suspend_vms(context: ServiceContext, vm_ids: list[int]) -> None:
     vms = {vm.id: vm for vm in context.call_sync2(context.s.vm.query)}
-    for vm_id in filter(
-        lambda v_id: v_id in vms and vms[v_id].status.state == 'RUNNING',
-        vm_ids
-    ):
+    for vm_id in vm_ids:
+        vm = vms.get(vm_id)
+        if vm is None or vm.status.state != 'RUNNING' or not vm.suspend_on_snapshot:
+            continue
         try:
             suspend_vm(context, vm_id)
         except Exception:

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -219,11 +219,18 @@ class ZettareplProcess:
                         context = None
                         if begin_context := c.call("vmware.periodic_snapshot_task_begin", task_id):
                             context = c.call("vmware.periodic_snapshot_task_proceed", begin_context, job=True)
+                        self.vmware_contexts[task_id] = context
+
                         if vm_context := c.call("vm.periodic_snapshot_task_begin", task_id):
-                            c.call("vm.suspend_vms", list(vm_context))
+                            try:
+                                c.call("vm.suspend_vms", list(vm_context))
+                            except ClientException as e:
+                                # The server-side suspend completes even if this call times out; swallow the
+                                # error so the VMs are still recorded below (and resumed by the end handler) and
+                                # the vmsynced marking is not skipped.
+                                logger.error("Failed to suspend VMs for snapshot task %r: %r", task_id, e.error)
 
                     self.vm_contexts[task_id] = vm_context
-                    self.vmware_contexts[task_id] = context
 
                     if context and context["vmsynced"]:
                         # If there were no failures and we successfully took some VMWare snapshots
@@ -231,13 +238,19 @@ class ZettareplProcess:
                         # inside it.
                         return message.response(properties={"freenas:vmsynced": "Y"})
 
-                if isinstance(message, (PeriodicSnapshotTaskSuccess, PeriodicSnapshotTaskError)):
+                elif isinstance(message, (PeriodicSnapshotTaskSuccess, PeriodicSnapshotTaskError)):
                     context = self.vmware_contexts.pop(task_id, None)
                     vm_context = self.vm_contexts.pop(task_id, None)
                     if context or vm_context:
                         with Client(private_methods=True) as c:
                             if context:
-                                c.call("vmware.periodic_snapshot_task_end", context, job=True)
+                                # Do not let a VMWare finalization failure prevent the VMs from being resumed.
+                                try:
+                                    c.call("vmware.periodic_snapshot_task_end", context, job=True)
+                                except ClientException:
+                                    logger.error(
+                                        "Failed to finalize VMWare snapshot for task %r", task_id, exc_info=True
+                                    )
                             if vm_context:
                                 c.call("vm.resume_suspended_vms", list(vm_context))
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_suspend_vms.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from middlewared.plugins.vm import lifecycle
+
+
+def make_vm(id_, name, state, suspend_on_snapshot):
+    return SimpleNamespace(
+        id=id_,
+        name=name,
+        status=SimpleNamespace(state=state),
+        suspend_on_snapshot=suspend_on_snapshot,
+    )
+
+
+def make_context(vms):
+    context = Mock()
+    context.call_sync2 = Mock(return_value=vms)
+    context.logger = Mock()
+    return context
+
+
+@pytest.mark.parametrize(
+    "vms,expected_suspended",
+    [
+        # Running and opted in -> suspended.
+        ([make_vm(1, "vm1", "RUNNING", True)], [1]),
+        # Running but opted out -> NOT suspended (the bug being fixed).
+        ([make_vm(1, "vm1", "RUNNING", False)], []),
+        # Opted in but not running -> nothing to suspend.
+        ([make_vm(1, "vm1", "STOPPED", True)], []),
+        ([make_vm(1, "vm1", "SUSPENDED", True)], []),
+        # Mixed: only the running, opted-in VM is suspended.
+        (
+            [
+                make_vm(1, "vm1", "RUNNING", True),
+                make_vm(2, "vm2", "RUNNING", False),
+                make_vm(3, "vm3", "SUSPENDED", True),
+                make_vm(4, "vm4", "STOPPED", True),
+            ],
+            [1],
+        ),
+    ],
+)
+def test_suspend_vms_only_running_opted_in(vms, expected_suspended):
+    context = make_context(vms)
+
+    with patch.object(lifecycle, "suspend_vm") as suspend_vm:
+        lifecycle.suspend_vms(context, [vm.id for vm in vms])
+
+    assert [c.args[1] for c in suspend_vm.call_args_list] == expected_suspended
+
+
+def test_suspend_vms_tolerates_unknown_id():
+    # An id passed in but absent from vm.query must not raise.
+    context = make_context([])
+
+    with patch.object(lifecycle, "suspend_vm") as suspend_vm:
+        lifecycle.suspend_vms(context, [999])
+
+    suspend_vm.assert_not_called()


### PR DESCRIPTION
## Problem

VMs with disks on a dataset covered by a periodic snapshot task could be left indefinitely in the libvirt `PAUSED` (`SUSPENDED`) state, recoverable only via `vm.resume` or a host reboot. Two independent bugs combined to cause this.

## Bug 1: `suspend_on_snapshot` was ignored for running VMs

`vm.suspend_vms` suspended every running VM whose disk was on the snapshotted dataset, regardless of the per-VM `suspend_on_snapshot` setting. The opt-out filter in `query_snapshot_begin` (`status NOT IN active AND suspend_on_snapshot = False`) only ever excluded *stopped* VMs, so it was a no-op for the running VMs that actually get suspended.

Fix: gate suspension in `suspend_vms` on `RUNNING and suspend_on_snapshot`. The filter is left in `suspend_vms` rather than `query_snapshot_begin` because the latter is also used by `cloud_backup.validate_zvol` purely as an attachment-existence check.

## Bug 2: a timed-out observer call orphaned the suspend/resume bracket

In `ZettareplProcess._observer`, `self.vm_contexts[task_id]` was stored *after* the `with Client` block. A client-side `Client.call` timeout during `vm.suspend_vms` does not cancel the server-side suspend, so the VMs were suspended but the context was never recorded; the later `PeriodicSnapshotTaskSuccess`/`Error` handler then popped `None` and never issued the resume.

Fix:
- Record `vm_contexts`/`vmware_contexts` before the calls that can time out.
- In the end handler, isolate VMware finalization in its own `try/except` so it cannot prevent the VM resume.

## Tests

Unit tests for `suspend_vms` covering the opt-in/running matrix and an unknown id.

Original PR: https://github.com/truenas/middleware/pull/19053
