### PR TITLE
NAS-141149 / 26.0.0-RC.1 / Use Docker Registries auth when checking for and pulling image updates (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/app_registry/utils.py
+++ b/src/middlewared/middlewared/plugins/app_registry/utils.py
@@ -1,10 +1,33 @@
 import base64
 
+from middlewared.utils.docker_registry import DEFAULT_DOCKER_REGISTRY, normalize_registry_authority
+
+# Docker CLI canonicalizes any Docker Hub login to this exact key in config.json and
+# only ever looks under this key when pulling a docker.io image — regardless of which
+# Hub hostname (docker.io / registry-1.docker.io / index.docker.io) the user typed.
+# Storing creds under any other key for a Hub registry produces a working-looking
+# config.json that docker silently ignores at pull time.
+DOCKER_HUB_CANONICAL_URI = 'https://index.docker.io/v1/'
+
+
+def _docker_cli_auth_key(uri: str) -> str:
+    """Map a stored registry URI to the auths-map key docker CLI will look under.
+
+    Pass-through for everything except Docker Hub aliases, which all collapse to
+    ``DOCKER_HUB_CANONICAL_URI`` so ``docker compose pull`` of a docker.io image
+    finds the credentials no matter which Hub URI the user entered in the UI.
+    """
+    if normalize_registry_authority(uri) == DEFAULT_DOCKER_REGISTRY:
+        return DOCKER_HUB_CANONICAL_URI
+    return uri
+
 
 def generate_docker_auth_config(auth_list: list[dict[str, str]]) -> dict:
     auths = {}
     for auth in auth_list:
-        auths[auth['uri']] = {
+        # Key by what docker CLI will look up, not by the raw stored URI — see
+        # _docker_cli_auth_key for the Docker Hub quirk this guards against.
+        auths[_docker_cli_auth_key(auth['uri'])] = {
             # Encode username:password in base64
             'auth': base64.b64encode(f'{auth["username"]}:{auth["password"]}'.encode()).decode(),
         }

--- a/src/middlewared/middlewared/plugins/apps_images/client.py
+++ b/src/middlewared/middlewared/plugins/apps_images/client.py
@@ -4,9 +4,10 @@ import urllib.parse
 import aiohttp
 
 from middlewared.service import CallError
+from middlewared.utils.docker_registry import DEFAULT_DOCKER_REGISTRY
 
 from .utils import (
-    DEFAULT_DOCKER_REGISTRY, DOCKER_AUTH_SERVICE, DOCKER_AUTH_HEADER, DOCKER_AUTH_URL, DOCKER_CONTENT_DIGEST_HEADER,
+    DOCKER_AUTH_SERVICE, DOCKER_AUTH_HEADER, DOCKER_AUTH_URL, DOCKER_CONTENT_DIGEST_HEADER,
     DOCKER_MANIFEST_LIST_SCHEMA_V2, DOCKER_MANIFEST_SCHEMA_V1, DOCKER_MANIFEST_SCHEMA_V2, DOCKER_RATELIMIT_URL,
     DOCKER_MANIFEST_OCI_V1, parse_auth_header, parse_digest_from_schema,
 )
@@ -62,15 +63,17 @@ class ContainerRegistryClientMixin:
 
         return response['response']['token']
 
-    async def _get_manifest_response(self, registry, image, tag, headers, mode, raise_error):
+    async def _get_manifest_response(self, registry, image, tag, headers, mode, raise_error, auth=None):
         manifest_url = f'https://{registry}/v2/{image}/manifests/{tag}'
         # 1) try getting manifest
         response = await self._api_call(manifest_url, headers=headers, mode=mode)
         if (error := response.get('error_obj')) and isinstance(error, aiohttp.ClientResponseError):
             if error.status == 401:
-                # 2) try to get token from manifest api call's response headers
+                # 2) try to get token from manifest api call's response headers; the token
+                # request is sent with Basic auth when registry creds are configured, so
+                # the returned token has read scope on private repos.
                 auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
-                headers['Authorization'] = f'Bearer {await self._get_token(**auth_data)}'
+                headers['Authorization'] = f'Bearer {await self._get_token(**auth_data, auth=auth)}'
                 # 3) Redo the manifest call with updated token
                 response = await self._api_call(manifest_url, headers=headers, mode=mode)
 
@@ -82,19 +85,22 @@ class ContainerRegistryClientMixin:
 
         return response
 
-    async def get_manifest_call_headers(self, registry, image, headers):
+    async def get_manifest_call_headers(self, registry, image, headers, auth=None):
         if registry == DEFAULT_DOCKER_REGISTRY:
-            headers['Authorization'] = f'Bearer {await self._get_token(scope=f"repository:{image}:pull")}'
+            headers['Authorization'] = f'Bearer {await self._get_token(scope=f"repository:{image}:pull", auth=auth)}'
         return headers
 
-    async def _get_repo_digest(self, registry, image, tag):
+    async def _get_repo_digest(self, registry, image, tag, auth=None):
+        # `auth` is the aiohttp BasicAuth kwargs dict ({'login', 'password'}) for the
+        # registry hosting this image, or None for anonymous access. It is threaded down
+        # to `_get_token` so the bearer token carries the user's read scope on private repos.
         response = await self._get_manifest_response(
             registry, image, tag, await self.get_manifest_call_headers(registry, image, {
                 'Accept': (f'{DOCKER_MANIFEST_SCHEMA_V2}, '
                            f'{DOCKER_MANIFEST_LIST_SCHEMA_V2}, '
                            f'{DOCKER_MANIFEST_SCHEMA_V1}, '
                            f'{DOCKER_MANIFEST_OCI_V1}')
-            }), 'get', True
+            }, auth=auth), 'get', True, auth=auth
         )
         digests = parse_digest_from_schema(response)
         digests.append(response['response_obj'].headers.get(DOCKER_CONTENT_DIGEST_HEADER))

--- a/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from middlewared.service import CallError, Service
 
 from .client import ContainerRegistryClientMixin
-from .utils import normalize_reference
+from .utils import get_normalized_auth_config, normalize_reference
 
 
 logger = logging.getLogger('docker_image')
@@ -29,10 +29,15 @@ class ContainerImagesService(Service, ContainerRegistryClientMixin):
 
     async def check_update(self):
         images = await self.middleware.call('app.image.query')
+        # Query stored Docker Registries once per cycle and key them by URI so the
+        # per-tag credential lookup can match the registry hosting each image.
+        app_registries = {
+            registry['uri']: registry for registry in await self.middleware.call('app.registry.query')
+        }
         for image in images:
             for tag in image['repo_tags']:
                 try:
-                    await self.check_update_for_image(tag, image)
+                    await self.check_update_for_image(tag, image, app_registries)
                 except CallError as e:
                     logger.error(str(e))
 
@@ -48,24 +53,36 @@ class ContainerImagesService(Service, ContainerRegistryClientMixin):
 
         return repo_digests
 
-    async def check_update_for_image(self, tag, image_details):
+    async def check_update_for_image(self, tag, image_details, app_registries=None):
+        if app_registries is None:
+            app_registries = {
+                registry['uri']: registry for registry in await self.middleware.call('app.registry.query')
+            }
         if not image_details['dangling']:
             parsed_reference = self.normalize_reference(tag)
+            # Without per-registry auth the manifest call hits the public/anonymous code
+            # path; for private repos (e.g. ghcr.io) that yields a token with no read scope,
+            # the retry 401s, and no update is ever detected. When credentials are configured
+            # we forward them as the aiohttp BasicAuth(**auth) kwargs shape the client expects.
+            auth = None
+            if creds := get_normalized_auth_config(app_registries, tag):
+                auth = {'login': creds['username'], 'password': creds['password']}
             self.IMAGE_CACHE[tag] = await self.compare_id_digests(
                 image_details,
                 parsed_reference['registry'],
                 parsed_reference['image'],
-                parsed_reference['tag']
+                parsed_reference['tag'],
+                auth,
             )
 
     async def clear_update_flag_for_tag(self, tag):
         self.IMAGE_CACHE[tag] = False
 
-    async def compare_id_digests(self, image_details, registry, image_str, tag_str):
+    async def compare_id_digests(self, image_details, registry, image_str, tag_str, auth=None):
         """
         Returns whether an update is available for an image.
         """
-        digest = await self._get_repo_digest(registry, image_str, tag_str)
+        digest = await self._get_repo_digest(registry, image_str, tag_str, auth=auth)
         return not any(
             digest.split('@', 1)[-1] == upstream_digest
             for upstream_digest in digest

--- a/src/middlewared/middlewared/plugins/apps_images/utils.py
+++ b/src/middlewared/middlewared/plugins/apps_images/utils.py
@@ -3,10 +3,10 @@ import re
 from collections import defaultdict
 
 from middlewared.service import CallError
+from middlewared.utils.docker_registry import DEFAULT_DOCKER_REGISTRY, normalize_registry_authority
 
 
 # Default values
-DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
 DEFAULT_DOCKER_REPO = 'library'
 DEFAULT_DOCKER_TAG = 'latest'
 DOCKER_CONTENT_DIGEST_HEADER = 'Docker-Content-Digest'
@@ -158,15 +158,19 @@ def normalize_docker_limits_header(headers: dict) -> dict:
 
 
 def get_normalized_auth_config(registry_info: dict[str, dict], image_tag: str) -> dict:
-    if not registry_info:
-        return {}
+    """Return stored credentials for the registry hosting ``image_tag``, or {}.
 
+    ``registry_info`` is keyed by the raw stored registry URI; we match by
+    normalized authority so a stored 'https://ghcr.io/' still matches a 'ghcr.io'
+    image reference (and any Docker Hub alias matches a docker.io image).
+    """
     user_wants_registry = normalize_reference(image_tag)['registry']
-    if user_wants_registry not in registry_info:
-        return {}
-
-    return {
-        'registry_uri': user_wants_registry,
-        'username': registry_info[user_wants_registry]['username'],
-        'password': registry_info[user_wants_registry]['password'],
-    }
+    target = normalize_registry_authority(user_wants_registry)
+    for uri, entry in registry_info.items():
+        if normalize_registry_authority(uri) == target:
+            return {
+                'registry_uri': user_wants_registry,
+                'username': entry['username'],
+                'password': entry['password'],
+            }
+    return {}

--- a/src/middlewared/middlewared/pytest/unit/utils/test_docker_registry.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_docker_registry.py
@@ -1,0 +1,33 @@
+import pytest
+
+from middlewared.utils.docker_registry import DEFAULT_DOCKER_REGISTRY, normalize_registry_authority
+
+
+@pytest.mark.parametrize(
+    "uri_or_reference,expected",
+    [
+        # Non-Hub registries collapse to a bare authority regardless of how typed.
+        # This is the original regression: a stored "https://ghcr.io/" URI must reduce
+        # to the same value as the "ghcr.io" registry an image reference parses to.
+        ("https://ghcr.io/", "ghcr.io"),
+        ("ghcr.io", "ghcr.io"),
+        ("https://ghcr.io/v2/", "ghcr.io"),
+        ("quay.io", "quay.io"),
+        # Every Docker Hub alias maps to the registry docker.io images normalize to.
+        ("docker.io", DEFAULT_DOCKER_REGISTRY),
+        ("index.docker.io", DEFAULT_DOCKER_REGISTRY),
+        ("https://index.docker.io/v1/", DEFAULT_DOCKER_REGISTRY),
+        ("registry-1.docker.io", DEFAULT_DOCKER_REGISTRY),
+        # Ports are part of the authority and must be preserved.
+        ("myregistry:5000", "myregistry:5000"),
+        ("https://myregistry:5000/", "myregistry:5000"),
+    ],
+)
+def test__normalize_registry_authority(uri_or_reference, expected):
+    assert normalize_registry_authority(uri_or_reference) == expected
+
+
+def test__normalize_registry_authority_is_idempotent():
+    for value in ("ghcr.io", "https://ghcr.io/", "docker.io", "myregistry:5000"):
+        once = normalize_registry_authority(value)
+        assert normalize_registry_authority(once) == once

--- a/src/middlewared/middlewared/utils/docker_registry.py
+++ b/src/middlewared/middlewared/utils/docker_registry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+# Registry containerd/normalize_reference maps any docker.io image to, and the
+# canonical authority every Docker Hub alias collapses to.
+DEFAULT_DOCKER_REGISTRY = "registry-1.docker.io"
+
+# Docker Hub answers under several interchangeable hostnames; they all refer to the
+# same registry and must be treated as one when matching stored credentials.
+DOCKER_HUB_REGISTRY_ALIASES = frozenset(
+    {
+        "docker.io",
+        "index.docker.io",
+        "registry-1.docker.io",
+    }
+)
+
+
+def normalize_registry_authority(uri_or_reference: str) -> str:
+    """Reduce a registry URI or image-reference registry to a canonical authority.
+
+    The registry portion of an image reference is a bare hostname (``ghcr.io``,
+    ``registry-1.docker.io``), but users can enter the URI in `app.registry` in
+    several equivalent forms (``https://ghcr.io/``, ``ghcr.io``,
+    ``https://index.docker.io/v1/``, etc). This strips scheme, path and trailing
+    slash down to ``host[:port]`` and collapses every Docker Hub alias to
+    ``DEFAULT_DOCKER_REGISTRY`` so credentials stored under any Hub form match
+    images that get normalized to registry-1.docker.io.
+    """
+    host = uri_or_reference
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.rstrip("/").split("/", 1)[0]
+    if host in DOCKER_HUB_REGISTRY_ALIASES:
+        return DEFAULT_DOCKER_REGISTRY
+    return host


### PR DESCRIPTION
This commit fixes an issue where the image update checker and the middleware's own image pull ignored the credentials stored in Docker Registries, so updates to private images (e.g. ghcr.io) were never detected and pulls 401'd. We now thread the stored registry credentials through the manifest/token calls and the pull fallback so the bearer token carries read scope on private repos.

The registry-URI authority normalization that both paths rely on (stripping scheme/path/slash and collapsing Docker Hub aliases) was duplicated across app_registry and apps_images with slightly diverging alias sets, so it now lives in a single middlewared.utils.docker_registry helper that both import, with unit tests covering the normalization.

Original PR: https://github.com/truenas/middleware/pull/19059
