### PR TITLE
NAS-141224 / 27.0.0-BETA.1 / Let TrueNAS Connect self-heal after deregistration

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/__init__.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/__init__.py
@@ -24,6 +24,7 @@ from .config import TrueNASConnectConfigServicePart
 from .finalize_registration import finalize_registration_impl
 from .heartbeat import heartbeat_start_impl
 from .hostname import TNCHostnameService, on_general_config_update, update_ips
+from .internal import handle_tnc_deregistration
 from .post_install import post_install_process_impl
 from .private_models import (
     TrueNASConnectUpdateEnvironment,
@@ -129,6 +130,10 @@ class TrueNASConnectService(GenericConfigService[TrueNASConnectEntry]):
     @private
     async def heartbeat_start(self) -> None:
         return await heartbeat_start_impl(self.context)
+
+    @private
+    async def handle_deregistration(self) -> None:
+        return await handle_tnc_deregistration(self.context)
 
     @private
     @job(lock='tnc_finalize_registration')

--- a/src/middlewared/middlewared/plugins/truenas_connect/acme.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/acme.py
@@ -156,6 +156,17 @@ class TNCACMEService(Service):
 
         # acme_config returns a dict from truenas_connect_utils.acme — keep dict access
         acme_cfg = self.call_sync2(self.s.tn_connect.acme.config)
+        # A 401 here means TNC no longer recognises us (the node was deregistered cloud-side), not
+        # that renewal is unneeded. Route it into the same unset path the heartbeat uses instead of
+        # silently swallowing it as "renewal not needed". Must be checked before the generic error
+        # branch below since a 401 also populates 'error'. .get() guards acme_config's early-return
+        # (disabled/no creds) which omits 'status_code'.
+        if acme_cfg.get('status_code') == 401:
+            logger.warning(
+                'TNC ACME config returned 401 during renewal check; node appears deregistered, unsetting TNC'
+            )
+            self.call_sync2(self.s.tn_connect.handle_deregistration)
+            return False, None
         if acme_cfg['error']:
             logger.error(
                 'Failed to fetch TNC ACME configuration when checking renewal: %r', acme_cfg['error']

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -1,31 +1,25 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import datetime
 import logging
 from typing import Any
 
 from truenas_connect_utils.config import get_account_id_and_system_id
-from truenas_connect_utils.status import Status
 from truenas_connect_utils.urls import get_heartbeat_url
 
-from middlewared.alert.source.truenas_connect import (
-    TNCDisabledAutoUnconfiguredAlert,
-    TNCHeartbeatConnectionFailureAlert,
-)
+from middlewared.alert.source.truenas_connect import TNCHeartbeatConnectionFailureAlert
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.disks_.disk_class import iterate_disks
 from middlewared.utils.version import parse_version_string
 
-from .internal import config_internal, delete_cert, unset_registration_details
+from .internal import config_internal, handle_tnc_deregistration
 from .request import Mode, auth_headers, tnc_request
 from .utils import (
     CONFIGURED_TNC_STATES,
     HEARTBEAT_INTERVAL,
     calculate_sleep,
     decode_and_validate_token,
-    get_unset_payload,
 )
 
 logger = logging.getLogger('truenas_connect')
@@ -71,7 +65,7 @@ async def heartbeat_start_impl(context: ServiceContext) -> None:
     logger.debug('TNC Heartbeat: Starting heartbeat service')
     tnc_config = await config_internal(context)
     creds = get_account_id_and_system_id(tnc_config)
-    if tnc_config['status'] != Status.CONFIGURED.name or creds is None:
+    if tnc_config['status'] not in CONFIGURED_TNC_STATES or creds is None:
         raise CallError('TrueNAS Connect is not configured properly')
 
     heartbeat_url = get_heartbeat_url(tnc_config).format(
@@ -121,20 +115,7 @@ async def heartbeat_start_impl(context: ServiceContext) -> None:
                     sleep_error = True
                 case 401:
                     logger.debug('TNC Heartbeat: Received 401, unsetting TNC')
-                    with contextlib.suppress(Exception):
-                        # This is called to just make sure that we setup a self-signed certificate and
-                        # remove any alerts which might be there as we are going to unset TNC
-                        await unset_registration_details(context, False)
-
-                    await context.middleware.call('datastore.update', 'truenas_connect', tnc_config['id'], {
-                        'enabled': False,
-                    } | get_unset_payload())
-                    new_entry = await context.call2(context.s.tn_connect.config)
-                    context.middleware.send_event(
-                        'tn_connect.config', 'CHANGED', fields=new_entry.model_dump(),
-                    )
-                    await context.call2(context.s.alert.oneshot_create, TNCDisabledAutoUnconfiguredAlert())
-                    await delete_cert(context, tnc_config['certificate'])
+                    await handle_tnc_deregistration(context)
                     return
                 case 500:
                     logger.debug('TNC Heartbeat: Received 500')

--- a/src/middlewared/middlewared/plugins/truenas_connect/internal.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/internal.py
@@ -8,11 +8,12 @@ from truenas_connect_utils.config import get_account_id_and_system_id
 from truenas_connect_utils.status import Status
 from truenas_connect_utils.urls import get_account_service_url
 
+from middlewared.alert.source.truenas_connect import TNCDisabledAutoUnconfiguredAlert
 from middlewared.api.current import TrueNASConnectEntry
 from middlewared.service import CallError, ServiceContext
 
 from .request import auth_headers, tnc_request
-from .utils import CLAIM_TOKEN_CACHE_KEY, TNC_IPS_CACHE_KEY
+from .utils import CLAIM_TOKEN_CACHE_KEY, TNC_IPS_CACHE_KEY, get_unset_payload
 
 logger = logging.getLogger("truenas_connect")
 
@@ -98,6 +99,34 @@ async def delete_cert(context: ServiceContext, cert_id: int) -> None:
     await delete_job.wait()
     if delete_job.error:
         logger.error("Failed to delete TNC certificate: %s", delete_job.error)
+
+
+async def handle_tnc_deregistration(context: ServiceContext) -> None:
+    # Canonical handler for "TNC told us we are deregistered" (HTTP 401). This is the only path
+    # that auto-unsets TNC and removes its certificate, so both the heartbeat (on a 401 response)
+    # and the renewal check (on a 401 from the ACME config fetch) route through it.
+    # Idempotent: a no-op once TNC is already unset, so concurrent callers are safe.
+    tnc_config = await config_internal(context)
+    if tnc_config["status"] == Status.DISABLED.name and tnc_config["certificate"] is None:
+        logger.debug("TNC already deregistered/unset, nothing to do")
+        return
+
+    logger.debug("Handling TNC deregistration (401), unsetting TNC")
+    with contextlib.suppress(Exception):
+        # Make sure we set up a self-signed certificate and clear any alerts as we are going to
+        # unset TNC. revoke_cert_and_account is False because TNC has already catered to these
+        # cases on its end (the 401 means it no longer knows about us).
+        await unset_registration_details(context, False)
+
+    await context.middleware.call("datastore.update", DATASTORE, tnc_config["id"], {
+        "enabled": False,
+    } | get_unset_payload())
+    new_entry = await context.call2(context.s.tn_connect.config)
+    context.middleware.send_event("tn_connect.config", "CHANGED", fields=new_entry.model_dump())
+    await context.call2(context.s.alert.oneshot_create, TNCDisabledAutoUnconfiguredAlert())
+
+    if tnc_config["certificate"] is not None:
+        await delete_cert(context, tnc_config["certificate"])
 
 
 async def ha_vips(context: ServiceContext) -> list[str]:

--- a/src/middlewared/middlewared/plugins/truenas_connect/state.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/state.py
@@ -30,8 +30,13 @@ async def state_check_impl(context: ServiceContext, restart_ui: bool = False) ->
     ):
         logger.debug('Middleware started and cert generation is already successful, updating UI')
         context.middleware.create_task(context.call2(context.s.tn_connect.acme.update_ui))
-    elif tnc_config.status == Status.CERT_RENEWAL_IN_PROGRESS.name:
-        logger.debug('Middleware started and cert renewal is in progress, initiating process')
+    elif tnc_config.status in (
+        Status.CERT_RENEWAL_IN_PROGRESS.name, Status.CERT_RENEWAL_FAILURE.name,
+    ):
+        # CERT_RENEWAL_FAILURE is included so a box that booted after a failed renewal re-attempts
+        # it. renew_cert re-runs check_renewal_needed and no-ops if renewal is not actually due, and
+        # a 401 there now routes into the unset path.
+        logger.debug('Middleware started and cert renewal needs to be (re)attempted, initiating process')
         context.middleware.create_task(context.call2(context.s.tn_connect.acme.renew_cert))
 
     if tnc_config.status in CONFIGURED_TNC_STATES:

--- a/src/middlewared/middlewared/plugins/truenas_connect/utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/utils.py
@@ -11,6 +11,10 @@ CONFIGURED_TNC_STATES = (
     Status.CONFIGURED.name,
     Status.CERT_RENEWAL_IN_PROGRESS.name,
     Status.CERT_RENEWAL_SUCCESS.name,
+    # A renewal failure still leaves a configured box (enabled, serving its old cert with a live
+    # registration). The heartbeat must keep running in this state so it can receive a 401 and
+    # self-unset if the node was deregistered cloud-side; IP sync should likewise continue.
+    Status.CERT_RENEWAL_FAILURE.name,
 )
 HEARTBEAT_INTERVAL = 120
 TNC_CERT_PREFIX = 'truenas_connect_'

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -2,12 +2,13 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from truenas_connect_utils.status import Status
 
 from middlewared.api.current import TrueNASConnectEntry
 from middlewared.plugins.truenas_connect.config import TrueNASConnectConfigServicePart
 from middlewared.plugins.truenas_connect.hostname import TNCHostnameService
-from middlewared.plugins.truenas_connect.utils import TNC_IPS_CACHE_KEY
-from middlewared.service import ValidationErrors
+from middlewared.plugins.truenas_connect.utils import CONFIGURED_TNC_STATES, TNC_IPS_CACHE_KEY
+from middlewared.service import CallError, ValidationErrors
 
 
 def make_tnc_entry(**overrides: Any) -> TrueNASConnectEntry:
@@ -459,3 +460,219 @@ class TestTNCHostnameService:
         assert cache_put_args[0] == TNC_IPS_CACHE_KEY
         assert cache_put_args[1] == []
         service.middleware.call_hook.assert_not_called()
+
+
+class _HeartbeatLoopReached(Exception):
+    """Raised by the patched heartbeat request so tests can prove the start guard was passed."""
+
+
+async def _run_heartbeat(status: str, creds: dict | None):
+    """Drive heartbeat_start_impl just past its start guard.
+
+    Everything between the guard and the first request is patched out; the request itself raises
+    _HeartbeatLoopReached. So: guard rejected -> CallError; guard passed -> _HeartbeatLoopReached.
+    """
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock(return_value='25.10.0')
+
+    with patch.object(hb, 'config_internal', new=AsyncMock(return_value={'status': status, 'id': 1})), \
+            patch.object(hb, 'get_account_id_and_system_id', return_value=creds), \
+            patch.object(hb, 'get_heartbeat_url', return_value='http://hb/{system_id}/{version}'), \
+            patch.object(hb, 'parse_version_string', return_value='25.10'), \
+            patch.object(hb, 'iterate_disks', return_value=[]), \
+            patch.object(hb, '_build_payload', new=AsyncMock(return_value={})), \
+            patch.object(hb, '_heartbeat_request', new=AsyncMock(side_effect=_HeartbeatLoopReached())):
+        await hb.heartbeat_start_impl(ctx)
+
+
+@pytest.mark.parametrize('status', [
+    Status.CONFIGURED.name,
+    Status.CERT_RENEWAL_IN_PROGRESS.name,
+    Status.CERT_RENEWAL_SUCCESS.name,
+    Status.CERT_RENEWAL_FAILURE.name,
+])
+@pytest.mark.asyncio
+async def test_heartbeat_guard_passes_for_configured_states(status):
+    """With valid creds, the heartbeat enters its loop (does not raise the guard CallError)."""
+    creds = {'account_id': 'a', 'system_id': 's'}
+    with pytest.raises(_HeartbeatLoopReached):
+        await _run_heartbeat(status, creds)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_guard_rejects_unconfigured_state():
+    """A non-configured status is rejected before any request is made."""
+    creds = {'account_id': 'a', 'system_id': 's'}
+    with pytest.raises(CallError):
+        await _run_heartbeat(Status.REGISTRATION_FINALIZATION_FAILED.name, creds)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_guard_rejects_when_no_creds():
+    """Missing creds is rejected even in a configured state."""
+    with pytest.raises(CallError):
+        await _run_heartbeat(Status.CONFIGURED.name, None)
+
+
+def test_cert_renewal_failure_is_configured_state():
+    assert Status.CERT_RENEWAL_FAILURE.name in CONFIGURED_TNC_STATES
+
+
+@pytest.mark.asyncio
+async def test_sync_ips_proceeds_in_renewal_failure():
+    """sync_ips must not early-return when the box is in CERT_RENEWAL_FAILURE."""
+    service = TNCHostnameService(MagicMock())
+    service.config = AsyncMock(return_value={})
+    service.register_update_ips = AsyncMock(return_value={'error': None})
+    service.middleware.call2 = AsyncMock(
+        return_value=make_tnc_entry(status=Status.CERT_RENEWAL_FAILURE.name),
+    )
+    service.middleware.call_hook = AsyncMock()
+
+    async def mock_middleware_call(method, *args, **kwargs):
+        if method == 'failover.is_single_master_node':
+            return True
+        elif method == 'system.general.config':
+            return {'ui_address': ['0.0.0.0'], 'ui_v6address': ['::']}
+        elif method == 'cache.get':
+            raise KeyError('miss')
+        elif method == 'cache.put':
+            return None
+        raise ValueError(f'Unexpected: {method}')
+
+    service.middleware.call = AsyncMock(side_effect=mock_middleware_call)
+
+    with patch(
+        'middlewared.plugins.truenas_connect.hostname.get_effective_ips',
+        new_callable=AsyncMock, return_value=['192.168.1.10'],
+    ):
+        await service.sync_ips(event_details={'type': 'ipaddress.change', 'iface': 'ens3'})
+
+    service.register_update_ips.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_deregistration_unsets_and_deletes_cert():
+    """A configured box with a cert is unset, an alert raised, and the cert deleted."""
+    from middlewared.plugins.truenas_connect import internal
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock()
+    ctx.middleware.send_event = MagicMock()
+    ctx.call2 = AsyncMock(return_value=MagicMock(model_dump=MagicMock(return_value={})))
+
+    with patch.object(
+        internal, 'config_internal',
+        new=AsyncMock(return_value={'status': Status.CONFIGURED.name, 'certificate': 15, 'id': 1}),
+    ), patch.object(internal, 'unset_registration_details', new=AsyncMock()) as unset, \
+            patch.object(internal, 'delete_cert', new=AsyncMock()) as delete_cert:
+        await internal.handle_tnc_deregistration(ctx)
+
+    unset.assert_awaited_once_with(ctx, False)
+    delete_cert.assert_awaited_once_with(ctx, 15)
+    ctx.middleware.send_event.assert_called_once()
+    # datastore.update flips enabled off and applies the unset payload
+    update_call = next(
+        c for c in ctx.middleware.call.call_args_list if c.args[0] == 'datastore.update'
+    )
+    payload = update_call.args[3]
+    assert payload['enabled'] is False
+    assert payload['certificate'] is None
+    assert payload['status'] == Status.DISABLED.name
+
+
+@pytest.mark.asyncio
+async def test_handle_deregistration_noop_when_already_unset():
+    """Idempotent: already DISABLED with no cert performs no datastore write or cert delete."""
+    from middlewared.plugins.truenas_connect import internal
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock()
+    ctx.call2 = AsyncMock()
+
+    with patch.object(
+        internal, 'config_internal',
+        new=AsyncMock(return_value={'status': Status.DISABLED.name, 'certificate': None, 'id': 1}),
+    ), patch.object(internal, 'unset_registration_details', new=AsyncMock()) as unset, \
+            patch.object(internal, 'delete_cert', new=AsyncMock()) as delete_cert:
+        await internal.handle_tnc_deregistration(ctx)
+
+    unset.assert_not_called()
+    delete_cert.assert_not_called()
+    ctx.middleware.call.assert_not_called()
+
+
+def _make_acme_service(acme_cfg):
+    """Build a TNCACMEService whose call_sync2 dispatches by service-shortcut identity.
+
+    Returns (service, dereg_calls); dereg_calls records when handle_deregistration is invoked.
+    """
+    from middlewared.plugins.truenas_connect.acme import TNCACMEService
+
+    service = TNCACMEService(MagicMock())
+    service.middleware.call_sync2 = MagicMock(return_value=MagicMock(certificate='PEM'))
+    dereg_calls = []
+
+    def dispatch(target, *args, **kwargs):
+        if target is service.s.tn_connect.config:
+            return MagicMock(certificate=15)
+        if target is service.s.tn_connect.acme.config:
+            return acme_cfg
+        if target is service.s.tn_connect.handle_deregistration:
+            dereg_calls.append(True)
+            return None
+        raise AssertionError(f'unexpected call_sync2 target: {target}')
+
+    service.call_sync2 = MagicMock(side_effect=dispatch)
+    return service, dereg_calls
+
+
+def test_check_renewal_401_routes_to_deregistration():
+    service, dereg_calls = _make_acme_service(
+        {'status_code': 401, 'error': "HTTP 401: 'Unauthorized'", 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == [True]
+
+
+def test_check_renewal_non_401_error_does_not_deregister():
+    service, dereg_calls = _make_acme_service(
+        {'status_code': 500, 'error': 'HTTP 500: boom', 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == []
+
+
+def test_check_renewal_error_without_status_code_does_not_deregister():
+    """acme_config's early-return omits status_code; .get() must not raise or trigger dereg."""
+    service, dereg_calls = _make_acme_service(
+        {'error': 'TrueNAS Connect is not enabled or not configured properly', 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == []
+
+
+@pytest.mark.asyncio
+async def test_state_check_failure_triggers_renew_and_heartbeat():
+    from middlewared.plugins.truenas_connect import state as state_mod
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.create_task = MagicMock()
+    ctx.call2 = AsyncMock(return_value=make_tnc_entry(status=Status.CERT_RENEWAL_FAILURE.name))
+
+    await state_mod.state_check_impl(ctx, restart_ui=False)
+
+    # One task for renew_cert (recovery branch) + one for heartbeat_start (CONFIGURED_TNC_STATES).
+    assert ctx.middleware.create_task.call_count == 2


### PR DESCRIPTION
This commit fixes an issue where a TrueNAS Connect certificate could not be deleted (even with force) because TNC stayed wedged in a renewal state and never auto-unset itself. The heartbeat is the only thing that unsets TNC and removes its cert when it gets a 401, but its start guard only allowed the CONFIGURED state while the loop it guards ran across all configured states, so it died immediately in CERT_RENEWAL_IN_PROGRESS/SUCCESS/FAILURE and never saw the 401 that signals deregistration.

We widen the guard to match the loop, add CERT_RENEWAL_FAILURE to the configured states (with a boot-time renewal retry), and surface a 401 from the renewal check into the same unset path instead of swallowing it as "renewal not needed".