### PR TITLE
NAS-141411 / 27.0.0-BETA.1 / Relax special class vdev consistency validation

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import errno
 import os
+from types import MappingProxyType
 
 from fenced.fence import ExitCode as FencedExitCodes
 
@@ -23,6 +24,19 @@ from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.size import format_size
 
 from .utils import RE_DRAID_DATA_DISKS, RE_DRAID_SPARE_DISKS, ZPOOL_CACHE_FILE
+
+# Redundancy/parity level per vdev type. Used to enforce that a redundant data
+# class is not paired with a non-redundant (parity 0) special vdev.
+VDEV_PARITY = MappingProxyType({
+    'STRIPE': 0,
+    'MIRROR': 1,
+    'RAIDZ1': 1,
+    'RAIDZ2': 2,
+    'RAIDZ3': 3,
+    'DRAID1': 1,
+    'DRAID2': 2,
+    'DRAID3': 3,
+})
 
 
 class PoolPoolNormalizeInfo(PoolEntry):
@@ -362,12 +376,21 @@ class PoolService(CRUDService):
                     rv.append(entry)
             return rv
 
+        data_redundant = False
         for topology_type in ('data', 'special', 'dedup'):
             lastdatatype = None
             topology_data = list(data['topology'].get(topology_type) or [])
             if old and old['topology']:
                 topology_data += disk_to_stripe(topology_type)
             for i, vdev in enumerate(topology_data):
+                if topology_type == 'special' and vdev['type'].startswith('DRAID'):
+                    # dRAID is not supported for special vdevs (matching truenas_pylibzfs).
+                    verrors.add(
+                        f'topology.{topology_type}.{i}.type',
+                        'dRAID is not supported for special vdevs.',
+                    )
+                    continue
+
                 numdisks = len(vdev['disks'])
                 minmap = {
                     'STRIPE': 1,
@@ -392,7 +415,20 @@ class PoolService(CRUDService):
                         'zfs.pool.validate_draid_configuration', f'{topology_type}.{i}', numdisks, nparity, vdev
                     ))
 
-                if lastdatatype and lastdatatype != vdev['type']:
+                if topology_type == 'data' and VDEV_PARITY[vdev['type']] >= 1:
+                    data_redundant = True
+
+                if topology_type == 'special':
+                    # Special vdevs may mix types (matching truenas_pylibzfs), so no
+                    # same-type check is applied here. A non-redundant special vdev is
+                    # still rejected when the data class is redundant, because losing
+                    # that vdev would otherwise be fatal to an otherwise-redundant pool.
+                    if data_redundant and VDEV_PARITY[vdev['type']] < 1:
+                        verrors.add(
+                            f'topology.{topology_type}.{i}.type',
+                            'A special vdev with no redundancy is not allowed when data vdevs are redundant.',
+                        )
+                elif lastdatatype and lastdatatype != vdev['type']:
                     verrors.add(
                         f'topology.{topology_type}.{i}.type',
                         f'You are not allowed to create a pool with different {topology_type} vdev types '

--- a/tests/api2/test_special_vdev.py
+++ b/tests/api2/test_special_vdev.py
@@ -8,39 +8,6 @@ from middlewared.test.integration.utils import call
 POOL_NAME = 'test_special_vdev_pool'
 
 
-def test_draid_special_vdev_gets_correct_allocation_bias():
-    """
-    CRITICAL: Test that DRAID special vdevs get VDEV_ALLOC_BIAS_SPECIAL.
-    This validates the special_vdev flag flow: middleware → py-libzfs.
-    Without this flag, DRAID special vdevs would be created as data vdevs.
-    """
-    unused_disks = call('disk.get_unused')
-    if len(unused_disks) < 5:
-        pytest.skip('Insufficient number of disks to perform this test')
-
-    with another_pool({
-        'name': POOL_NAME,
-        'topology': {
-            'data': [{
-                'type': 'MIRROR',
-                'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
-            }],
-            'special': [{
-                'type': 'DRAID1',
-                'disks': [disk['name'] for disk in unused_disks[2:5]],
-                'draid_spare_disks': 0,
-            }]
-        },
-        'allow_duplicate_serials': True,
-    }) as pool:
-        # Verify DRAID special vdev exists in topology
-        assert len(pool['topology']['special']) == 1
-        assert pool['topology']['special'][0]['name'].startswith('draid1:')
-
-        # Verify pool is detected as DRAID pool (tests is_draid_pool includes special)
-        assert call('pool.is_draid_pool', pool['name']) is True
-
-
 def test_multiple_special_vdevs_same_type():
     """
     Test that multiple special vdevs of the same type can be created.
@@ -76,13 +43,47 @@ def test_multiple_special_vdevs_same_type():
         assert pool['topology']['special'][1]['type'].upper() == 'RAIDZ1'
 
 
-def test_special_vdev_mixed_types_should_fail():
+def test_special_vdev_mixed_types_is_allowed():
     """
-    Test middleware validation: mixing different vdev types in special topology fails.
-    This is middleware-enforced (pool.py:308-314), not ZFS.
+    Special vdevs may mix types (e.g. MIRROR + RAIDZ1). truenas_pylibzfs applies
+    no same-type rule to the special class, so middleware must not either.
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 7:
+        pytest.skip('Insufficient number of disks to perform this test')
+
+    with another_pool({
+        'name': POOL_NAME,
+        'topology': {
+            'data': [{
+                'type': 'MIRROR',
+                'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
+            }],
+            'special': [
+                {
+                    'type': 'RAIDZ1',
+                    'disks': [unused_disks[2]['name'], unused_disks[3]['name'], unused_disks[4]['name']]
+                },
+                {
+                    'type': 'MIRROR',
+                    'disks': [unused_disks[5]['name'], unused_disks[6]['name']]
+                }
+            ]
+        },
+        'allow_duplicate_serials': True,
+    }) as pool:
+        assert len(pool['topology']['special']) == 2
+        assert {v['type'].upper() for v in pool['topology']['special']} == {'RAIDZ1', 'MIRROR'}
+
+
+def test_special_vdev_draid_is_rejected():
+    """
+    dRAID is not permitted for special vdevs (matching truenas_pylibzfs). The
+    special class only accepts MIRROR/RAIDZ/STRIPE, so a DRAID type is rejected
+    during pool create validation.
+    """
+    unused_disks = call('disk.get_unused')
+    if len(unused_disks) < 5:
         pytest.skip('Insufficient number of disks to perform this test')
 
     with pytest.raises(ValidationErrors) as ve:
@@ -93,50 +94,95 @@ def test_special_vdev_mixed_types_should_fail():
                     'type': 'MIRROR',
                     'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
                 }],
-                'special': [
-                    {
-                        'type': 'RAIDZ1',
-                        'disks': [unused_disks[2]['name'], unused_disks[3]['name'], unused_disks[4]['name']]
-                    },
-                    {
-                        'type': 'MIRROR',
-                        'disks': [unused_disks[5]['name'], unused_disks[6]['name']]
-                    }
-                ]
+                'special': [{
+                    'type': 'DRAID1',
+                    'disks': [disk['name'] for disk in unused_disks[2:5]],
+                }]
             },
             'allow_duplicate_serials': True,
         }, job=True)
 
-    # Verify middleware validation caught it
-    assert ve.value.errors[0].attribute == 'pool_create.topology.special.1.type'
-    assert 'You are not allowed to create a pool with different special vdev types' in ve.value.errors[0].errmsg
-    assert 'RAIDZ1' in ve.value.errors[0].errmsg and 'MIRROR' in ve.value.errors[0].errmsg
+    assert ve.value.errors[0].attribute == 'pool_create.topology.special.0.type'
+    assert 'dRAID is not supported for special vdevs' in ve.value.errors[0].errmsg
 
 
-def test_draid_with_dedicated_spares_is_allowed():
+def test_non_redundant_special_on_redundant_data_is_rejected():
     """
-    Dedicated spares may coexist with dRAID vdevs.
+    A non-redundant (STRIPE) special vdev is not allowed when the data class is
+    redundant, since losing the special vdev would be fatal to the pool. This
+    matches the redundancy floor enforced by truenas_pylibzfs.
     """
     unused_disks = call('disk.get_unused')
-    if len(unused_disks) < 6:
+    if len(unused_disks) < 3:
+        pytest.skip('Insufficient number of disks to perform this test')
+
+    with pytest.raises(ValidationErrors) as ve:
+        call('pool.create', {
+            'name': POOL_NAME,
+            'topology': {
+                'data': [{
+                    'type': 'MIRROR',
+                    'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
+                }],
+                'special': [{
+                    'type': 'STRIPE',
+                    'disks': [unused_disks[2]['name']]
+                }]
+            },
+            'allow_duplicate_serials': True,
+        }, job=True)
+
+    assert ve.value.errors[0].attribute == 'pool_create.topology.special.0.type'
+    assert 'no redundancy' in ve.value.errors[0].errmsg
+
+
+def test_non_redundant_special_on_striped_data_is_allowed():
+    """
+    When the data class is not redundant (STRIPE), the redundancy floor does not
+    apply, so a non-redundant special vdev is permitted.
+    """
+    unused_disks = call('disk.get_unused')
+    if len(unused_disks) < 2:
         pytest.skip('Insufficient number of disks to perform this test')
 
     with another_pool({
         'name': POOL_NAME,
         'topology': {
             'data': [{
-                'type': 'MIRROR',
-                'disks': [unused_disks[0]['name'], unused_disks[1]['name']]
+                'type': 'STRIPE',
+                'disks': [unused_disks[0]['name']]
             }],
             'special': [{
+                'type': 'STRIPE',
+                'disks': [unused_disks[1]['name']]
+            }]
+        },
+        'allow_duplicate_serials': True,
+    }) as pool:
+        assert len(pool['topology']['special']) == 1
+
+
+def test_dedicated_spares_coexist_with_draid_data():
+    """
+    Dedicated spares may coexist with a dRAID vdev. dRAID is not permitted for
+    special vdevs, so this exercises the data class.
+    """
+    unused_disks = call('disk.get_unused')
+    if len(unused_disks) < 4:
+        pytest.skip('Insufficient number of disks to perform this test')
+
+    with another_pool({
+        'name': POOL_NAME,
+        'topology': {
+            'data': [{
                 'type': 'DRAID1',
-                'disks': [unused_disks[2]['name'], unused_disks[3]['name'], unused_disks[4]['name']],
+                'disks': [unused_disks[0]['name'], unused_disks[1]['name'], unused_disks[2]['name']],
                 'draid_spare_disks': 0,
             }],
-            'spares': [unused_disks[5]['name']]
+            'spares': [unused_disks[3]['name']]
         },
         'allow_duplicate_serials': True,
     }) as pool:
         # The combination is accepted and the dedicated spare is present.
         assert len(pool['topology']['spare']) == 1
-        assert pool['topology']['special'][0]['name'].startswith('draid1:')
+        assert pool['topology']['data'][0]['name'].startswith('draid1:')


### PR DESCRIPTION
This commit relaxes the consistency checks for vdev types used in special vdevs. Doing a mix-and-match topology is considered to be a deviation generally from best practice, but as long as the administrator is careful to make sure they don't spread it too wide (for example, mirror + 5-wide RAIDZ1) then the impact should be relatively minor. Allowing this is generally a loaded foot-gun for administrators since the topology changes cannot be undone once they are committed; and if they run into performance issues related to the imbalanced topology then they may have little recourse to fix the issues. It is generally best for users to follow best practices as defined by the support / engineering teams, but we are relaxing in this case to allow more user / product flexibility.