### PR TITLE
NAS-141323 / 27.0.0-BETA.1 / Prevent truesearch dataset recursion when tiered

### DIFF
--- a/src/middlewared/middlewared/plugins/truesearch.py
+++ b/src/middlewared/middlewared/plugins/truesearch.py
@@ -51,11 +51,17 @@ class TrueSearchService(Service):
         """
         What directories will it index.
         """
-        return await self.process_directories(await self.raw_directories())
+        # When ZFS tiering is enabled the SMB server no longer traverses into nested dataset
+        # mountpoints under a share, so don't index datasets that aren't reachable through the share.
+        traverse = not (await self.call2(self.s.zfs.tier.config)).enabled
+        return await self.process_directories(await self.raw_directories(), traverse=traverse)
 
-    async def process_directories(self, directories: set[str]) -> list[str]:
+    async def process_directories(self, directories: set[str], traverse: bool = True) -> list[str]:
         """
         :param directories: a list of share directories
+        :param traverse: whether the share protocol descends into nested dataset mountpoints. When
+            False (ZFS tiering is enabled, which stops the SMB server from traversing nested
+            datasets) only the share directories themselves are indexed.
         :return: a list of directories that TrueSearch will index
 
         The reason these do not match is that TrueSearch does not traverse filesystem boundaries.
@@ -80,11 +86,13 @@ class TrueSearchService(Service):
 
         result = set()
         for directory in directories:
-            result |= self._processed_directories_for_directory(mountpoints, directory)
+            result |= self._processed_directories_for_directory(mountpoints, directory, traverse)
 
         return list(sorted(result))
 
-    def _processed_directories_for_directory(self, mountpoints: dict[str, bool], directory: str) -> set[str]:
+    def _processed_directories_for_directory(
+        self, mountpoints: dict[str, bool], directory: str, traverse: bool = True
+    ) -> set[str]:
         result = set()
         match mountpoints.get(directory):
             case True:
@@ -93,10 +101,11 @@ class TrueSearchService(Service):
             case False:
                 # The dataset is not encrypted. Add the directory
                 result.add(directory)
-                # And all the nested non-encrypted datasets
-                for mountpoint, encrypted in mountpoints.items():
-                    if os.path.commonpath([mountpoint, directory]) == directory and not encrypted:
-                        result.add(mountpoint)
+                if traverse:
+                    # And all the nested non-encrypted datasets
+                    for mountpoint, encrypted in mountpoints.items():
+                        if os.path.commonpath([mountpoint, directory]) == directory and not encrypted:
+                            result.add(mountpoint)
 
                 return result
             case _:

--- a/src/middlewared/middlewared/plugins/zfs/tier.py
+++ b/src/middlewared/middlewared/plugins/zfs/tier.py
@@ -379,6 +379,15 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
         else:
             verb = "RELOAD"
         await self.middleware.call("service.control", verb, "truenas_zfstierd")
+
+        if new.enabled != old.enabled:
+            # Tiering state drives the global SMB `shadow:no_dataset_traversal` setting and the set of
+            # directories TrueSearch indexes. Regenerate and apply both so a runtime toggle takes effect.
+            await self.middleware.call("etc.generate", "smb")
+            if await self.middleware.call("service.started", "cifs"):
+                await (await self.middleware.call("service.control", "RELOAD", "cifs")).wait(raise_error=True)
+            await self.call2(self.s.truesearch.configure)
+
         return new
 
     @api_method(

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truesearch.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truesearch.py
@@ -36,6 +36,33 @@ async def test_process_directories(directories, datasets, result):
 
 
 @pytest.mark.asyncio
+async def test_process_directories_no_traverse():
+    # When traverse=False (ZFS tiering enabled, which stops the SMB server from descending into
+    # nested datasets), only the share directory itself is indexed -- not the nested datasets.
+    datasets = {
+        "tank": False, "tank/users": False, "tank/users/alice": False, "tank/users/bob": False,
+        "tank/users/alice/books": False, "tank/users/alice/documents": True,
+    }
+    middleware = Mock()
+    middleware.call2 = AsyncMock(return_value=[
+        {
+            "type": "FILESYSTEM",
+            "properties": {
+                "mountpoint": {
+                    "value": f"/mnt/{dataset}"
+                },
+                "encryption": {
+                    "value": "on" if encrypted else "off"
+                },
+            }
+        }
+        for dataset, encrypted in datasets.items()
+    ])
+    result = await TrueSearchService(middleware).process_directories({"/mnt/tank/users"}, traverse=False)
+    assert result == ["/mnt/tank/users"]
+
+
+@pytest.mark.asyncio
 async def test_legacy_mountpoint():
     middleware = Mock()
     middleware.call2 = AsyncMock(return_value=[

--- a/tests/api2/zfs_tier/test_shares.py
+++ b/tests/api2/zfs_tier/test_shares.py
@@ -21,7 +21,7 @@ from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.nfs import nfs_share
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
-from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils import call, mock, ssh
 
 
 @contextlib.contextmanager
@@ -172,3 +172,39 @@ def test_smb_conf_shadow_no_dataset_traversal_when_tiering_enabled(tier_ds):
         assert value.lower() in ("yes", "true"), (
             f"Expected shadow:no_dataset_traversal=Yes/True when tiering enabled, got: {value!r}"
         )
+
+
+# ----------------------------------------------------------------------------
+# TrueSearch indexing must track the SMB no-traversal behaviour: when tiering
+# is enabled, nested datasets under a share are not reachable over SMB, so they
+# must not be indexed; when disabled, SMB traverses again and they must be.
+# Live counterpart of the unit coverage in
+# src/middlewared/middlewared/pytest/unit/plugins/test_truesearch.py and a
+# tiering-aware analogue of tests/api2/test_truesearch.py::test_index_new_dataset.
+# ----------------------------------------------------------------------------
+
+
+def test_truesearch_directories_track_tiering(tier_ds):
+    nested_ds = f"{tier_ds}/nested"
+    call("pool.dataset.create", {"name": nested_ds})
+    share_dir = f"/mnt/{tier_ds}"
+    nested_mp = f"/mnt/{nested_ds}"
+
+    name = _unique("ts_tier")
+    original_protocols = call("smb.config")["search_protocols"]
+    # SPOTLIGHT requires the indexing service to look available; force it.
+    with mock("truesearch.unavailable_reasons", return_value=[]):
+        call("smb.update", {"search_protocols": ["SPOTLIGHT"]})
+        try:
+            with smb_share(share_dir, name):
+                # tier_pool has tiering enabled -> nested dataset is not indexed.
+                dirs = call("truesearch.directories")
+                assert share_dir in dirs, dirs
+                assert nested_mp not in dirs, dirs
+
+                # Disable tiering -> SMB traverses again -> nested dataset is indexed.
+                with _temporarily_disabled():
+                    dirs = call("truesearch.directories")
+                    assert nested_mp in dirs, dirs
+        finally:
+            call("smb.update", {"search_protocols": original_protocols})


### PR DESCRIPTION
This commit disables truesearch dataset recursion when tiering globally enabled. This prevents unintended information disclosure for paths outside of SMB share roots.