### PR TITLE
NAS-141383 / 26.0.0-RC.1 / Fix a few API tests (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/shell.py
+++ b/src/middlewared/middlewared/test/integration/utils/shell.py
@@ -11,27 +11,44 @@ logger = logging.getLogger(__name__)
 
 ansi_escape_8bit = re.compile(br"(?:\x1B[<-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[<-~])")
 
+# zsh shows an interactive first-run menu when the account has no zsh startup
+# files; it must be dismissed with `q` before the shell is usable.
+ZSH_FIRST_RUN = b"You are seeing this message because you have no zsh startup files"
+
+# Sentinels bracketing the command output. The form we *type* splices in an
+# empty string (`""`) so the echoed command line never contains the assembled
+# marker -- only the shell's evaluation of `echo` emits it. Reading until the
+# assembled OUT_END (rather than a bare prompt) makes output capture immune to
+# zsh prompt redraws, which otherwise get mistaken for the end of output and
+# truncate the result before the command has even run.
+OUT_START_TYPED = b'TN_WS_OUT""_START'
+OUT_START = b"TN_WS_OUT_START"
+OUT_END_TYPED = b'TN_WS_OUT""_END'
+OUT_END = b"TN_WS_OUT_END"
 
 def webshell_exec(command: str | bytes, token=None, username="root", timeout=10):
     """
-    Execute a command through the webshell and return the output.
+    Execute a command through the webshell and return its output.
 
     Args:
         command: Command to execute (e.g., "whoami" or "midclt call system.info")
         token: Authentication token (if None, will generate one)
-        username: Username for the shell (default: "root")
+        username: Username for the shell (default: "root"); selects the expected
+            prompt character (root uses "# ", others "% ")
         timeout: WebSocket timeout in seconds
 
     Returns:
-        str: Command output with ANSI escape codes removed
+        str: Command output with ANSI escape codes removed, captured between
+        sentinels so it excludes the prompt and the echoed command line.
     """
     if token is None:
         token = call('auth.generate_token', 300, {}, True)
 
-    if username == "root":
-        prompt = b"# "
-    else:
-        prompt = b"% "
+    prompt = b"# " if username == "root" else b"% "
+
+    if isinstance(command, bytes):
+        command = command.decode()
+    command = command.rstrip("\n")
 
     ws = websocket.create_connection(websocket_url() + "/websocket/shell", timeout=timeout)
     try:
@@ -41,41 +58,43 @@ def webshell_exec(command: str | bytes, token=None, username="root", timeout=10)
         auth_response = json.loads(msg.decode())
         assert auth_response["msg"] == "connected", f"Authentication failed: {auth_response}"
 
-        # Wait for shell prompt
+        # Wait for the shell prompt before sending anything; the shell isn't
+        # ready to receive input until then. Dismiss the zsh first-run menu if
+        # it appears.
         for _ in range(60):
             resp_opcode, msg = ws.recv_data()
             clean_msg = ansi_escape_8bit.sub(b"", msg)
             logger.debug("Waiting for prompt, received: %r", clean_msg)
-            # Handle zsh first-run message
-            if b"You are seeing this message because you have no zsh startup files" in clean_msg:
+            if ZSH_FIRST_RUN in clean_msg:
                 ws.send_binary(b"q\n")
             if clean_msg.endswith(prompt):
                 break
 
-        # Send the command
-        if isinstance(command, str):
-            command = command.encode()
-        ws.send_binary(command)
-        if not command.endswith(b"\n"):
-            ws.send_binary(b"\n")
+        # Bracket the command with sentinels and read until the closing marker
+        # rather than a prompt, so prompt redraws can't be mistaken for the end
+        # of output.
+        ws.send_binary(
+            b"echo " + OUT_START_TYPED + b"; " + command.encode() + b"; echo " + OUT_END_TYPED + b"\n"
+        )
 
-        # Read output until we see the prompt again
         output = b""
-        for _ in range(60):
+        for _ in range(120):
             resp_opcode, msg = ws.recv_data()
             output += msg
-            clean_output = ansi_escape_8bit.sub(b"", msg)
-            logger.debug("Command output received: %r", clean_output)
-            if clean_output.endswith(prompt):
+            if OUT_END in ansi_escape_8bit.sub(b"", output):
                 break
+        else:
+            raise AssertionError(f"webshell: command output not terminated: {output!r}")
 
-        # Clean ANSI codes from final output
-        clean_output = ansi_escape_8bit.sub(b"", output).decode("ascii", errors="ignore")
-        return clean_output
+        clean = ansi_escape_8bit.sub(b"", output)
+        # The echoed command line only contains the spliced *_TYPED markers, so
+        # the first assembled OUT_START / OUT_END are the echo's own output.
+        body = clean.split(OUT_START, 1)[1].split(OUT_END, 1)[0]
+        return body.decode("ascii", errors="ignore")
     finally:
         ws.close()
-        # Give middleware time to kill user's zsh on connection close (otherwise, it will prevent user's home directory
-        # dataset from being destroyed)
+        # Give middleware time to kill the user's zsh on connection close,
+        # otherwise it can block destruction of the user's home directory dataset.
         time.sleep(5)
 
 
@@ -85,5 +104,5 @@ def assert_shell_works(token, username="root"):
 
     Connects to the webshell, runs 'whoami', and verifies the username appears in the output.
     """
-    output = webshell_exec("whoami", token=token, username=username, timeout=10)
-    assert username in output.split()
+    output = webshell_exec("whoami", token=token, username=username)
+    assert username in output.split(), output

--- a/tests/api2/test_audit_websocket.py
+++ b/tests/api2/test_audit_websocket.py
@@ -513,7 +513,11 @@ def test_api_key_login_failed():
                             "username": None
                         },
                     },
-                    "error": "Invalid API key",
+                    # A malformed/nonexistent API key has no keyring entry, so
+                    # pam_truenas reports PAM_AUTHINFO_UNAVAIL and the api-key PAM
+                    # stack (default=die) propagates it. The response_type still
+                    # maps to AUTH_ERR.
+                    "error": "[PAM_AUTHINFO_UNAVAIL]: pam_authenticate() failed",
                 },
                 "success": False,
             }

--- a/tests/api2/test_reporting_realtime.py
+++ b/tests/api2/test_reporting_realtime.py
@@ -174,7 +174,11 @@ def test_realtime_pool_keys_match_pool_query(realtime_event):
     pool_names = frozenset(pool["name"] for pool in call("pool.query"))
     if not pool_names:
         pytest.skip("no imported pools — cannot validate event pool keys")
-    unexpected = realtime_event["pools"].keys() - pool_names
+    # The realtime event is sourced from query_imported_fast_impl(), which
+    # reports every imported pool including the boot pool; pool.query only
+    # returns data pools. Allow the boot pool so it isn't flagged unexpected.
+    allowed = pool_names | {call("boot.pool_name")}
+    unexpected = realtime_event["pools"].keys() - allowed
     assert not unexpected, f"event reported pools not in pool.query: {unexpected}"
     for pool_name, sub in realtime_event["pools"].items():
         # pool.py:18 filters out falsy values, so any visible stat must be truthy


### PR DESCRIPTION
* Reporting realtime shows stats on boot pool and so we should expect it.

* pam / auth stack now properly reports in *audit* messages why the authentication failed (minimally including PAM error code).

* harden our webshell tests

Original PR: https://github.com/truenas/middleware/pull/19133
