### PR TITLE
NAS-141356 / 26.0.0-RC.1 / Revert test expectations wrongly backported by NAS-141279

### DIFF
--- a/tests/unit/test_api_key_keyring.py
+++ b/tests/unit/test_api_key_keyring.py
@@ -120,14 +120,14 @@ def test__convert_raw_key_invalid_format():
 
 
 def test__convert_raw_key_wrong_size():
-    """Test that keys with incorrect size are rejected by the length check."""
+    """Test that keys with incorrect size are rejected by regex pattern."""
     with Client() as c:
-        # Key too short (63 chars instead of 64) - caught by the size check
-        with pytest.raises(Exception, match='Unexpected key size'):
+        # Key too short (63 chars instead of 64) - caught by regex pattern
+        with pytest.raises(Exception, match='Not a valid raw API key'):
             c.call('api_key.convert_raw_key', '123-' + 'a' * 63)
 
-        # Key too long (65 chars instead of 64) - caught by the size check
-        with pytest.raises(Exception, match='Unexpected key size'):
+        # Key too long (65 chars instead of 64) - caught by regex pattern
+        with pytest.raises(Exception, match='Not a valid raw API key'):
             c.call('api_key.convert_raw_key', '123-' + 'a' * 65)
 
 

--- a/tests/unit/test_utmp.py
+++ b/tests/unit/test_utmp.py
@@ -70,9 +70,8 @@ def unix_pam_authenticator(username: str, origin: ConnectionOrigin):
     # Constructor now takes username and origin
     pam_hdl = authenticator.UnixPamAuthenticator(username=username, origin=origin)
 
-    # Authenticate. The unix-socket authenticator ignores the password but the
-    # method signature requires one, so pass an empty string.
-    pam_resp = pam_hdl.authenticate(username, '')
+    # Authenticate (no origin parameter)
+    pam_resp = pam_hdl.authenticate(username)
     assert pam_resp.code == PAMCode.PAM_SUCCESS, pam_resp.reason
 
     # Login (no session parameter)


### PR DESCRIPTION
Commit 73131a9947 (NAS-141279, backport of master PR #19081) rewrote test_utmp.py and test_api_key_keyring.py to match master's implementations, but stable/26 differs, so the tests broke:

- InternalPamAuthenticator.authenticate() takes only (self, username) on stable/26 -- auth.py:pam_authenticate() calls it with one arg. Master added a password argument. Restore authenticate(username).

- api_key.convert_raw_key rejects wrong-length keys via the RAW_KEY_PATTERN regex on stable/26 ("Not a valid raw API key"); the separate "Unexpected key size" length check is only reachable on master's non-length regex. Restore the regex-pattern expectation.

Reverts only the two broken test hunks to their pre-73131a9947 state; the legitimate `assert self.ctx is not None` change in authenticator.py is kept.