### PR TITLE
NAS-141273 / 25.10.5 / Remove shared pydantic `Field()` from API type aliases

### DIFF
--- a/src/middlewared/middlewared/api/base/types/__init__.py
+++ b/src/middlewared/middlewared/api/base/types/__init__.py
@@ -2,6 +2,7 @@ from .dict import *  # noqa
 from .fc import *  # noqa
 from .filesystem import *  # noqa
 from .iscsi import *  # noqa
+from .json_schema import *  # noqa
 from .ldap import * # noqa
 from .list import *  # noqa
 from .network import *  # noqa

--- a/src/middlewared/middlewared/api/base/types/json_schema.py
+++ b/src/middlewared/middlewared/api/base/types/json_schema.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from pydantic import GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+
+__all__ = ["JsonSchemaExtra"]
+
+
+class JsonSchemaExtra:
+    """Annotated metadata that merges extra keys into a field's generated JSON schema.
+
+    Use this instead of ``Field(examples=..., json_schema_extra=...)`` inside a *shared*
+    ``Annotated`` type alias. ``Field(...)`` produces a single ``FieldInfo`` instance that
+    is reused by every model field referencing the alias. Pydantic's field-merge machinery
+    shallow-copies that ``FieldInfo`` and shares its ``_attributes_set`` dict, so a stray
+    ``default`` recorded for one consumer leaks into all the others (silently turning
+    required fields optional). ``JsonSchemaExtra`` is a plain immutable metadata object with
+    no such mutable state, so it is safe to embed in a shared alias.
+    """
+
+    __slots__ = ("extra",)
+
+    def __init__(self, **extra: Any) -> None:
+        self.extra = extra
+
+    def __get_pydantic_json_schema__(self, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema.update(self.extra)
+        return json_schema

--- a/src/middlewared/middlewared/api/base/types/list.py
+++ b/src/middlewared/middlewared/api/base/types/list.py
@@ -1,7 +1,9 @@
 from typing import Annotated, TypeVar
 
 from pydantic_core import PydanticCustomError
-from pydantic import AfterValidator, Field
+from pydantic import AfterValidator
+
+from middlewared.api.base.types.json_schema import JsonSchemaExtra
 
 __all__ = ['UniqueList']
 
@@ -19,4 +21,4 @@ def _validate_unique_list(v: list[T]) -> list[T]:
     return v
 
 
-UniqueList = Annotated[list[T], AfterValidator(_validate_unique_list), Field(json_schema_extra={'uniqueItems': True})]
+UniqueList = Annotated[list[T], AfterValidator(_validate_unique_list), JsonSchemaExtra(uniqueItems=True)]

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -4,7 +4,8 @@ import re
 from typing import Annotated, Literal
 
 import pydantic
-from pydantic import AfterValidator, Field
+from annotated_types import Ge, Le
+from pydantic import AfterValidator
 
 from ..validators import match_validator
 
@@ -61,7 +62,7 @@ def _validate_nameserver(address: pydantic.IPvAnyAddress) -> str:
     return str_form
 
 
-TcpPort = Annotated[int, Field(ge=1, le=65535)]
+TcpPort = Annotated[int, Ge(1), Le(65535)]
 Hostname = Annotated[str, AfterValidator(match_validator(
     re.compile(r"^[a-z.\-0-9]*[a-z0-9]$", re.IGNORECASE),
     "Hostname can only contain letters, numbers, periods, and dashes and must end with a letter or number"

--- a/src/middlewared/middlewared/api/base/types/nvmet.py
+++ b/src/middlewared/middlewared/api/base/types/nvmet.py
@@ -2,7 +2,8 @@ import re
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import AfterValidator, Field
+from annotated_types import MaxLen, MinLen
+from pydantic import AfterValidator
 
 __all__ = [
     "NQN"
@@ -46,4 +47,4 @@ def _validate_nqn(nqn: str):
     return nqn
 
 
-NQN = Annotated[str, Field(min_length=MIN_NQN_LEN, max_length=MAX_NQN_LEN), AfterValidator(_validate_nqn)]
+NQN = Annotated[str, MinLen(MIN_NQN_LEN), MaxLen(MAX_NQN_LEN), AfterValidator(_validate_nqn)]

--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -1,15 +1,16 @@
 from typing import Annotated, Any
 
+from annotated_types import MinLen
 from pydantic import (
     AfterValidator,
     BeforeValidator,
-    Field,
     GetCoreSchemaHandler,
     HttpUrl as _HttpUrl,
     PlainSerializer,
 )
 from pydantic_core import CoreSchema, core_schema, PydanticKnownError
 
+from middlewared.api.base.types.json_schema import JsonSchemaExtra
 from middlewared.api.base.validators import time_validator, email_validator
 from middlewared.utils.netbios import validate_netbios_name, validate_netbios_domain
 from middlewared.utils.smb import validate_smb_share_name
@@ -64,9 +65,11 @@ LongString = Annotated[
     BeforeValidator(LongStringWrapper),
     PlainSerializer(lambda x: x.value if isinstance(x, LongStringWrapper) else x),
 ]
-NonEmptyString = Annotated[str, Field(min_length=1)]
-LongNonEmptyString = Annotated[LongString, Field(min_length=1)]
-TimeString = Annotated[str, AfterValidator(time_validator), Field(examples=["00:00", "06:30", "18:00", "23:00"])]
+NonEmptyString = Annotated[str, MinLen(1)]
+LongNonEmptyString = Annotated[LongString, MinLen(1)]
+TimeString = Annotated[
+    str, AfterValidator(time_validator), JsonSchemaExtra(examples=["00:00", "06:30", "18:00", "23:00"])
+]
 EmailString = Annotated[str, AfterValidator(email_validator)]
 NetbiosDomain = Annotated[str, AfterValidator(validate_netbios_domain)]
 NetbiosName = Annotated[str, AfterValidator(validate_netbios_name)]

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -1,7 +1,7 @@
 import string
 from typing import Annotated
 
-from pydantic import Field
+from annotated_types import Ge, Le, MinLen
 from pydantic.functional_validators import AfterValidator
 
 from middlewared.utils.sid import sid_is_valid
@@ -70,15 +70,15 @@ def validate_sid(value: str) -> str:
 
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
-RemoteUsername = Annotated[str, Field(min_length=1)]
+RemoteUsername = Annotated[str, MinLen(1)]
 GroupName = Annotated[
     str,
     AfterValidator(lambda x: validate_name(x, valid_start_chars=GROUP_VALID_START, max_length=None))
 ]
-LocalUID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
+LocalUID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
-LocalGID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
+LocalGID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
-ContainerXID = Annotated[int, Field(ge=1, le=XID_MAX)]
+ContainerXID = Annotated[int, Ge(1), Le(XID_MAX)]
 
 SID = Annotated[str, AfterValidator(validate_sid)]

--- a/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -102,7 +102,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -30,7 +31,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -28,7 +28,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, single_argument_args
 
@@ -116,7 +116,7 @@ class PCI(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -102,7 +102,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -30,7 +31,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -28,7 +28,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_1/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_1/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, single_argument_args
 
@@ -116,7 +116,7 @@ class PCI(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -102,7 +102,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -30,7 +31,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -28,7 +28,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_2/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_2/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, single_argument_args
 
@@ -116,7 +116,7 @@ class PCI(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_04_2/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -114,7 +114,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -8,6 +8,7 @@ from middlewared.api.base import (
     RemoteUsername,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 from typing import Annotated, Literal, Self
 from middlewared.utils.filesystem.acl import (
@@ -36,7 +37,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -122,7 +122,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
+from middlewared.api.base import BaseModel, JsonSchemaExtra, TimeString
 from middlewared.utils import filters
 from middlewared.utils.cron import croniter_for_schedule
 
@@ -18,11 +18,14 @@ def validate_query_filters(qf: list) -> list:
 
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_query_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -16,7 +16,8 @@ from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 
-from pydantic import Field, Secret, model_validator, field_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, model_validator, field_validator
 from typing import Annotated, Any, Literal
 
 __all__ = [
@@ -27,7 +28,7 @@ __all__ = [
     'DirectoryServicesCertificateChoicesArgs', 'DirectoryServicesCertificateChoicesResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -181,7 +182,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -189,7 +190,7 @@ class PrimaryDomainIdmap(BaseModel):
     builtin: BuiltinDomainTdb = Field(default=BuiltinDomainTdb())
     """ UID and GID range configuration for automatically generated accounts linked to well-known and BUILTIN accounts \
     on Windows servers. """
-    idmap_domain: DomainIdmap
+    idmap_domain: DomainIdmap = RID_Idmap(idmap_backend='RID')
     """ This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the \
     TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on \
     the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory \
@@ -237,7 +238,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, match_validator, NonEmptyString, single_argument_args,
@@ -195,7 +195,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel, NonEmptyString, NotRequired, single_argument_args, single_argument_result, ForUpdateMetaclass, Excluded,
@@ -405,7 +405,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
@@ -2,10 +2,12 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
-from middlewared.api.base import BaseModel, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+)
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
 
@@ -34,8 +36,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -38,7 +39,7 @@ class ReportingUpdateResult(BaseModel):
     """The updated reporting configuration."""
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -37,7 +37,7 @@ class GraphiteExporter(BaseModel):
     """Pattern to match charts for export (supports wildcards)."""
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_0/smb.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Literal, Self, Union
-from pydantic import AfterValidator, Field, field_validator, IPvAnyInterface, model_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator, IPvAnyInterface, model_validator
 from middlewared.api.base import (
     BaseModel,
     excluded_field,
@@ -496,7 +496,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, field_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
 from middlewared.validators import RE_MAC_ADDRESS
@@ -175,7 +175,7 @@ class CDROM(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -157,7 +157,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_1/acl.py
@@ -8,6 +8,7 @@ from middlewared.api.base import (
     RemoteUsername,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 from typing import Annotated, Literal, Self
 from middlewared.utils.filesystem.acl import (
@@ -36,7 +37,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_1/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_1/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -122,7 +122,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/common.py
+++ b/src/middlewared/middlewared/api/v25_10_1/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
+from middlewared.api.base import BaseModel, JsonSchemaExtra, TimeString
 from middlewared.utils import filters
 from middlewared.utils.cron import croniter_for_schedule
 
@@ -18,11 +18,14 @@ def validate_query_filters(qf: list) -> list:
 
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_query_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_1/directory_services.py
@@ -16,7 +16,8 @@ from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 
-from pydantic import Field, Secret, model_validator, field_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, model_validator, field_validator
 from typing import Annotated, Any, Literal
 
 __all__ = [
@@ -28,7 +29,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -182,7 +183,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -190,7 +191,7 @@ class PrimaryDomainIdmap(BaseModel):
     builtin: BuiltinDomainTdb = Field(default=BuiltinDomainTdb())
     """ UID and GID range configuration for automatically generated accounts linked to well-known and BUILTIN accounts \
     on Windows servers. """
-    idmap_domain: DomainIdmap
+    idmap_domain: DomainIdmap = RID_Idmap(idmap_backend='RID')
     """ This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the \
     TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on \
     the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory \
@@ -238,7 +239,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, match_validator, NonEmptyString, single_argument_args,
@@ -195,7 +195,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel, NonEmptyString, NotRequired, single_argument_args, single_argument_result, ForUpdateMetaclass, Excluded,
@@ -405,7 +405,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
@@ -2,11 +2,11 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
@@ -36,8 +36,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_1/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -38,7 +39,7 @@ class ReportingUpdateResult(BaseModel):
     """The updated reporting configuration."""
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_1/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -37,7 +37,7 @@ class GraphiteExporter(BaseModel):
     """Pattern to match charts for export (supports wildcards)."""
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_1/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_1/smb.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Literal, Self, Union
-from pydantic import AfterValidator, Field, field_validator, IPvAnyInterface, model_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator, IPvAnyInterface, model_validator
 from middlewared.api.base import (
     BaseModel,
     excluded_field,
@@ -590,7 +590,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_1/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, field_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
 from middlewared.validators import RE_MAC_ADDRESS
@@ -175,7 +175,7 @@ class CDROM(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_1/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -158,7 +158,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_2/acl.py
@@ -8,6 +8,7 @@ from middlewared.api.base import (
     RemoteUsername,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 from typing import Annotated, Literal, Self
 from middlewared.utils.filesystem.acl import (
@@ -36,7 +37,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_2/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_2/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -122,7 +122,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/common.py
+++ b/src/middlewared/middlewared/api/v25_10_2/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
+from middlewared.api.base import BaseModel, JsonSchemaExtra, TimeString
 from middlewared.utils import filters
 from middlewared.utils.cron import croniter_for_schedule
 
@@ -18,11 +18,14 @@ def validate_query_filters(qf: list) -> list:
 
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_query_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_2/directory_services.py
@@ -16,7 +16,8 @@ from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 
-from pydantic import Field, Secret, model_validator, field_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, model_validator, field_validator
 from typing import Annotated, Any, Literal
 
 __all__ = [
@@ -28,7 +29,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -182,7 +183,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -190,7 +191,7 @@ class PrimaryDomainIdmap(BaseModel):
     builtin: BuiltinDomainTdb = Field(default=BuiltinDomainTdb())
     """ UID and GID range configuration for automatically generated accounts linked to well-known and BUILTIN accounts \
     on Windows servers. """
-    idmap_domain: DomainIdmap
+    idmap_domain: DomainIdmap = RID_Idmap(idmap_backend='RID')
     """ This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the \
     TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on \
     the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory \
@@ -238,7 +239,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, match_validator, NonEmptyString, single_argument_args,
@@ -197,7 +197,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel, NonEmptyString, NotRequired, single_argument_args, single_argument_result, ForUpdateMetaclass, Excluded,
@@ -405,7 +405,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
@@ -2,11 +2,11 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
@@ -36,8 +36,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_2/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -38,7 +39,7 @@ class ReportingUpdateResult(BaseModel):
     """The updated reporting configuration."""
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_2/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -37,7 +37,7 @@ class GraphiteExporter(BaseModel):
     """Pattern to match charts for export (supports wildcards)."""
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_2/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_2/smb.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Literal, Self, Union
-from pydantic import AfterValidator, Field, field_validator, IPvAnyInterface, model_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator, IPvAnyInterface, model_validator
 from middlewared.api.base import (
     BaseModel,
     excluded_field,
@@ -590,7 +590,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_2/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, field_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
 from middlewared.validators import RE_MAC_ADDRESS
@@ -175,7 +175,7 @@ class CDROM(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_2/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -158,7 +158,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_3/acl.py
@@ -8,6 +8,7 @@ from middlewared.api.base import (
     RemoteUsername,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 from typing import Annotated, Literal, Self
 from middlewared.utils.filesystem.acl import (
@@ -36,7 +37,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_3/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_3/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -122,7 +122,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/common.py
+++ b/src/middlewared/middlewared/api/v25_10_3/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
+from middlewared.api.base import BaseModel, JsonSchemaExtra, TimeString
 from middlewared.utils import filters
 from middlewared.utils.cron import croniter_for_schedule
 
@@ -18,11 +18,14 @@ def validate_query_filters(qf: list) -> list:
 
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_query_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_3/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_3/directory_services.py
@@ -16,7 +16,8 @@ from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 
-from pydantic import Field, Secret, model_validator, field_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, model_validator, field_validator
 from typing import Annotated, Any, Literal
 
 __all__ = [
@@ -28,7 +29,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -182,7 +183,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -190,7 +191,7 @@ class PrimaryDomainIdmap(BaseModel):
     builtin: BuiltinDomainTdb = Field(default=BuiltinDomainTdb())
     """ UID and GID range configuration for automatically generated accounts linked to well-known and BUILTIN accounts \
     on Windows servers. """
-    idmap_domain: DomainIdmap
+    idmap_domain: DomainIdmap = RID_Idmap(idmap_backend='RID')
     """ This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the \
     TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on \
     the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory \
@@ -238,7 +239,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_3/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, match_validator, NonEmptyString, single_argument_args,
@@ -197,7 +197,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_3/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel, NonEmptyString, NotRequired, single_argument_args, single_argument_result, ForUpdateMetaclass, Excluded,
@@ -405,7 +405,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_3/pool_snapshot.py
@@ -2,11 +2,11 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
@@ -36,8 +36,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_3/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_3/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -38,7 +39,7 @@ class ReportingUpdateResult(BaseModel):
     """The updated reporting configuration."""
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_3/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_3/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -37,7 +37,7 @@ class GraphiteExporter(BaseModel):
     """Pattern to match charts for export (supports wildcards)."""
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_3/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_3/smb.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Literal, Self, Union
-from pydantic import AfterValidator, Field, field_validator, IPvAnyInterface, model_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator, IPvAnyInterface, model_validator
 from middlewared.api.base import (
     BaseModel,
     excluded_field,
@@ -590,7 +590,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_3/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, field_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
 from middlewared.validators import RE_MAC_ADDRESS
@@ -175,7 +175,7 @@ class CDROM(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_3/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_3/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -158,7 +158,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_4/acl.py
@@ -8,6 +8,7 @@ from middlewared.api.base import (
     RemoteUsername,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 from typing import Annotated, Literal, Self
 from middlewared.utils.filesystem.acl import (
@@ -36,7 +37,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_4/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_4/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, single_argument_args, ForUpdateMetaclass, NonEmptyString,
@@ -122,7 +122,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/common.py
+++ b/src/middlewared/middlewared/api/v25_10_4/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import Annotated, Self
 
-from middlewared.api.base import BaseModel, TimeString
+from middlewared.api.base import BaseModel, JsonSchemaExtra, TimeString
 from middlewared.utils import filters
 from middlewared.utils.cron import croniter_for_schedule
 
@@ -18,11 +18,14 @@ def validate_query_filters(qf: list) -> list:
 
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_query_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_query_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_4/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_4/directory_services.py
@@ -16,7 +16,8 @@ from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 
-from pydantic import Field, Secret, model_validator, field_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, model_validator, field_validator
 from typing import Annotated, Any, Literal
 
 __all__ = [
@@ -28,7 +29,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -182,7 +183,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -190,7 +191,7 @@ class PrimaryDomainIdmap(BaseModel):
     builtin: BuiltinDomainTdb = Field(default=BuiltinDomainTdb())
     """ UID and GID range configuration for automatically generated accounts linked to well-known and BUILTIN accounts \
     on Windows servers. """
-    idmap_domain: DomainIdmap
+    idmap_domain: DomainIdmap = RID_Idmap(idmap_backend='RID')
     """ This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the \
     TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs based on \
     the Active Directory account SID. Another common option is the AD backend, which reads predefined Active Directory \
@@ -238,7 +239,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_4/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, match_validator, NonEmptyString, single_argument_args,
@@ -197,7 +197,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_4/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel, NonEmptyString, NotRequired, single_argument_args, single_argument_result, ForUpdateMetaclass, Excluded,
@@ -405,7 +405,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_4/pool_snapshot.py
@@ -2,11 +2,11 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
@@ -36,8 +36,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_4/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_4/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -38,7 +39,7 @@ class ReportingUpdateResult(BaseModel):
     """The updated reporting configuration."""
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_4/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_4/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -37,7 +37,7 @@ class GraphiteExporter(BaseModel):
     """Pattern to match charts for export (supports wildcards)."""
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_4/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_4/smb.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Literal, Self, Union
-from pydantic import AfterValidator, Field, field_validator, IPvAnyInterface, model_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator, IPvAnyInterface, model_validator
 from middlewared.api.base import (
     BaseModel,
     excluded_field,
@@ -590,7 +590,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_4/virt_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, field_validator
+from pydantic import AfterValidator, Discriminator, Field, field_validator
 
 from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
 from middlewared.validators import RE_MAC_ADDRESS
@@ -175,7 +175,7 @@ class CDROM(Device):
 
 DeviceType: TypeAlias = Annotated[
     Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
-    Field(discriminator='dev_type')
+    Discriminator('dev_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_4/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_4/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, model_validator, RootModel, Secret
+from pydantic import ConfigDict, Discriminator, Field, model_validator, RootModel, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -158,7 +158,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -83,6 +83,7 @@ option_list = [
     "test_dir=",
     "tests=",
     "ha_license=",
+    "ha-license-path=",
     "hostname=",
     "show_locals"
 ]
@@ -156,6 +157,9 @@ for output, arg in myopts:
         test_dir = arg
     elif output == '--ha_license':
         ha_license = arg
+    elif output == '--ha-license-path':
+        with open(arg) as f:
+            ha_license = f.read().strip()
     elif output == '--show_locals':
         show_locals = True
 


### PR DESCRIPTION
## Problem

Several API fields that are declared *required* are silently treated as
**optional with a bogus default** at runtime. For example, on the current API
(v25_10_4):

    VMRAWDevice.path = '127.0.0.1'   # required path field, no default declared

`VMRAWDevice.path` is `path: NonEmptyString = Field(pattern=...)` — it should be
required, but it inherits `'127.0.0.1'` (leaked from `VMDisplayDevice.bind`).
So `vm.device.create` for a RAW device with no `path` passes validation and
silently uses `'127.0.0.1'` as the file path instead of being rejected.

## Root cause

Our shared string/number type aliases embed a single `Field()` instance, e.g.:

    NonEmptyString = Annotated[str, Field(min_length=1)]

Because the alias is a module-level constant, *every* field annotated
`NonEmptyString` shares that one `FieldInfo`. Pydantic 2.10's
`FieldInfo.merge_field_infos()` shallow-copies a `FieldInfo` (`copy.copy`) and
then mutates `copy._attributes_set` — but `copy.copy` shares the
`_attributes_set` dict, so the mutation lands on the *shared* instance:

  - A field declared `shell: NonEmptyString = "/usr/bin/zsh"` records
    `default` into the shared alias's `_attributes_set`.
  - A later field declared `target: NonEmptyString = Field(pattern=...)` rebuilds
    its `FieldInfo` from that polluted `_attributes_set` and inherits the stale
    `default`, becoming optional.

Which value leaks, and whether a given field is hit, depends purely on module
import order — making this an order-dependent latent bug across the whole API.
The same mechanism affects discriminated-union aliases
(`Annotated[A | B, Field(discriminator=...)]`) and every other shared alias that
embeds a `Field()`.

## Fix

Stop putting a `Field()` inside shared `Annotated` type aliases. Replace it with
plain, immutable annotated-metadata objects that have no mutable `_attributes_set`
for pydantic to pollute:

  - constraints (`min_length`, `max_length`, `ge/gt/le/lt`) → `annotated_types`
    (`MinLen`, `MaxLen`, `Ge`, `Gt`, `Le`)
  - `pattern` → `pydantic.StringConstraints`
  - `discriminator` → `pydantic.Discriminator`
  - `examples` / `json_schema_extra` / `description` → new `JsonSchemaExtra`
    helper (a frozen metadata object that merges keys into the generated JSON
    schema; see `api/base/types/json_schema.py` for the rationale)

Special cases:
  - `DomainIdmap` carried a `default=` inside its `Field(discriminator=...)`;
    `Discriminator` can't hold a default, so the default was relocated to the
    consuming field `idmap_domain` (behavior preserved).
  - `ExporterType` was `Annotated[GraphiteExporter, Field(discriminator=...)]` — a
    single-member "union". Since `Discriminator` requires a `Union`, and a
    one-member discriminated union is meaningless, it's collapsed to the bare
    type `GraphiteExporter`.
  - `QF_FIELD`'s redundant `default=[]` was dropped — every `QueryFilters`
    consumer already supplies its own default, so no call sites changed.