### PR TITLE
NAS-141287 / 27.0.0-BETA.1 / Fix TrueCloud Backup hang on restic JSON error messages (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -96,58 +96,76 @@ def restic_check_progress(job, proc, track_progress=False):
     time_delta = ""
     action = ""
     while True:
-        read = proc.stdout.readline().decode("utf-8", "ignore")
-        if read == "":
+        raw = proc.stdout.readline().decode("utf-8", "ignore")
+        if raw == "":
             break
 
+        # Any failure to parse or handle a single message must not kill this
+        # thread: it is the only consumer of `proc.stdout`, and if it stops
+        # draining the pipe `restic` blocks writing to it and the job hangs
+        # indefinitely. Record the offending line and keep reading instead.
         try:
-            read = json.loads(read)
-        except json.JSONDecodeError:
-            # Can happen with some error messages
-            job.internal_data["messages"] = job.internal_data["messages"][-4:] + [read]
-            job.logs_fd.write((read + "\n").encode("utf-8", "ignore"))
+            try:
+                read = json.loads(raw)
+            except json.JSONDecodeError:
+                # Can happen with some error messages
+                job.internal_data["messages"] = job.internal_data["messages"][-4:] + [raw]
+                job.logs_fd.write((raw + "\n").encode("utf-8", "ignore"))
+                continue
+
+            msg = None
+            msg_type = read["message_type"]
+            match msg_type:
+                case "status":
+                    if (remaining := read.get("seconds_remaining")) is not None:
+                        try:
+                            time_delta = str(timedelta(seconds=remaining))
+                        except OverflowError:
+                            # Invalid `restic` output yields to
+                            # OverflowError: Python int too large to convert to C int
+                            # OverflowError: days=1785711940; must have magnitude <= 999999999
+                            pass
+
+                    progress_buffer.set_progress(
+                        read["percent_done"] * 100,
+                        (f"{time_delta} remaining\n" if time_delta else "") + action
+                    )
+                    continue
+
+                case "verbose_status":
+                    action = " ".join([read[key] for key in ("item", "action") if key in read])
+                    msg = action
+
+                case "summary":
+                    job.logs_fd.write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
+                    job.logs_excerpt = "\n".join(f"{k}: {v}" for k, v in read.items())
+                    continue
+
+                case "error":
+                    # `restic` nests the text as {"error": {"message": "..."}}; the
+                    # scripting docs spell it "error.message" but that is the path to
+                    # the nested field, not a flat key. Tolerate the legacy plain-string
+                    # form and an empty object (restic #4945) as well.
+                    err = read.get("error")
+                    if isinstance(err, dict):
+                        action = err.get("message") or "unknown error"
+                    else:
+                        action = str(err) if err else "unknown error"
+                    msg = "".join([
+                        "Error",
+                        f" in {item}" if (item := read.get("item")) else "",
+                        f" while {during}" if (during := read.get("during")) else "",
+                        ": ",
+                        action
+                    ])
+                    job.logs_fd.write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
+
+            if msg:
+                job.internal_data["messages"] = job.internal_data["messages"][-4:] + [msg]
+
+            progress_buffer.set_progress(description=(f"{time_delta} remaining\n" if time_delta else "") + action)
+        except Exception:
+            job.middleware.logger.warning("Unexpected error handling restic message %r", raw, exc_info=True)
+            job.internal_data["messages"] = job.internal_data["messages"][-4:] + [raw]
+            job.logs_fd.write((raw + "\n").encode("utf-8", "ignore"))
             continue
-
-        msg = None
-        msg_type = read["message_type"]
-        match msg_type:
-            case "status":
-                if (remaining := read.get("seconds_remaining")) is not None:
-                    try:
-                        time_delta = str(timedelta(seconds=remaining))
-                    except OverflowError:
-                        # Invalid `restic` output yields to
-                        # OverflowError: Python int too large to convert to C int
-                        # OverflowError: days=1785711940; must have magnitude <= 999999999
-                        pass
-
-                progress_buffer.set_progress(
-                    read["percent_done"] * 100,
-                    (f"{time_delta} remaining\n" if time_delta else "") + action
-                )
-                continue
-
-            case "verbose_status":
-                action = " ".join([read[key] for key in ("item", "action") if key in read])
-                msg = action
-
-            case "summary":
-                job.logs_fd.write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
-                job.logs_excerpt = "\n".join(f"{k}: {v}" for k, v in read.items())
-                continue
-
-            case "error":
-                action = read["error.message"]
-                msg = "".join([
-                    "Error",
-                    f" in {item}" if (item := read.get("item")) else "",
-                    f" while {during}" if (during := read.get("during")) else "",
-                    ": ",
-                    action
-                ])
-                job.logs_fd.write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
-
-        if msg:
-            job.internal_data["messages"] = job.internal_data["messages"][-4:] + [msg]
-
-        progress_buffer.set_progress(description=(f"{time_delta} remaining\n" if time_delta else "") + action)

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -95,6 +95,7 @@ def restic_check_progress(job, proc, track_progress=False):
     progress_buffer = JobProgressBuffer(job)
     time_delta = ""
     action = ""
+    logged_unexpected = False
     while True:
         raw = proc.stdout.readline().decode("utf-8", "ignore")
         if raw == "":
@@ -157,7 +158,12 @@ def restic_check_progress(job, proc, track_progress=False):
 
             progress_buffer.set_progress(description=(f"{time_delta} remaining\n" if time_delta else "") + action)
         except Exception:
-            job.middleware.logger.warning("Unexpected error handling restic message %r", raw, exc_info=True)
+            # `status` messages arrive many times per second, so a recurring
+            # failure here could flood the system log. Emit the traceback only
+            # once per run; the raw line still goes to the (bounded) job log.
+            if not logged_unexpected:
+                job.middleware.logger.warning("Unexpected error handling restic message %r", raw, exc_info=True)
+                logged_unexpected = True
             job.internal_data["messages"] = job.internal_data["messages"][-4:] + [raw]
             job.logs_fd.write((raw + "\n").encode("utf-8", "ignore"))
             continue

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -109,7 +109,7 @@ def restic_check_progress(job, proc, track_progress=False):
             try:
                 read = json.loads(raw)
             except json.JSONDecodeError:
-                # Can happen with some error messages
+                # Can happen if the command doesn't fully support JSON output (see restic scripting docs).
                 job.internal_data["messages"] = job.internal_data["messages"][-4:] + [raw]
                 job.logs_fd.write((raw + "\n").encode("utf-8", "ignore"))
                 continue

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -142,15 +142,7 @@ def restic_check_progress(job, proc, track_progress=False):
                     continue
 
                 case "error":
-                    # `restic` nests the text as {"error": {"message": "..."}}; the
-                    # scripting docs spell it "error.message" but that is the path to
-                    # the nested field, not a flat key. Tolerate the legacy plain-string
-                    # form and an empty object (restic #4945) as well.
-                    err = read.get("error")
-                    if isinstance(err, dict):
-                        action = err.get("message") or "unknown error"
-                    else:
-                        action = str(err) if err else "unknown error"
+                    action = read["error"]["message"]
                     msg = "".join([
                         "Error",
                         f" in {item}" if (item := read.get("item")) else "",

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_backup_restic.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_backup_restic.py
@@ -46,18 +46,22 @@ def test_error_message_is_decoded_from_nested_object():
     job = make_job()
     restic_check_progress(
         job,
-        make_proc([line({
-            "message_type": "error",
-            "error": {"message": "repository is already locked"},
-            "during": "archival",
-            "item": "/mnt/tank/data",
-        })]),
+        make_proc(
+            [
+                line(
+                    {
+                        "message_type": "error",
+                        "error": {"message": "repository is already locked"},
+                        "during": "archival",
+                        "item": "/mnt/tank/data",
+                    }
+                )
+            ]
+        ),
         track_progress=True,
     )
 
-    assert job.internal_data["messages"] == [
-        "Error in /mnt/tank/data while archival: repository is already locked"
-    ]
+    assert job.internal_data["messages"] == ["Error in /mnt/tank/data while archival: repository is already locked"]
     # The nested access succeeded, so the broad guard must NOT have fired.
     job.middleware.logger.warning.assert_not_called()
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_backup_restic.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_backup_restic.py
@@ -1,0 +1,88 @@
+# flake8: noqa
+import io
+import json
+from unittest.mock import MagicMock
+
+from middlewared.plugins.cloud_backup.restic import restic_check_progress
+
+
+class FakeStdout:
+    """Minimal stand-in for `proc.stdout`: yields the given byte lines, then EOF."""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+    def read(self):
+        data = b"".join(self._lines)
+        self._lines = []
+        return data
+
+
+def make_proc(lines):
+    proc = MagicMock()
+    proc.stdout = FakeStdout(lines)
+    return proc
+
+
+def make_job():
+    job = MagicMock()
+    job.internal_data = {}
+    job.logs_fd = io.BytesIO()
+    return job
+
+
+def line(obj):
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def test_error_message_is_decoded_from_nested_object():
+    # restic nests the text as {"error": {"message": "..."}}. This is the exact
+    # shape that previously crashed with KeyError: 'error.message'.
+    job = make_job()
+    restic_check_progress(
+        job,
+        make_proc([line({
+            "message_type": "error",
+            "error": {"message": "repository is already locked"},
+            "during": "archival",
+            "item": "/mnt/tank/data",
+        })]),
+        track_progress=True,
+    )
+
+    assert job.internal_data["messages"] == [
+        "Error in /mnt/tank/data while archival: repository is already locked"
+    ]
+    # The nested access succeeded, so the broad guard must NOT have fired.
+    job.middleware.logger.warning.assert_not_called()
+
+
+def test_malformed_error_does_not_kill_reader_and_logs_once():
+    # An unexpected message shape (e.g. restic's pre-0.17.1 empty `{}`) must not
+    # raise out of the reader thread (which would stop draining stdout and hang
+    # the job). It is recorded and the traceback is logged at most once per run.
+    job = make_job()
+    bad = line({"message_type": "error", "error": {}, "during": "archival", "item": "/x"})
+    restic_check_progress(job, make_proc([bad, bad]), track_progress=True)
+
+    # Both malformed lines recorded, but only one system-log traceback emitted.
+    assert job.internal_data["messages"] == [bad.decode(), bad.decode()]
+    job.middleware.logger.warning.assert_called_once()
+
+
+def test_status_message_updates_progress():
+    job = make_job()
+    restic_check_progress(
+        job,
+        make_proc([line({"message_type": "status", "percent_done": 0.5})]),
+        track_progress=True,
+    )
+
+    job.set_progress.assert_called()
+    assert job.set_progress.call_args.args[0] == 50.0
+    job.middleware.logger.warning.assert_not_called()


### PR DESCRIPTION
### Problem

`restic_check_progress()` crashed with `KeyError: 'error.message'` whenever restic emitted an `error` message in its JSON output. restic nests the text as `{"error": {"message": "..."}}` — the scripting docs spell it `error.message`, but that is the path to a nested field, not a flat key.

Two consequences:

- The real restic error was swallowed; the job/UI showed only `'error.message'`, making failures undiagnosable.
- In the threaded reader, the `KeyError` silently killed the only consumer of restic's stdout. With nobody draining the pipe, restic blocked on a full pipe and the job hung in `RUNNING` at 0% indefinitely.

### Fix

- Read the message from the nested object: `read["error"]["message"]`. Verified against upstream — the `error` value is always a JSON object (never a plain string), and the `message` field is guaranteed present since restic 0.17.1; TrueNAS ships 0.18.0.
- Wrap the per-message processing in a guard so a malformed/unexpected line can never kill the reader thread (which is what caused the hang). The offending line is recorded to the job log and the reader keeps draining stdout.
- The guard's traceback is logged at most once per run, since high-frequency `status` messages could otherwise flood the system log.

### Tests

Adds `test_cloud_backup_restic.py`: nested error message is decoded, a malformed error survives without killing the reader and is logged once, and `status` messages still drive progress.

Original PR: https://github.com/truenas/middleware/pull/19092
