### PR TITLE
NAS-141362 / 27.0.0-BETA.1 / Fix handling field aliases in `APIVersionsAdapter` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_alias.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_adapt_alias.py
@@ -1,0 +1,28 @@
+from pydantic import Field
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+
+from .utils import TestModelProvider
+
+
+class SettingsV1(BaseModel):
+    query_options: str = Field(alias="query-options", default="canary")
+
+
+class SettingsV2(BaseModel):
+    query_options: str = Field(alias="query-options", default="canary")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version1,value,version2,result", [
+    ("v1", {"query-options": "options"}, "v2", {"query-options": "options"}),
+    ("v2", {"query-options": "options"}, "v1", {"query-options": "options"}),
+])
+async def test_adapt(version1, value, version2, result):
+    adapter = APIVersionsAdapter([
+        APIVersion("v1", TestModelProvider({"Settings": SettingsV1})),
+        APIVersion("v2", TestModelProvider({"Settings": SettingsV2})),
+    ])
+    assert await adapter.adapt(value, "Settings", version1, version2) == result


### PR DESCRIPTION
Not handling field aliases properly results in a series of tests failing:

```
test_query_method[legacy_api_client=v25.10.3-query_method=audit.query] api2.test_legacy_api

middlewared.service_exception.ValidationErrors: [EINVAL] data.query_filters: Extra inputs are not permitted
[EINVAL] data.query_options: Extra inputs are not permitted
```

Original PR: https://github.com/truenas/middleware/pull/19108
