### PR TITLE
NAS-141304 / 26.0.0-RC.1 / fix HA and SED disks (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -518,28 +518,42 @@ class DiskEntry:
         finally:
             os.close(dev_fd)
 
-    def _sed_open(self, dev_fd: int | None, writable: bool) -> tuple[int, bool]:
-        """Return (fd, should_close). If dev_fd is provided, use it; otherwise open one."""
+    @contextlib.contextmanager
+    def _sed_fd(self, dev_fd: int | None, writable: bool) -> typing.Iterator[int]:
+        """Yield an fd for SED operations.
+
+        When ``dev_fd`` is provided it is used as-is and left open for the
+        caller to manage. Otherwise ``self.devpath`` is opened and closed on
+        exit.
+
+        ``os.open`` may raise (most notably ``FileNotFoundError`` when the
+        device node has gone away because the disk was physically pulled or the
+        kernel reassigned it a new name). This is intentionally NOT swallowed
+        here so each caller maps it to its own "unqueryable" return value via
+        the ``try``/``except`` it already wraps this in.
+        """
         if dev_fd is not None:
-            return dev_fd, False
+            yield dev_fd
+            return
         flags = os.O_NONBLOCK | (os.O_RDWR if writable else os.O_RDONLY)
-        return os.open(self.devpath, flags), True
+        fd = os.open(self.devpath, flags)
+        try:
+            yield fd
+        finally:
+            os.close(fd)
 
     def sed_device_info(self, dev_fd: int | None = None) -> dict | None:
         """Perform TCG Level 0 Discovery. No authentication required.
 
         Returns:
             dict with device_type, ssc_type, locking, tper, geometry, etc.
-            None if the device does not support TCG or on any error.
+            None if the device does not support TCG, is missing, or on any error.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=False)
         try:
-            return sed.get_device_info(fd)
+            with self._sed_fd(dev_fd, writable=False) as fd:
+                return sed.get_device_info(fd)  # type: ignore[no-any-return]
         except Exception:
             return None
-        finally:
-            if should_close:
-                os.close(fd)
 
     def is_sed(self, dev_fd: int | None = None) -> bool:
         """Check if the disk supports SED (TCG Opal/Enterprise)."""
@@ -552,30 +566,29 @@ class DiskEntry:
         """Return the SED status string for this disk.
 
         Returns one of: 'NO_SED', 'FAILED', 'UNINITIALIZED', 'LOCKED', 'UNLOCKED'.
+        A missing device node (e.g. the disk was pulled) reports 'FAILED', i.e.
+        temporarily unqueryable rather than a loss of SED capability.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=False)
         try:
-            info = sed.get_device_info(fd)
+            with self._sed_fd(dev_fd, writable=False) as fd:
+                info = sed.get_device_info(fd)
 
-            locking = info["locking"]
-            if not locking["supported"]:
-                return "NO_SED"
-            if info.get("ssc_type") == "enterprise":
-                # Enterprise SSC drives may or may not report locking.enabled
-                # accurately when factory-fresh — this is manufacturer-dependent.
-                # Use the MSID authentication probe as the source of truth.
-                if sed.is_uninitialized(fd, device_info=info):
+                locking = info["locking"]
+                if not locking["supported"]:
+                    return "NO_SED"
+                if info.get("ssc_type") == "enterprise":
+                    # Enterprise SSC drives may or may not report locking.enabled
+                    # accurately when factory-fresh — this is manufacturer-dependent.
+                    # Use the MSID authentication probe as the source of truth.
+                    if sed.is_uninitialized(fd, device_info=info):
+                        return "UNINITIALIZED"
+                elif not locking["enabled"]:
                     return "UNINITIALIZED"
-            elif not locking["enabled"]:
-                return "UNINITIALIZED"
-            if locking["locked"]:
-                return "LOCKED"
-            return "UNLOCKED"
+                if locking["locked"]:
+                    return "LOCKED"
+                return "UNLOCKED"
         except Exception:
             return "FAILED"
-        finally:
-            if should_close:
-                os.close(fd)
 
     def sed_unlock(self, password: str, dev_fd: int | None = None) -> tuple[bool, str | None]:
         """Unlock a SED disk.
@@ -588,39 +601,36 @@ class DiskEntry:
             (True, None) on success or if already unlocked.
             (False, error_message) on failure.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=True)
         try:
-            info = sed.get_device_info(fd)
-            if not info["locking"]["locked"]:
-                return True, None
+            with self._sed_fd(dev_fd, writable=True) as fd:
+                info = sed.get_device_info(fd)
+                if not info["locking"]["locked"]:
+                    return True, None
 
-            pw_bytes = password.encode("utf-8")
+                pw_bytes = password.encode("utf-8")
 
-            # 1) Try raw password (drives provisioned with truenas_pylibsed)
-            try:
-                sed.unlock(fd, pw_bytes, device_info=info)
-                return True, None
-            except Exception:
-                pass
+                # 1) Try raw password (drives provisioned with truenas_pylibsed)
+                try:
+                    sed.unlock(fd, pw_bytes, device_info=info)
+                    return True, None
+                except Exception:
+                    pass
 
-            # 2) Try PBKDF2 hash with Linux serial (sedutil-cli on Linux)
-            try:
-                sed.unlock(fd, sedutil_hash_password(password, info["lnx_serial"]), device_info=info)
-                return True, None
-            except Exception:
-                pass
+                # 2) Try PBKDF2 hash with Linux serial (sedutil-cli on Linux)
+                try:
+                    sed.unlock(fd, sedutil_hash_password(password, info["lnx_serial"]), device_info=info)
+                    return True, None
+                except Exception:
+                    pass
 
-            # 3) Try PBKDF2 hash with BSD serial (sedutil-cli on FreeBSD)
-            try:
-                sed.unlock(fd, sedutil_hash_password(password, info["bsd_serial"]), device_info=info)
-                return True, None
-            except Exception as e:
-                return False, str(e)
+                # 3) Try PBKDF2 hash with BSD serial (sedutil-cli on FreeBSD)
+                try:
+                    sed.unlock(fd, sedutil_hash_password(password, info["bsd_serial"]), device_info=info)
+                    return True, None
+                except Exception as e:
+                    return False, str(e)
         except Exception as e:
             return False, str(e)
-        finally:
-            if should_close:
-                os.close(fd)
 
     def sed_initial_setup(self, password: str, dev_fd: int | None = None) -> str:
         """Provision a fresh SED disk with the given password.
@@ -632,23 +642,31 @@ class DiskEntry:
             'SUCCESS'          - Setup completed successfully
             'SETUP_FAILED'     - Initial setup call failed
         """
-        fd, should_close = self._sed_open(dev_fd, writable=True)
         try:
-            info = sed.get_device_info(fd)
-            if not info["locking"]["supported"]:
-                return "NO_SED"
+            with self._sed_fd(dev_fd, writable=True) as fd:
+                info = sed.get_device_info(fd)
+                if not info["locking"]["supported"]:
+                    return "NO_SED"
 
-            pw_bytes = password.encode("utf-8")
+                pw_bytes = password.encode("utf-8")
 
-            if info.get("ssc_type") == "enterprise":
-                # Enterprise SSC drives may or may not report locking.enabled
-                # accurately when factory-fresh — this is manufacturer-dependent.
-                # Use the MSID authentication probe as the source of truth.
-                try:
-                    uninitialized = sed.is_uninitialized(fd, device_info=info)
-                except Exception:
-                    return "SETUP_FAILED"
-                if not uninitialized:
+                if info.get("ssc_type") == "enterprise":
+                    # Enterprise SSC drives may or may not report locking.enabled
+                    # accurately when factory-fresh — this is manufacturer-dependent.
+                    # Use the MSID authentication probe as the source of truth.
+                    try:
+                        uninitialized = sed.is_uninitialized(fd, device_info=info)
+                    except Exception:
+                        return "SETUP_FAILED"
+                    if not uninitialized:
+                        try:
+                            locking_info = sed.get_locking_info(fd, pw_bytes, device_info=info)
+                            if locking_info["read_lock_enabled"] and locking_info["write_lock_enabled"]:
+                                return "ACCESS_GRANTED"
+                            return "LOCKING_DISABLED"
+                        except Exception:
+                            return "SETUP_FAILED"
+                elif info["locking"]["enabled"]:
                     try:
                         locking_info = sed.get_locking_info(fd, pw_bytes, device_info=info)
                         if locking_info["read_lock_enabled"] and locking_info["write_lock_enabled"]:
@@ -656,25 +674,14 @@ class DiskEntry:
                         return "LOCKING_DISABLED"
                     except Exception:
                         return "SETUP_FAILED"
-            elif info["locking"]["enabled"]:
+
                 try:
-                    locking_info = sed.get_locking_info(fd, pw_bytes, device_info=info)
-                    if locking_info["read_lock_enabled"] and locking_info["write_lock_enabled"]:
-                        return "ACCESS_GRANTED"
-                    return "LOCKING_DISABLED"
+                    sed.initial_setup(fd, pw_bytes, device_info=info)
+                    return "SUCCESS"
                 except Exception:
                     return "SETUP_FAILED"
-
-            try:
-                sed.initial_setup(fd, pw_bytes, device_info=info)
-                return "SUCCESS"
-            except Exception:
-                return "SETUP_FAILED"
         except Exception:
             return "NO_SED"
-        finally:
-            if should_close:
-                os.close(fd)
 
     def sed_factory_reset(self, psid: str, dev_fd: int | None = None) -> tuple[bool, str]:
         """Factory reset a SED disk using the PSID from the drive label.
@@ -685,16 +692,13 @@ class DiskEntry:
             (True, 'SUCCESS') on success.
             (False, error_message) on failure.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=True)
         try:
-            info = sed.get_device_info(fd)
-            sed.factory_reset(fd, psid.encode("utf-8"), device_info=info)
-            return True, "SUCCESS"
+            with self._sed_fd(dev_fd, writable=True) as fd:
+                info = sed.get_device_info(fd)
+                sed.factory_reset(fd, psid.encode("utf-8"), device_info=info)
+                return True, "SUCCESS"
         except Exception as e:
             return False, str(e)
-        finally:
-            if should_close:
-                os.close(fd)
 
     def sed_change_password(
         self,
@@ -708,16 +712,13 @@ class DiskEntry:
             (True, 'SUCCESS') on success.
             (False, error_message) on failure.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=True)
         try:
-            info = sed.get_device_info(fd)
-            sed.change_password(fd, old_password, new_password, device_info=info)
-            return True, "SUCCESS"
+            with self._sed_fd(dev_fd, writable=True) as fd:
+                info = sed.get_device_info(fd)
+                sed.change_password(fd, old_password, new_password, device_info=info)
+                return True, "SUCCESS"
         except Exception as e:
             return False, str(e)
-        finally:
-            if should_close:
-                os.close(fd)
 
     def sed_locking_info(self, password: str, dev_fd: int | None = None) -> dict | None:
         """Query the global locking range (range 0) properties.
@@ -726,15 +727,15 @@ class DiskEntry:
             dict with range_start, range_length, read_lock_enabled, etc.
             None on authentication failure or error.
         """
-        fd, should_close = self._sed_open(dev_fd, writable=False)
         try:
-            info = sed.get_device_info(fd)
-            return sed.get_locking_info(fd, password.encode("utf-8"), device_info=info)
+            with self._sed_fd(dev_fd, writable=False) as fd:
+                info = sed.get_device_info(fd)
+                locking_info: dict[str, typing.Any] = sed.get_locking_info(
+                    fd, password.encode("utf-8"), device_info=info
+                )
+                return locking_info
         except Exception:
             return None
-        finally:
-            if should_close:
-                os.close(fd)
 
 
 def iterate_disks() -> collections.abc.Generator[DiskEntry]:


### PR DESCRIPTION
## Don't let a missing device node crash pool.query/disk.query

`DiskEntry.sed_status()` (and the other SED helpers) opened the device node
*before* their `try` block, so a `FileNotFoundError` from a missing `/dev/X`
escaped uncaught. This propagated all the way up:

    sed_status -> disk.disk_extend -> disk.query -> pool.pool_normalize_info -> pool.query

One stale disk reference took down the *entire* `pool.query`, breaking every
API consumer (notably the UI) instead of just that one disk.

The SED open now happens *inside* each method's existing `try`, so a vanished
device maps to the normal "unqueryable" return value: `sed_status` -> `FAILED`,
`is_sed`/`sed_device_info` -> `False`/`None`. `FAILED` is the intended status
for a temporarily unreadable drive, so it's excluded from the `LOCKED` filter
(no false "pool locked" messages). This also hardens the `is_sed` calls made
during `disk.sync`/`sync_all`, which had the same exposure.

## Why it occurred

The DB stores a disk's *last-known* `disk_name`, which is not guaranteed to
point at a live `/dev` node at query time:

- After a disk is physically pulled, its row stays active until the `remove`
  udev event's `disk.sync_all` finishes (can take seconds on large systems);
  a `pool.query` in that window opens the dead node.
- On HA, `disk_name` is replicated from the master, so it reflects the
  master's kernel naming. After failover the new master can briefly hold names
  that don't exist locally until `disk.sync_all` re-localizes them, and
  `hook_setup_ha` calls `pool.query` in that gap.

These windows are inherent to a cached `disk_name`, so the durable fix is to
make the consumer tolerate a missing node rather than crash.

This was found and reproduced by platform team on internal hardware and confirmed to have fixed all the problems they were seeing.

Original PR: https://github.com/truenas/middleware/pull/19095
