### PR TITLE
NAS-141271 / 27.0.0-BETA.1 / Report when a debug is too large to attach to a bug ticket

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -235,7 +235,7 @@ class SupportService(ConfigService):
 
             with tempfile.NamedTemporaryFile("w+b") as f:
                 def copy1():
-                    nonlocal has_debug
+                    nonlocal has_debug, debug_attach_error
                     try:
                         rbytes = 0
                         while True:
@@ -245,6 +245,14 @@ class SupportService(ConfigService):
 
                             rbytes += len(r)
                             if rbytes > DEBUG_MAX_SIZE * 1048576:
+                                debug_attach_error = (
+                                    f'The debug file exceeds the {DEBUG_MAX_SIZE}MiB size limit. '
+                                    f'Please generate and attach a debug manually.'
+                                )
+                                self.logger.warning(
+                                    'Debug exceeded %dMiB limit for ticket %s; not attaching.',
+                                    DEBUG_MAX_SIZE, ticket,
+                                )
                                 return
 
                             f.write(r)
@@ -256,6 +264,11 @@ class SupportService(ConfigService):
 
                 await self.middleware.run_in_thread(copy1)
                 await debug_job.wait()
+                if debug_job.error:
+                    has_debug = False
+                    if not debug_attach_error:
+                        debug_attach_error = f'Failed to generate debug: {debug_job.error}'
+                    self.logger.warning('Debug generation failed for ticket %s: %s', ticket, debug_job.error)
 
                 if has_debug:
                     job.set_progress(80, 'Attaching debug file')


### PR DESCRIPTION
When a user files a support ticket from the WebUI with **Attach debug** selected, the ticket is created on JIRA, but the debug is sometimes silently not attached. `support.new_ticket` streams the generated debug into a temporary file and enforces a `DEBUG_MAX_SIZE` (30 MiB) cap on the *compressed* archive. If that cap was exceeded, the copy routine returned early **without** setting `has_debug` and **without** recording any error, so the job completed successfully with `has_debug=False` and `debug_attach_error=None`. The WebUI only shows a warning when `debug_attach_error` is set, so the user saw a plain "Ticket submitted successfully" message and reasonably assumed the debug was attached when it was not.

A related path had the same symptom: if `system.debug` itself failed (for example the HA per-node oversize guard in `system/debug.py` raising a `CallError`), `debug_job.error` was never checked, so a closed output pipe could leave `has_debug=True` and the code would attempt to attach an empty/incomplete file.

No WebUI change is required; the existing success dialog already displays `debug_attach_error`.

<img width="817" height="255" alt="debug-size-warning" src="https://github.com/user-attachments/assets/f4fb0571-abbd-4f4e-93d3-c984cd81baec" />
