### PR TITLE
NAS-141417 / 27.0.0-BETA.1 / Convert hardware plugin to the typesafe pattern

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -37,6 +37,7 @@ jobs:
             middlewared/plugins/cron/ \
             middlewared/plugins/docker/ \
             middlewared/plugins/ftp/ \
+            middlewared/plugins/hardware/ \
             middlewared/plugins/init_shutdown_script/ \
             middlewared/plugins/kmip/ \
             middlewared/plugins/mail/ \

--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -47,7 +47,7 @@ class MemoryErrorsAlertSource(AlertSource):
 
     async def check(self) -> list[Alert[Any]]:
         alerts: list[Alert[Any]] = []
-        for mem_ctrl, info in (await self.middleware.call('hardware.memory.error_info')).items():
+        for mem_ctrl, info in (await self.call2(self.s.hardware.memory.error_info)).items():
             location = f'memory controller {mem_ctrl}'
             if (val := info['uncorrected_errors_with_no_dimm_info']) is not None and val > 0:
                 # this means that there were uncorrected errors where no additional information

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -3,13 +3,18 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertClassConfig, AlertLevel, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
 from middlewared.utils import ProductType
+
+if TYPE_CHECKING:
+    from middlewared.plugins.hardware.m_series_nvdimm import NvdimmInfo
 
 WEBUI_SUPPORT_FORM = (
     'Please contact iXsystems Support using the "File Ticket" button in the System Settings->General->Support form'
@@ -135,36 +140,36 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
     schedule = IntervalSchedule(datetime.timedelta(minutes=5))
     products = (ProductType.ENTERPRISE,)
 
-    def produce_alerts(self, nvdimm: Any, alerts: list[Alert[Any]], old_bios: bool) -> None:
+    def produce_alerts(self, nvdimm: NvdimmInfo, alerts: list[Alert[Any]], old_bios: bool) -> None:
         persistency_restored = 0x4
         arm_info = 0x40
-        dev = nvdimm['dev']
+        dev = nvdimm.dev
         old_bios_alert_already_generated = old_bios
-        for _hex, vals in nvdimm['critical_health_info'].items():
+        for _hex, vals in nvdimm.critical_health_info.items():
             hex_int = int(_hex, 16)
             if hex_int & ~(persistency_restored | arm_info):
                 alerts.append(Alert(
                     NVDIMMAlert(dev=dev, value=_hex, status=','.join(vals))
                 ))
 
-            if nvdimm['specrev'] >= 22 and not (hex_int & arm_info):
+            if nvdimm.specrev >= 22 and not (hex_int & arm_info):
                 alerts.append(Alert(
                     NVDIMMAlert(dev=dev, value='ARM STATUS', status='NOT ARMED')
                 ))
 
         for i in ('nvm_health_info', 'nvm_error_threshold_status', 'nvm_warning_threshold_status'):
-            for _hex, vals in nvdimm[i].items():
+            for _hex, vals in getattr(nvdimm, i).items():
                 if int(_hex, 16) != 0:
                     alerts.append(Alert(
                         NVDIMMAlert(dev=dev, value=_hex, status=','.join(vals))
                     ))
 
-        if (val := int(nvdimm['nvm_lifetime'].rstrip('%'))) < 20:
+        if nvdimm.nvm_lifetime is not None and (val := int(nvdimm.nvm_lifetime.rstrip('%'))) < 20:
             mod_alert: type[NVDIMMMemoryModLifetimeWarningAlert] | type[NVDIMMMemoryModLifetimeCriticalAlert]
             mod_alert = NVDIMMMemoryModLifetimeWarningAlert if val > 10 else NVDIMMMemoryModLifetimeCriticalAlert
             alerts.append(Alert(mod_alert(dev=dev, value=val)))
 
-        if nvdimm['index'] == 0 and (val := int(nvdimm['es_lifetime'].rstrip('%'))) < 20:
+        if nvdimm.index == 0 and nvdimm.es_lifetime is not None and (val := int(nvdimm.es_lifetime.rstrip('%'))) < 20:
             # we only check this value for the 0th slot nvdimm since M60 has 2 and the way
             # they're physically cabled, prevents monitoring the 2nd nvdimm's energy source
             # (it always reports -1%)
@@ -172,20 +177,20 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
             es_alert = NVDIMMESLifetimeWarningAlert if val > 10 else NVDIMMESLifetimeCriticalAlert
             alerts.append(Alert(es_alert(dev=dev, value=val)))
 
-        if 'not_armed' in nvdimm['state_flags']:
+        if 'not_armed' in nvdimm.state_flags:
             alerts.append(Alert(
                 NVDIMMAlert(dev=dev, value='ARM STATUS', status='NOT ARMED')
             ))
 
-        if (run_fw := nvdimm['running_firmware']) is not None:
-            if run_fw not in nvdimm['qualified_firmware']:
+        if (run_fw := nvdimm.running_firmware) is not None:
+            if run_fw not in nvdimm.qualified_firmware:
                 alerts.append(Alert(NVDIMMInvalidFirmwareVersionAlert(dev=dev)))
-            elif run_fw != nvdimm['recommended_firmware']:
+            elif (rec_fw := nvdimm.recommended_firmware) is not None and run_fw != rec_fw:
                 alerts.append(Alert(
-                    NVDIMMRecommendedFirmwareVersionAlert(dev=dev, rv=run_fw, uv=nvdimm['recommended_firmware'])
+                    NVDIMMRecommendedFirmwareVersionAlert(dev=dev, rv=run_fw, uv=rec_fw)
                 ))
 
-        if not old_bios_alert_already_generated and nvdimm['old_bios']:
+        if not old_bios_alert_already_generated and nvdimm.old_bios:
             alerts.append(Alert(OldBiosVersionAlert()))
             old_bios_alert_already_generated = True
 
@@ -193,11 +198,11 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
         alerts: list[Alert[Any]] = []
         sys = ('TRUENAS-M40', 'TRUENAS-M50', 'TRUENAS-M60')
         if self.middleware.call_sync('truenas.get_chassis_hardware').startswith(sys):
-            old_bios = self.middleware.call_sync('mseries.bios.is_old_version')
+            old_bios = self.call_sync2(self.s.mseries.bios.is_old_version)
             if old_bios:
                 alerts.append(Alert(OldBiosVersionAlert()))
 
-            for nvdimm in self.middleware.call_sync('mseries.nvdimm.info'):
+            for nvdimm in self.call_sync2(self.s.mseries.nvdimm.info):
                 try:
                     self.produce_alerts(nvdimm, alerts, old_bios)
                 except Exception:

--- a/src/middlewared/middlewared/api/base/handler/result.py
+++ b/src/middlewared/middlewared/api/base/handler/result.py
@@ -11,24 +11,26 @@ from .remove_secrets import remove_secrets
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["serialize_result", "serialize_dataclasses"]
+__all__ = ["serialize_result", "serialize_nonmodel_result"]
 
 
-def serialize_dataclasses(result: typing.Any) -> typing.Any:
-    """Recursively convert dataclass instances within a method result into plain dicts.
+def serialize_nonmodel_result(result: typing.Any) -> typing.Any:
+    """Serialize a method result that has no `BaseModel` return type into JSON-friendly data.
 
-    This is the dataclass analogue of `serialize_result`: it is used for methods that return
-    dataclasses without a `BaseModel` return type (e.g. private methods consumed in-process but
-    still reachable over the wire), so the result can be JSON-serialized for transport.
+    Used for methods that return objects without a pydantic return model (e.g. private methods
+    consumed in-process but still reachable over the wire). Currently this recursively converts
+    dataclass instances into plain dicts; other object types may be handled here in the future.
     """
+    # `is_dataclass()` is also true for the dataclass *type* itself; restrict to instances since
+    # `asdict()` requires an instance and would raise on a bare class.
     if dataclasses.is_dataclass(result) and not isinstance(result, type):
         return dataclasses.asdict(result)
     if isinstance(result, list):
-        return [serialize_dataclasses(item) for item in result]
+        return [serialize_nonmodel_result(item) for item in result]
     if isinstance(result, tuple):
-        return tuple(serialize_dataclasses(item) for item in result)
+        return tuple(serialize_nonmodel_result(item) for item in result)
     if isinstance(result, dict):
-        return {key: serialize_dataclasses(value) for key, value in result.items()}
+        return {key: serialize_nonmodel_result(value) for key, value in result.items()}
     return result
 
 

--- a/src/middlewared/middlewared/api/base/handler/result.py
+++ b/src/middlewared/middlewared/api/base/handler/result.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import typing
 
@@ -10,7 +11,25 @@ from .remove_secrets import remove_secrets
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["serialize_result"]
+__all__ = ["serialize_result", "serialize_dataclasses"]
+
+
+def serialize_dataclasses(result: typing.Any) -> typing.Any:
+    """Recursively convert dataclass instances within a method result into plain dicts.
+
+    This is the dataclass analogue of `serialize_result`: it is used for methods that return
+    dataclasses without a `BaseModel` return type (e.g. private methods consumed in-process but
+    still reachable over the wire), so the result can be JSON-serialized for transport.
+    """
+    if dataclasses.is_dataclass(result) and not isinstance(result, type):
+        return dataclasses.asdict(result)
+    if isinstance(result, list):
+        return [serialize_dataclasses(item) for item in result]
+    if isinstance(result, tuple):
+        return tuple(serialize_dataclasses(item) for item in result)
+    if isinstance(result, dict):
+        return {key: serialize_dataclasses(value) for key, value in result.items()}
+    return result
 
 
 def serialize_result(

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -112,6 +112,12 @@ from middlewared.plugins.container.lxc import LXCConfigService
 from middlewared.plugins.cron import CronJobService
 from middlewared.plugins.docker import DockerService
 from middlewared.plugins.ftp import FTPService
+from middlewared.plugins.hardware import (
+    HardwareMemoryService,
+    HardwareVirtualization,
+    MseriesBiosService,
+    MseriesNvdimmService,
+)
 from middlewared.plugins.init_shutdown_script import InitShutdownScriptService
 from middlewared.plugins.keyvalue import KeyValueService
 from middlewared.plugins.kmip import KMIPService
@@ -194,6 +200,20 @@ class AcmeServicesContainer(BaseServiceContainer):
         self.dns = AcmeDnsServicesContainer(middleware)
 
 
+class HardwareServicesContainer(BaseServiceContainer):
+    def __init__(self, middleware: "Middleware"):
+        super().__init__(middleware)
+        self.memory = HardwareMemoryService(middleware)
+        self.virtualization = HardwareVirtualization(middleware)
+
+
+class MseriesServicesContainer(BaseServiceContainer):
+    def __init__(self, middleware: "Middleware"):
+        super().__init__(middleware)
+        self.bios = MseriesBiosService(middleware)
+        self.nvdimm = MseriesNvdimmService(middleware)
+
+
 class PoolServicesContainer(BaseServiceContainer):
     def __init__(self, middleware: "Middleware"):
         super().__init__(middleware)
@@ -235,11 +255,13 @@ class ServiceContainer(BaseServiceContainer):
         self.cronjob = CronJobService(middleware)
         self.docker = DockerService(middleware)
         self.ftp = FTPService(middleware)
+        self.hardware = HardwareServicesContainer(middleware)
         self.initshutdownscript = InitShutdownScriptService(middleware)
         self.keyvalue = KeyValueService(middleware)
         self.kmip = KMIPService(middleware)
         self.lxc = LXCConfigService(middleware)
         self.mail = MailService(middleware)
+        self.mseries = MseriesServicesContainer(middleware)
         self.pool = PoolServicesContainer(middleware)
         self.port = PortService(middleware)
         self.pwenc = PWEncService(middleware)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -37,7 +37,7 @@ import middlewared.service
 from .api.aliases import aliases as api_versions_aliases
 from .api.base.handler.dump_params import dump_params
 from .api.base.handler.model_provider import LazyModuleModelProvider, ModuleModelProvider, ProxyModelProvider
-from .api.base.handler.result import serialize_dataclasses, serialize_result
+from .api.base.handler.result import serialize_nonmodel_result, serialize_result
 from .api.base.handler.version import APIVersion, APIVersionsAdapter
 from .api.base.model import BaseModel
 from .api.base.server.api import API
@@ -1111,7 +1111,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
         if new_style_returns_model:
             return serialize_result(new_style_returns_model, result, expose_secrets, self.dump_result_allow_fallback)
         else:
-            return serialize_dataclasses(result)
+            return serialize_nonmodel_result(result)
 
     async def authorize_method_call(
         self,

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -37,7 +37,7 @@ import middlewared.service
 from .api.aliases import aliases as api_versions_aliases
 from .api.base.handler.dump_params import dump_params
 from .api.base.handler.model_provider import LazyModuleModelProvider, ModuleModelProvider, ProxyModelProvider
-from .api.base.handler.result import serialize_result
+from .api.base.handler.result import serialize_dataclasses, serialize_result
 from .api.base.handler.version import APIVersion, APIVersionsAdapter
 from .api.base.model import BaseModel
 from .api.base.server.api import API
@@ -1111,7 +1111,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
         if new_style_returns_model:
             return serialize_result(new_style_returns_model, result, expose_secrets, self.dump_result_allow_fallback)
         else:
-            return result
+            return serialize_dataclasses(result)
 
     async def authorize_method_call(
         self,

--- a/src/middlewared/middlewared/plugins/hardware/__init__.py
+++ b/src/middlewared/middlewared/plugins/hardware/__init__.py
@@ -1,0 +1,80 @@
+from typing import Any
+
+from middlewared.api import api_method
+from middlewared.api.current import (
+    HardwareVirtualizationVariantArgs,
+    HardwareVirtualizationVariantResult,
+)
+from middlewared.service import Service, private
+
+from . import m_series_bios as _bios
+from . import m_series_nvdimm as _nvdimm
+from . import mem_info as _mem
+from . import virt_detection as _virt
+from .m_series_nvdimm import NvdimmInfo
+
+__all__ = (
+    "MseriesBiosService",
+    "MseriesNvdimmService",
+    "HardwareMemoryService",
+    "HardwareVirtualization",
+)
+
+
+class MseriesBiosService(Service):
+
+    class Config:
+        private = True
+        namespace = "mseries.bios"
+
+    def is_old_version(self) -> bool:
+        return _bios.is_old_version(self.middleware)
+
+
+class MseriesNvdimmService(Service):
+
+    class Config:
+        private = True
+        namespace = "mseries.nvdimm"
+
+    def info(self) -> list[NvdimmInfo]:
+        return _nvdimm.info(self.middleware)
+
+
+class HardwareMemoryService(Service):
+
+    class Config:
+        namespace = "hardware.memory"
+        private = True
+
+    def error_info(self) -> dict[str, Any]:
+        return _mem.error_info()
+
+
+class HardwareVirtualization(Service):
+
+    class Config:
+        cli_namespace = "hardware.virtualization"
+        namespace = "hardware.virtualization"
+
+    @api_method(
+        HardwareVirtualizationVariantArgs,
+        HardwareVirtualizationVariantResult,
+        roles=["SYSTEM_GENERAL_READ"],
+        check_annotations=True,
+    )
+    def variant(self) -> str:
+        """Report the virtualization variation of TrueNAS system"""
+        return _virt.detect_variant()
+
+    @private
+    def variant_impl(self) -> str:
+        return _virt.detect_variant()
+
+    @private
+    def is_virtualized(self) -> bool:
+        return _virt.is_virtualized()
+
+    @private
+    def guest_vms_supported(self) -> bool:
+        return _virt.guest_vms_supported()

--- a/src/middlewared/middlewared/plugins/hardware/m_series_bios.py
+++ b/src/middlewared/middlewared/plugins/hardware/m_series_bios.py
@@ -1,23 +1,23 @@
+from __future__ import annotations
+
 import datetime
+import functools
+from typing import TYPE_CHECKING
 
-from middlewared.service import Service
-from middlewared.utils.functools_ import cache
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
 
-class MseriesBiosService(Service):
+@functools.cache
+def is_old_version(middleware: Middleware) -> bool:
+    chassis = middleware.call_sync("truenas.get_chassis_hardware")
+    bios_dates = {
+        "TRUENAS-M40": datetime.date(2020, 2, 20),
+        "TRUENAS-M50": datetime.date(2020, 12, 3),
+        "TRUENAS-M60": datetime.date(2020, 12, 3),
+    }
+    min_bios_date = next((v for k, v in bios_dates.items() if chassis.startswith(k)), None)
+    if min_bios_date and (bios := middleware.call_sync("system.dmidecode_info")["bios-release-date"]):
+        return bool(bios < min_bios_date)
 
-    class Config:
-        private = True
-        namespace = 'mseries.bios'
-
-    @cache
-    def is_old_version(self):
-        chassis = self.middleware.call_sync("truenas.get_chassis_hardware")
-        bios_dates = {
-            "TRUENAS-M40": datetime.date(2020, 2, 20),
-            "TRUENAS-M50": datetime.date(2020, 12, 3),
-            "TRUENAS-M60": datetime.date(2020, 12, 3),
-        }
-        min_bios_date = next((v for k, v in bios_dates.items() if chassis.startswith(k)), None)
-        if min_bios_date and (bios := self.middleware.call_sync("system.dmidecode_info")["bios-release-date"]):
-            return bios < min_bios_date
+    return False

--- a/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
@@ -1,186 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 import glob
+import logging
 import re
 import subprocess
+from typing import TYPE_CHECKING, Any
 
-from middlewared.service import Service
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
+
+logger = logging.getLogger(__name__)
 
 
-class MseriesNvdimmService(Service):
+@dataclass(slots=True, kw_only=True)
+class NvdimmInfo:
+    index: int
+    dev: str
+    dev_path: str
+    specrev: int
+    state_flags: list[str]
+    critical_health_info: dict[str, list[str]]
+    nvm_health_info: dict[str, list[str]]
+    nvm_error_threshold_status: dict[str, list[str]]
+    nvm_warning_threshold_status: dict[str, list[str]]
+    nvm_lifetime: str | None
+    nvm_temperature: str | None
+    es_lifetime: str | None
+    es_temperature: str | None
+    vendor: str | None
+    device: str | None
+    rev_id: str | None
+    subvendor: str | None
+    subdevice: str | None
+    subrev_id: str | None
+    part_num: str | None
+    size: str | None
+    clock_speed: str | None
+    qualified_firmware: list[str]
+    recommended_firmware: str | None
+    running_firmware: str | None
+    old_bios: bool
 
-    class Config:
-        private = True
-        namespace = 'mseries.nvdimm'
 
-    def run_ixnvdimm(self, nvmem_dev):
-        out = subprocess.run(
-            ["ixnvdimm", nvmem_dev],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            encoding="utf-8",
-            errors="ignore",
-        ).stdout
-        specrev = subprocess.run(
-            ['ixnvdimm', '-r', nvmem_dev, 'SPECREV'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            encoding="utf-8",
-            errors="ignore",
-        ).stdout
+def run_ixnvdimm(nvmem_dev: str) -> tuple[str, str]:
+    out = subprocess.run(
+        ["ixnvdimm", nvmem_dev],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        errors="ignore",
+    ).stdout
+    specrev = subprocess.run(
+        ['ixnvdimm', '-r', nvmem_dev, 'SPECREV'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        errors="ignore",
+    ).stdout
 
-        return out, specrev
+    return out, specrev
 
-    def get_running_firmware_vers_and_detect_old_bios(self, output):
-        result = {'running_firmware': None, 'old_bios': True}
-        if m := re.search(r"selected: [0-9]+ running: ([0-9]+)", output):
-            running_slot = int(m.group(1))
-            if m := re.search(rf"slot{running_slot}: ([0-9])([0-9])", output):
-                result['running_firmware'] = f"{m.group(1)}.{m.group(2)}"
-                result['old_bios'] = False
 
-        return result
+def get_running_firmware_vers_and_detect_old_bios(output: str) -> dict[str, Any]:
+    result: dict[str, Any] = {'running_firmware': None, 'old_bios': True}
+    if m := re.search(r"selected: [0-9]+ running: ([0-9]+)", output):
+        running_slot = int(m.group(1))
+        if m := re.search(rf"slot{running_slot}: ([0-9])([0-9])", output):
+            result['running_firmware'] = f"{m.group(1)}.{m.group(2)}"
+            result['old_bios'] = False
 
-    def get_module_health(self, output):
-        if (m := re.search(r"Module Health:[^\n]+", output)):
-            return m.group().split("Module Health: ")[-1].strip()
+    return result
 
-    def vendor_info(self, output):
-        mapping = {
-            '0x2c80_0x4e32_0x31_0x3480_0x4131_0x01': {
-                'vendor': '0x2c80', 'device': '0x4e32', 'rev_id': '0x31',
-                'subvendor': '0x3480', 'subdevice': '0x4131', 'subrev_id': '0x01',
-                'part_num': '18ASF2G72PF12G6V21AB',
-                'size': '16GB', 'clock_speed': '2666MHz',
-                'qualified_firmware': ['2.6'],
-                'recommended_firmware': '2.6',
-            },
-            '0x2c80_0x4e36_0x31_0x3480_0x4231_0x02': {
-                'vendor': '0x2c80', 'device': '0x4e36', 'rev_id': '0x31',
-                'subvendor': '0x3480', 'subdevice': '0x4231', 'subrev_id': '0x02',
-                'part_num': '18ASF2G72PF12G9WP1AB',
-                'size': '16GB', 'clock_speed': '2933MHz',
-                'qualified_firmware': ['2.2'],
-                'recommended_firmware': '2.2',
-            },
-            '0x2c80_0x4e33_0x31_0x3480_0x4231_0x01': {
-                'vendor': '0x2c80', 'device': '0x4e33', 'rev_id': '0x31',
-                'subvendor': '0x3480', 'subdevice': '0x4231', 'subrev_id': '0x01',
-                'part_num': '36ASS4G72PF12G9PR1AB',
-                'size': '32GB', 'clock_speed': '2933MHz',
-                'qualified_firmware': ['2.4'],
-                'recommended_firmware': '2.4',
-            },
-            '0xce01_0x4e38_0x33_0xc180_0x4331_0x01': {
-                'vendor': '0xce01', 'device': '0x4e38', 'rev_id': '0x33',
-                'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
-                'part_num': 'AGIGA8811-016ACA',
-                'size': '16GB', 'clock_speed': '2933MHz',
-                'qualified_firmware': ['0.8'],
-                'recommended_firmware': '0.8',
-            },
-            '0xce01_0x4e42_0x31_0xc180_0x4331_0x01': {
-                'vendor': '0xce01', 'device': '0x4e42', 'rev_id': '0x31',
-                'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
-                'part_num': 'AGIGA8811-016BCA',
-                'size': '16GB', 'clock_speed': '2933MHz',
-                'qualified_firmware': ['3.0'],
-                'recommended_firmware': '3.0',
-            },
-            '0xce01_0x4e39_0x34_0xc180_0x4331_0x01': {
-                'vendor': '0xce01', 'device': '0x4e39', 'rev_id': '0x34',
-                'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
-                'part_num': 'AGIGA8811-032ACA',
-                'size': '32GB', 'clock_speed': '2933MHz',
-                'qualified_firmware': ['0.8'],
-                'recommended_firmware': '0.8',
-            },
-            'unknown': {
-                'vendor': None, 'device': None, 'rev_id': None,
-                'subvendor': None, 'subdevice': None, 'subrev_id': None,
-                'part_num': None,
-                'size': None, 'clock_speed': None,
-                'qualified_firmware': [],
-                'recommended_firmware': None,
+
+def get_module_health(output: str) -> str | None:
+    if (m := re.search(r"Module Health:[^\n]+", output)):
+        return m.group().split("Module Health: ")[-1].strip()
+
+    return None
+
+
+def vendor_info(output: str) -> dict[str, Any]:
+    mapping: dict[str, dict[str, Any]] = {
+        '0x2c80_0x4e32_0x31_0x3480_0x4131_0x01': {
+            'vendor': '0x2c80', 'device': '0x4e32', 'rev_id': '0x31',
+            'subvendor': '0x3480', 'subdevice': '0x4131', 'subrev_id': '0x01',
+            'part_num': '18ASF2G72PF12G6V21AB',
+            'size': '16GB', 'clock_speed': '2666MHz',
+            'qualified_firmware': ['2.6'],
+            'recommended_firmware': '2.6',
+        },
+        '0x2c80_0x4e36_0x31_0x3480_0x4231_0x02': {
+            'vendor': '0x2c80', 'device': '0x4e36', 'rev_id': '0x31',
+            'subvendor': '0x3480', 'subdevice': '0x4231', 'subrev_id': '0x02',
+            'part_num': '18ASF2G72PF12G9WP1AB',
+            'size': '16GB', 'clock_speed': '2933MHz',
+            'qualified_firmware': ['2.2'],
+            'recommended_firmware': '2.2',
+        },
+        '0x2c80_0x4e33_0x31_0x3480_0x4231_0x01': {
+            'vendor': '0x2c80', 'device': '0x4e33', 'rev_id': '0x31',
+            'subvendor': '0x3480', 'subdevice': '0x4231', 'subrev_id': '0x01',
+            'part_num': '36ASS4G72PF12G9PR1AB',
+            'size': '32GB', 'clock_speed': '2933MHz',
+            'qualified_firmware': ['2.4'],
+            'recommended_firmware': '2.4',
+        },
+        '0xce01_0x4e38_0x33_0xc180_0x4331_0x01': {
+            'vendor': '0xce01', 'device': '0x4e38', 'rev_id': '0x33',
+            'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
+            'part_num': 'AGIGA8811-016ACA',
+            'size': '16GB', 'clock_speed': '2933MHz',
+            'qualified_firmware': ['0.8'],
+            'recommended_firmware': '0.8',
+        },
+        '0xce01_0x4e42_0x31_0xc180_0x4331_0x01': {
+            'vendor': '0xce01', 'device': '0x4e42', 'rev_id': '0x31',
+            'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
+            'part_num': 'AGIGA8811-016BCA',
+            'size': '16GB', 'clock_speed': '2933MHz',
+            'qualified_firmware': ['3.0'],
+            'recommended_firmware': '3.0',
+        },
+        '0xce01_0x4e39_0x34_0xc180_0x4331_0x01': {
+            'vendor': '0xce01', 'device': '0x4e39', 'rev_id': '0x34',
+            'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
+            'part_num': 'AGIGA8811-032ACA',
+            'size': '32GB', 'clock_speed': '2933MHz',
+            'qualified_firmware': ['0.8'],
+            'recommended_firmware': '0.8',
+        },
+        'unknown': {
+            'vendor': None, 'device': None, 'rev_id': None,
+            'subvendor': None, 'subdevice': None, 'subrev_id': None,
+            'part_num': None,
+            'size': None, 'clock_speed': None,
+            'qualified_firmware': [],
+            'recommended_firmware': None,
+        }
+    }
+    result = mapping['unknown']
+    vend_key = subvend_key = None
+    if (match := re.search(r'vendor: (?P<v>\w+) device: (?P<d>\w+) revision: (?P<r>\w+)', output)):
+        vend_key = '_'.join([f'0x{v}' for v in match.groupdict().values()])
+
+    if (match := re.search(r'subvendor: (?P<v>\w+) subdevice: (?P<d>\w+) subrevision: (?P<r>\w+)', output)):
+        subvend_key = '_'.join([f'0x{v}' for v in match.groupdict().values()])
+
+    if all((vend_key, subvend_key)):
+        result = mapping.get(f'{vend_key}_{subvend_key}', mapping['unknown'])
+
+    return result
+
+
+def health_info(output: str) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        'critical_health_info': {},
+        'nvm_health_info': {},
+        'nvm_error_threshold_status': {},
+        'nvm_warning_threshold_status': {},
+        'nvm_lifetime': None,
+        'nvm_temperature': None,
+        'es_lifetime': None,
+        'es_temperature': None,
+    }
+    if m := re.search(r'Critical Health Info: (.*)', output):
+        bit, vals = m.group(1).split(' ', 1)
+        result['critical_health_info'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
+    if m := re.search(r'Module Health: (.*)', output):
+        bit, vals = m.group(1).split(' ', 1)
+        result['nvm_health_info'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
+    if m := re.search(r'Error Threshold Status: (.*)', output):
+        bit, vals = m.group(1).split(' ', 1)
+        result['nvm_error_threshold_status'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
+    if m := re.search(r'Warning Threshold Status: (.*)', output):
+        bit, vals = m.group(1).split(' ', 1)
+        result['nvm_warning_threshold_status'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
+    if m := re.search(r'NVM Lifetime: (.*)', output):
+        result['nvm_lifetime'] = m.group(1).split(' ', 1)[0]
+    if m := re.search(r'Module Current Temperature: (.*)', output):
+        result['nvm_temperature'] = m.group(1).split(' ', 1)[0]
+    if m := re.search(r'ES Lifetime Percentage: (.*)', output):
+        result['es_lifetime'] = m.group(1).split(' ', 1)[0]
+    if m := re.search(r'ES Current Temperature: (.*)', output):
+        result['es_temperature'] = m.group(1).split(' ', 1)[0]
+
+    return result
+
+
+def state_flags(nmem: str) -> list[str]:
+    try:
+        with open(f'/sys/bus/nd/devices/{nmem.removeprefix("/dev/")}/nfit/flags') as f:
+            flags = f.read().strip().split()
+    except Exception:
+        flags = []
+
+    return flags
+
+
+def info(middleware: Middleware) -> list[NvdimmInfo]:
+    results: list[NvdimmInfo] = []
+    sys = ("TRUENAS-M40", "TRUENAS-M50", "TRUENAS-M60")
+    if not middleware.call_sync("truenas.get_chassis_hardware").startswith(sys):
+        return results
+
+    try:
+        for nmem in glob.glob("/dev/nmem*"):
+            output, specrev = run_ixnvdimm(nmem)
+
+            entry: dict[str, Any] = {
+                'index': int(nmem[len('/dev/nmem')]),
+                'dev': nmem.removeprefix('/dev/'),
+                'dev_path': nmem,
+                'specrev': int(specrev.strip()),
+                'state_flags': state_flags(nmem),
             }
-        }
-        result = mapping['unknown']
-        vend_key = subvend_key = None
-        if (match := re.search(r'vendor: (?P<v>\w+) device: (?P<d>\w+) revision: (?P<r>\w+)', output)):
-            vend_key = '_'.join([f'0x{v}' for v in match.groupdict().values()])
+            entry.update(health_info(output))
+            entry.update(vendor_info(output))
+            entry.update(get_running_firmware_vers_and_detect_old_bios(output))
+            results.append(NvdimmInfo(**entry))
 
-        if (match := re.search(r'subvendor: (?P<v>\w+) subdevice: (?P<d>\w+) subrevision: (?P<r>\w+)', output)):
-            subvend_key = '_'.join([f'0x{v}' for v in match.groupdict().values()])
+    except Exception:
+        logger.error("Unhandled exception obtaining nvdimm info", exc_info=True)
 
-        if all((vend_key, subvend_key)):
-            result = mapping.get(f'{vend_key}_{subvend_key}', mapping['unknown'])
-
-        return result
-
-    def health_info(self, output):
-        result = {
-            'critical_health_info': {},
-            'nvm_health_info': {},
-            'nvm_error_threshold_status': {},
-            'nvm_warning_threshold_status': {},
-            'nvm_lifetime': None,
-            'nvm_temperature': None,
-            'es_lifetime': None,
-            'es_temperature': None,
-        }
-        if m := re.search(r'Critical Health Info: (.*)', output):
-            bit, vals = m.group(1).split(' ', 1)
-            result['critical_health_info'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
-        if m := re.search(r'Module Health: (.*)', output):
-            bit, vals = m.group(1).split(' ', 1)
-            result['nvm_health_info'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
-        if m := re.search(r'Error Threshold Status: (.*)', output):
-            bit, vals = m.group(1).split(' ', 1)
-            result['nvm_error_threshold_status'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
-        if m := re.search(r'Warning Threshold Status: (.*)', output):
-            bit, vals = m.group(1).split(' ', 1)
-            result['nvm_warning_threshold_status'][bit] = [i for i in vals.lstrip('<').rstrip('>').split(',') if i]
-        if m := re.search(r'NVM Lifetime: (.*)', output):
-            result['nvm_lifetime'] = m.group(1).split(' ', 1)[0]
-        if m := re.search(r'Module Current Temperature: (.*)', output):
-            result['nvm_temperature'] = m.group(1).split(' ', 1)[0]
-        if m := re.search(r'ES Lifetime Percentage: (.*)', output):
-            result['es_lifetime'] = m.group(1).split(' ', 1)[0]
-        if m := re.search(r'ES Current Temperature: (.*)', output):
-            result['es_temperature'] = m.group(1).split(' ', 1)[0]
-
-        return result
-
-    def state_flags(self, nmem):
-        try:
-            with open(f'/sys/bus/nd/devices/{nmem.removeprefix("/dev/")}/nfit/flags') as f:
-                state_flags = f.read().strip().split()
-        except Exception:
-            state_flags = []
-
-        return state_flags
-
-    def info(self):
-        results = []
-        sys = ("TRUENAS-M40", "TRUENAS-M50", "TRUENAS-M60")
-        if not self.middleware.call_sync("truenas.get_chassis_hardware").startswith(sys):
-            return results
-
-        try:
-            for nmem in glob.glob("/dev/nmem*"):
-                output, specrev = self.run_ixnvdimm(nmem)
-
-                info = {
-                    'index': int(nmem[len('/dev/nmem')]),
-                    'dev': nmem.removeprefix('/dev/'),
-                    'dev_path': nmem,
-                    'specrev': int(specrev.strip()),
-                    'state_flags': self.state_flags(nmem),
-                }
-                info.update(self.health_info(output))
-                info.update(self.vendor_info(output))
-                info.update(self.get_running_firmware_vers_and_detect_old_bios(output))
-                results.append(info)
-
-        except Exception:
-            self.logger.error("Unhandled exception obtaining nvdimm info", exc_info=True)
-        else:
-            return results
+    return results

--- a/src/middlewared/middlewared/plugins/hardware/mem_info.py
+++ b/src/middlewared/middlewared/plugins/hardware/mem_info.py
@@ -1,58 +1,51 @@
 from pathlib import Path
+from typing import Any
 
-from middlewared.service import Service
 
+def error_info() -> dict[str, Any]:
+    results: dict[str, Any] = {}
+    mc_path = Path('/sys/devices/system/edac/mc')
+    if not mc_path.exists():
+        return results
 
-class HardwareMemoryService(Service):
+    dimm_or_rank = 'dimm'
+    mc_idx = 0
+    for mc in filter(lambda x: x.is_dir() and x.name.startswith('mc'), mc_path.iterdir()):
+        mc_info: dict[str, Any] = {mc.name: {}}
+        if mc_idx == 0 and not (mc / f'{dimm_or_rank}{mc_idx}').exists():
+            # AMD systems use "rank" as top-level dir while Intel uses dimm
+            dimm_or_rank = 'rank'
 
-    class Config:
-        namespace = 'hardware.memory'
-        private = True
+        # top-level memory controller information
+        for key, _file in (
+            ('corrected_errors', 'ce_count'),
+            ('uncorrected_errors', 'ue_count'),
+            ('corrected_errors_with_no_dimm_info', 'ce_noinfo_count'),
+            ('uncorrected_errors_with_no_dimm_info', 'ue_noinfo_count'),
+        ):
+            try:
+                value: int | None = int((mc / _file).read_text().strip())
+            except (FileNotFoundError, ValueError):
+                value = None
 
-    def error_info(self):
-        results = {}
-        mc_path = Path('/sys/devices/system/edac/mc')
-        if not mc_path.exists():
-            return results
+            mc_info[mc.name].update({key: value})
 
-        dimm_or_rank = 'dimm'
-        mc_idx = 0
-        for mc in filter(lambda x: x.is_dir() and x.name.startswith('mc'), mc_path.iterdir()):
-            mc_info = {mc.name: {}}
-            if mc_idx == 0 and not (mc / f'{dimm_or_rank}{mc_idx}').exists():
-                # AMD systems use "rank" as top-level dir while Intel uses dimm
-                dimm_or_rank = 'rank'
-
-            # top-level memory controller information
+        # specific dimm module memory information
+        for dimm in filter(lambda x: x.is_dir() and x.name.startswith(dimm_or_rank), mc.iterdir()):
+            # looks like /sys/devices/edac/mc0/dimm(or rank){0/1/2}
+            mc_info[mc.name][dimm.name] = {}
             for key, _file in (
-                ('corrected_errors', 'ce_count'),
-                ('uncorrected_errors', 'ue_count'),
-                ('corrected_errors_with_no_dimm_info', 'ce_noinfo_count'),
-                ('uncorrected_errors_with_no_dimm_info', 'ue_noinfo_count'),
+                ('corrected_errors', 'dimm_ce_count'),
+                ('uncorrected_errors', 'dimm_ue_count'),
             ):
                 try:
-                    value = int((mc / _file).read_text().strip())
+                    value = int((dimm / _file).read_text().strip())
                 except (FileNotFoundError, ValueError):
                     value = None
 
-                mc_info[mc.name].update({key: value})
+                mc_info[mc.name][dimm.name].update({key: value})
 
-            # specific dimm module memory information
-            for dimm in filter(lambda x: x.is_dir() and x.name.startswith(dimm_or_rank), mc.iterdir()):
-                # looks like /sys/devices/edac/mc0/dimm(or rank){0/1/2}
-                mc_info[mc.name][dimm.name] = {}
-                for key, _file in (
-                    ('corrected_errors', 'dimm_ce_count'),
-                    ('uncorrected_errors', 'dimm_ue_count'),
-                ):
-                    try:
-                        value = int((dimm / _file).read_text().strip())
-                    except (FileNotFoundError, ValueError):
-                        value = None
+        mc_idx += 1
+        results.update(mc_info)
 
-                    mc_info[mc.name][dimm.name].update({key: value})
-
-            mc_idx += 1
-            results.update(mc_info)
-
-        return results
+    return results

--- a/src/middlewared/middlewared/plugins/hardware/virt_detection.py
+++ b/src/middlewared/middlewared/plugins/hardware/virt_detection.py
@@ -1,42 +1,18 @@
+import functools
 import os
 import subprocess
 
-from middlewared.api import api_method
-from middlewared.api.current import (
-    HardwareVirtualizationVariantArgs,
-    HardwareVirtualizationVariantResult,
-)
-from middlewared.service import Service, private
-from middlewared.utils.functools_ import cache
+
+@functools.cache
+def detect_variant() -> str:
+    rv = subprocess.run(["systemd-detect-virt"], capture_output=True)
+    return rv.stdout.decode().strip()
 
 
-class HardwareVirtualization(Service):
-    class Config:
-        cli_namespace = "hardware.virtualization"
-        namespace = "hardware.virtualization"
+def is_virtualized() -> bool:
+    return detect_variant() != "none"
 
-    @api_method(
-        HardwareVirtualizationVariantArgs,
-        HardwareVirtualizationVariantResult,
-        roles=['SYSTEM_GENERAL_READ']
-    )
-    def variant(self) -> str:
-        """Report the virtualization variation of TrueNAS system"""
-        return self.variant_impl()
 
-    @private
-    @cache
-    def variant_impl(self) -> str:
-        rv = subprocess.run(["systemd-detect-virt"], capture_output=True)
-        return rv.stdout.decode().strip()
-
-    @private
-    def is_virtualized(self) -> bool:
-        """Detect if the TrueNAS system is virtualized"""
-        return self.variant_impl() != 'none'
-
-    @private
-    @cache
-    def guest_vms_supported(self) -> bool:
-        """Detect if TrueNAS system supports guest VMs"""
-        return os.path.exists('/dev/kvm')
+@functools.cache
+def guest_vms_supported() -> bool:
+    return os.path.exists("/dev/kvm")

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -274,8 +274,8 @@ class UsageService(Service):
             'version': await self.middleware.call('system.version'),
             'is_vendored': await self.middleware.call('system.vendor.is_vendored'),
             'vendor_name': await self.middleware.call('system.vendor.name'),
-            'is_virtualized': await self.middleware.call('hardware.virtualization.is_virtualized'),
-            'hypervisor': await self.middleware.call('hardware.virtualization.variant'),
+            'is_virtualized': await self.call2(self.s.hardware.virtualization.is_virtualized),
+            'hypervisor': await self.call2(self.s.hardware.virtualization.variant),
         }
 
     async def gather_system(self, context):

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_mseries_nvdimm.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_mseries_nvdimm.py
@@ -16,18 +16,18 @@ def _nvdimm(**overrides: Any) -> NvdimmInfo:
     """A healthy NVDIMM that on its own produces no alerts; override fields per test."""
     base: dict[str, Any] = dict(
         index=0,
-        dev='nmem0',
-        dev_path='/dev/nmem0',
+        dev="nmem0",
+        dev_path="/dev/nmem0",
         specrev=21,
         state_flags=[],
         critical_health_info={},
         nvm_health_info={},
         nvm_error_threshold_status={},
         nvm_warning_threshold_status={},
-        nvm_lifetime='99%',
-        nvm_temperature='40',
-        es_lifetime='99%',
-        es_temperature='40',
+        nvm_lifetime="99%",
+        nvm_temperature="40",
+        es_lifetime="99%",
+        es_temperature="40",
         vendor=None,
         device=None,
         rev_id=None,
@@ -37,9 +37,9 @@ def _nvdimm(**overrides: Any) -> NvdimmInfo:
         part_num=None,
         size=None,
         clock_speed=None,
-        qualified_firmware=['2.6'],
-        recommended_firmware='2.6',
-        running_firmware='2.6',
+        qualified_firmware=["2.6"],
+        recommended_firmware="2.6",
+        running_firmware="2.6",
         old_bios=False,
     )
     base.update(overrides)
@@ -58,42 +58,46 @@ def test_healthy_nvdimm_produces_no_alerts():
 
 
 def test_low_memory_module_lifetime_alert():
-    alerts = _produce(_nvdimm(nvm_lifetime='15%'))
+    alerts = _produce(_nvdimm(nvm_lifetime="15%"))
     assert len(alerts) == 1, alerts
     assert isinstance(alerts[0].instance, NVDIMMMemoryModLifetimeWarningAlert)
     assert alerts[0].instance.value == 15
 
 
 def test_running_firmware_not_qualified_alert():
-    alerts = _produce(_nvdimm(running_firmware='1.0', qualified_firmware=['2.6']))
+    alerts = _produce(_nvdimm(running_firmware="1.0", qualified_firmware=["2.6"]))
     assert len(alerts) == 1, alerts
     assert isinstance(alerts[0].instance, NVDIMMInvalidFirmwareVersionAlert)
 
 
 def test_running_firmware_below_recommended_alert():
-    alerts = _produce(_nvdimm(
-        running_firmware='2.6', qualified_firmware=['2.6', '3.0'], recommended_firmware='3.0',
-    ))
+    alerts = _produce(
+        _nvdimm(
+            running_firmware="2.6",
+            qualified_firmware=["2.6", "3.0"],
+            recommended_firmware="3.0",
+        )
+    )
     assert len(alerts) == 1, alerts
     instance = alerts[0].instance
     assert isinstance(instance, NVDIMMRecommendedFirmwareVersionAlert)
-    assert instance.rv == '2.6'
-    assert instance.uv == '3.0'
+    assert instance.rv == "2.6"
+    assert instance.uv == "3.0"
 
 
 def test_not_armed_state_flag_alert():
-    alerts = _produce(_nvdimm(state_flags=['not_armed']))
+    alerts = _produce(_nvdimm(state_flags=["not_armed"]))
     assert len(alerts) == 1, alerts
     assert isinstance(alerts[0].instance, NVDIMMAlert)
-    assert alerts[0].instance.status == 'NOT ARMED'
+    assert alerts[0].instance.status == "NOT ARMED"
 
 
 def test_critical_health_info_bit_alert():
-    alerts = _produce(_nvdimm(critical_health_info={'0x2': ['some_failure']}))
+    alerts = _produce(_nvdimm(critical_health_info={"0x2": ["some_failure"]}))
     assert len(alerts) == 1, alerts
     assert isinstance(alerts[0].instance, NVDIMMAlert)
-    assert alerts[0].instance.value == '0x2'
-    assert alerts[0].instance.status == 'some_failure'
+    assert alerts[0].instance.value == "0x2"
+    assert alerts[0].instance.status == "some_failure"
 
 
 def test_old_bios_flag_alert():

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_mseries_nvdimm.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_mseries_nvdimm.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+from middlewared.alert.source.mseries_nvdimm_and_bios import (
+    NVDIMMAlert,
+    NVDIMMAndBIOSAlertSource,
+    NVDIMMInvalidFirmwareVersionAlert,
+    NVDIMMMemoryModLifetimeWarningAlert,
+    NVDIMMRecommendedFirmwareVersionAlert,
+    OldBiosVersionAlert,
+)
+from middlewared.plugins.hardware.m_series_nvdimm import NvdimmInfo
+from middlewared.pytest.unit.middleware import Middleware
+
+
+def _nvdimm(**overrides: Any) -> NvdimmInfo:
+    """A healthy NVDIMM that on its own produces no alerts; override fields per test."""
+    base: dict[str, Any] = dict(
+        index=0,
+        dev='nmem0',
+        dev_path='/dev/nmem0',
+        specrev=21,
+        state_flags=[],
+        critical_health_info={},
+        nvm_health_info={},
+        nvm_error_threshold_status={},
+        nvm_warning_threshold_status={},
+        nvm_lifetime='99%',
+        nvm_temperature='40',
+        es_lifetime='99%',
+        es_temperature='40',
+        vendor=None,
+        device=None,
+        rev_id=None,
+        subvendor=None,
+        subdevice=None,
+        subrev_id=None,
+        part_num=None,
+        size=None,
+        clock_speed=None,
+        qualified_firmware=['2.6'],
+        recommended_firmware='2.6',
+        running_firmware='2.6',
+        old_bios=False,
+    )
+    base.update(overrides)
+    return NvdimmInfo(**base)
+
+
+def _produce(nvdimm: NvdimmInfo, old_bios: bool = False) -> list:
+    source = NVDIMMAndBIOSAlertSource(Middleware())
+    alerts: list = []
+    source.produce_alerts(nvdimm, alerts, old_bios)
+    return alerts
+
+
+def test_healthy_nvdimm_produces_no_alerts():
+    assert _produce(_nvdimm()) == []
+
+
+def test_low_memory_module_lifetime_alert():
+    alerts = _produce(_nvdimm(nvm_lifetime='15%'))
+    assert len(alerts) == 1, alerts
+    assert isinstance(alerts[0].instance, NVDIMMMemoryModLifetimeWarningAlert)
+    assert alerts[0].instance.value == 15
+
+
+def test_running_firmware_not_qualified_alert():
+    alerts = _produce(_nvdimm(running_firmware='1.0', qualified_firmware=['2.6']))
+    assert len(alerts) == 1, alerts
+    assert isinstance(alerts[0].instance, NVDIMMInvalidFirmwareVersionAlert)
+
+
+def test_running_firmware_below_recommended_alert():
+    alerts = _produce(_nvdimm(
+        running_firmware='2.6', qualified_firmware=['2.6', '3.0'], recommended_firmware='3.0',
+    ))
+    assert len(alerts) == 1, alerts
+    instance = alerts[0].instance
+    assert isinstance(instance, NVDIMMRecommendedFirmwareVersionAlert)
+    assert instance.rv == '2.6'
+    assert instance.uv == '3.0'
+
+
+def test_not_armed_state_flag_alert():
+    alerts = _produce(_nvdimm(state_flags=['not_armed']))
+    assert len(alerts) == 1, alerts
+    assert isinstance(alerts[0].instance, NVDIMMAlert)
+    assert alerts[0].instance.status == 'NOT ARMED'
+
+
+def test_critical_health_info_bit_alert():
+    alerts = _produce(_nvdimm(critical_health_info={'0x2': ['some_failure']}))
+    assert len(alerts) == 1, alerts
+    assert isinstance(alerts[0].instance, NVDIMMAlert)
+    assert alerts[0].instance.value == '0x2'
+    assert alerts[0].instance.status == 'some_failure'
+
+
+def test_old_bios_flag_alert():
+    alerts = _produce(_nvdimm(old_bios=True), old_bios=False)
+    assert len(alerts) == 1, alerts
+    assert isinstance(alerts[0].instance, OldBiosVersionAlert)

--- a/src/middlewared/middlewared/pytest/unit/api/handler/result/test_dataclasses.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/result/test_dataclasses.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from middlewared.api.base.handler.result import serialize_dataclasses
+from middlewared.api.base.handler.result import serialize_nonmodel_result
 
 
 @dataclass(slots=True, kw_only=True)
@@ -17,34 +17,34 @@ class Outer:
 
 
 def test_single_dataclass_becomes_dict():
-    result = serialize_dataclasses(Inner(a=1, b="x"))
+    result = serialize_nonmodel_result(Inner(a=1, b="x"))
     assert result == {"a": 1, "b": "x"}
     assert isinstance(result, dict)
 
 
 def test_list_of_dataclasses():
-    result = serialize_dataclasses([Inner(a=1, b=None), Inner(a=2, b="y")])
+    result = serialize_nonmodel_result([Inner(a=1, b=None), Inner(a=2, b="y")])
     assert result == [{"a": 1, "b": None}, {"a": 2, "b": "y"}]
 
 
 def test_nested_dataclass_is_recursive():
-    result = serialize_dataclasses(Outer(name="n", tags=["t1"], inner=Inner(a=5, b="z")))
+    result = serialize_nonmodel_result(Outer(name="n", tags=["t1"], inner=Inner(a=5, b="z")))
     assert result == {"name": "n", "tags": ["t1"], "inner": {"a": 5, "b": "z"}}
 
 
 def test_dataclasses_nested_in_dict_and_list():
-    result = serialize_dataclasses({"items": [Inner(a=1, b="x")], "count": 1})
+    result = serialize_nonmodel_result({"items": [Inner(a=1, b="x")], "count": 1})
     assert result == {"items": [{"a": 1, "b": "x"}], "count": 1}
 
 
 def test_plain_result_passes_through_unchanged():
     value = {"data": {"id": [1, 2, 3], "name": "x"}, "flag": True, "n": None}
-    assert serialize_dataclasses(value) == value
+    assert serialize_nonmodel_result(value) == value
     # non-dataclass scalars are returned as-is
-    assert serialize_dataclasses("string") == "string"
-    assert serialize_dataclasses(42) == 42
+    assert serialize_nonmodel_result("string") == "string"
+    assert serialize_nonmodel_result(42) == 42
 
 
 def test_dataclass_type_is_not_converted():
     # a dataclass *class* (not an instance) must pass through untouched
-    assert serialize_dataclasses(Inner) is Inner
+    assert serialize_nonmodel_result(Inner) is Inner

--- a/src/middlewared/middlewared/pytest/unit/api/handler/result/test_dataclasses.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/result/test_dataclasses.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from middlewared.api.base.handler.result import serialize_dataclasses
+
+
+@dataclass(slots=True, kw_only=True)
+class Inner:
+    a: int
+    b: str | None
+
+
+@dataclass(slots=True, kw_only=True)
+class Outer:
+    name: str
+    tags: list[str]
+    inner: Inner
+
+
+def test_single_dataclass_becomes_dict():
+    result = serialize_dataclasses(Inner(a=1, b="x"))
+    assert result == {"a": 1, "b": "x"}
+    assert isinstance(result, dict)
+
+
+def test_list_of_dataclasses():
+    result = serialize_dataclasses([Inner(a=1, b=None), Inner(a=2, b="y")])
+    assert result == [{"a": 1, "b": None}, {"a": 2, "b": "y"}]
+
+
+def test_nested_dataclass_is_recursive():
+    result = serialize_dataclasses(Outer(name="n", tags=["t1"], inner=Inner(a=5, b="z")))
+    assert result == {"name": "n", "tags": ["t1"], "inner": {"a": 5, "b": "z"}}
+
+
+def test_dataclasses_nested_in_dict_and_list():
+    result = serialize_dataclasses({"items": [Inner(a=1, b="x")], "count": 1})
+    assert result == {"items": [{"a": 1, "b": "x"}], "count": 1}
+
+
+def test_plain_result_passes_through_unchanged():
+    value = {"data": {"id": [1, 2, 3], "name": "x"}, "flag": True, "n": None}
+    assert serialize_dataclasses(value) == value
+    # non-dataclass scalars are returned as-is
+    assert serialize_dataclasses("string") == "string"
+    assert serialize_dataclasses(42) == 42
+
+
+def test_dataclass_type_is_not_converted():
+    # a dataclass *class* (not an instance) must pass through untouched
+    assert serialize_dataclasses(Inner) is Inner


### PR DESCRIPTION
## Context
The hardware plugin is a directory of four mostly-private legacy services (mseries.bios, mseries.nvdimm, hardware.memory, plus hardware.virtualization). Only hardware.virtualization.variant is public over the wire; the rest return plain dicts/bools consumed internally by alert sources and usage reporting, so Pydantic models would be pure overhead.

## Solution
Applied the port-plugin pattern: lean Service shims in __init__.py that delegate to plain, fully type-annotated module functions, keeping the existing dict/primitive return shapes so no consumer changes are needed. The one public method gets check_annotations=True against the existing HardwareVirtualizationVariant models. Registered the services in main.py's ServiceContainer via nested hardware/mseries containers and added the plugin to mypy.yml.