### PR TITLE
NAS-141221 / 26.0.0-RC.1 / Handle absent system.advanced foreign key constraints in migrations (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-03-06_01-25_remove_syslog_tls_certificate_authority.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-03-06_01-25_remove_syslog_tls_certificate_authority.py
@@ -17,9 +17,21 @@ depends_on = None
 
 
 def upgrade():
+    has_fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority = False
+    conn = op.get_bind()
+    for sql in map(dict, conn.execute(sa.text(
+        "SELECT sql FROM sqlite_schema WHERE type = 'table' AND tbl_name = 'system_advanced'"
+    )).mappings().all()):
+        if "fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority" in sql["sql"]:
+            has_fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority = True
+
     with op.batch_alter_table('system_advanced', schema=None) as batch_op:
         batch_op.drop_index('ix_system_advanced_adv_syslog_tls_certificate_authority_id')
-        batch_op.drop_constraint('fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority', type_='foreignkey')
+        if has_fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority:
+            batch_op.drop_constraint(
+                'fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority',
+                type_='foreignkey',
+            )
         batch_op.drop_column('adv_syslog_tls_certificate_authority_id')
 
 

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-08-29_15-41_second_syslog_server.py
@@ -29,10 +29,22 @@ def upgrade():
     else:
         server, transport, cert_id = None, None, None
 
+    has_fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate = False
+    conn = op.get_bind()
+    for sql in map(dict, conn.execute(sa.text(
+        "SELECT sql FROM sqlite_schema WHERE type = 'table' AND tbl_name = 'system_advanced'"
+    )).mappings().all()):
+        if "fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate" in sql["sql"]:
+            has_fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate = True
+
     with op.batch_alter_table('system_advanced', schema=None) as batch_op:
         batch_op.add_column(sa.Column('adv_syslogservers', sa.TEXT(), nullable=False, server_default='[]'))
         batch_op.drop_index('ix_system_advanced_adv_syslog_tls_certificate_id')
-        batch_op.drop_constraint('fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate', type_='foreignkey')
+        if has_fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate:
+            batch_op.drop_constraint(
+                'fk_system_advanced_adv_syslog_tls_certificate_id_system_certificate',
+                type_='foreignkey',
+            )
         batch_op.drop_column('adv_syslog_tls_certificate_id')
         batch_op.drop_column('adv_syslogserver')
         batch_op.drop_column('adv_syslog_transport')


### PR DESCRIPTION
The root cause of the issue is not clear. I have a weak suspicion that the table was recreated manually, because of
```
sqlite> .schema system_advanced
CREATE TABLE IF NOT EXISTS "system_advanced" (
	id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, 
	adv_consolemenu BOOLEAN NOT NULL, 
        ...
	adv_kernel_extra_options TEXT DEFAULT ('') NOT NULL, 
	adv_syslog_audit BOOLEAN NOT NULL, adv_login_banner TEXT DEFAULT '' NOT NULL, 
	FOREIGN KEY(adv_syslog_tls_certificate_authority_id) REFERENCES system_certificateauthority (id), 
	FOREIGN KEY(adv_syslog_tls_certificate_id) REFERENCES system_certificate (id)
);
```
Note `adv_syslog_audit BOOLEAN NOT NULL, adv_login_banner TEXT DEFAULT '' NOT NULL, ` on single line. Alembic does not generate such code.

Original PR: https://github.com/truenas/middleware/pull/19115
