### PR TITLE
NAS-141006 / 26.0.0-RC.1 / Stop writing cluster_mode in scst.conf (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -165,19 +165,12 @@
 
     standby_node_requires_reload = False
     fix_cluster_mode = []
-    cluster_mode_targets = []
     cluster_mode_luns = {}
     clustered_extents = set()
-    active_extents = []
     standby_write_empty_config = False
     skipped_wwpns = set()
     if failover_status == "MASTER":
         local_ip = middleware.call_sync("failover.local_ip")
-        dlm_ready = middleware.call_sync("dlm.node_ready")
-        if alua_enabled:
-            active_extents = middleware.call_sync("iscsi.extent.active_extents")
-            clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
-            cluster_mode_targets = middleware.call_sync("iscsi.target.cluster_mode_targets")
     elif failover_status == "BACKUP":
         if alua_enabled:
             if standby_write_empty_config := middleware.call_sync("iscsi.alua.standby_write_empty_config"):
@@ -205,7 +198,8 @@
                     standby_node_requires_reload = True
                 else:
                     if _cmt_cml is not None:
-                        cluster_mode_targets, cluster_mode_luns = _cmt_cml
+                        # First tuple element (cluster_mode_targets) is unused here.
+                        _, cluster_mode_luns = _cmt_cml
                 clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
         else:
             middleware.call_sync("iscsi.target.logout_ha_targets")
@@ -301,12 +295,10 @@
     else:
         cml = calc_copy_manager_luns(all_rw_extent_names)
 
-    def set_active_lun_to_cluster_mode(extentname):
-        if extentname in active_extents and extentname in clustered_extents:
-            return True
-        return False
-
     def set_standby_lun_to_cluster_mode(device, targetname):
+        # Predicate used only to decide whether to queue standby_fix_cluster_mode
+        # for this device. cluster_mode is no longer written via scst.conf; it is
+        # managed by middleware via direct sysfs writes (iscsi.scst.path_write_if_needed).
         if device in clustered_extents:
             if targetname in cluster_mode_luns and int(device.split(':')[-1]) in cluster_mode_luns[targetname]:
                 return True
@@ -343,19 +335,16 @@ HANDLER dev_disk {
 %             if devices:
 %                 for device in devices:
 
-        DEVICE ${device} {
-## We will only enter cluster_mode here if two conditions are satisfied:
-## 1. We are already in cluster_mode, AND
-## 2. The corresponding LUN on the MASTER is in cluster_mode
-## Note we use a similar check to determine whether the target will be enabled.
-%                 if set_standby_lun_to_cluster_mode(device, name):
-            cluster_mode 1
-%                 else:
+## cluster_mode is intentionally omitted from scst.conf and managed via direct
+## sysfs writes (iscsi.scst.path_write_if_needed). The predicate below is used
+## only to decide whether to queue iscsi.alua.standby_fix_cluster_mode for this
+## device (i.e. it is not yet in cluster_mode on both nodes).
+%                 if not set_standby_lun_to_cluster_mode(device, name):
 <%
     fix_cluster_mode.append(device)
 %>\
-            cluster_mode 0
 %                 endif
+        DEVICE ${device} {
         }
 %                 endfor
 %             endif
@@ -405,13 +394,8 @@ HANDLER ${handler} {
 %       endif
         t10_vend_id ${extent['vendor']}
         t10_dev_id ${extent['t10_dev_id']}
-%       if failover_status == "MASTER" and alua_enabled and dlm_ready:
-%       if set_active_lun_to_cluster_mode(extent['name']):
-        cluster_mode 1
-%       else:
-        cluster_mode 0
-%       endif
-%       endif
+##      cluster_mode is intentionally omitted; middleware manages it via direct
+##      sysfs writes (iscsi.scst.path_write_if_needed).
 %       if failover_status == "BACKUP" and alua_enabled:
         active 0
 %       endif

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -208,6 +208,8 @@ class ISCSIGlobalService(SystemServiceService):
                 if loaded:
                     self.logger.warning('Insufficent unload delay when turning off ALUA')
                 await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_targets')
+                # Clear cluster_mode on ACTIVE
+                await self.middleware.call('iscsi.scst.set_all_cluster_mode', 0)
 
         await self._update_service(old, new, options={'ha_propagate': False})
 

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -41,6 +41,21 @@ class iSCSITargetService(Service):
         else:
             raise ValueError(f'Unexpected path "{realpath}"')
 
+    def path_write_if_needed(self, path, text):
+        """Like path_write, but read first and skip if first line already matches."""
+        p = pathlib.Path(path)
+        realpath = str(p.resolve())
+        if not (realpath.startswith(SCST_BASE) and p.exists()):
+            raise ValueError(f'Unexpected path "{realpath}"')
+        want = text.split('\n', 1)[0]
+        try:
+            have = p.read_text().split('\n', 1)[0]
+        except Exception:
+            have = None
+        if have == want:
+            return
+        p.write_text(text)
+
     async def set_all_cluster_mode(self, value):
         text = f'{int(value)}\n'
         paths = await self.middleware.call('iscsi.scst.cluster_mode_paths')
@@ -48,7 +63,7 @@ class iSCSITargetService(Service):
             for chunk in itertools.batched(paths, 10):
                 await asyncio.gather(
                     *[
-                        self.middleware.call('iscsi.scst.path_write', path, text)
+                        self.middleware.call('iscsi.scst.path_write_if_needed', path, text)
                         for path in chunk
                     ]
                 )
@@ -97,7 +112,7 @@ class iSCSITargetService(Service):
 
     async def set_device_cluster_mode(self, device, value):
         await self.middleware.call(
-            'iscsi.scst.path_write',
+            'iscsi.scst.path_write_if_needed',
             f'{SCST_DEVICES}/{sanitize_extent(device)}/cluster_mode',
             f'{int(value)}\n',
         )
@@ -111,7 +126,7 @@ class iSCSITargetService(Service):
         if paths:
             await asyncio.gather(
                 *[
-                    self.middleware.call('iscsi.scst.path_write', path, text)
+                    self.middleware.call('iscsi.scst.path_write_if_needed', path, text)
                     for path in paths
                 ]
             )


### PR DESCRIPTION
Make middleware the sole writer of SCST's per-device `cluster_mode` sysfs attribute.

Two writers were competing for the attribute on both nodes: `pyscstadmin.apply_config_file` (driven by `/etc/scst.conf`) and direct sysfs writes from middleware. The standby's `scst.conf.mako` renders based on data that includes the active's runtime cluster_mode, fetched via `failover.call_remote`. Under load that data could be unstable enough for the standby to emit `cluster_mode 0` for already-clustered devices; pyscstadmin's apply then wrote 0 to the runtime, destroying their per-extent DLM lockspaces. `iscsi.alua.standby_fix_cluster_mode` would then re-cluster them, the cycle repeating.

This PR removes the race by handing cluster_mode ownership entirely to middleware.

- `iscsi.scst.path_write_if_needed`: read first and write only if the first line differs. Idempotent same-value writes no longer take the global `scst_mutex` kernel-side.
- `scst.conf.mako`: stop emitting `cluster_mode` in DEVICE blocks

Requires the matching truenas_pyscstadmin PR (#[15](https://github.com/truenas/truenas_pyscstadmin/pull/15)).

----
Passing (extended) CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/2543/).


Original PR: https://github.com/truenas/middleware/pull/19074
