### PR TITLE
NAS-141238 / 27.0.0-BETA.1 / midcli: safeguard for possible memory leaks in python-prompt-toolkit

### DIFF
--- a/src/freenas/etc/systemd/system/getty@tty1.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/getty@tty1.service.d/override.conf
@@ -9,3 +9,5 @@ StandardOutput=tty
 StartLimitBurst=0
 # Do not overload the system with momentary infinite restarts in case something goes wrong
 RestartSec=5
+# Safeguard for possible memory leaks in python-prompt-toolkit
+MemoryMax=512M


### PR DESCRIPTION
The actual issue is fixed by https://github.com/truenas/midcli/pull/130