### PR TITLE
NAS-141321 / 27.0.0-BETA.1 / Suspend VMs on snapshot by default (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-06-08_12-30_vm_suspend_on_snapshot_default.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-06-08_12-30_vm_suspend_on_snapshot_default.py
@@ -1,0 +1,28 @@
+"""VM suspend_on_snapshot default to true
+
+Revision ID: 7d3a1f9c2e84
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-08 12:30:00.000000+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7d3a1f9c2e84"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("vm_vm", schema=None) as batch_op:
+        batch_op.alter_column(
+            "suspend_on_snapshot",
+            existing_type=sa.Boolean(),
+            server_default="1",
+            existing_nullable=False,
+        )
+    op.execute("UPDATE vm_vm SET suspend_on_snapshot = 1")

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-06-11_15-08_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-06-11_15-08_merge.py
@@ -1,0 +1,24 @@
+"""Merge migration for NAS-141321: suspend VMs on snapshot by default (revision 7d3a1f9c2e84).
+
+Revision ID: de51ca6f583a
+Revises: 9ca2e97e239c, 7d3a1f9c2e84
+Create Date: 2026-06-11 15:08:52.992346+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'de51ca6f583a'
+down_revision = ('9ca2e97e239c', '7d3a1f9c2e84')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v25_04_2/vm.py
+++ b/src/middlewared/middlewared/api/v25_04_2/vm.py
@@ -54,7 +54,7 @@ class VMEntry(BaseModel):
     nodeset: str | None = None  # TODO: Same as above
     enable_cpu_topology_extension: bool = False
     pin_vcpus: bool = False
-    suspend_on_snapshot: bool = False
+    suspend_on_snapshot: bool = True
     trusted_platform_module: bool = False
     memory: int = Field(ge=20)
     min_memory: int | None = Field(ge=20, default=None)

--- a/src/middlewared/middlewared/api/v25_10_0/vm.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm.py
@@ -86,7 +86,7 @@ class VMEntry(BaseModel):
             "Whether to pin virtual CPUs to specific host CPU cores. Improves performance but reduces host flexibility."
         ),
     )
-    suspend_on_snapshot: bool = Field(default=False, description="Whether to suspend the VM when taking snapshots.")
+    suspend_on_snapshot: bool = Field(default=True, description="Whether to suspend the VM when taking snapshots.")
     trusted_platform_module: bool = Field(
         default=False,
         description="Whether to enable virtual Trusted Platform Module (TPM) for the VM.",

--- a/src/middlewared/middlewared/api/v25_10_1/vm.py
+++ b/src/middlewared/middlewared/api/v25_10_1/vm.py
@@ -86,7 +86,7 @@ class VMEntry(BaseModel):
             "Whether to pin virtual CPUs to specific host CPU cores. Improves performance but reduces host flexibility."
         ),
     )
-    suspend_on_snapshot: bool = Field(default=False, description="Whether to suspend the VM when taking snapshots.")
+    suspend_on_snapshot: bool = Field(default=True, description="Whether to suspend the VM when taking snapshots.")
     trusted_platform_module: bool = Field(
         default=False,
         description="Whether to enable virtual Trusted Platform Module (TPM) for the VM.",

--- a/src/middlewared/middlewared/api/v25_10_2/vm.py
+++ b/src/middlewared/middlewared/api/v25_10_2/vm.py
@@ -86,7 +86,7 @@ class VMEntry(BaseModel):
             "Whether to pin virtual CPUs to specific host CPU cores. Improves performance but reduces host flexibility."
         ),
     )
-    suspend_on_snapshot: bool = Field(default=False, description="Whether to suspend the VM when taking snapshots.")
+    suspend_on_snapshot: bool = Field(default=True, description="Whether to suspend the VM when taking snapshots.")
     trusted_platform_module: bool = Field(
         default=False,
         description="Whether to enable virtual Trusted Platform Module (TPM) for the VM.",

--- a/src/middlewared/middlewared/api/v26_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm.py
@@ -90,7 +90,7 @@ class VMEntry(BaseModel):
             "Whether to pin virtual CPUs to specific host CPU cores. Improves performance but reduces host flexibility."
         ),
     )
-    suspend_on_snapshot: bool = Field(default=False, description="Whether to suspend the VM when taking snapshots.")
+    suspend_on_snapshot: bool = Field(default=True, description="Whether to suspend the VM when taking snapshots.")
     trusted_platform_module: bool = Field(
         default=False,
         description="Whether to enable virtual Trusted Platform Module (TPM) for the VM.",

--- a/src/middlewared/middlewared/api/v27_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm.py
@@ -86,7 +86,7 @@ class VMEntry(BaseModel):
             "Whether to pin virtual CPUs to specific host CPU cores. Improves performance but reduces host flexibility."
         ),
     )
-    suspend_on_snapshot: bool = Field(default=False, description="Whether to suspend the VM when taking snapshots.")
+    suspend_on_snapshot: bool = Field(default=True, description="Whether to suspend the VM when taking snapshots.")
     trusted_platform_module: bool = Field(
         default=False,
         description="Whether to enable virtual Trusted Platform Module (TPM) for the VM.",

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -66,7 +66,7 @@ class VMModel(sa.Model):
     nodeset = sa.Column(sa.Text(), default=None, nullable=True)
     pin_vcpus = sa.Column(sa.Boolean(), default=False)
     hide_from_msr = sa.Column(sa.Boolean(), default=False)
-    suspend_on_snapshot = sa.Column(sa.Boolean(), default=False)
+    suspend_on_snapshot = sa.Column(sa.Boolean(), default=True)
     ensure_display_device = sa.Column(sa.Boolean(), default=True)
     arch_type = sa.Column(sa.String(255), default=None, nullable=True)
     machine_type = sa.Column(sa.String(255), default=None, nullable=True)


### PR DESCRIPTION
## Summary

Change the default value of the per-VM `suspend_on_snapshot` setting from `false` to `true`, so that newly created VMs — and existing ones that never explicitly set it — are quiesced while a periodic snapshot of their disk dataset is taken. This produces crash-consistent disk images instead of snapshotting a running VM's storage live.

This restores the effective behavior that existed before #19053. Prior to that PR, `vm.suspend_vms` suspended every running VM on its dataset's snapshot regardless of the per-VM `suspend_on_snapshot` value — so in practice running VMs were *always* suspended. #19053 fixed the flag so it is actually honored. But because the field defaulted to `false`, honoring it meant most VMs would no longer be suspended on snapshot — a regression from the long-standing behavior. Flipping the default to `true` keeps suspend-on-snapshot as the out-of-the-box behavior while still letting users opt out per VM.

## Migration / upgrade behavior

On upgrade, every existing VM has `suspend_on_snapshot` set to `true`, regardless of its prior value. This is deliberate: before #19053 these VMs were already being suspended on snapshot, so setting the flag to `true` preserves the behavior they had rather than silently changing it.

Original PR: https://github.com/truenas/middleware/pull/19091
