### PR TITLE
NAS-141372 / 27.0.0-BETA.1 / Cleanup SSH tests code

### DIFF
--- a/src/middlewared/middlewared/test/integration/runner/config.py
+++ b/src/middlewared/middlewared/test/integration/runner/config.py
@@ -29,7 +29,7 @@ def write_config(ctx: Context) -> None:
         artifacts = "{ctx.artifacts}"
         isns_ip = "{ctx.isns_ip}"
         extended_tests = {ctx.extended_tests}
-        sshKey = "{ctx.ssh_key}"
+        sshKey = {ctx.ssh_key!r}
     """)
 
     with open("auto_config.py", "w") as f:

--- a/src/middlewared/middlewared/test/integration/runner/context.py
+++ b/src/middlewared/middlewared/test/integration/runner/context.py
@@ -11,7 +11,7 @@ import sys
 from middlewared.test.integration.utils.client import client
 
 from .args import RunArgs
-from .ssh import add_ssh_key, create_key, setup_ssh_agent
+from .ssh import create_key
 
 
 @dataclasses.dataclass
@@ -81,13 +81,11 @@ def context_from_args(args: RunArgs, workdir: str) -> Context:
     local_home = os.path.expanduser("~")
     dotssh_path = local_home + "/.ssh"
     ssh_key_path = dotssh_path + "/test_id_rsa"
-    setup_ssh_agent()
     os.makedirs(dotssh_path, exist_ok=True)
     if not os.path.exists(ssh_key_path):
         create_key(ssh_key_path)
-    add_ssh_key(ssh_key_path)
-    with open(ssh_key_path, "r") as f:
-        ssh_key = f.readlines()[0].rstrip()
+    with open(ssh_key_path + ".pub", "r") as f:
+        ssh_key = f.read()
 
     return Context(
         **d,

--- a/src/middlewared/middlewared/test/integration/runner/ssh.py
+++ b/src/middlewared/middlewared/test/integration/runner/ssh.py
@@ -1,51 +1,8 @@
-import os
-import re
-from subprocess import PIPE, run
-
-
-def start_ssh_agent() -> bool:
-    process = run(["ssh-agent", "-s"], stdout=PIPE, universal_newlines=True)
-    to_recompile = r"SSH_AUTH_SOCK=(?P<socket>[^;]+).*SSH_AGENT_PID=(?P<pid>\d+)"
-    OUTPUT_PATTERN = re.compile(to_recompile, re.MULTILINE | re.DOTALL)
-    match = OUTPUT_PATTERN.search(process.stdout)
-    if match is None:
-        return False
-    else:
-        agentData = match.groupdict()
-        os.environ["SSH_AUTH_SOCK"] = agentData["socket"]
-        os.environ["SSH_AGENT_PID"] = agentData["pid"]
-        return True
-
-
-def is_agent_setup() -> bool:
-    return os.environ.get("SSH_AUTH_SOCK") is not None
-
-
-def setup_ssh_agent() -> bool:
-    if is_agent_setup():
-        return True
-    else:
-        return start_ssh_agent()
+from subprocess import run
 
 
 def create_key(keyPath: str) -> bool:
     process = run('ssh-keygen -t rsa -f %s -q -N ""' % keyPath, shell=True)
-    if process.returncode != 0:
-        return False
-    else:
-        return True
-
-
-def if_key_listed() -> bool:
-    process = run("ssh-add -L", shell=True)
-    if process.returncode != 0:
-        return False
-    else:
-        return True
-
-
-def add_ssh_key(keyPath: str) -> bool:
-    process = run(["ssh-add", keyPath])
     if process.returncode != 0:
         return False
     else:

--- a/src/middlewared/middlewared/test/integration/utils/legacy_functions.py
+++ b/src/middlewared/middlewared/test/integration/utils/legacy_functions.py
@@ -56,7 +56,7 @@ def POST(testpath, payload=None, controller_a=False, **optional):
     return postit
 
 
-def SSH_TEST(command, username, passwrd, host=None, timeout=120):
+def SSH_TEST(command, username, passwrd, host=None, timeout=120, key_path=None):
     target = host or get_host_ip(SRVTarget.DEFAULT)
 
     cmd = [] if passwrd is None else ["sshpass", "-p", passwrd]
@@ -70,6 +70,10 @@ def SSH_TEST(command, username, passwrd, host=None, timeout=120):
         "VerifyHostKeyDNS=no",
         "-o",
         "LogLevel=error",
+    ]
+    if key_path:
+        cmd += ["-i", key_path]
+    cmd += [
         f"{username}@{target}",
         command,
     ]

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -4,8 +4,7 @@ import os
 
 import pytest
 
-from auto_config import sshKey, user, password
-from middlewared.test.integration.runner.ssh import if_key_listed
+from auto_config import keyPath, sshKey, user, password
 from middlewared.test.integration.utils import fail, ssh
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils.legacy_functions import SSH_TEST
@@ -89,9 +88,7 @@ def test_005_ssh_using_root_password():
 
 
 def test_006_setup_and_login_using_root_ssh_key():
-    assert os.environ.get('SSH_AUTH_SOCK') is not None
-    assert if_key_listed() is True  # horrible function name
-    results = SSH_TEST('ls -la', user, None)
+    results = SSH_TEST('ls -la', user, None, key_path=keyPath)
     assert results['result'] is True, results['output']
 
 


### PR DESCRIPTION
No need to use SSH agent, we can just supply the key from the file.

Additionally, fixes a regression introduced with runtest.py rewrite that made `test_005_ssh_using_root_password` fail.