### PR TITLE
NAS-141261 / 26.0.0-RC.1 / Serialize rootfs read-only/sysext toggles with a shared lock (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/disable-rootfs-protection
+++ b/src/freenas/usr/local/libexec/disable-rootfs-protection
@@ -10,6 +10,7 @@ from pathlib import Path
 from subprocess import run
 
 from middlewared.utils import ProductType
+from middlewared.utils.rootfs_protection import rootfs_protection_lock
 from truenas_os_pyutils.mount import statmount
 
 
@@ -138,14 +139,18 @@ if __name__ == '__main__':
     except FileNotFoundError:
         pass
 
-    print('Flagging root dataset as developer mode')
-    rv = run([ZFS_CMD, 'get', '-o', 'name', '-H', 'name', '/'], capture_output=True)
-    root = rv.stdout.decode().strip()
-    run([ZFS_CMD, 'set', 'truenas:developer=on', root])
+    # Serialize against the initramfs rebuild (boot.update_initramfs ->
+    # truenas-initrd.py), which transiently re-locks the rootfs and would
+    # otherwise make the chmods below fail with EROFS.
+    with rootfs_protection_lock():
+        print('Flagging root dataset as developer mode')
+        rv = run([ZFS_CMD, 'get', '-o', 'name', '-H', 'name', '/'], capture_output=True)
+        root = rv.stdout.decode().strip()
+        run([ZFS_CMD, 'set', 'truenas:developer=on', root])
 
-    for entry in datasets:
-        set_readwrite(entry)
+        for entry in datasets:
+            set_readwrite(entry)
 
-    chmod_files()
+        chmod_files()
 
     sys.exit(0)

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import subprocess
 
 from pydantic import Field
 
@@ -13,6 +14,7 @@ from middlewared.api.current import (
 from middlewared.service import CallError, Service, job, private
 from middlewared.utils import run, BOOT_POOL_NAME_VALID
 from middlewared.utils.disks import valid_zfs_partition_uuids
+from middlewared.utils.rootfs_protection import rootfs_protection_lock
 
 
 BOOT_ATTACH_REPLACE_LOCK = 'boot_attach_replace'
@@ -141,7 +143,7 @@ class BootService(Service):
         # If the user is upgrading his disks, let's set expand to True to make sure that we
         # register the new disks capacity which increase the size of the pool
         await self.middleware.call('zfs.pool.online', BOOT_POOL_NAME, zfs_dev_part['name'], True)
-        await self.update_initramfs()
+        await self.middleware.call('boot.update_initramfs')
 
     @api_method(BootDetachArgs, BootDetachResult, roles=['DISK_WRITE'])
     async def detach(self, dev):
@@ -150,7 +152,7 @@ class BootService(Service):
         """
         await self.check_update_ashift_property()
         await self.middleware.call('zfs.pool.detach', BOOT_POOL_NAME, dev, {'clear_label': True})
-        await self.update_initramfs()
+        await self.middleware.call('boot.update_initramfs')
 
     @api_method(BootReplaceArgs, BootReplaceResult, roles=['DISK_WRITE'])
     @job(lock=BOOT_ATTACH_REPLACE_LOCK)
@@ -188,7 +190,7 @@ class BootService(Service):
 
         job.set_progress(100, 'Installing boot loader')
         await self.middleware.call('boot.install_loader', dev)
-        await self.update_initramfs()
+        await self.middleware.call('boot.update_initramfs')
 
     @api_method(BootScrubArgs, BootScrubResult, roles=['BOOT_ENV_WRITE'])
     @job(lock='boot_scrub')
@@ -213,9 +215,12 @@ class BootService(Service):
         return interval
 
     @api_method(BootUpdateInitramfsArgs, BootUpdateInitramfsResult, private=True)
-    async def update_initramfs(self, options):
+    def update_initramfs(self, options):
         """
         Returns true if initramfs was updated and false otherwise.
+
+        Synchronous and blocking (subprocess + lock); callers in async context
+        invoke it via ``middleware.call`` so it runs in the io thread pool.
         """
         args = ['/']
         if options['database']:
@@ -223,11 +228,15 @@ class BootService(Service):
         if options['force']:
             args.extend(['-f'])
 
+        # Hold the rootfs-protection lock across the rebuild so it can't race
+        # disable-rootfs-protection (see middlewared.utils.rootfs_protection):
+        # truenas-initrd.py transiently makes the rootfs writable and restores it.
         # NOTE: truenas-initrd.py is provided by truenas/upgrade_pyutils repository
-        cp = await run(
-            '/usr/local/bin/truenas-initrd.py', *args,
-            encoding='utf8', errors='ignore', check=False
-        )
+        with rootfs_protection_lock():
+            cp = subprocess.run(
+                ['/usr/local/bin/truenas-initrd.py', *args],
+                capture_output=True, encoding='utf8', errors='ignore',
+            )
         if cp.returncode > 1:
             raise CallError(f'Failed to update initramfs: {cp.stdout} {cp.stderr}')
 

--- a/src/middlewared/middlewared/plugins/system_advanced/nvidia.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/nvidia.py
@@ -9,6 +9,7 @@ from middlewared.api.current import (
     SystemAdvancedNvidiaPresentResult,
 )
 from middlewared.service import private, Service
+from middlewared.utils.rootfs_protection import rootfs_protection_lock
 
 
 class SystemAdvancedService(Service):
@@ -57,8 +58,11 @@ class SystemAdvancedService(Service):
             refresh = False
 
         if refresh:
-            subprocess.run(['systemd-sysext', 'refresh'], capture_output=True, check=True, text=True)
-            subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
+            # systemd-sysext refresh re-overlays /usr; hold the rootfs lock so it
+            # can't race the initramfs rebuild or disable-rootfs-protection.
+            with rootfs_protection_lock():
+                subprocess.run(['systemd-sysext', 'refresh'], capture_output=True, check=True, text=True)
+                subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
 
         if config['nvidia']:
             cp = subprocess.run(

--- a/src/middlewared/middlewared/utils/rootfs_protection.py
+++ b/src/middlewared/middlewared/utils/rootfs_protection.py
@@ -1,0 +1,29 @@
+"""
+Cross-process lock serializing operations that flip the read-only state of the
+root filesystem, so they can't clobber one another.
+"""
+
+from collections.abc import Iterator
+import contextlib
+import fcntl
+import os
+import threading
+
+from middlewared.utils import MIDDLEWARE_RUN_DIR
+
+ROOTFS_PROTECTION_LOCK = os.path.join(MIDDLEWARE_RUN_DIR, "rootfs-protection.lock")
+
+# Process-local guard taken before the cross-process flock so threads in the
+# same process can't race each other regardless of how the file lock is opened.
+_thread_lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def rootfs_protection_lock() -> Iterator[None]:
+    os.makedirs(MIDDLEWARE_RUN_DIR, exist_ok=True)
+    with (
+        _thread_lock,
+        open(ROOTFS_PROTECTION_LOCK, "w") as f,
+    ):
+        fcntl.flock(f, fcntl.LOCK_EX)
+        yield


### PR DESCRIPTION
Remove the ability for concurrent calls to do things with root filesystem unlocked (either administratively through disable-rootfs-protection) or internal middleware callers that do things in /usr to clobber each other.

Protection takes belt-and-suspenders approach of taking pthread lock, then taking flock.

Original PR: https://github.com/truenas/middleware/pull/19069
