### PR TITLE
NAS-141224 / 26.0.0-RC.1 / Let TrueNAS Connect self-heal after deregistration (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/acme.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/acme.py
@@ -134,6 +134,17 @@ class TNCACMEService(Service):
             return True, None
 
         acme_config = self.middleware.call_sync('tn_connect.acme.config')
+        # A 401 here means TNC no longer recognises us (the node was deregistered cloud-side), not
+        # that renewal is unneeded. Route it into the same unset path the heartbeat uses instead of
+        # silently swallowing it as "renewal not needed". Must be checked before the generic error
+        # branch below since a 401 also populates 'error'. .get() guards acme_config's early-return
+        # (disabled/no creds) which omits 'status_code'.
+        if acme_config.get('status_code') == 401:
+            logger.warning(
+                'TNC ACME config returned 401 during renewal check; node appears deregistered, unsetting TNC'
+            )
+            self.middleware.call_sync('tn_connect.handle_tnc_deregistration')
+            return False, None
         if acme_config['error']:
             logger.error(
                 'Failed to fetch TNC ACME configuration when checking renewal: %r', acme_config['error']

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -1,10 +1,8 @@
 import asyncio
-import contextlib
 import datetime
 import logging
 
 from truenas_connect_utils.config import get_account_id_and_system_id
-from truenas_connect_utils.status import Status
 from truenas_connect_utils.urls import get_heartbeat_url
 
 from middlewared.service import CallError, Service
@@ -13,7 +11,7 @@ from middlewared.utils.version import parse_version_string
 
 from .mixin import TNCAPIMixin
 from .utils import (
-    calculate_sleep, CONFIGURED_TNC_STATES, decode_and_validate_token, get_unset_payload, HEARTBEAT_INTERVAL,
+    calculate_sleep, CONFIGURED_TNC_STATES, decode_and_validate_token, HEARTBEAT_INTERVAL,
 )
 
 
@@ -34,7 +32,7 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
         logger.debug('TNC Heartbeat: Starting heartbeat service')
         tnc_config = await self.middleware.call('tn_connect.config_internal')
         creds = get_account_id_and_system_id(tnc_config)
-        if tnc_config['status'] != Status.CONFIGURED.name or creds is None:
+        if tnc_config['status'] not in CONFIGURED_TNC_STATES or creds is None:
             raise CallError('TrueNAS Connect is not configured properly')
 
         heartbeat_url = get_heartbeat_url(tnc_config).format(
@@ -82,19 +80,7 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
                         sleep_error = True
                     case 401:
                         logger.debug('TNC Heartbeat: Received 401, unsetting TNC')
-                        with contextlib.suppress(Exception):
-                            # This is called to just make sure that we setup a self-signed certificate and
-                            # remove any alerts which might be there as we are going to unset TNC
-                            await self.middleware.call('tn_connect.unset_registration_details', False)
-
-                        await self.middleware.call('datastore.update', 'truenas_connect', tnc_config['id'], {
-                            'enabled': False,
-                        } | get_unset_payload())
-                        self.middleware.send_event(
-                            'tn_connect.config', 'CHANGED', fields=await self.middleware.call('tn_connect.config')
-                        )
-                        await self.middleware.call('alert.oneshot_create', 'TNCDisabledAutoUnconfigured', None)
-                        await self.middleware.call('tn_connect.delete_cert', tnc_config['certificate'])
+                        await self.middleware.call('tn_connect.handle_tnc_deregistration')
                         return
                     case 500:
                         logger.debug('TNC Heartbeat: Received 500')

--- a/src/middlewared/middlewared/plugins/truenas_connect/state.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/state.py
@@ -34,8 +34,13 @@ class TrueNASConnectStateService(Service):
         ):
             logger.debug('Middleware started and cert generation is already successful, updating UI')
             self.middleware.create_task(self.middleware.call('tn_connect.acme.update_ui'))
-        elif tnc_config['status'] == Status.CERT_RENEWAL_IN_PROGRESS.name:
-            logger.debug('Middleware started and cert renewal is in progress, initiating process')
+        elif tnc_config['status'] in (
+            Status.CERT_RENEWAL_IN_PROGRESS.name, Status.CERT_RENEWAL_FAILURE.name,
+        ):
+            # CERT_RENEWAL_FAILURE is included so a box that booted after a failed renewal re-attempts
+            # it. renew_cert re-runs check_renewal_needed and no-ops if renewal is not actually due, and
+            # a 401 there now routes into the unset path.
+            logger.debug('Middleware started and cert renewal needs to be (re)attempted, initiating process')
             self.middleware.create_task(self.middleware.call('tn_connect.acme.renew_cert'))
 
         if tnc_config['status'] in CONFIGURED_TNC_STATES:

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -263,6 +263,32 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         if delete_job.error:
             logger.error('Failed to delete TNC certificate: %s', delete_job.error)
 
+    @private
+    async def handle_tnc_deregistration(self):
+        # Canonical handler for "TNC told us we are deregistered" (HTTP 401). This is the only path
+        # that auto-unsets TNC and removes its certificate, so both the heartbeat (on a 401 response)
+        # and the renewal check (on a 401 from the ACME config fetch) route through it.
+        # Idempotent: a no-op once TNC is already unset, so concurrent callers are safe.
+        tnc_config = await self.config_internal()
+        if tnc_config['status'] == Status.DISABLED.name and tnc_config['certificate'] is None:
+            logger.debug('TNC already deregistered/unset, nothing to do')
+            return
+
+        logger.debug('Handling TNC deregistration (401), unsetting TNC')
+        with contextlib.suppress(Exception):
+            # Make sure we set up a self-signed certificate and clear any alerts as we are going to
+            # unset TNC. revoke_cert_and_account is False because TNC has already catered to these
+            # cases on its end (the 401 means it no longer knows about us).
+            await self.unset_registration_details(False)
+
+        await self.middleware.call('datastore.update', 'truenas_connect', tnc_config['id'], {
+            'enabled': False,
+        } | get_unset_payload())
+        self.middleware.send_event('tn_connect.config', 'CHANGED', fields=await self.config())
+        await self.middleware.call('alert.oneshot_create', 'TNCDisabledAutoUnconfigured', None)
+        if tnc_config['certificate'] is not None:
+            await self.delete_cert(tnc_config['certificate'])
+
     @api_method(
         TrueNASConnectIpChoicesArgs, TrueNASConnectIpChoicesResult, roles=['TRUENAS_CONNECT_READ'], removed_in='v26',
     )

--- a/src/middlewared/middlewared/plugins/truenas_connect/utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/utils.py
@@ -13,6 +13,10 @@ CONFIGURED_TNC_STATES = (
     Status.CONFIGURED.name,
     Status.CERT_RENEWAL_IN_PROGRESS.name,
     Status.CERT_RENEWAL_SUCCESS.name,
+    # A renewal failure still leaves a configured box (enabled, serving its old cert with a live
+    # registration). The heartbeat must keep running in this state so it can receive a 401 and
+    # self-unset if the node was deregistered cloud-side; IP sync should likewise continue.
+    Status.CERT_RENEWAL_FAILURE.name,
 )
 HEARTBEAT_INTERVAL = 120
 TNC_CERT_PREFIX = 'truenas_connect_'

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -1,10 +1,15 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from middlewared.service import ValidationErrors
+from truenas_connect_utils.status import Status
+
+from middlewared.service import CallError, ValidationErrors
+from middlewared.plugins.truenas_connect.acme import TNCACMEService
+from middlewared.plugins.truenas_connect.heartbeat import TNCHeartbeatService
+from middlewared.plugins.truenas_connect.state import TrueNASConnectStateService
 from middlewared.plugins.truenas_connect.update import TrueNASConnectService
 from middlewared.plugins.truenas_connect.hostname import TNCHostnameService
-from middlewared.plugins.truenas_connect.utils import TNC_IPS_CACHE_KEY
+from middlewared.plugins.truenas_connect.utils import CONFIGURED_TNC_STATES, TNC_IPS_CACHE_KEY
 
 
 @pytest.fixture
@@ -389,3 +394,191 @@ class TestTNCHostnameService:
         assert cache_put_args[0] == TNC_IPS_CACHE_KEY
         assert cache_put_args[1] == []
         service.middleware.call_hook.assert_not_called()
+
+
+def test_cert_renewal_failure_is_configured_state():
+    assert Status.CERT_RENEWAL_FAILURE.name in CONFIGURED_TNC_STATES
+
+
+@pytest.mark.asyncio
+async def test_handle_deregistration_unsets_and_deletes_cert():
+    """A configured box with a cert is unset, an alert raised, and the cert deleted."""
+    service = TrueNASConnectService(MagicMock())
+    service.config_internal = AsyncMock(
+        return_value={'status': Status.CONFIGURED.name, 'certificate': 15, 'id': 1},
+    )
+    service.config = AsyncMock(return_value={'id': 1})
+    service.unset_registration_details = AsyncMock()
+    service.delete_cert = AsyncMock()
+    service.middleware.send_event = MagicMock()
+
+    calls = []
+
+    async def mock_call(method, *args, **kwargs):
+        calls.append((method, args))
+        return None
+
+    service.middleware.call = AsyncMock(side_effect=mock_call)
+
+    await service.handle_tnc_deregistration()
+
+    service.unset_registration_details.assert_awaited_once_with(False)
+    service.delete_cert.assert_awaited_once_with(15)
+    service.middleware.send_event.assert_called_once()
+    update_call = next(c for c in calls if c[0] == 'datastore.update')
+    payload = update_call[1][2]
+    assert payload['enabled'] is False
+    assert payload['certificate'] is None
+    assert payload['status'] == Status.DISABLED.name
+    assert any(c[0] == 'alert.oneshot_create' and c[1][0] == 'TNCDisabledAutoUnconfigured' for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_handle_deregistration_noop_when_already_unset():
+    """Idempotent: already DISABLED with no cert performs no datastore write or cert delete."""
+    service = TrueNASConnectService(MagicMock())
+    service.config_internal = AsyncMock(
+        return_value={'status': Status.DISABLED.name, 'certificate': None, 'id': 1},
+    )
+    service.unset_registration_details = AsyncMock()
+    service.delete_cert = AsyncMock()
+    service.middleware.call = AsyncMock()
+
+    await service.handle_tnc_deregistration()
+
+    service.unset_registration_details.assert_not_called()
+    service.delete_cert.assert_not_called()
+    service.middleware.call.assert_not_called()
+
+
+def _make_acme_service(acme_cfg):
+    """Build a TNCACMEService whose call_sync dispatches by method name.
+
+    Returns (service, dereg_calls); dereg_calls records when handle_tnc_deregistration is invoked.
+    """
+    service = TNCACMEService(MagicMock())
+    dereg_calls = []
+
+    def call_sync(method, *args, **kwargs):
+        if method == 'tn_connect.config':
+            return {'certificate': 15}
+        if method == 'certificate.get_instance':
+            return {'certificate': 'PEM'}
+        if method == 'tn_connect.acme.config':
+            return acme_cfg
+        if method == 'tn_connect.handle_tnc_deregistration':
+            dereg_calls.append(True)
+            return None
+        raise AssertionError(f'unexpected call_sync: {method}')
+
+    service.middleware.call_sync = MagicMock(side_effect=call_sync)
+    return service, dereg_calls
+
+
+def test_check_renewal_401_routes_to_deregistration():
+    service, dereg_calls = _make_acme_service(
+        {'status_code': 401, 'error': "HTTP 401: 'Unauthorized'", 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == [True]
+
+
+def test_check_renewal_non_401_error_does_not_deregister():
+    service, dereg_calls = _make_acme_service(
+        {'status_code': 500, 'error': 'HTTP 500: boom', 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == []
+
+
+def test_check_renewal_error_without_status_code_does_not_deregister():
+    """acme_config's early-return omits status_code; .get() must not raise or trigger dereg."""
+    service, dereg_calls = _make_acme_service(
+        {'error': 'TrueNAS Connect is not enabled or not configured properly', 'acme_details': {}},
+    )
+    with patch('middlewared.plugins.truenas_connect.acme.get_cert_id', return_value='cid'):
+        result = service.check_renewal_needed()
+    assert result == (False, None)
+    assert dereg_calls == []
+
+
+@pytest.mark.asyncio
+async def test_state_check_failure_triggers_renew_and_heartbeat():
+    """Booting in CERT_RENEWAL_FAILURE re-attempts renewal and starts the heartbeat."""
+    service = TrueNASConnectStateService(MagicMock())
+    service.middleware.create_task = MagicMock()
+
+    async def mock_call(method, *args, **kwargs):
+        if method == 'tn_connect.config':
+            return {'status': Status.CERT_RENEWAL_FAILURE.name}
+        return None
+
+    service.middleware.call = AsyncMock(side_effect=mock_call)
+
+    await service.check(restart_ui=False)
+
+    # One task for renew_cert (recovery branch) + one for heartbeat.start (CONFIGURED_TNC_STATES).
+    assert service.middleware.create_task.call_count == 2
+
+
+class _HeartbeatLoopReached(Exception):
+    """Raised by the patched heartbeat request so tests can prove the start guard was passed."""
+
+
+async def _run_heartbeat_start(status: str, creds: dict | None):
+    """Drive TNCHeartbeatService.start just past its guard.
+
+    The request call is patched to raise _HeartbeatLoopReached: guard rejected -> CallError;
+    guard passed -> _HeartbeatLoopReached.
+    """
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    service = TNCHeartbeatService(MagicMock())
+    service.payload = AsyncMock(return_value={})
+    service.call = AsyncMock(side_effect=_HeartbeatLoopReached())
+
+    async def mock_call(method, *args, **kwargs):
+        if method == 'tn_connect.config_internal':
+            return {'status': status, 'id': 1}
+        if method == 'system.version_short':
+            return '25.10'
+        return None
+
+    service.middleware.call = AsyncMock(side_effect=mock_call)
+
+    with patch.object(hb, 'get_account_id_and_system_id', return_value=creds), \
+            patch.object(hb, 'get_heartbeat_url', return_value='http://hb/{system_id}/{version}'), \
+            patch.object(hb, 'parse_version_string', return_value='25.10'), \
+            patch.object(hb, 'iterate_disks', return_value=[]):
+        await service.start()
+
+
+@pytest.mark.parametrize('status', [
+    Status.CONFIGURED.name,
+    Status.CERT_RENEWAL_IN_PROGRESS.name,
+    Status.CERT_RENEWAL_SUCCESS.name,
+    Status.CERT_RENEWAL_FAILURE.name,
+])
+@pytest.mark.asyncio
+async def test_heartbeat_guard_passes_for_configured_states(status):
+    """With valid creds, the heartbeat enters its loop (does not raise the guard CallError)."""
+    with pytest.raises(_HeartbeatLoopReached):
+        await _run_heartbeat_start(status, {'account_id': 'a', 'system_id': 's'})
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_guard_rejects_unconfigured_state():
+    """A non-configured status is rejected before any request is made."""
+    with pytest.raises(CallError):
+        await _run_heartbeat_start(Status.REGISTRATION_FINALIZATION_FAILED.name, {'account_id': 'a', 'system_id': 's'})
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_guard_rejects_when_no_creds():
+    """Missing creds is rejected even in a configured state."""
+    with pytest.raises(CallError):
+        await _run_heartbeat_start(Status.CONFIGURED.name, None)


### PR DESCRIPTION
This commit fixes an issue where a TrueNAS Connect certificate could not be deleted (even with force) because TNC stayed wedged in a renewal state and never auto-unset itself. The heartbeat is the only thing that unsets TNC and removes its cert when it gets a 401, but its start guard only allowed the CONFIGURED state while the loop it guards ran across all configured states, so it died immediately in CERT_RENEWAL_IN_PROGRESS/SUCCESS/FAILURE and never saw the 401 that signals deregistration.

We widen the guard to match the loop, add CERT_RENEWAL_FAILURE to the configured states (with a boot-time renewal retry), and surface a 401 from the renewal check into the same unset path instead of swallowing it as "renewal not needed".

Original PR: https://github.com/truenas/middleware/pull/19079
