### PR TITLE
NAS-141234 / 27.0.0-BETA.1 / Drop VM and container devices on pwenc secret reset

### DIFF
--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -54,6 +54,10 @@ class PWEncService(Service):
         )
         self.middleware.call_sync('datastore.sql', 'DELETE FROM tasks_rsync WHERE rsync_ssh_credentials_id IS NOT NULL')
         self.middleware.call_sync('datastore.sql', 'DELETE FROM system_keychaincredential')
+        # `attributes` is the only payload here and is encrypted; without the key it decrypts to {},
+        # which fails dtype validation and breaks vm/container.query. Parent tables aren't encrypted.
+        self.middleware.call_sync('datastore.sql', 'DELETE FROM vm_device')
+        self.middleware.call_sync('datastore.sql', 'DELETE FROM container_device')
         # If config is restored without secret seed then SMB auth won't be possible. Disable SMB for all users.
         self.middleware.call_sync('datastore.sql', 'UPDATE account_bsdusers SET bsdusr_smb=0')
 


### PR DESCRIPTION
## Problem
vm_device.attributes and container_device.attributes are sa.JSON(encrypted=True). When the pwenc secret that wrote them is gone, every read decrypts to {}, which then fails the dtype-discriminated attributes validation and makes vm.query / container.query raise for every caller — including port.ports_mapping, which cascades into the Containers pool validator.

## Solution
Delete both tables in the pwenc reset routine, matching how other rows whose only payload is an encrypted blob are handled (keychain, cloud credentials, ACME DNS). The blobs are unrecoverable once the key is gone, and attributes has no valid empty form to fall back to. vm_vm and container_container have no encrypted columns, so they're left intact to preserve the user's VM / container list for reconfiguration.