### PR TITLE
NAS-141412 / 27.0.0-BETA.1 / audit: serialize truenas_verify baseline against /usr race

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -3,6 +3,7 @@ import os
 from truenas_verify import mtree_verify
 
 from middlewared.utils.jsonpath import query_filters_json_path_parse, query_select_json_path_parse
+from middlewared.utils.rootfs_protection import rootfs_protection_lock
 
 AUDIT_DATASET_PATH = '/audit'
 AUDIT_LIFETIME = 7
@@ -122,6 +123,13 @@ def setup_truenas_verify(sysver: str) -> int:
         # Takes too much time on developer middleware restart
         return 0
 
-    verify_rc = mtree_verify.do_verify(['init', sysver])
+    # do_verify reads the whole rootfs to build the as-installed baseline. It
+    # runs as a first-boot system.ready handler alongside boot.update_initramfs,
+    # which overlays a read-only functioning-dpkg sysext on /usr for the duration
+    # of its rebuild. Reading /usr while that overlay is mounted captures the
+    # overlay's dpkg files instead of the installed ones (spurious discrepancies),
+    # so take the same lock boot.update_initramfs holds across the rebuild.
+    with rootfs_protection_lock():
+        verify_rc = mtree_verify.do_verify(['init', sysver])
 
     return verify_rc


### PR DESCRIPTION
setup_truenas_verify generates the as-installed truenas_verify baseline by reading the entire rootfs. It runs as a first-boot system.ready handler, concurrently with boot.update_initramfs (another system.ready agent), which overlays a read-only functioning-dpkg sysext on /usr for the duration of its truenas-initrd.py rebuild.

When the baseline read hits /usr while that overlay is mounted, it captures the overlay's dpkg files instead of the installed ones, producing spurious discrepancies (e.g. '/usr/bin/dpkg: got mode 0o755, expected: 644', '/usr/local/bin/dpkg: incorrect file type.') and a non-clean install log.

Wrap the do_verify call in rootfs_protection_lock() so it can't overlap the sysext rebuild. Only caller is audit's run_in_thread(setup_truenas_verify), so the blocking flock stays off the event loop, and do_verify never calls back into middleware, so there is no deadlock.