### PR TITLE
NAS-141379 / 27.0.0-BETA.1 / Render security_group ACG for FC targets on non-HA systems

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -123,11 +123,15 @@
 
     def fc_initiator_access_for_target(target):
         initiator_access = set()
-        for group in target['groups']:
-            group_initiators = initiators[group['initiator']]['initiators'] if group['initiator'] else []
-            for initiator in group_initiators:
-                if wwn := wwn_as_colon_hex(initiator):
-                    initiator_access.add(wwn)
+        # Callers may invoke this before checking that the fcport resolved
+        # to a real middleware target; the result is unused in that case
+        # but we still need to not crash.
+        if target is not None:
+            for group in target['groups']:
+                group_initiators = initiators[group['initiator']]['initiators'] if group['initiator'] else []
+                for initiator in group_initiators:
+                    if wwn := wwn_as_colon_hex(initiator):
+                        initiator_access.add(wwn)
         # Always emit a security_group ACG: scstadmin's del_group on an
         # ACG with attached FC sessions fails with -EBUSY, leaving running
         # config out of sync with /etc/scst.conf. The wildcard keeps the
@@ -725,6 +729,7 @@ TARGET_DRIVER qla2x00t {
 <%
     wwpn = wwn_as_colon_hex(fcport['wwpn'])
     target = fcport_to_target(fcport)
+    fc_initiator_access = fc_initiator_access_for_target(target)
     parent_host = fcport_to_parent_host(fcport)
 %>
     % if wwpn and target:
@@ -735,9 +740,15 @@ TARGET_DRIVER qla2x00t {
 % endif  ## parent_host
         rel_tgt_id ${fc_target_rel_tgt_id(target, fcport)}
         enabled 1
+        GROUP security_group {
+%   for initiator_wwpn in fc_initiator_access:
+            INITIATOR ${initiator_wwpn}
+%   endfor
+
         % for associated_target in associated_targets[fcport['target']['id']]:
         LUN ${associated_target['lunid']} ${extents[associated_target['extent']]['name']}
         % endfor
+        }
     }
     % endif  ## wwpn and target
 % endfor

--- a/tests/sharing_protocols/fibre_channel/test_fibre_channel.py
+++ b/tests/sharing_protocols/fibre_channel/test_fibre_channel.py
@@ -379,7 +379,26 @@ def str_to_colon_hex(string):
         return ':'.join(string[i:i + 2] for i in range(2, len(string), 2))
 
 
+def parse_group(lines):
+    """Parse a GROUP block body. The 'GROUP <name> {' line has already been consumed."""
+    group = {'LUN': {}, 'INITIATOR': []}
+    while lines:
+        line = lines.pop(0).strip()
+        if line == '}':
+            return group
+        elif line == '' or line.startswith('#'):
+            continue
+        sline = line.split()
+        if sline[0] == 'LUN':
+            group['LUN'][sline[1]] = sline[2]
+        elif sline[0] == 'INITIATOR':
+            group['INITIATOR'].append(sline[1])
+        elif len(sline) == 2:
+            group[sline[0]] = sline[1]
+
+
 def parse_values(lines):
+    """Parse a TARGET block body. The 'TARGET <id> {' line has already been consumed."""
     values = {'LUN': {}}
     while lines:
         line = lines.pop(0).strip()
@@ -390,6 +409,9 @@ def parse_values(lines):
         sline = line.split()
         if sline[0] == 'LUN':
             values['LUN'][sline[1]] = sline[2]
+        elif sline[0] == 'GROUP' and sline[-1] == '{':
+            group_name = sline[1]
+            values.setdefault('GROUP', {})[group_name] = parse_group(lines)
         elif len(sline) == 2:
             values[sline[0]] = sline[1]
 
@@ -635,9 +657,15 @@ class TestFixtureFibreChannel(AbstractFibreChannel):
                     key1 = str_to_colon_hex(NODE_A_1_WWPN)
                 assert key0 in scst_qla_targets
                 assert scst_qla_targets[key0] == {
-                    'LUN': {'0': 'fcextent0'},
+                    'LUN': {},
                     'enabled': '1',
-                    'rel_tgt_id': str(mapped_rel_tgt_id + rel_tgt_id_node_offset)
+                    'rel_tgt_id': str(mapped_rel_tgt_id + rel_tgt_id_node_offset),
+                    'GROUP': {
+                        'security_group': {
+                            'INITIATOR': ['*'],
+                            'LUN': {'0': 'fcextent0'},
+                        },
+                    },
                 }
                 assert key1 in scst_qla_targets
                 assert scst_qla_targets[key1] == {
@@ -699,26 +727,44 @@ class TestFixtureFibreChannel(AbstractFibreChannel):
                         assert len(scst_qla_targets) == 2
                         assert key0 in scst_qla_targets
                         assert scst_qla_targets[key0] == {
-                            'LUN': {'0': 'fcextent0'},
+                            'LUN': {},
                             'enabled': '1',
-                            'rel_tgt_id': str(mapped_rel_tgt_id + rel_tgt_id_node_offset)
+                            'rel_tgt_id': str(mapped_rel_tgt_id + rel_tgt_id_node_offset),
+                            'GROUP': {
+                                'security_group': {
+                                    'INITIATOR': ['*'],
+                                    'LUN': {'0': 'fcextent0'},
+                                },
+                            },
                         }
                         assert key1 in scst_qla_targets
                         assert scst_qla_targets[key1] == {
-                            'LUN': {'0': 'fcextent2'},
+                            'LUN': {},
                             'enabled': '1',
-                            'rel_tgt_id': str(mapped_rel_tgt_id2 + rel_tgt_id_node_offset)
+                            'rel_tgt_id': str(mapped_rel_tgt_id2 + rel_tgt_id_node_offset),
+                            'GROUP': {
+                                'security_group': {
+                                    'INITIATOR': ['*'],
+                                    'LUN': {'0': 'fcextent2'},
+                                },
+                            },
                         }
                         # Check iSCSI target
                         iqn2 = 'iqn.2005-10.org.freenas.ctl:fctarget2'
                         iscsi_targets = parse_iscsi(lines)
                         assert len(iscsi_targets) == 1
                         assert iqn2 in iscsi_targets
-                        assert iscsi_targets[iqn2] == {
+                        parsed_iscsi = iscsi_targets[iqn2]
+                        assert parsed_iscsi['LUN'] == {}
+                        assert parsed_iscsi['rel_tgt_id'] == str(rel_tgt_id2 + rel_tgt_id_node_offset)
+                        assert parsed_iscsi['enabled'] == '1'
+                        assert parsed_iscsi['per_portal_acl'] == '1'
+                        # The test target was created via target_lun_zero with an empty
+                        # groups list, so no INITIATOR lines render on the iSCSI side
+                        # (the mako loop over target['groups'] yields nothing).
+                        assert parsed_iscsi['GROUP']['security_group'] == {
+                            'INITIATOR': [],
                             'LUN': {'0': 'fcextent2'},
-                            'rel_tgt_id': str(rel_tgt_id2 + rel_tgt_id_node_offset),
-                            'enabled': '1',
-                            'per_portal_acl': '1'
                         }
 
                         # Make sure we can't update the old fcport using the in-use port
@@ -958,11 +1004,17 @@ class TestFixtureFibreChannel(AbstractFibreChannel):
                 }
                 assert key2 in scst_qla_targets
                 assert scst_qla_targets[key2] == {
-                    'LUN': {'0': 'fcextent1'},
+                    'LUN': {},
                     'enabled': '1',
                     'node_name': key0,
                     'parent_host': key0,
-                    'rel_tgt_id': str(5001 + rel_tgt_id_node_offset)
+                    'rel_tgt_id': str(5001 + rel_tgt_id_node_offset),
+                    'GROUP': {
+                        'security_group': {
+                            'INITIATOR': ['*'],
+                            'LUN': {'0': 'fcextent1'},
+                        },
+                    },
                 }
 
             # NPIV target no longer mapped.  Now reduce npiv to zero


### PR DESCRIPTION
The non-HA branch of the FC rendering in scst.conf.mako emitted bare TARGET blocks with the LUN at target level, ignoring any configured initiator setting on the target. Non-HA users could not restrict FC initiator access by WWPN - middleware accepted the configuration but silently dropped it during rendering.

Also: Parse GROUP blocks in scst.conf test parser. The FC rendering in the tests now wrap LUNs in GROUP security_group. Teach the test parser to recurse into GROUP blocks and update assertions to match the nested structure.

----
Manually tested updated test_fibre_channel.py against both HA and non-HA systems.