### PR TITLE
NAS-141369 / 27.0.0-BETA.1 / Fix container/VM migrations crash when ran without pwenc secret

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2025-10-13_12-00_add_mac_to_vm_nics.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2025-10-13_12-00_add_mac_to_vm_nics.py
@@ -33,7 +33,10 @@ def upgrade():
     conn = op.get_bind()
 
     for row in conn.execute(text("SELECT * FROM vm_device")).mappings().all():
-        attributes = json.loads(decrypt(row['attributes']))
+        if not (decrypted := decrypt(row['attributes'])):
+            continue
+
+        attributes = json.loads(decrypted)
 
         if attributes.get('dtype') != 'NIC':
             continue

--- a/src/middlewared/middlewared/alembic/versions/26.0/2025-11-05_13-37-00_container_fields_cleanup.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2025-11-05_13-37-00_container_fields_cleanup.py
@@ -24,7 +24,10 @@ def upgrade():
     conn = op.get_bind()
 
     for device in conn.execute(text("SELECT * FROM container_device")).mappings().all():
-        attributes = json.loads(decrypt(device['attributes']))
+        if not (decrypted := decrypt(device['attributes'])):
+            continue
+
+        attributes = json.loads(decrypted)
 
         if attributes.get('dtype') not in ('DISK', 'RAW', 'USB'):
             continue

--- a/src/middlewared/middlewared/alembic/versions/26.0/2025-11-06_21-48-00_disk_raw_container_cleanup.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2025-11-06_21-48-00_disk_raw_container_cleanup.py
@@ -25,7 +25,10 @@ def upgrade():
 
     # Get all container devices and delete those with dtype 'DISK' or 'RAW'
     for device in conn.execute(text("SELECT * FROM container_device")).mappings().all():
-        attributes = json.loads(decrypt(device['attributes']))
+        if not (decrypted := decrypt(device['attributes'])):
+            continue
+
+        attributes = json.loads(decrypted)
 
         if attributes.get('dtype') in ('DISK', 'RAW'):
             conn.execute(


### PR DESCRIPTION
When container/VM migrations are ran without valid pwenc secret present (config imported without pwenc secret), they crash the migration process, because `decrypt` returns an empty string, and we try to `json.loads` it. We should skip empty strings in this case, the same way we do in all other similar migrations.