### PR TITLE
NAS-141362 / 25.10.4.1 / Fix handling field aliases in `APIVersionsAdapter`

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/version.py
+++ b/src/middlewared/middlewared/api/base/handler/version.py
@@ -162,10 +162,13 @@ class APIVersionsAdapter:
         new_model: type[BaseModel],
         direction: Direction,
     ):
+        current_model_fields = {field.alias or name: field for name, field in current_model.model_fields.items()}
+        new_model_fields = {field.alias or name: field for name, field in new_model.model_fields.items()}
+
         for k in value:
-            if k in current_model.model_fields and k in new_model.model_fields:
-                current_model_field = current_model.model_fields[k].annotation
-                new_model_field = new_model.model_fields[k].annotation
+            if k in current_model_fields and k in new_model_fields:
+                current_model_field = current_model_fields[k].annotation
+                new_model_field = new_model_fields[k].annotation
                 if (
                     isinstance(value[k], dict) and
                     (current_nested_model := model_field_is_model(current_model_field, value_hint=value[k])) and
@@ -188,7 +191,7 @@ class APIVersionsAdapter:
                     ]
 
         if new_model.__class__ is not ForUpdateMetaclass:
-            for k, field in new_model.model_fields.items():
+            for k, field in new_model_fields.items():
                 if k not in value and not field.is_required():
                     value[k] = field.get_default()
 
@@ -199,7 +202,7 @@ class APIVersionsAdapter:
                 value = new_model.from_previous(value)
 
         for k in list(value):
-            if k in current_model.model_fields and k not in new_model.model_fields:
+            if k in current_model_fields and k not in new_model_fields:
                 value.pop(k)
 
         for k, v in list(value.items()):

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_alias.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_alias.py
@@ -1,0 +1,28 @@
+from pydantic import Field
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+
+from .utils import TestModelProvider
+
+
+class SettingsV1(BaseModel):
+    query_options: str = Field(alias="query-options", default="canary")
+
+
+class SettingsV2(BaseModel):
+    query_options: str = Field(alias="query-options", default="canary")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version1,value,version2,result", [
+    ("v1", {"query-options": "options"}, "v2", {"query-options": "options"}),
+    ("v2", {"query-options": "options"}, "v1", {"query-options": "options"}),
+])
+async def test_adapt(version1, value, version2, result):
+    adapter = APIVersionsAdapter([
+        APIVersion("v1", TestModelProvider({"Settings": SettingsV1})),
+        APIVersion("v2", TestModelProvider({"Settings": SettingsV2})),
+    ])
+    assert await adapter.adapt(value, "Settings", version1, version2) == result


### PR DESCRIPTION
Not handling field aliases properly results in a series of tests failing:

```
test_query_method[legacy_api_client=v25.10.3-query_method=audit.query] api2.test_legacy_api

middlewared.service_exception.ValidationErrors: [EINVAL] data.query_filters: Extra inputs are not permitted
[EINVAL] data.query_options: Extra inputs are not permitted
```