### PR TITLE
NAS-141397 / 26.0.0-RC.1 / disable STIG tests (failing for months) (by yocalebo)

### DIFF
--- a/tests/stig/conftest.py
+++ b/tests/stig/conftest.py
@@ -153,5 +153,8 @@ def setup_server_single():
 
 
 def pytest_sessionstart(session):
-    setup_fn = setup_server_ha if ha else setup_server_single
-    setup_fn()
+    # The entire STIG test module is currently disabled (every test in this
+    # directory is marked skipped), so skip the server setup that would
+    # otherwise run before collection. The setup helpers above are kept intact
+    # so the suite can be re-enabled by removing the skip markers and this guard.
+    return

--- a/tests/stig/test_01_stig.py
+++ b/tests/stig/test_01_stig.py
@@ -12,6 +12,9 @@ from truenas_api_client import ValidationErrors
 
 from auto_config import ha
 
+# The entire STIG test module is currently disabled.
+pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
+
 # Alias
 pp = pytest.param
 STIG_ACTIVE = False

--- a/tests/stig/test_02_openssl.py
+++ b/tests/stig/test_02_openssl.py
@@ -4,6 +4,8 @@ import time
 from middlewared.test.integration.utils import call, ssh
 from auto_config import ha
 
+# The entire STIG test module is currently disabled.
+pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
 
 retry = 5
 fips_version = "3.1.2"

--- a/tests/stig/test_03_stig_auditing.py
+++ b/tests/stig/test_03_stig_auditing.py
@@ -18,6 +18,9 @@ from middlewared.test.integration.utils import call, ssh
 from os.path import dirname, join as path_join
 from time import sleep
 
+# The entire STIG test module is currently disabled.
+pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
+
 # Alias
 pp = pytest.param
 


### PR DESCRIPTION
~67% of ALL our CI/CD tests failures are these STIG related tests. I'm disabling them and have opened a ticket for them to be investigated. Until then, this PR disables the tests so we stop skewing our test failure results.

Original PR: https://github.com/truenas/middleware/pull/19137
