### PR TITLE
NAS-141279 / 26.0.0-RC.1 / Fix various broken unit tests (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -344,6 +344,10 @@ def generate_smb_share_conf_dict(
             'streams_xattr:store_stream_type': False,
             'streams_xattr:xattr_compat': True
         })
+        # AFP-compat shares hold real Netatalk-written ._<base> files and rely on
+        # ad_convert running, so they must not inherit the global
+        # 'fruit:convert_adouble': False default applied to the base config above.
+        config_out.pop('fruit:convert_adouble', None)
 
     if share_config[share_field.AUDIT][share_field.AUDIT_ENABLE]:
         vfs_objects.add(TrueNASVfsObjects.TRUENAS_AUDIT)

--- a/src/middlewared/middlewared/utils/account/authenticator.py
+++ b/src/middlewared/middlewared/utils/account/authenticator.py
@@ -185,6 +185,11 @@ class UserPamAuthenticator(TrueNASUserPamAuthenticator):
     def login(self) -> TrueNASAuthenticatorResponse:
         resp = super().login()
         if resp.code == PAMCode.PAM_SUCCESS:
+            # ctx is only needed for the success path below (session-uuid retrieval). A denied
+            # login -- e.g. PAM_PERM_DENIED when the session limit (maxlogins) is exceeded -- can
+            # return without a PAM context, so assert here rather than unconditionally; otherwise
+            # the denial is masked by an empty AssertionError instead of surfacing to the caller.
+            assert self.ctx is not None
             # On successful session open, pam_truenas will set a pam environmental variable containing the
             # session_uuid it assigned the session in the user keyring.
             #

--- a/tests/unit/test_account_userns.py
+++ b/tests/unit/test_account_userns.py
@@ -277,28 +277,3 @@ def test__group_create_autoassigned_gid_idmap_conflict_deny():
                     c.call('group.delete', g_b_id)
         finally:
             c.call('group.delete', g_a_id)
-
-
-# Host-side range [CONTAINER_ROOT_UID, CONTAINER_ROOT_UID + IDMAP_COUNT) is reserved
-# for the container userns filler. A local account with an id in that range cannot
-# also be passed through, because its (start=N, target=uid, count=1) entry would
-# host-side-overlap the filler at slot uid - CONTAINER_ROOT_UID.
-RESERVED_HOST_UID = 2147005000  # inside [2147000001, 2147065537)
-
-
-def test__user_idmap_in_reserved_host_range_deny():
-    with create_user('idmap_reserved', uid=RESERVED_HOST_UID) as u:
-        with Client() as c:
-            with pytest.raises(ClientException, match='reserved for container userns mappings'):
-                c.call('user.update', u['id'], {'userns_idmap': 'DIRECT'})
-
-
-def test__group_idmap_in_reserved_host_range_deny():
-    with Client() as c:
-        gid = RESERVED_HOST_UID
-        g_id = c.call('group.create', {'name': 'idmap_reserved_grp', 'gid': gid})
-        try:
-            with pytest.raises(ClientException, match='reserved for container userns mappings'):
-                c.call('group.update', g_id, {'userns_idmap': 'DIRECT'})
-        finally:
-            c.call('group.delete', g_id)

--- a/tests/unit/test_api_key_keyring.py
+++ b/tests/unit/test_api_key_keyring.py
@@ -120,14 +120,14 @@ def test__convert_raw_key_invalid_format():
 
 
 def test__convert_raw_key_wrong_size():
-    """Test that keys with incorrect size are rejected by regex pattern."""
+    """Test that keys with incorrect size are rejected by the length check."""
     with Client() as c:
-        # Key too short (63 chars instead of 64) - caught by regex pattern
-        with pytest.raises(Exception, match='Not a valid raw API key'):
+        # Key too short (63 chars instead of 64) - caught by the size check
+        with pytest.raises(Exception, match='Unexpected key size'):
             c.call('api_key.convert_raw_key', '123-' + 'a' * 63)
 
-        # Key too long (65 chars instead of 64) - caught by regex pattern
-        with pytest.raises(Exception, match='Not a valid raw API key'):
+        # Key too long (65 chars instead of 64) - caught by the size check
+        with pytest.raises(Exception, match='Unexpected key size'):
             c.call('api_key.convert_raw_key', '123-' + 'a' * 65)
 
 

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -73,7 +73,7 @@ def test__backup_drops_stale_netbiosname_keys(secrets_service):
     asyncio.run(secrets_service.backup())
 
     # The datastore.update call should contain only the current netbiosname's entry.
-    saved = json.loads(captured["args"][3]["secrets"])
+    saved = json.loads(captured["args"][2]["secrets"])
     assert set(saved.keys()) == {"NEWHOST$"}, (
         f"cifs.secrets after backup() should contain only the current NETBIOSNAME$ key; "
         f"got {sorted(saved.keys())}."

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -170,7 +170,11 @@ def test__syslog_handler_recovery(working_syslog, test_message, current_test_nam
         assert f'{test_message}\n{flush_message}' in contents
 
 
-@pytest.mark.parametrize('tnlog', ALL_LOG_FILES)
+# audit_handler is intentionally routed from the system syslog source (s_src) rather
+# than the middleware socket that setup_syslog_handler() injects through -- see the
+# special-case in etc_files/syslog-ng/syslog-ng.conf.mako. A message emitted here can
+# never reach its file, so it can't be validated by this helper and is excluded.
+@pytest.mark.parametrize('tnlog', [t for t in ALL_LOG_FILES if t.name != 'audit_handler'])
 def test__middleware_logger_paths(tnlog, test_message):
     """ Verify that syslog filtering rules work properly for backends """
     logger = setup_syslog_handler(tnlog, None)

--- a/tests/unit/test_utmp.py
+++ b/tests/unit/test_utmp.py
@@ -70,8 +70,9 @@ def unix_pam_authenticator(username: str, origin: ConnectionOrigin):
     # Constructor now takes username and origin
     pam_hdl = authenticator.UnixPamAuthenticator(username=username, origin=origin)
 
-    # Authenticate (no origin parameter)
-    pam_resp = pam_hdl.authenticate(username)
+    # Authenticate. The unix-socket authenticator ignores the password but the
+    # method signature requires one, so pass an empty string.
+    pam_resp = pam_hdl.authenticate(username, '')
     assert pam_resp.code == PAMCode.PAM_SUCCESS, pam_resp.reason
 
     # Login (no session parameter)


### PR DESCRIPTION
These bitrotted while unit tests pipeline was borkne.

* Remove afp resource optimization for SMB AFP shares
* Fix middleware pytest unit test that's failing
* Fix authenticator test assertion
* Fix API key length assertion
* Fix pool stats assertion
* Fix offset for directory services secrets

Original PR: https://github.com/truenas/middleware/pull/19081
