### PR TITLE
NAS-141166 / 26.0.0-RC.1 / Remove stale ARC graph names from reporting API (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v26_0_0/reporting.py
@@ -55,8 +55,8 @@ class ReportingQuery(BaseModel):
 
 class GraphIdentifier(BaseModel):
     name: typing.Literal[
-        'cpu', 'cputemp', 'disk', 'interface', 'load', 'processes', 'memory', 'uptime', 'arcactualrate', 'arcrate',
-        'arcsize', 'arcresult', 'disktemp', 'upscharge', 'upsruntime', 'upsvoltage', 'upscurrent', 'upsfrequency',
+        'cpu', 'cputemp', 'disk', 'interface', 'load', 'processes', 'memory', 'uptime',
+        'arcsize', 'disktemp', 'upscharge', 'upsruntime', 'upsvoltage', 'upscurrent', 'upsfrequency',
         'upsload', 'upstemperature',
     ] = Field(
         description=(
@@ -70,10 +70,7 @@ class GraphIdentifier(BaseModel):
             "* `processes`: Process count and statistics\n"
             "* `memory`: Memory usage statistics\n"
             "* `uptime`: System uptime\n"
-            "* `arcactualrate`: ZFS ARC actual hit rate\n"
-            "* `arcrate`: ZFS ARC hit rate\n"
             "* `arcsize`: ZFS ARC cache size\n"
-            "* `arcresult`: ZFS ARC operation results\n"
             "* `disktemp`: Disk temperature readings\n"
             "* `upscharge`: UPS battery charge level\n"
             "* `upsruntime`: UPS estimated runtime\n"
@@ -93,6 +90,9 @@ class GraphIdentifier(BaseModel):
     )
 
 
+_REMOVED_GRAPH_NAMES = frozenset({'arcrate', 'arcactualrate', 'arcresult'})
+
+
 class ReportingNetdataGetDataArgs(BaseModel):
     graphs: list[GraphIdentifier] = Field(
         min_length=1,
@@ -102,6 +102,11 @@ class ReportingNetdataGetDataArgs(BaseModel):
         default_factory=lambda: ReportingQuery(),
         description="Query parameters for filtering and formatting the returned data.",
     )
+
+    @classmethod
+    def from_previous(cls, value):
+        value['graphs'] = [g for g in value['graphs'] if g.get('name') not in _REMOVED_GRAPH_NAMES]
+        return value
 
 
 class Aggregations(BaseModel):

--- a/src/middlewared/middlewared/plugins/reporting/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/graphs.py
@@ -84,7 +84,10 @@ class ReportingService(Service):
         query_params = await self.middleware.call('reporting.translate_query_params', query)
         graph_plugins = collections.defaultdict(list)
         for graph in graphs:
-            graph_plugins[self.__graphs[graph['name']]].append(graph['identifier'])
+            plugin = self.__graphs.get(graph['name'])
+            if plugin is None:
+                raise CallError(f'{graph["name"]!r} is not a valid graph plugin.', errno.ENOENT)
+            graph_plugins[plugin].append(graph['identifier'])
 
         results = []
         async for result in fetch_data_from_graph_plugins(graph_plugins, query_params, query['aggregate']):

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_reporting_graph_filter.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_reporting_graph_filter.py
@@ -1,0 +1,96 @@
+import pytest
+
+from middlewared.api.base.handler.accept import validate_model
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+from middlewared.api.v25_10_2.reporting import (
+    ReportingNetdataGetDataArgs as ReportingNetdataGetDataArgs_v25_10_2,
+)
+from middlewared.api.v25_10_3.reporting import (
+    ReportingNetdataGetDataArgs as ReportingNetdataGetDataArgs_v25_10_3,
+)
+from middlewared.api.v25_10_4.reporting import (
+    ReportingNetdataGetDataArgs as ReportingNetdataGetDataArgs_v25_10_4,
+)
+from middlewared.api.v26_0_0.reporting import (
+    ReportingNetdataGetDataArgs as ReportingNetdataGetDataArgs_v26_0_0,
+)
+from middlewared.service_exception import ValidationErrors
+
+from .utils import TestModelProvider
+
+
+def _build_adapter():
+    return APIVersionsAdapter(
+        [
+            APIVersion(
+                "v25.10.2",
+                TestModelProvider(
+                    {
+                        "ReportingNetdataGetDataArgs": ReportingNetdataGetDataArgs_v25_10_2,
+                    }
+                ),
+            ),
+            APIVersion(
+                "v25.10.3",
+                TestModelProvider(
+                    {
+                        "ReportingNetdataGetDataArgs": ReportingNetdataGetDataArgs_v25_10_3,
+                    }
+                ),
+            ),
+            APIVersion(
+                "v25.10.4",
+                TestModelProvider(
+                    {
+                        "ReportingNetdataGetDataArgs": ReportingNetdataGetDataArgs_v25_10_4,
+                    }
+                ),
+            ),
+            APIVersion(
+                "v26.0.0",
+                TestModelProvider(
+                    {
+                        "ReportingNetdataGetDataArgs": ReportingNetdataGetDataArgs_v26_0_0,
+                    }
+                ),
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("removed_name", ["arcrate", "arcactualrate", "arcresult"])
+async def test_removed_graph_names_are_filtered_when_upgrading(removed_name):
+    adapter = _build_adapter()
+    value = {
+        "graphs": [{"name": removed_name, "identifier": None}, {"name": "cpu", "identifier": None}],
+        "query": {},
+    }
+
+    result = await adapter.adapt(value, "ReportingNetdataGetDataArgs", "v25.10.2", "v26.0.0")
+
+    assert [g["name"] for g in result["graphs"]] == ["cpu"]
+
+
+@pytest.mark.asyncio
+async def test_all_removed_graphs_triggers_validation_error():
+    adapter = _build_adapter()
+    value = {
+        "graphs": [{"name": "arcrate", "identifier": None}, {"name": "arcresult", "identifier": None}],
+        "query": {},
+    }
+
+    adapted = await adapter.adapt(value, "ReportingNetdataGetDataArgs", "v25.10.2", "v26.0.0")
+    assert adapted["graphs"] == []
+    with pytest.raises(ValidationErrors):
+        validate_model(ReportingNetdataGetDataArgs_v26_0_0, adapted)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("removed_name", ["arcrate", "arcactualrate", "arcresult"])
+async def test_current_v26_rejects_removed_names_directly(removed_name):
+    with pytest.raises(ValidationErrors):
+        validate_model(
+            ReportingNetdataGetDataArgs_v26_0_0,
+            {"graphs": [{"name": removed_name, "identifier": None}], "query": {}},
+        )


### PR DESCRIPTION
## Problem

`reporting.get_data` accepted three graph names — `arcrate`, `arcactualrate`, `arcresult` — whose backing plugin classes were deleted during the ZFS netdata plugin rewrite. The Pydantic `Literal` and the in-memory `__graphs` dict drifted out of sync, so passing any of them crashed `netdata_get_data` with an uncaught `KeyError`.

## Solution

Removed the dead names from `GraphIdentifier.name`'s `Literal` and docstring in both `v26_0_0/reporting.py` and `v27_0_0/reporting.py`. Added a `ReportingNetdataGetDataArgs.from_previous` on each so legacy WS clients walking the adapter chain get the dead entries silently filtered instead of a hard rejection at the final v27 boundary. Hardened the dispatch site in `plugins/reporting/graphs.py` to raise `CallError(ENOENT)` for any unknown name — mirroring what `netdata_graph` already does — so future schema/implementation drift surfaces as a clean RPC error rather than an unhandled exception.

Original PR: https://github.com/truenas/middleware/pull/19072
