### PR TITLE
NAS-141370 / 26.0.0-RC.1 / Fix `list_partitions` crash (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info.py
@@ -117,7 +117,7 @@ class DiskService(Service):
         if not bd.children:
             return parts
 
-        req_keys = ('ID_PART_ENTRY_' + i for i in ('TYPE', 'UUID', 'NUMBER', 'SIZE'))
+        req_keys = ['ID_PART_ENTRY_' + i for i in ('TYPE', 'UUID', 'NUMBER', 'SIZE')]
         for p in filter(lambda p: all(p.get(k) for k in req_keys), bd.children):
             part_name = self.get_partition_for_disk(disk, p['ID_PART_ENTRY_NUMBER'])
             pinfo = get_partition_size_info(disk, int(p['ID_PART_ENTRY_OFFSET']), int(p['ID_PART_ENTRY_SIZE']))


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/disk_info.py", line 122, in list_partitions
    part_name = self.get_partition_for_disk(disk, p['ID_PART_ENTRY_NUMBER'])
                                                  ~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pyudev/device/_device.py", line 973, in __getitem__
    return self.properties.__getitem__(prop)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3/dist-packages/pyudev/device/_device.py", line 1100, in __getitem__
    raise KeyError(prop)
KeyError: 'ID_PART_ENTRY_NUMBER'
```

The root cause of the issue is that `req_keys` was a generator, and iterating over the second, the third, and so-on time returns an empty list. Which makes `all(p.get(k) for k in req_keys)` always `True`. Which makes `filter` expression not filter out partitions without specified keys.

Original PR: https://github.com/truenas/middleware/pull/19117
