### PR TITLE
NAS-140265 / 27.0.0-BETA.1 / Always render security_group ACG for FC targets

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -128,7 +128,11 @@
             for initiator in group_initiators:
                 if wwn := wwn_as_colon_hex(initiator):
                     initiator_access.add(wwn)
-        return initiator_access
+        # Always emit a security_group ACG: scstadmin's del_group on an
+        # ACG with attached FC sessions fails with -EBUSY, leaving running
+        # config out of sync with /etc/scst.conf. The wildcard keeps the
+        # ACG in place so initiator transitions are in-place ACN updates.
+        return initiator_access or {'*'}
 
     # There are several changes that must occur if ALUA is enabled,
     # and these are different depending on whether this is the


### PR DESCRIPTION
When an FC target's middleware initiator setting resolves to no WWPNs, the mako previously dropped the GROUP security_group block entirely. pyscstadmin's diff then has to issue del_group against the running kernel, which SCST rejects with -EBUSY while FC sessions remain attached. The result is /etc/scst.conf and the running configuration silently diverging until a stop/start of the iscsi service.

Default the rendered initiator set to {'*'} when no WWPN restriction is configured so the ACG is always present. Initiator updates then become in-place INITIATOR add/remove operations rather than del_group; SCST applies those cleanly.

----
Tested manually with FC.