### PR TITLE
NAS-141255 / 26.0.0-RC.1 / Bust global permissions lock (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -169,7 +169,7 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem change owner', audit_extended=lambda data: data['path']
     )
-    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
+    @job(lock=lambda args: f'perm_change:{os.path.normpath(args[0]["path"])}')
     def chown(self, job, data):
         """
         Change owner or group of file at `path`.
@@ -228,7 +228,7 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set permission', audit_extended=lambda data: data['path']
     )
-    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
+    @job(lock=lambda args: f'perm_change:{os.path.normpath(args[0]["path"])}')
     def setperm(self, job, data):
         """
         Set unix permissions on given `path`.
@@ -630,7 +630,7 @@ class FilesystemService(Service):
         audit='Filesystem set ACL',
         audit_extended=lambda data: data['path']
     )
-    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
+    @job(lock=lambda args: f'perm_change:{os.path.normpath(args[0]["path"])}')
     def setacl(self, job, data):
         """
         Set ACL of a given path. Takes the following parameters:

--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -169,7 +169,7 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem change owner', audit_extended=lambda data: data['path']
     )
-    @job(lock="perm_change")
+    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
     def chown(self, job, data):
         """
         Change owner or group of file at `path`.
@@ -228,7 +228,7 @@ class FilesystemService(Service):
         roles=['FILESYSTEM_ATTRS_WRITE'],
         audit='Filesystem set permission', audit_extended=lambda data: data['path']
     )
-    @job(lock="perm_change")
+    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
     def setperm(self, job, data):
         """
         Set unix permissions on given `path`.
@@ -630,7 +630,7 @@ class FilesystemService(Service):
         audit='Filesystem set ACL',
         audit_extended=lambda data: data['path']
     )
-    @job(lock="perm_change")
+    @job(lock=lambda args: f'perm_change:{args[0]["path"]}')
     def setacl(self, job, data):
         """
         Set ACL of a given path. Takes the following parameters:


### PR DESCRIPTION
This commit replaces our global permissions mutation lock with a per-path one. In the default case for UI / API changes of permissions, the job is recursive and locked to a particular dataset, and API call is made against dataset mountpoints. This means that we can loosen things up generally to allow greater concurrency in permissions operations safely. In order to foot-shoot, a user would have to go out of their way to create permissions jobs that interact with each other and the impact of the foot shooting is that the last mutation wins (no chance of corruption).

Original PR: https://github.com/truenas/middleware/pull/19060
