### PR TITLE
NAS-141329 / 26.0.0-RC.1 / fix SED unlock on failover event (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sed.py
+++ b/src/middlewared/middlewared/plugins/disk_/sed.py
@@ -250,6 +250,14 @@ class DiskService(Service):
             'disk.query', filters, {'extra': {'passwords': True, 'real_names': True}}
         ):
             name = disk['real_name']
+            if name is None:
+                # The disk's identifier doesn't currently resolve to a present
+                # device (e.g. pulled, or not yet enumerated after failover).
+                # We can't unlock a device node we can't locate, so skip it.
+                self.logger.warning(
+                    '%s: SED disk has no resolvable device, skipping unlock', disk['identifier']
+                )
+                continue
             # user can specify a per-disk password and/or a global password
             # we default to using the per-disk password with fallback to global
             passwd = disk['passwd'] if disk['passwd'] else global_passwd
@@ -266,9 +274,10 @@ class DiskService(Service):
         if not disks_to_unlock:
             return
 
-        def _unlock(d):
+        async def _unlock(d):
             entry = DiskEntry(name=d['name'], devpath=f'/dev/{d["name"]}')
-            return d['name'], *entry.sed_unlock(d['passwd'])
+            success, error = await asyncio.to_thread(entry.sed_unlock, d['passwd'])
+            return d['name'], success, error
 
         failed_to_unlock = []
         for name, success, error in await asyncio_map(_unlock, disks_to_unlock, limit=16):


### PR DESCRIPTION
# Fix SED disk unlock on failover

Two bugs on the `vrrp_master` SED-unlock path, surfaced during further failover
testing of https://github.com/truenas/middleware/pull/19095.

## 1. Unlock raised TypeError instead of unlocking

`disk.sed_unlock_all` passed a *synchronous* `_unlock` helper to `asyncio_map`,
which awaits its callable. Awaiting the returned tuple raised
`TypeError: object tuple can't be used in 'await' expression`, so no locked SED
disks were unlocked on failover. `_unlock` is now `async` and runs the blocking
unlock via `asyncio.to_thread`, matching `setup_sed_disk`.

## 2. Unresolvable disks tried to open `/dev/None`

`map_disks_to_passwd` set `name = disk['real_name']`, which is `None` when a
disk's identifier doesn't resolve to a currently-present device (e.g. not yet
enumerated after failover). It still queued that disk, so `_unlock` tried to
open `/dev/None` -> `ENOENT` -> bogus "failed to unlock" error. Such disks are
now skipped (logged once) since a device node we can't locate can't be unlocked.

Original PR: https://github.com/truenas/middleware/pull/19100
