### PR TITLE
NAS-140629 / 27.0.0-BETA.1 / Allow dedicated spares with dRAID (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -392,12 +392,6 @@ class PoolService(CRUDService):
                         'zfs.pool.validate_draid_configuration', f'{topology_type}.{i}', numdisks, nparity, vdev
                     ))
 
-                    if data['topology'].get('spares'):
-                        verrors.add(
-                            'topology.spares',
-                            'Dedicated spare disks should not be used with dRAID.'
-                        )
-
                 if lastdatatype and lastdatatype != vdev['type']:
                     verrors.add(
                         f'topology.{topology_type}.{i}.type',

--- a/tests/api2/test_special_vdev.py
+++ b/tests/api2/test_special_vdev.py
@@ -138,5 +138,5 @@ def test_draid_with_dedicated_spares_is_allowed():
         'allow_duplicate_serials': True,
     }) as pool:
         # The combination is accepted and the dedicated spare is present.
-        assert len(pool['topology']['spares']) == 1
+        assert len(pool['topology']['spare']) == 1
         assert pool['topology']['special'][0]['name'].startswith('draid1:')

--- a/tests/api2/test_special_vdev.py
+++ b/tests/api2/test_special_vdev.py
@@ -113,33 +113,30 @@ def test_special_vdev_mixed_types_should_fail():
     assert 'RAIDZ1' in ve.value.errors[0].errmsg and 'MIRROR' in ve.value.errors[0].errmsg
 
 
-def test_draid_special_with_dedicated_spares_should_fail():
+def test_draid_with_dedicated_spares_is_allowed():
     """
-    Test middleware validation: DRAID special vdevs cannot be used with dedicated spares.
-    This validates the fix at pool.py:302-306 (spare → spares).
+    Dedicated spares may coexist with dRAID vdevs.
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 6:
         pytest.skip('Insufficient number of disks to perform this test')
 
-    with pytest.raises(ValidationErrors) as ve:
-        call('pool.create', {
-            'name': POOL_NAME,
-            'topology': {
-                'data': [{
-                    'type': 'MIRROR',
-                    'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
-                }],
-                'special': [{
-                    'type': 'DRAID1',
-                    'disks': [unused_disks[2]['name'], unused_disks[3]['name'], unused_disks[4]['name']],
-                    'draid_spare_disks': 0,
-                }],
-                'spares': [unused_disks[5]['name']]
-            },
-            'allow_duplicate_serials': True,
-        }, job=True)
-
-    # Verify middleware validation caught it
-    assert ve.value.errors[0].attribute == 'pool_create.topology.spares'
-    assert 'Dedicated spare disks should not be used with dRAID' in ve.value.errors[0].errmsg
+    with another_pool({
+        'name': POOL_NAME,
+        'topology': {
+            'data': [{
+                'type': 'MIRROR',
+                'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
+            }],
+            'special': [{
+                'type': 'DRAID1',
+                'disks': [unused_disks[2]['name'], unused_disks[3]['name'], unused_disks[4]['name']],
+                'draid_spare_disks': 0,
+            }],
+            'spares': [unused_disks[5]['name']]
+        },
+        'allow_duplicate_serials': True,
+    }) as pool:
+        # The combination is accepted and the dedicated spare is present.
+        assert len(pool['topology']['spares']) == 1
+        assert pool['topology']['special'][0]['name'].startswith('draid1:')


### PR DESCRIPTION
## Summary

Removes the middleware validation that rejected creating a pool with dRAID vdevs and dedicated hot spares (`Dedicated spare disks should not be used with dRAID.`). This combination is now fully supported by ZFS and is genuinely useful, so the block is no longer warranted.

## Background

The validation was kept until the two ZFS issues it relied on were resolved. Both have now been fixed upstream and backported to `truenas/zfs` `stable/26`, so the combination behaves well on TrueNAS 26:

- truenas/zfs#398: ZED now prefers dRAID distributed spares over dedicated ones. A dedicated spare on a dRAID pool is therefore a sensible second line of defence rather than a footgun consumed first.
- truenas/zfs#396: `spa_vdev_attach()` was reworked so a hot spare can now replace special/dedup vdev members (the kernel enforces a rotational-characteristic match and returns `ENOTSUP` on mismatch). Only log vdevs remain ineligible for spare replacement.

Original PR: https://github.com/truenas/middleware/pull/19057
