### PR TITLE
NAS-141273 / 27.0.0-BETA.1 / Remove shared pydantic `Field()` from API type aliases (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/base/types/__init__.py
+++ b/src/middlewared/middlewared/api/base/types/__init__.py
@@ -4,6 +4,7 @@ from .dict import *  # noqa
 from .fc import *  # noqa
 from .filesystem import *  # noqa
 from .iscsi import *  # noqa
+from .json_schema import *  # noqa
 from .ldap import * # noqa
 from .list import *  # noqa
 from .network import *  # noqa

--- a/src/middlewared/middlewared/api/base/types/json_schema.py
+++ b/src/middlewared/middlewared/api/base/types/json_schema.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from pydantic import GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+
+__all__ = ["JsonSchemaExtra"]
+
+
+class JsonSchemaExtra:
+    """Annotated metadata that merges extra keys into a field's generated JSON schema.
+
+    Use this instead of ``Field(examples=..., json_schema_extra=...)`` inside a *shared*
+    ``Annotated`` type alias. ``Field(...)`` produces a single ``FieldInfo`` instance that
+    is reused by every model field referencing the alias. Pydantic's field-merge machinery
+    shallow-copies that ``FieldInfo`` and shares its ``_attributes_set`` dict, so a stray
+    ``default`` recorded for one consumer leaks into all the others (silently turning
+    required fields optional). ``JsonSchemaExtra`` is a plain immutable metadata object with
+    no such mutable state, so it is safe to embed in a shared alias.
+    """
+
+    __slots__ = ("extra",)
+
+    def __init__(self, **extra: Any) -> None:
+        self.extra = extra
+
+    def __get_pydantic_json_schema__(self, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema.update(self.extra)
+        return json_schema

--- a/src/middlewared/middlewared/api/base/types/list.py
+++ b/src/middlewared/middlewared/api/base/types/list.py
@@ -1,7 +1,9 @@
 from typing import Annotated, TypeVar
 
-from pydantic import AfterValidator, Field
 from pydantic_core import PydanticCustomError
+from pydantic import AfterValidator, Field
+
+from middlewared.api.base.types.json_schema import JsonSchemaExtra
 
 __all__ = ['UniqueList']
 
@@ -19,4 +21,4 @@ def _validate_unique_list(v: list[T]) -> list[T]:
     return v
 
 
-UniqueList = Annotated[list[T], AfterValidator(_validate_unique_list), Field(json_schema_extra={'uniqueItems': True})]
+UniqueList = Annotated[list[T], AfterValidator(_validate_unique_list), JsonSchemaExtra(uniqueItems=True)]

--- a/src/middlewared/middlewared/api/base/types/list.py
+++ b/src/middlewared/middlewared/api/base/types/list.py
@@ -1,7 +1,7 @@
 from typing import Annotated, TypeVar
 
+from pydantic import AfterValidator
 from pydantic_core import PydanticCustomError
-from pydantic import AfterValidator, Field
 
 from middlewared.api.base.types.json_schema import JsonSchemaExtra
 

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -5,8 +5,8 @@ import ipaddress
 import re
 from typing import Annotated, Literal
 
-import pydantic
 from annotated_types import Ge, Le
+import pydantic
 from pydantic import AfterValidator
 
 from ..validators import match_validator

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -6,7 +6,8 @@ import re
 from typing import Annotated, Literal
 
 import pydantic
-from pydantic import AfterValidator, Field
+from annotated_types import Ge, Le
+from pydantic import AfterValidator
 
 from ..validators import match_validator
 
@@ -73,7 +74,7 @@ def _validate_nameserver(address: pydantic.IPvAnyAddress) -> str:
     return str_form
 
 
-TcpPort = Annotated[int, Field(ge=1, le=65535)]
+TcpPort = Annotated[int, Ge(1), Le(65535)]
 Hostname = Annotated[str, AfterValidator(match_validator(
     re.compile(r"^[a-z.\-0-9]*[a-z0-9]$", re.IGNORECASE),
     "Hostname can only contain letters, numbers, periods, and dashes and must end with a letter or number"

--- a/src/middlewared/middlewared/api/base/types/nvmet.py
+++ b/src/middlewared/middlewared/api/base/types/nvmet.py
@@ -4,7 +4,8 @@ import re
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import AfterValidator, Field
+from annotated_types import MaxLen, MinLen
+from pydantic import AfterValidator
 
 __all__ = [
     "NQN"
@@ -48,4 +49,4 @@ def _validate_nqn(nqn: str) -> str:
     return nqn
 
 
-NQN = Annotated[str, Field(min_length=MIN_NQN_LEN, max_length=MAX_NQN_LEN), AfterValidator(_validate_nqn)]
+NQN = Annotated[str, MinLen(MIN_NQN_LEN), MaxLen(MAX_NQN_LEN), AfterValidator(_validate_nqn)]

--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -6,13 +6,10 @@ import uuid
 from annotated_types import MaxLen, MinLen
 from pydantic import (
     AfterValidator,
-    BeforeValidator,
-    Field,
-    GetCoreSchemaHandler,
+)
+from pydantic import (
     HttpUrl as _HttpUrl,
 )
-from pydantic_core import CoreSchema, core_schema, PydanticKnownError
-
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base.types.json_schema import JsonSchemaExtra

--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 from typing import Annotated
 import uuid
 
+from annotated_types import MaxLen, MinLen
 from pydantic import (
     AfterValidator,
+    BeforeValidator,
     Field,
-)
-from pydantic import (
+    GetCoreSchemaHandler,
     HttpUrl as _HttpUrl,
 )
+from pydantic_core import CoreSchema, core_schema, PydanticKnownError
+
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
+from middlewared.api.base.types.json_schema import JsonSchemaExtra
 from middlewared.api.base.validators import email_validator, time_validator
 from middlewared.utils.netbios import validate_netbios_domain, validate_netbios_name
 from middlewared.utils.smb import validate_smb_share_name
@@ -33,10 +37,12 @@ def uuidv4_validator(value: str) -> str:
 
 HttpUrl = Annotated[_HttpUrl, AfterValidator(str)]
 # By default, our strings are no more than 1024 characters long. This string is 2**31-1 characters long (SQLite limit).
-LongString = Annotated[str, Field(max_length=2 ** 31 - 1)]
-NonEmptyString = Annotated[str, Field(min_length=1)]
-LongNonEmptyString = Annotated[LongString, Field(min_length=1)]
-TimeString = Annotated[str, AfterValidator(time_validator), Field(examples=["00:00", "06:30", "18:00", "23:00"])]
+LongString = Annotated[str, MaxLen(2 ** 31 - 1)]
+NonEmptyString = Annotated[str, MinLen(1)]
+LongNonEmptyString = Annotated[LongString, MinLen(1)]
+TimeString = Annotated[
+    str, AfterValidator(time_validator), JsonSchemaExtra(examples=["00:00", "06:30", "18:00", "23:00"])
+]
 EmailString = Annotated[str, AfterValidator(email_validator)]
 NetbiosDomain = Annotated[str, AfterValidator(validate_netbios_domain)]
 NetbiosName = Annotated[str, AfterValidator(validate_netbios_name)]

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -1,7 +1,7 @@
 import string
 from typing import Annotated
 
-from pydantic import Field
+from annotated_types import Ge, Le, MinLen
 from pydantic.functional_validators import AfterValidator
 
 from middlewared.utils.sid import sid_is_valid
@@ -61,16 +61,16 @@ def validate_sid(value: str) -> str:
 
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
-RemoteUsername = Annotated[str, Field(min_length=1)]
+RemoteUsername = Annotated[str, MinLen(1)]
 GroupName = Annotated[
     str,
     AfterValidator(lambda x: validate_name(x, valid_start_chars=GROUP_VALID_START, max_length=None))
 ]
-LocalUID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
+LocalUID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
-LocalGID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
+LocalGID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
-ContainerXID = Annotated[int, Field(ge=1, le=XID_MAX)]
+ContainerXID = Annotated[int, Ge(1), Le(XID_MAX)]
 
 SID = Annotated[str, AfterValidator(validate_sid)]
 

--- a/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -34,7 +35,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -32,7 +32,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_1/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -34,7 +35,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_1/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -32,7 +32,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_2/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -105,7 +105,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_04_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -34,7 +35,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_04_2/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -32,7 +32,7 @@ class GraphiteExporter(BaseModel):
     matching_charts: NonEmptyString = '*'
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_04_2/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_04_2/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, RootModel, Secret, model_validator
+from pydantic import ConfigDict, Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -124,7 +124,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -12,6 +12,7 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,
@@ -39,7 +40,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_0/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acl.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal, Self
 
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 
 from middlewared.api.base import (
@@ -12,7 +13,6 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
-from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,

--- a/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -3,16 +3,21 @@ from typing import Annotated, Self
 
 from pydantic import AfterValidator, Field, model_validator
 
-from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+)
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -4,7 +4,12 @@ from typing import Annotated, Self
 from pydantic import AfterValidator, Field, model_validator
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+    BaseModel,
+    JsonSchemaExtra,
+    TimeString,
+    croniter_for_schedule,
+    validate_filters,
+    validate_options,
 )
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Any, Literal
 
+from annotated_types import Ge, Le
 from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
@@ -19,7 +20,6 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
-from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',

--- a/src/middlewared/middlewared/api/v25_10_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_0/directory_services.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, Secret, field_validator, model_validator
+from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
     LDAP_DN,
@@ -19,6 +19,7 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
+from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',
@@ -28,7 +29,7 @@ __all__ = [
     'DirectoryServicesCertificateChoicesArgs', 'DirectoryServicesCertificateChoicesResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -235,7 +236,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -248,6 +249,7 @@ class PrimaryDomainIdmap(BaseModel):
         ),
     )
     idmap_domain: DomainIdmap = Field(
+        default=RID_Idmap(idmap_backend='RID'),
         description=(
             "This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the "
             "TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs "
@@ -309,7 +311,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel,
@@ -207,7 +207,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -509,7 +509,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
@@ -2,10 +2,12 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
-from middlewared.api.base import BaseModel, Excluded, NonEmptyString, NotRequired, excluded_field, single_argument_args
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+)
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
 __all__ = [
@@ -33,8 +35,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool_snapshot.py
@@ -6,7 +6,13 @@ from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field
+    BaseModel,
+    Excluded,
+    JsonSchemaExtra,
+    NonEmptyString,
+    NotRequired,
+    excluded_field,
+    single_argument_args,
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 

--- a/src/middlewared/middlewared/api/v25_10_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -37,7 +38,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry = Field(description="The updated reporting configuration.")
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -42,7 +42,7 @@ class GraphiteExporter(BaseModel):
     )
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_0/smb.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Self, Union
 
-from pydantic import AfterValidator, Field, IPvAnyInterface, field_validator, model_validator
+from pydantic import AfterValidator, Discriminator, Field, IPvAnyInterface, field_validator, model_validator
 
 from middlewared.api.base import (
     SID,
@@ -679,7 +679,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, RootModel, Secret, model_validator
+from pydantic import ConfigDict, Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -201,7 +201,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_1/acl.py
@@ -12,6 +12,7 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,
@@ -39,7 +40,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_1/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_1/acl.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal, Self
 
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 
 from middlewared.api.base import (
@@ -12,7 +13,6 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
-from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,

--- a/src/middlewared/middlewared/api/v25_10_1/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_1/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/common.py
+++ b/src/middlewared/middlewared/api/v25_10_1/common.py
@@ -3,16 +3,21 @@ from typing import Annotated, Self
 
 from pydantic import AfterValidator, Field, model_validator
 
-from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+)
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/common.py
+++ b/src/middlewared/middlewared/api/v25_10_1/common.py
@@ -4,7 +4,12 @@ from typing import Annotated, Self
 from pydantic import AfterValidator, Field, model_validator
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+    BaseModel,
+    JsonSchemaExtra,
+    TimeString,
+    croniter_for_schedule,
+    validate_filters,
+    validate_options,
 )
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]

--- a/src/middlewared/middlewared/api/v25_10_1/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_1/directory_services.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Any, Literal
 
+from annotated_types import Ge, Le
 from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
@@ -19,7 +20,6 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
-from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',

--- a/src/middlewared/middlewared/api/v25_10_1/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_1/directory_services.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, Secret, field_validator, model_validator
+from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
     LDAP_DN,
@@ -19,6 +19,7 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
+from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',
@@ -29,7 +30,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -236,7 +237,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -249,6 +250,7 @@ class PrimaryDomainIdmap(BaseModel):
         ),
     )
     idmap_domain: DomainIdmap = Field(
+        default=RID_Idmap(idmap_backend='RID'),
         description=(
             "This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the "
             "TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs "
@@ -310,7 +312,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel,
@@ -207,7 +207,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -509,7 +509,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
@@ -2,10 +2,12 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
-from middlewared.api.base import BaseModel, Excluded, NonEmptyString, NotRequired, excluded_field, single_argument_args
+from middlewared.api.base import (
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
+)
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
 __all__ = [
@@ -33,8 +35,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_1/pool_snapshot.py
@@ -6,7 +6,13 @@ from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
+    BaseModel,
+    Excluded,
+    JsonSchemaExtra,
+    NonEmptyString,
+    NotRequired,
+    excluded_field,
+    single_argument_args,
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 

--- a/src/middlewared/middlewared/api/v25_10_1/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_1/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -37,7 +38,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry = Field(description="The updated reporting configuration.")
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_1/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_1/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -42,7 +42,7 @@ class GraphiteExporter(BaseModel):
     )
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_1/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_1/smb.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Self, Union
 
-from pydantic import AfterValidator, Field, IPvAnyInterface, field_validator, model_validator
+from pydantic import AfterValidator, Discriminator, Field, IPvAnyInterface, field_validator, model_validator
 
 from middlewared.api.base import (
     SID,
@@ -826,7 +826,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_1/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_1/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, RootModel, Secret, model_validator
+from pydantic import ConfigDict, Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -202,7 +202,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_2/acl.py
@@ -12,6 +12,7 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
+from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,
@@ -39,7 +40,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v25_10_2/acl.py
+++ b/src/middlewared/middlewared/api/v25_10_2/acl.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal, Self
 
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 
 from middlewared.api.base import (
@@ -12,7 +13,6 @@ from middlewared.api.base import (
     excluded_field,
     single_argument_args,
 )
-from annotated_types import Ge, Le
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
     NFS4_SPECIAL_ENTRIES,

--- a/src/middlewared/middlewared/api/v25_10_2/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_2/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/common.py
+++ b/src/middlewared/middlewared/api/v25_10_2/common.py
@@ -3,16 +3,21 @@ from typing import Annotated, Self
 
 from pydantic import AfterValidator, Field, model_validator
 
-from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+)
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [[["name", "=", "bob"]], [["name", "=", "larry"]]]]],
+    ]),
+    AfterValidator(validate_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/common.py
+++ b/src/middlewared/middlewared/api/v25_10_2/common.py
@@ -4,7 +4,12 @@ from typing import Annotated, Self
 from pydantic import AfterValidator, Field, model_validator
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+    BaseModel,
+    JsonSchemaExtra,
+    TimeString,
+    croniter_for_schedule,
+    validate_filters,
+    validate_options,
 )
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel"]

--- a/src/middlewared/middlewared/api/v25_10_2/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_2/directory_services.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Any, Literal
 
+from annotated_types import Ge, Le
 from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
@@ -19,7 +20,6 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
-from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',

--- a/src/middlewared/middlewared/api/v25_10_2/directory_services.py
+++ b/src/middlewared/middlewared/api/v25_10_2/directory_services.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, Secret, field_validator, model_validator
+from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
     LDAP_DN,
@@ -19,6 +19,7 @@ from middlewared.api.base import (
 from middlewared.plugins.idmap_.idmap_constants import TRUENAS_IDMAP_MAX, TRUENAS_IDMAP_MIN
 from middlewared.utils.directoryservices.credential import DSCredType
 from middlewared.utils.lang import undefined
+from annotated_types import Ge, Le
 
 __all__ = [
     'DirectoryServicesCacheRefreshArgs', 'DirectoryServicesCacheRefreshResult',
@@ -29,7 +30,7 @@ __all__ = [
     'DirectoryServicesSyncKeytabArgs', 'DirectoryServicesSyncKeytabResult',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -236,7 +237,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -249,6 +250,7 @@ class PrimaryDomainIdmap(BaseModel):
         ),
     )
     idmap_domain: DomainIdmap = Field(
+        default=RID_Idmap(idmap_backend='RID'),
         description=(
             "This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the "
             "TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs "
@@ -310,7 +312,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool.py
@@ -1,7 +1,7 @@
 import re
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, Field, PositiveInt, Secret, StringConstraints
+from pydantic import AfterValidator, Discriminator, Field, PositiveInt, Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel,
@@ -213,7 +213,7 @@ class PoolCreateTopologyDataVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev = Annotated[
     PoolCreateTopologyDataVdevDRAID | PoolCreateTopologyDataVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -509,7 +509,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
@@ -2,10 +2,12 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
-from middlewared.api.base import BaseModel, Excluded, NonEmptyString, NotRequired, excluded_field, single_argument_args
+from middlewared.api.base import (
+    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
+)
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 
 __all__ = [
@@ -33,8 +35,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v25_10_2/pool_snapshot.py
@@ -6,7 +6,13 @@ from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
-    BaseModel, LongString, single_argument_args, NonEmptyString, NotRequired, Excluded, excluded_field, JsonSchemaExtra
+    BaseModel,
+    Excluded,
+    JsonSchemaExtra,
+    NonEmptyString,
+    NotRequired,
+    excluded_field,
+    single_argument_args,
 )
 from middlewared.plugins.zfs_.validation_utils import validate_snapshot_name
 

--- a/src/middlewared/middlewared/api/v25_10_2/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_2/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -37,7 +38,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry = Field(description="The updated reporting configuration.")
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_2/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_2/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -42,7 +42,7 @@ class GraphiteExporter(BaseModel):
     )
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v25_10_2/smb.py
+++ b/src/middlewared/middlewared/api/v25_10_2/smb.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Self, Union
 
-from pydantic import AfterValidator, Field, IPvAnyInterface, field_validator, model_validator
+from pydantic import AfterValidator, Discriminator, Field, IPvAnyInterface, field_validator, model_validator
 
 from middlewared.api.base import (
     SID,
@@ -826,7 +826,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v25_10_2/vm_device.py
+++ b/src/middlewared/middlewared/api/v25_10_2/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, RootModel, Secret, model_validator
+from pydantic import ConfigDict, Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -202,7 +202,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/acl.py
+++ b/src/middlewared/middlewared/api/v26_0_0/acl.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal, Self
 
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 
 from middlewared.api.base import (
@@ -39,7 +40,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v26_0_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v26_0_0/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -104,7 +104,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/common.py
+++ b/src/middlewared/middlewared/api/v26_0_0/common.py
@@ -4,7 +4,12 @@ from typing import Annotated, Literal, Self
 from pydantic import AfterValidator, Field, model_validator
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+    BaseModel,
+    JsonSchemaExtra,
+    TimeString,
+    croniter_for_schedule,
+    validate_filters,
+    validate_options,
 )
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
@@ -94,7 +99,10 @@ class QueryOptions(BaseModel):
 
 
 class QueryArgs(BaseModel):
-    filters: QueryFilters = []
+    filters: QueryFilters = Field(
+        default=[],
+        description=QF_DOC,
+    )
     options: QueryOptions = Field(
         default=QueryOptions(),
         description="Query options including pagination, ordering, and additional parameters.",

--- a/src/middlewared/middlewared/api/v26_0_0/common.py
+++ b/src/middlewared/middlewared/api/v26_0_0/common.py
@@ -3,7 +3,9 @@ from typing import Annotated, Literal, Self
 
 from pydantic import AfterValidator, Field, model_validator
 
-from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+)
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
            "StorageTier"]
@@ -12,11 +14,14 @@ StorageTier = Literal['REGULAR', 'PERFORMANCE']
 """Storage performance tier. `REGULAR` uses standard-capacity drives; `PERFORMANCE` uses fast media (e.g. NVMe)."""
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [["name", "=", "bob"], ["name", "=", "larry"]]]],
-])
-QueryFilters = Annotated[list, QF_FIELD, AfterValidator(validate_filters)]
+QueryFilters = Annotated[
+    list,
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [["name", "=", "bob"], ["name", "=", "larry"]]]],
+    ]),
+    AfterValidator(validate_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/container_device.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Discriminator, Field
 
 from middlewared.api.base import (
     BaseModel,
@@ -85,7 +85,7 @@ class ContainerUSBDevice(BaseModel):
 
 ContainerDeviceType: TypeAlias = Annotated[
     ContainerFilesystemDevice | ContainerGPUDevice | ContainerNICDevice | ContainerUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v26_0_0/directory_services.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, Secret, field_validator, model_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
     LDAP_DN,
@@ -29,7 +30,7 @@ __all__ = [
     'DirectoryServicesStatusChangedEvent',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -239,7 +240,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -252,6 +253,7 @@ class PrimaryDomainIdmap(BaseModel):
         ),
     )
     idmap_domain: DomainIdmap = Field(
+        default=RID_Idmap(idmap_backend='RID'),
         description=(
             "This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the "
             "TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs "
@@ -313,7 +315,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/pool.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, PositiveInt, Secret
+from pydantic import Discriminator, Field, PositiveInt, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -187,7 +187,7 @@ class PoolCreateTopologyVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev: TypeAlias = Annotated[
     PoolCreateTopologyVdevDRAID | PoolCreateTopologyVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret, model_validator
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -518,7 +518,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_snapshot.py
@@ -2,12 +2,13 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
     BaseModel,
     Excluded,
+    JsonSchemaExtra,
     LongString,
     NonEmptyString,
     NotRequired,
@@ -41,8 +42,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v26_0_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -37,7 +38,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry = Field(description="The updated reporting configuration.")
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v26_0_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -42,7 +42,7 @@ class GraphiteExporter(BaseModel):
     )
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v26_0_0/smb.py
+++ b/src/middlewared/middlewared/api/v26_0_0/smb.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Self, Union
 
-from pydantic import AfterValidator, Field, IPvAnyInterface, field_validator, model_validator
+from pydantic import AfterValidator, Discriminator, Field, IPvAnyInterface, field_validator, model_validator
 
 from middlewared.api.base import (
     SID,
@@ -908,7 +908,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v26_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, RootModel, Secret, model_validator
+from pydantic import ConfigDict, Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -201,7 +201,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/acl.py
+++ b/src/middlewared/middlewared/api/v27_0_0/acl.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal, Self
 
+from annotated_types import Ge, Le
 from pydantic import Field, model_validator
 
 from middlewared.api.base import (
@@ -39,7 +40,7 @@ __all__ = [
 
 ACL_MAX_ID = 2 ** 32 // 2 - 1
 
-AceWhoId = Annotated[int, Field(ge=ACL_UNDEFINED_ID, le=ACL_MAX_ID)]
+AceWhoId = Annotated[int, Ge(ACL_UNDEFINED_ID), Le(ACL_MAX_ID)]
 
 NFS4ACE_BasicPermset = Literal[
     NFS4ACE_MaskSimple.FULL_CONTROL,

--- a/src/middlewared/middlewared/api/v27_0_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v27_0_0/acme_dns_authenticator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -105,7 +105,7 @@ class ShellSchemaArgs(ShellSchema):
 
 AuthType: TypeAlias = Annotated[
     CloudFlareSchema | DigitalOceanSchema | OVHSchema | Route53Schema | ShellSchema,
-    Field(discriminator='authenticator')
+    Discriminator('authenticator')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/common.py
+++ b/src/middlewared/middlewared/api/v27_0_0/common.py
@@ -4,7 +4,12 @@ from typing import Annotated, Any, Literal, Self
 from pydantic import AfterValidator, Field, model_validator
 
 from middlewared.api.base import (
-    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+    BaseModel,
+    JsonSchemaExtra,
+    TimeString,
+    croniter_for_schedule,
+    validate_filters,
+    validate_options,
 )
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
@@ -94,7 +99,10 @@ class QueryOptions(BaseModel):
 
 
 class QueryArgs(BaseModel):
-    filters: QueryFilters = []
+    filters: QueryFilters = Field(
+        default=[],
+        description=QF_DOC,
+    )
     options: QueryOptions = Field(
         default=QueryOptions(),
         description="Query options including pagination, ordering, and additional parameters.",

--- a/src/middlewared/middlewared/api/v27_0_0/common.py
+++ b/src/middlewared/middlewared/api/v27_0_0/common.py
@@ -3,7 +3,9 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import AfterValidator, Field, model_validator
 
-from middlewared.api.base import BaseModel, TimeString, croniter_for_schedule, validate_filters, validate_options
+from middlewared.api.base import (
+    BaseModel, JsonSchemaExtra, TimeString, croniter_for_schedule, validate_filters, validate_options
+)
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs", "GenericQueryResult", "CronModel", "TimeCronModel",
            "StorageTier"]
@@ -12,11 +14,14 @@ StorageTier = Literal['REGULAR', 'PERFORMANCE']
 """Storage performance tier. `REGULAR` uses standard-capacity drives; `PERFORMANCE` uses fast media (e.g. NVMe)."""
 
 QF_DOC = 'List of filters for query results. See API documentation for "Query Methods" for more guidance.'
-QF_FIELD = Field(default=[], description=QF_DOC, examples=[
-    [["name", "=", "bob"]],
-    [["OR", [["name", "=", "bob"], ["name", "=", "larry"]]]],
-])
-QueryFilters = Annotated[list[Any], QF_FIELD, AfterValidator(validate_filters)]
+QueryFilters = Annotated[
+    list[Any],
+    JsonSchemaExtra(description=QF_DOC, examples=[
+        [["name", "=", "bob"]],
+        [["OR", [["name", "=", "bob"], ["name", "=", "larry"]]]],
+    ]),
+    AfterValidator(validate_filters),
+]
 
 
 class QueryOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/container_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/container_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Discriminator, Field
 
 from middlewared.api.base import (
     BaseModel,
@@ -85,7 +85,7 @@ class ContainerUSBDevice(BaseModel):
 
 ContainerDeviceType: TypeAlias = Annotated[
     ContainerFilesystemDevice | ContainerGPUDevice | ContainerNICDevice | ContainerUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v27_0_0/directory_services.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, Secret, field_validator, model_validator
+from annotated_types import Ge, Le
+from pydantic import Discriminator, Field, Secret, field_validator, model_validator
 
 from middlewared.api.base import (
     LDAP_DN,
@@ -29,7 +30,7 @@ __all__ = [
     'DirectoryServicesStatusChangedEvent',
 ]
 
-IdmapId = Annotated[int, Field(ge=TRUENAS_IDMAP_MIN, le=TRUENAS_IDMAP_MAX)]
+IdmapId = Annotated[int, Ge(TRUENAS_IDMAP_MIN), Le(TRUENAS_IDMAP_MAX)]
 
 DSStatus = Literal['DISABLED', 'FAULTED', 'LEAVING', 'JOINING', 'HEALTHY']
 DSType = Literal['ACTIVEDIRECTORY', 'IPA', 'LDAP']
@@ -239,7 +240,7 @@ class BuiltinDomainTdb(IdmapDomainBase):
 
 DomainIdmap = Annotated[
     AD_Idmap | LDAP_Idmap | RFC2307_Idmap | RID_Idmap,
-    Field(discriminator='idmap_backend', default=RID_Idmap(idmap_backend='RID'))
+    Discriminator('idmap_backend')
 ]
 
 
@@ -252,6 +253,7 @@ class PrimaryDomainIdmap(BaseModel):
         ),
     )
     idmap_domain: DomainIdmap = Field(
+        default=RID_Idmap(idmap_backend='RID'),
         description=(
             "This configuration defines how domain accounts joined to TrueNAS are mapped to Unix UIDs and GIDs on the "
             "TrueNAS server. Most TrueNAS deployments use the RID backend, which algorithmically assigns UIDs and GIDs "
@@ -313,7 +315,7 @@ class CredLDAPMTLS(BaseModel):
 
 DSCred = Annotated[
     CredKRBUser | CredKRBPrincipal | CredLDAPPlain | CredLDAPAnonymous | CredLDAPMTLS,
-    Field(discriminator='credential_type')
+    Discriminator('credential_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/pool.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, PositiveInt, Secret
+from pydantic import Discriminator, Field, PositiveInt, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -182,7 +182,7 @@ class PoolCreateTopologyVdevNonDRAID(BaseModel):
 
 PoolCreateTopologyDataVdev: TypeAlias = Annotated[
     PoolCreateTopologyVdevDRAID | PoolCreateTopologyVdevNonDRAID,
-    Field(discriminator="type")
+    Discriminator("type")
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BeforeValidator, ConfigDict, Field, Secret, model_validator
+from pydantic import BeforeValidator, ConfigDict, Discriminator, Field, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -509,7 +509,7 @@ class PoolDatasetProjectQuota(_PoolDatasetQuota):
 
 PoolDatasetQuota = Annotated[
     PoolDatasetUserGroupQuota | PoolDatasetDatasetQuota | PoolDatasetProjectQuota,
-    Field(discriminator='quota_type')
+    Discriminator('quota_type')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool_snapshot.py
@@ -2,12 +2,13 @@ from abc import ABC
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, StringConstraints
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 from middlewared.api.base import (
     BaseModel,
     Excluded,
+    JsonSchemaExtra,
     LongString,
     NonEmptyString,
     NotRequired,
@@ -41,8 +42,12 @@ SNAPSHOT_NAME = Annotated[
     NonEmptyString,
     BeforeValidator(_validate_snapshot_name),
 ]
-UserPropertyKey = Annotated[str, Field(description="ZFS user property key in namespace:property format (e.g., "
-                                       "'custom:backup_policy', 'org:created_by').", pattern='.*:.*')]
+UserPropertyKey = Annotated[
+    str,
+    StringConstraints(pattern='.*:.*'),
+    JsonSchemaExtra(description="ZFS user property key in namespace:property format (e.g., "
+                                "'custom:backup_policy', 'org:created_by')."),
+]
 
 
 class PoolSnapshotEntryPropertyFields(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/reporting.py
+++ b/src/middlewared/middlewared/api/v27_0_0/reporting.py
@@ -1,5 +1,6 @@
 import typing
 
+from annotated_types import Gt
 from pydantic import Field
 
 from middlewared.api.base import (
@@ -40,7 +41,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry = Field(description="The updated reporting configuration.")
 
 
-timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Gt(0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v27_0_0/reporting_exporters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict, Field
 
@@ -42,7 +42,7 @@ class GraphiteExporter(BaseModel):
     )
 
 
-ExporterType: TypeAlias = Annotated[GraphiteExporter, Field(discriminator='exporter_type')]
+ExporterType: TypeAlias = GraphiteExporter
 
 
 # Reporting Exporter Service

--- a/src/middlewared/middlewared/api/v27_0_0/smb.py
+++ b/src/middlewared/middlewared/api/v27_0_0/smb.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Self, Union
 
-from pydantic import AfterValidator, Field, IPvAnyInterface, field_validator, model_validator
+from pydantic import AfterValidator, Discriminator, Field, IPvAnyInterface, field_validator, model_validator
 
 from middlewared.api.base import (
     SID,
@@ -896,7 +896,7 @@ SmbShareOptions = Annotated[
         LegacyOpt, DefaultOpt, TimeMachineOpt, MultiprotocolOpt, TimeLockedOpt, PrivateDatasetOpt, ExternalOpt,
         VeeamRepositoryOpt, FCPStorageOpt,
     ],
-    Field(discriminator='purpose')
+    Discriminator('purpose')
 ]
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm_device.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, RootModel, Secret, model_validator
+from pydantic import Discriminator, Field, RootModel, Secret, model_validator
 
 from middlewared.api.base import (
     BaseModel,
@@ -200,7 +200,7 @@ class VMUSBDevice(BaseModel):
 
 VMDeviceType: TypeAlias = Annotated[
     VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
-    Field(discriminator='dtype')
+    Discriminator('dtype')
 ]
 
 


### PR DESCRIPTION
## Problem

Several API fields that are declared *required* are silently treated as
**optional with a bogus default** at runtime. For example, on the current API
(v25_10_4):

    VMRAWDevice.path = '127.0.0.1'   # required path field, no default declared

`VMRAWDevice.path` is `path: NonEmptyString = Field(pattern=...)` — it should be
required, but it inherits `'127.0.0.1'` (leaked from `VMDisplayDevice.bind`).
So `vm.device.create` for a RAW device with no `path` passes validation and
silently uses `'127.0.0.1'` as the file path instead of being rejected.

## Root cause

Our shared string/number type aliases embed a single `Field()` instance, e.g.:

    NonEmptyString = Annotated[str, Field(min_length=1)]

Because the alias is a module-level constant, *every* field annotated
`NonEmptyString` shares that one `FieldInfo`. Pydantic 2.10's
`FieldInfo.merge_field_infos()` shallow-copies a `FieldInfo` (`copy.copy`) and
then mutates `copy._attributes_set` — but `copy.copy` shares the
`_attributes_set` dict, so the mutation lands on the *shared* instance:

  - A field declared `shell: NonEmptyString = "/usr/bin/zsh"` records
    `default` into the shared alias's `_attributes_set`.
  - A later field declared `target: NonEmptyString = Field(pattern=...)` rebuilds
    its `FieldInfo` from that polluted `_attributes_set` and inherits the stale
    `default`, becoming optional.

Which value leaks, and whether a given field is hit, depends purely on module
import order — making this an order-dependent latent bug across the whole API.
The same mechanism affects discriminated-union aliases
(`Annotated[A | B, Field(discriminator=...)]`) and every other shared alias that
embeds a `Field()`.

## Fix

Stop putting a `Field()` inside shared `Annotated` type aliases. Replace it with
plain, immutable annotated-metadata objects that have no mutable `_attributes_set`
for pydantic to pollute:

  - constraints (`min_length`, `max_length`, `ge/gt/le/lt`) → `annotated_types`
    (`MinLen`, `MaxLen`, `Ge`, `Gt`, `Le`)
  - `pattern` → `pydantic.StringConstraints`
  - `discriminator` → `pydantic.Discriminator`
  - `examples` / `json_schema_extra` / `description` → new `JsonSchemaExtra`
    helper (a frozen metadata object that merges keys into the generated JSON
    schema; see `api/base/types/json_schema.py` for the rationale)

Special cases:
  - `DomainIdmap` carried a `default=` inside its `Field(discriminator=...)`;
    `Discriminator` can't hold a default, so the default was relocated to the
    consuming field `idmap_domain` (behavior preserved).
  - `ExporterType` was `Annotated[GraphiteExporter, Field(discriminator=...)]` — a
    single-member "union". Since `Discriminator` requires a `Union`, and a
    one-member discriminated union is meaningless, it's collapsed to the bare
    type `GraphiteExporter`.
  - `QF_FIELD`'s redundant `default=[]` was dropped — every `QueryFilters`
    consumer already supplies its own default, so no call sites changed.

Original PR: https://github.com/truenas/middleware/pull/19078
