### PR TITLE
NAS-141280 / 26.0.0-RC.1 / Skip STANDBY iSCSI work when local iscsitarget is stopped (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -792,6 +792,19 @@ class iSCSITargetAluaService(Service):
             return False
         return True
 
+    async def should_operate_on_standby(self):
+        """Return True iff an ALUA config change made on this (ACTIVE) node also requires
+        coordinating work on the STANDBY.
+
+        Requires that ALUA is enabled, the local iscsitarget service is actually running
+        (otherwise the local-side change was a no-op), and the peer is reachable.
+        """
+        if not await self.middleware.call('iscsi.global.alua_enabled'):
+            return False
+        if not await self.middleware.call('service.started', 'iscsitarget'):
+            return False
+        return await self.middleware.call('failover.remote_connected')
+
     async def wait_for_alua_settled(self, sleep_interval=1, retries=10):
         while retries > 0:
             if await self.middleware.call('iscsi.alua.settled'):

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -208,20 +208,19 @@ class iSCSITargetExtentService(SharingService):
         target_name = None
         assoc = []
         if old['enabled'] != new['enabled']:
-            if await self.middleware.call('iscsi.global.alua_enabled'):
-                if await self.middleware.call('failover.remote_connected'):
-                    try:
-                        assoc = await self.middleware.call(
-                            'iscsi.targetextent.query',
-                            [['extent', '=', id_]],
-                            {'get': True}
-                        )
-                        target_name = (await self.middleware.call(
-                            'iscsi.target.query',
-                            [['id', '=', assoc['target']]],
-                            {'select': ['name'], 'get': True}))['name']
-                    except MatchNotFound:
-                        pass
+            if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
+                try:
+                    assoc = await self.middleware.call(
+                        'iscsi.targetextent.query',
+                        [['extent', '=', id_]],
+                        {'get': True}
+                    )
+                    target_name = (await self.middleware.call(
+                        'iscsi.target.query',
+                        [['id', '=', assoc['target']]],
+                        {'select': ['name'], 'get': True}))['name']
+                except MatchNotFound:
+                    pass
 
         if assoc and target_name:
             # ALUA is enabled and we changed the enabled state of a mapped extent
@@ -354,8 +353,7 @@ class iSCSITargetExtentService(SharingService):
             )
         finally:
             await self._service_change('iscsitarget', 'reload')
-            if all([await self.middleware.call("iscsi.global.alua_enabled"),
-                    await self.middleware.call('failover.remote_connected')]):
+            if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
                 await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
     @private

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -67,8 +67,7 @@ class iSCSITargetToExtentService(CRUDService):
         )
 
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
-        alua_enabled = await self.middleware.call('iscsi.global.alua_enabled')
-        if alua_enabled and await self.middleware.call('failover.remote_connected'):
+        if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
             target_id = data['target']
             target_name = (await self.middleware.call('iscsi.target.query',
                                                       [['id', '=', target_id]],
@@ -181,11 +180,8 @@ class iSCSITargetToExtentService(CRUDService):
         # on the internal target, if this is an ALUA system.
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
-        # Next, perform any necessary fixup on the STANDBY system if ALUA is enabled.
-        if (
-            await self.middleware.call("iscsi.global.alua_enabled")
-            and await self.middleware.call('failover.remote_connected')
-        ):
+        # Next, perform any necessary fixup on the STANDBY system if ALUA is operating.
+        if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
             target_name = (await self.middleware.call('iscsi.target.query',
                                                       [['id', '=', associated_target['target']]],
                                                       {'select': ['name'], 'get': True}))['name']

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -142,11 +142,8 @@ class iSCSITargetService(CRUDService):
         # First process the local (MASTER) config
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
-        # Then process the remote (BACKUP) config if we are HA and ALUA is enabled.
-        if (
-            await self.middleware.call("iscsi.global.alua_enabled")
-            and await self.middleware.call('failover.remote_connected')
-        ):
+        # Then process the remote (BACKUP) config if we are HA and ALUA is operating.
+        if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
             await self.middleware.call(
                 'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
             )
@@ -359,9 +356,11 @@ class iSCSITargetService(CRUDService):
         # First process the local (MASTER) config
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
-        # Then process the BACKUP config if we are HA and ALUA is enabled.
+        # Then process the BACKUP config if we are HA and ALUA is operating.
+        # Note: alua_enabled is also used below to decide whether to reset params on
+        # the HA: iqn variant, independent of whether the peer is reachable.
         alua_enabled = await self.middleware.call("iscsi.global.alua_enabled")
-        run_on_peer = alua_enabled and await self.middleware.call('failover.remote_connected')
+        run_on_peer = await self.middleware.call('iscsi.alua.should_operate_on_standby')
         if run_on_peer:
             await self.middleware.call(
                 'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
@@ -427,11 +426,8 @@ class iSCSITargetService(CRUDService):
         )
         rv = await self.middleware.call('datastore.delete', self._config.datastore, id_)
 
-        # If HA and ALUA handle BACKUP first
-        if (
-            await self.middleware.call("iscsi.global.alua_enabled")
-            and await self.middleware.call('failover.remote_connected')
-        ):
+        # If HA and ALUA is operating, handle BACKUP first
+        if await self.middleware.call('iscsi.alua.should_operate_on_standby'):
             await self.middleware.call('failover.call_remote', 'iscsi.target.remove_target', [target["name"]])
             await self.middleware.call(
                 'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},


### PR DESCRIPTION
iSCSI CRUD paths gated STANDBY-side reloads and ALUA settle-waits on (iscsi.global.alua_enabled AND failover.remote_connected). Replace with iscsi.alua.should_operate_on_standby, which additionally requires service.started('iscsitarget')

----
Passing (extended) CI tests [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/2547/).

Original PR: https://github.com/truenas/middleware/pull/19082
