### PR TITLE
NAS-140868 / 26.0.0-RC.1 / Expand reporting tests (#18870)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting.py
@@ -173,7 +173,7 @@ class ReportingRealtimeEventSourceArgs(BaseModel):
 class ReportingRealtimeEventSourceEvent(BaseModel):
     cpu: dict
     """CPU performance metrics for real-time monitoring."""
-    disls: "ReportingRealtimeEventSourceEventDisks"
+    disks: "ReportingRealtimeEventSourceEventDisks"
     """Disk performance metrics for real-time monitoring."""
     interfaces: dict
     """Network interface statistics for real-time monitoring."""

--- a/src/middlewared/middlewared/api/v25_10_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_1/reporting.py
@@ -173,7 +173,7 @@ class ReportingRealtimeEventSourceArgs(BaseModel):
 class ReportingRealtimeEventSourceEvent(BaseModel):
     cpu: dict
     """CPU performance metrics for real-time monitoring."""
-    disls: "ReportingRealtimeEventSourceEventDisks"
+    disks: "ReportingRealtimeEventSourceEventDisks"
     """Disk performance metrics for real-time monitoring."""
     interfaces: dict
     """Network interface statistics for real-time monitoring."""

--- a/src/middlewared/middlewared/api/v25_10_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_2/reporting.py
@@ -173,7 +173,7 @@ class ReportingRealtimeEventSourceArgs(BaseModel):
 class ReportingRealtimeEventSourceEvent(BaseModel):
     cpu: dict
     """CPU performance metrics for real-time monitoring."""
-    disls: "ReportingRealtimeEventSourceEventDisks"
+    disks: "ReportingRealtimeEventSourceEventDisks"
     """Disk performance metrics for real-time monitoring."""
     interfaces: dict
     """Network interface statistics for real-time monitoring."""

--- a/src/middlewared/middlewared/api/v25_10_3/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_3/reporting.py
@@ -173,7 +173,7 @@ class ReportingRealtimeEventSourceArgs(BaseModel):
 class ReportingRealtimeEventSourceEvent(BaseModel):
     cpu: dict
     """CPU performance metrics for real-time monitoring."""
-    disls: "ReportingRealtimeEventSourceEventDisks"
+    disks: "ReportingRealtimeEventSourceEventDisks"
     """Disk performance metrics for real-time monitoring."""
     interfaces: dict
     """Network interface statistics for real-time monitoring."""

--- a/src/middlewared/middlewared/api/v26_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v26_0_0/reporting.py
@@ -173,7 +173,7 @@ class ReportingRealtimeEventSourceArgs(BaseModel):
 class ReportingRealtimeEventSourceEvent(BaseModel):
     cpu: dict
     """CPU performance metrics for real-time monitoring."""
-    disls: "ReportingRealtimeEventSourceEventDisks"
+    disks: "ReportingRealtimeEventSourceEventDisks"
     """Disk performance metrics for real-time monitoring."""
     interfaces: dict
     """Network interface statistics for real-time monitoring."""

--- a/tests/api2/test_reporting_realtime.py
+++ b/tests/api2/test_reporting_realtime.py
@@ -1,6 +1,105 @@
 import time
 
+import pytest
+
 from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.utils import call, client
+
+
+# Expected topology of `reporting.realtime.stats` (and the matching
+# `reporting.realtime` event payload). Mirrors `ReportingRealtimeEventSourceEvent`
+# in src/middlewared/middlewared/api/v27_0_0/reporting.py.
+#
+# Top-level keys are fixed. Sub-keys are fixed for memory / zfs / disks. Sub-keys
+# for cpu / interfaces / pools are host-dependent (per-core, per-interface,
+# per-pool) and validated separately against system.cpu_info / interface.query /
+# pool.query.
+EXPECTED_STATS_TOPOLOGY: dict[str, frozenset[str] | None] = {
+    "cpu": None,
+    "disks": frozenset(
+        {
+            "busy",
+            "read_bytes",
+            "write_bytes",
+            "read_ops",
+            "write_ops",
+        }
+    ),
+    "interfaces": None,
+    "memory": frozenset(
+        {
+            "arc_size",
+            "arc_free_memory",
+            "arc_available_memory",
+            "physical_memory_total",
+            "physical_memory_available",
+        }
+    ),
+    "pools": None,
+    "zfs": frozenset(
+        {
+            "demand_accesses_per_second",
+            "demand_data_accesses_per_second",
+            "demand_metadata_accesses_per_second",
+            "demand_data_hits_per_second",
+            "demand_data_io_hits_per_second",
+            "demand_data_misses_per_second",
+            "demand_data_hit_percentage",
+            "demand_data_io_hit_percentage",
+            "demand_data_miss_percentage",
+            "demand_metadata_hits_per_second",
+            "demand_metadata_io_hits_per_second",
+            "demand_metadata_misses_per_second",
+            "demand_metadata_hit_percentage",
+            "demand_metadata_io_hit_percentage",
+            "demand_metadata_miss_percentage",
+            "l2arc_hits_per_second",
+            "l2arc_misses_per_second",
+            "total_l2arc_accesses_per_second",
+            "l2arc_access_hit_percentage",
+            "l2arc_miss_percentage",
+            "bytes_read_per_second_from_the_l2arc",
+            "bytes_written_per_second_to_the_l2arc",
+        }
+    ),
+}
+
+EXPECTED_TOP_LEVEL_KEYS = frozenset(EXPECTED_STATS_TOPOLOGY)
+EXPECTED_CPU_PER_CORE_KEYS = frozenset({"usage", "temp"})
+
+
+def _collect_one_event(c, timeout=8):
+    events = []
+
+    def callback(type_, **message):
+        events.append((type_, message.get("fields") or {}))
+
+    c.subscribe("reporting.realtime", callback, sync=True)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not events:
+        time.sleep(0.5)
+    assert events, "no reporting.realtime event received within timeout"
+    return events[0][1]
+
+
+def _assert_matches_topology(payload, label):
+    assert payload.keys() == EXPECTED_TOP_LEVEL_KEYS, (
+        f"{label}: {payload.keys() ^ EXPECTED_TOP_LEVEL_KEYS}"
+    )
+    for top_key, expected_subkeys in EXPECTED_STATS_TOPOLOGY.items():
+        if expected_subkeys is None:
+            # Host-dependent block — only assert it's a dict here.
+            assert isinstance(payload[top_key], dict), f"{label}.{top_key}"
+            continue
+        assert payload[top_key].keys() == expected_subkeys, (
+            f"{label}.{top_key}: {payload[top_key].keys() ^ expected_subkeys}"
+        )
+
+
+@pytest.fixture(scope="module")
+def realtime_event():
+    with client() as c:
+        return _collect_one_event(c)
 
 
 def test_reporting_realtime():
@@ -15,3 +114,69 @@ def test_reporting_realtime():
         time.sleep(5)
 
         assert events
+
+
+def test_realtime_event_topology(realtime_event):
+    _assert_matches_topology(realtime_event, "event")
+
+
+def test_realtime_event_memory_values(realtime_event):
+    memory = realtime_event["memory"]
+    for key, value in memory.items():
+        assert isinstance(value, int) and value >= 0, f"{key}: {value!r}"
+    assert memory["physical_memory_total"] > 0
+
+
+def test_realtime_event_zfs_values(realtime_event):
+    for key, value in realtime_event["zfs"].items():
+        assert value >= 0, f"{key}: {value!r}"
+
+
+def test_realtime_event_disks_values(realtime_event):
+    for key, value in realtime_event["disks"].items():
+        assert isinstance(value, (int, float)) and value >= 0, f"{key}: {value!r}"
+
+
+def test_realtime_event_cpu_keys(realtime_event):
+    core_count = call("system.cpu_info")["core_count"]
+    expected = frozenset({"cpu"} | {f"cpu{i}" for i in range(core_count)})
+    assert realtime_event["cpu"].keys() == expected
+    for core, sub in realtime_event["cpu"].items():
+        assert sub.keys() == EXPECTED_CPU_PER_CORE_KEYS
+
+
+def test_realtime_event_matches_internal_stats_call():
+    """
+    Cross-check: `reporting.realtime.stats` is the private synchronous RPC the
+    event source itself drives. Calling it directly and subscribing to the
+    event must produce the same payload structure with consistent values for
+    stable fields (physical_memory_total, top-level keys).
+
+    Per-second rate fields drift between the two reads, so we only assert
+    structural equivalence and exactness on values that don't change at runtime.
+    """
+    stats = call("reporting.realtime.stats")
+    assert stats, "reporting.realtime.stats returned empty (netdata down?)"
+
+    with client() as c:
+        event = _collect_one_event(c)
+
+    _assert_matches_topology(stats, "stats")
+    _assert_matches_topology(event, "event")
+    assert event["cpu"].keys() == stats["cpu"].keys()
+    assert (
+        event["memory"]["physical_memory_total"]
+        == stats["memory"]["physical_memory_total"]
+    )
+
+
+def test_realtime_pool_keys_match_pool_query(realtime_event):
+    pool_names = frozenset(pool["name"] for pool in call("pool.query"))
+    if not pool_names:
+        pytest.skip("no imported pools — cannot validate event pool keys")
+    unexpected = realtime_event["pools"].keys() - pool_names
+    assert not unexpected, f"event reported pools not in pool.query: {unexpected}"
+    for pool_name, sub in realtime_event["pools"].items():
+        # pool.py:18 filters out falsy values, so any visible stat must be truthy
+        for stat_key, value in sub.items():
+            assert value, f"{pool_name}.{stat_key}: {value!r}"

--- a/tests/unit/test_metrics_arcstat.py
+++ b/tests/unit/test_metrics_arcstat.py
@@ -1,0 +1,100 @@
+import pytest
+
+from truenas_pylibzfs import kstat
+
+from middlewared.utils.metrics.arcstat import (
+    ArcStatDescriptions,
+    calculate_arc_stats_impl,
+    get_arc_stats,
+)
+
+
+# Attributes consumed by calculate_arc_demand_stats_impl, calculate_l2arc_stats_impl
+# and calculate_arc_stats_impl. If `truenas_pylibzfs.kstat.ArcStats` ever drops or
+# renames any of these, the upstream rename must come with a coordinated middleware
+# update.
+KSTAT_REQUIRED_ATTRS = (
+    "memory_free_bytes",
+    "memory_available_bytes",
+    "size",
+    "demand_data_hits",
+    "demand_metadata_hits",
+    "demand_data_iohits",
+    "demand_metadata_iohits",
+    "demand_data_misses",
+    "demand_metadata_misses",
+    "l2_size",
+    "l2_hits",
+    "l2_misses",
+    "l2_read_bytes",
+    "l2_write_bytes",
+)
+
+PERCENT_KEYS = frozenset(
+    {"ddh%", "ddi%", "ddm%", "dmh%", "dmi%", "dmm%", "l2hit%", "l2miss%"}
+)
+
+
+def test_get_arc_stats_runs():
+    """Direct regression guard for the import bug fixed in bbe0e4."""
+    assert get_arc_stats()
+
+
+def test_get_arc_stats_keys_match_descriptions():
+    assert get_arc_stats().keys() == ArcStatDescriptions.keys()
+
+
+def test_get_arc_stats_value_shape():
+    for key, value in get_arc_stats().items():
+        assert isinstance(value, tuple) and len(value) == 2, f"{key}: {value!r}"
+        numeric, description = value
+        assert isinstance(numeric, (int, float)), f"{key}: numeric is {type(numeric)}"
+        assert description == ArcStatDescriptions[key]
+
+
+def test_get_arc_stats_size_invariants():
+    stats = get_arc_stats()
+    for key in ("free", "avail", "size"):
+        numeric, _ = stats[key]
+        assert isinstance(numeric, int)
+    # A live ARC always holds something
+    assert stats["size"][0] > 0
+    # Cumulative-derived rates should never be negative
+    for key in ("dread", "ddread", "dmread", "l2read", "l2bytes", "l2wbytes"):
+        assert stats[key][0] >= 0, f"{key}: {stats[key][0]!r}"
+    for key in PERCENT_KEYS:
+        assert 0 <= stats[key][0] <= 100, f"{key}: {stats[key][0]!r}"
+
+
+def test_get_arc_stats_demand_percentages_sum():
+    """When the read counter is non-zero the three percent components sum to 100."""
+    raw_stats = calculate_arc_stats_impl(kstat.get_arcstats(), 1)
+    if raw_stats["ddread"][0] > 0:
+        total = raw_stats["ddh%"][0] + raw_stats["ddi%"][0] + raw_stats["ddm%"][0]
+        assert abs(total - 100) <= 0.5
+    if raw_stats["dmread"][0] > 0:
+        total = raw_stats["dmh%"][0] + raw_stats["dmi%"][0] + raw_stats["dmm%"][0]
+        assert abs(total - 100) <= 0.5
+    if raw_stats["l2read"][0] > 0:
+        total = raw_stats["l2hit%"][0] + raw_stats["l2miss%"][0]
+        assert abs(total - 100) <= 0.5
+
+
+@pytest.mark.parametrize("intv", [1, 2, 5])
+def test_get_arc_stats_intv(intv):
+    stats = get_arc_stats(intv)
+    assert stats.keys() == ArcStatDescriptions.keys()
+    for key in PERCENT_KEYS:
+        assert 0 <= stats[key][0] <= 100
+
+
+@pytest.mark.parametrize("attr", KSTAT_REQUIRED_ATTRS)
+def test_kstat_get_arcstats_attrs(attr):
+    """
+    Asserts that every attribute the calculation helpers reach for is present
+    on the live kstat.ArcStats object. Catches regressions like the one in
+    bbe0e4 where the import surface of truenas_pylibzfs.kstat changed.
+    """
+    snapshot = kstat.get_arcstats()
+    assert hasattr(snapshot, attr), f"kstat.ArcStats is missing {attr!r}"
+    assert isinstance(getattr(snapshot, attr), int)

--- a/tests/unit/test_metrics_cpu_usage.py
+++ b/tests/unit/test_metrics_cpu_usage.py
@@ -1,0 +1,65 @@
+import time
+
+from middlewared.utils.cpu import cpu_info
+from middlewared.utils.metrics.cpu_usage import calculate_cpu_usage, get_cpu_usage
+
+# /proc/stat exposes 10 numeric fields per cpu line on modern Linux:
+# user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice
+PROC_STAT_FIELDS = 10
+
+
+def test_first_call_zero():
+    """No prior sample → every value reported as 0 (cpu_usage.py:45-47)."""
+    usage, cached = get_cpu_usage(None)
+    assert usage and cached
+    for core, value in usage.items():
+        assert value == 0, f"{core}: expected 0 on first call, got {value!r}"
+
+
+def test_second_call_in_range():
+    _, cached = get_cpu_usage(None)
+    # Allow the cpu counters to advance so the second sample produces non-zero
+    # deltas — the calculation degrades to 0 if delta_time is 0.
+    time.sleep(0.2)
+    usage, _ = get_cpu_usage(cached)
+    for core, value in usage.items():
+        assert isinstance(value, float), f"{core}: expected float, got {type(value)}"
+        assert 0.0 <= value <= 100.0, f"{core}: {value!r} outside 0-100"
+
+
+def test_keys_match_proc_stat():
+    usage, cached = get_cpu_usage(None)
+    assert usage.keys() == cached.keys()
+    assert "cpu" in usage
+    expected_cores = frozenset(f"cpu{i}" for i in range(cpu_info()["core_count"]))
+    assert expected_cores <= usage.keys()
+
+
+def test_cached_values_are_lists_of_int():
+    _, cached = get_cpu_usage(None)
+    for core, values in cached.items():
+        assert isinstance(values, list), f"{core}: cached values not a list"
+        assert values, f"{core}: cached values list is empty"
+        for v in values:
+            assert isinstance(v, int)
+        assert len(values) == PROC_STAT_FIELDS, f"{core}: {len(values)} fields"
+
+
+def test_calculate_cpu_usage_zero_delta():
+    """Identical sample lists → no time elapsed → 0.0."""
+    sample = [100, 0, 50, 1000, 0, 0, 0, 0, 0, 0]
+    assert calculate_cpu_usage(sample, sample) == 0.0
+
+
+def test_calculate_cpu_usage_idle_only():
+    """All elapsed time was idle → 0% active."""
+    old = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    new = [0, 0, 0, 100, 0, 0, 0, 0, 0, 0]  # only idle advanced
+    assert calculate_cpu_usage(new, old) == 0.0
+
+
+def test_calculate_cpu_usage_fully_active():
+    """All elapsed time was non-idle/non-iowait → 100%."""
+    old = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    new = [50, 0, 50, 0, 0, 0, 0, 0, 0, 0]
+    assert calculate_cpu_usage(new, old) == 100.0

--- a/tests/unit/test_metrics_pool_stats.py
+++ b/tests/unit/test_metrics_pool_stats.py
@@ -1,0 +1,31 @@
+from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
+from middlewared.utils.zfs import query_imported_fast_impl
+
+
+POOL_STAT_KEYS = frozenset({"used", "avail"})
+
+
+def test_get_pool_dataset_stats_shape():
+    """Boot pool is always imported on TrueNAS, so the result is non-empty."""
+    stats = get_pool_dataset_stats()
+    assert stats, "expected at least the boot pool"
+    for guid, values in stats.items():
+        assert isinstance(guid, str) and guid.isdigit(), (
+            f"{guid!r} is not a numeric GUID"
+        )
+        assert values.keys() >= POOL_STAT_KEYS, f"{guid}: {values!r}"
+        assert isinstance(values["used"], int) and values["used"] >= 0
+        assert isinstance(values["avail"], int) and values["avail"] >= 0
+
+
+def test_get_pool_dataset_stats_includes_boot_pool():
+    """
+    The unit-test environment has no imported data pools (only boot-pool). The
+    helper must still produce results — direct guard for the no-data-pool case.
+    """
+    imported = query_imported_fast_impl()
+    stats = get_pool_dataset_stats()
+    # Every pool reported by the kstat-based fast query should appear in the
+    # zfs-list-derived stats.
+    missing = imported.keys() - stats.keys()
+    assert not missing, f"kstat-imported guids missing from stats: {missing}"

--- a/tests/unit/test_metrics_pool_stats.py
+++ b/tests/unit/test_metrics_pool_stats.py
@@ -2,7 +2,7 @@ from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
 from middlewared.utils.zfs import query_imported_fast_impl
 
 
-POOL_STAT_KEYS = frozenset({"used", "avail"})
+POOL_STAT_KEYS = frozenset({"used", "available"})
 
 
 def test_get_pool_dataset_stats_shape():
@@ -15,7 +15,7 @@ def test_get_pool_dataset_stats_shape():
         )
         assert values.keys() >= POOL_STAT_KEYS, f"{guid}: {values!r}"
         assert isinstance(values["used"], int) and values["used"] >= 0
-        assert isinstance(values["avail"], int) and values["avail"] >= 0
+        assert isinstance(values["available"], int) and values["available"] >= 0
 
 
 def test_get_pool_dataset_stats_includes_boot_pool():

--- a/tests/unit/test_realtime_reporting.py
+++ b/tests/unit/test_realtime_reporting.py
@@ -1,0 +1,254 @@
+"""
+Live tests for plugins.reporting.realtime_reporting.* helpers.
+
+Each helper consumes a `netdata_metrics` dict produced by
+`netdata.get_all_metrics`; we feed in real netdata data *and* an empty dict to
+exercise the `safely_retrieve_dimension` defensive paths.
+"""
+
+import glob
+
+import pytest
+
+from truenas_api_client import Client
+
+from middlewared.plugins.reporting.realtime_reporting.arcstat import get_arc_stats
+from middlewared.plugins.reporting.realtime_reporting.cgroup import get_cgroup_stats
+from middlewared.plugins.reporting.realtime_reporting.cpu import get_cpu_stats
+from middlewared.plugins.reporting.realtime_reporting.ifstat import get_interface_stats
+from middlewared.plugins.reporting.realtime_reporting.iostat import get_disk_stats
+from middlewared.plugins.reporting.realtime_reporting.memory import get_memory_info
+from middlewared.plugins.reporting.realtime_reporting.pool import get_pool_stats
+from middlewared.utils.cpu import cpu_info
+from middlewared.utils.disks import get_disk_names
+from middlewared.utils.disks_.disk_class import iterate_disks
+
+
+ZFS_EVENT_KEYS = frozenset(
+    {
+        "demand_accesses_per_second",
+        "demand_data_accesses_per_second",
+        "demand_metadata_accesses_per_second",
+        "demand_data_hits_per_second",
+        "demand_data_io_hits_per_second",
+        "demand_data_misses_per_second",
+        "demand_data_hit_percentage",
+        "demand_data_io_hit_percentage",
+        "demand_data_miss_percentage",
+        "demand_metadata_hits_per_second",
+        "demand_metadata_io_hits_per_second",
+        "demand_metadata_misses_per_second",
+        "demand_metadata_hit_percentage",
+        "demand_metadata_io_hit_percentage",
+        "demand_metadata_miss_percentage",
+        "l2arc_hits_per_second",
+        "l2arc_misses_per_second",
+        "total_l2arc_accesses_per_second",
+        "l2arc_access_hit_percentage",
+        "l2arc_miss_percentage",
+        "bytes_read_per_second_from_the_l2arc",
+        "bytes_written_per_second_to_the_l2arc",
+    }
+)
+
+ZFS_PERCENT_KEYS = frozenset(k for k in ZFS_EVENT_KEYS if k.endswith("_percentage"))
+
+MEMORY_EVENT_KEYS = frozenset(
+    {
+        "arc_size",
+        "arc_free_memory",
+        "arc_available_memory",
+        "physical_memory_total",
+        "physical_memory_available",
+    }
+)
+
+DISK_EVENT_KEYS = frozenset(
+    {"read_ops", "read_bytes", "write_ops", "write_bytes", "busy"}
+)
+
+CPU_PER_CORE_KEYS = frozenset({"usage", "temp"})
+
+
+@pytest.fixture(scope="module")
+def netdata_metrics():
+    with Client(private_methods=True) as c:
+        data = c.call("netdata.get_all_metrics")
+    if not data:
+        pytest.skip("netdata returned no metrics — service may be down or warming up")
+    return data
+
+
+@pytest.fixture(scope="module")
+def interface_names():
+    with Client(private_methods=True) as c:
+        return [
+            iface["name"]
+            for iface in c.call(
+                "interface.query", [], {"extra": {"retrieve_names_only": True}}
+            )
+        ]
+
+
+# --- get_arc_stats ----------------------------------------------------------
+
+
+def test_arc_stats_empty_dict_safe():
+    result = get_arc_stats({})
+    assert result.keys() == ZFS_EVENT_KEYS
+    for key, value in result.items():
+        assert value == 0, f"{key}: {value!r}"
+
+
+def test_arc_stats_live_shape(netdata_metrics):
+    result = get_arc_stats(netdata_metrics)
+    assert result.keys() == ZFS_EVENT_KEYS
+    for key, value in result.items():
+        assert isinstance(value, (int, float)), f"{key}: {type(value).__name__}"
+        assert value >= 0, f"{key}: {value!r}"
+    for key in ZFS_PERCENT_KEYS:
+        assert result[key] <= 100, f"{key}: {result[key]!r}"
+
+
+# --- get_memory_info --------------------------------------------------------
+
+
+def test_memory_empty_dict_safe():
+    result = get_memory_info({})
+    assert result.keys() == MEMORY_EVENT_KEYS
+    for key, value in result.items():
+        assert value == 0, f"{key}: {value!r}"
+
+
+def test_memory_live_shape(netdata_metrics):
+    result = get_memory_info(netdata_metrics)
+    assert result.keys() == MEMORY_EVENT_KEYS
+    for key, value in result.items():
+        assert isinstance(value, (int, float)), f"{key}: {type(value).__name__}"
+        assert value >= 0, f"{key}: {value!r}"
+    assert result["physical_memory_total"] > 0
+    assert result["physical_memory_total"] >= result["physical_memory_available"]
+    assert result["arc_size"] > 0
+
+
+# --- get_cpu_stats ----------------------------------------------------------
+
+
+def _expected_cpu_keys():
+    return frozenset({"cpu"} | {f"cpu{i}" for i in range(cpu_info()["core_count"])})
+
+
+def test_cpu_empty_dict_safe():
+    result = get_cpu_stats({})
+    assert result.keys() == _expected_cpu_keys()
+    for core, sub in result.items():
+        assert sub.keys() == CPU_PER_CORE_KEYS, f"{core}: {sub.keys()!r}"
+        assert sub["usage"] == 0
+        assert sub["temp"] is None
+
+
+def test_cpu_live_shape(netdata_metrics):
+    result = get_cpu_stats(netdata_metrics)
+    assert result.keys() == _expected_cpu_keys()
+    for core, sub in result.items():
+        assert sub.keys() == CPU_PER_CORE_KEYS
+        assert isinstance(sub["usage"], (int, float))
+        assert 0 <= sub["usage"] <= 100, f"{core}: usage={sub['usage']!r}"
+        assert sub["temp"] is None or isinstance(sub["temp"], (int, float))
+
+
+# --- get_disk_stats ---------------------------------------------------------
+
+
+def test_disk_empty_inputs_safe():
+    result = get_disk_stats({}, [], {})
+    assert result.keys() == DISK_EVENT_KEYS
+    for key, value in result.items():
+        assert value == 0, f"{key}: {value!r}"
+
+
+def test_disk_live_shape(netdata_metrics):
+    disks = get_disk_names()
+    disk_mapping = {entry.name: entry.identifier for entry in iterate_disks()}
+    result = get_disk_stats(netdata_metrics, disks, disk_mapping)
+    assert result.keys() == DISK_EVENT_KEYS
+    for key, value in result.items():
+        assert isinstance(value, (int, float)), f"{key}: {type(value).__name__}"
+        assert value >= 0, f"{key}: {value!r}"
+
+
+# --- get_interface_stats ----------------------------------------------------
+
+
+def test_interface_empty_inputs_safe():
+    result = get_interface_stats({}, [])
+    assert dict(result) == {}
+
+
+def test_interface_live_shape(netdata_metrics, interface_names):
+    if not interface_names:
+        pytest.skip("no network interfaces reported by interface.query")
+    result = get_interface_stats(netdata_metrics, interface_names)
+    assert result.keys() == frozenset(interface_names)
+    for name, sub in result.items():
+        assert sub["link_state"] in ("LINK_STATE_UP", "LINK_STATE_DOWN"), (
+            f"{name}: {sub['link_state']!r}"
+        )
+        assert isinstance(sub["speed"], (int, float)) and sub["speed"] >= 0
+        assert isinstance(sub["received_bytes_rate"], (int, float))
+        assert isinstance(sub["sent_bytes_rate"], (int, float))
+        assert sub["received_bytes_rate"] >= 0
+        assert sub["sent_bytes_rate"] >= 0
+
+
+# --- get_pool_stats ---------------------------------------------------------
+
+
+def test_pool_empty_dict_safe():
+    result = get_pool_stats({})
+    assert dict(result) == {}
+
+
+def test_pool_live_shape(netdata_metrics):
+    """
+    The unit-test environment has no imported data pools so the returned dict
+    is allowed to be empty — we only assert the *shape* of any entries.
+    """
+    result = get_pool_stats(netdata_metrics)
+    for pool_name, sub in result.items():
+        assert isinstance(pool_name, str) and pool_name
+        assert isinstance(sub, dict)
+        for stat_key, value in sub.items():
+            assert isinstance(stat_key, str)
+            # pool.py:18 filters out falsy values, so anything we see must
+            # be truthy — typically a positive int byte-count.
+            assert value
+
+
+# --- get_cgroup_stats -------------------------------------------------------
+
+
+def test_cgroup_empty_inputs_safe():
+    assert dict(get_cgroup_stats({}, [])) == {}
+
+
+def test_cgroup_live_runs(netdata_metrics):
+    """
+    Heuristic for cgroup names mirrors the metric-count approximation used in
+    plugins/reporting/rest.py — every *.service cgroup file becomes a candidate.
+    The helper may legitimately return an empty dict on a host with no
+    container/vm services, but it must not crash.
+    """
+    cgroups = sorted(
+        {
+            path.rsplit("/", 1)[-1].removesuffix(".service")
+            for path in glob.glob("/sys/fs/cgroup/**/*.service", recursive=True)
+        }
+    )
+    result = get_cgroup_stats(netdata_metrics, cgroups)
+    for cgroup_name, sub in result.items():
+        assert isinstance(cgroup_name, str)
+        assert isinstance(sub, dict)
+        for metric_name, context in sub.items():
+            assert isinstance(metric_name, str)
+            assert isinstance(context, dict)


### PR DESCRIPTION
This fixes a schema field name typo for reporting disks (appears in API docs, but does not change surfaced reporting.realtime event field names -- typo only was in docs) in addition to adding explicit testing for internal utilities as well as validating shape of returned responses.

NOTE: this fixes a previously broken merge of branch with same name.