### PR TITLE
NAS-141307 / 26.0.0-RC.1 / Generate API changelog pages that compare adjacent versions (by creatorcary)

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -38,5 +38,6 @@ jobs:
         run: |
           mypy \
             --follow-imports silent \
+            --ignore-missing-imports \
             src/middlewared_docs/changelog.py \
             src/middlewared_docs/generate_docs.py

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -33,3 +33,10 @@ jobs:
             --exclude middlewared/etc_files \
             --follow-imports silent \
             --strict
+
+      - name: mypy middlewared_docs
+        run: |
+          mypy \
+            --follow-imports silent \
+            src/middlewared_docs/changelog.py \
+            src/middlewared_docs/generate_docs.py

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,6 +15,9 @@ jobs:
     - uses: astral-sh/ruff-action@v3
       with:
         src: src/middlewared
+    - uses: astral-sh/ruff-action@v3
+      with:
+        src: src/middlewared_docs
     - name: Find new Python files
       id: new-files
       run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,4 +21,4 @@ jobs:
           PYTHONPATH=. FAKE_ENV=1 pytest-3 -v --disable-pytest-warnings middlewared/pytest
 
       - name: Docs changelog tests
-        run: pytest-3 -v --disable-pytest-warnings src/middlewared_docs/test_changelog.py
+        run: pytest-3 -v --disable-pytest-warnings src/middlewared_docs/tests/

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,3 +19,6 @@ jobs:
         run: |
           cd src/middlewared
           PYTHONPATH=. FAKE_ENV=1 pytest-3 -v --disable-pytest-warnings middlewared/pytest
+
+      - name: Docs changelog tests
+        run: pytest-3 -v --disable-pytest-warnings src/middlewared_docs/test_changelog.py

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -1,19 +1,45 @@
 # -*- coding=utf-8 -*-
 """Cross-version API changelog computation.
 
-Given two adjacent :class:`APIDump` objects, produce a :class:`Changelog`
-describing which methods were added, removed, or had their schemas changed.
-The schema diff is intentionally shallow (top-level call parameters and return
-value) — deeper changes are surfaced as a generic note pointing the reader at
-the per-method page.
+Given two :class:`APIDump` objects — any two versions, not necessarily adjacent —
+produce a :class:`Changelog` describing which methods were added, removed, or had
+their schemas changed. Every schema change is reported exactly, at any nesting
+depth, as a human-readable line addressing the changed node by path:
+
+- object fields join with dots (``options.force``), array items append ``[]``
+  (``apps[].options``), map values (an ``additionalProperties``/``patternProperties``
+  schema) append ``[*]``, fixed tuple members append ``[i]``, and titled union
+  branches join like fields (``AppQueryResultItem.action_required``); untitled
+  union branches (e.g. nullable wrappers) are descended in place.
+- union variants are identified by their Pydantic-generated branch title, falling
+  back to a type summary for untitled branches.
+
+The diff is semantic, not cosmetic. It reads only the schema keys ``type``,
+``enum``, ``const``, ``default``, ``required``, ``properties``, ``items``,
+``prefixItems``, ``additionalProperties``, ``patternProperties``, ``propertyNames``,
+``anyOf``, ``oneOf``, and ``title`` (the latter only to identify call parameters
+and union branches). Description/example wording and validation-constraint keys
+(``minLength``, ``pattern``, ...) are never read, so changes to them produce no
+changelog entry. Ignored keys are skipped by never reading them — NOT by stripping
+them from the schemas first: API models contain *fields* named ``description``,
+``type``, or ``default``, and deleting keys by name would corrupt them.
+
+The schemas are trusted to follow SCHEMA_RULES.md (formalized in
+api_dump.schema.json), which is why this module indexes into them without
+defensive checks.
 """
 from __future__ import annotations
 
 import dataclasses
+import json
 import typing
 
 if typing.TYPE_CHECKING:
     from middlewared.api.base.server.doc import APIDump, APIDumpMethod
+
+_MISSING = object()
+# Defaults longer than this are reported without their values.
+_MAX_RENDERED_VALUE_LENGTH = 50
 
 
 @dataclasses.dataclass
@@ -35,7 +61,12 @@ class Changelog:
 
 
 def _union_branches(schema: dict) -> list[dict] | None:
-    """If `schema` is a oneOf/anyOf, return its branches; else None."""
+    """If `schema` is a oneOf/anyOf, return its branches; else None.
+
+    The two combiners are treated identically: a oneOf+discriminator (Pydantic tagged
+    union) accepts the same payloads as the equivalent anyOf, so flipping between them
+    is not a reportable change.
+    """
     for combiner in ("oneOf", "anyOf"):
         if combiner in schema:
             return schema[combiner]
@@ -50,116 +81,302 @@ def _branch_name(branch: dict) -> str:
 
 def _type_summary(schema: dict) -> str:
     """Render a brief human-readable type summary for a JSON-Schema fragment."""
-    if not isinstance(schema, dict):
-        return "unknown"
-
     branches = _union_branches(schema)
     if branches is not None:
-        return " | ".join(_branch_name(b) for b in branches)
+        # Deduplicate: unions of similarly-shaped untitled branches would otherwise
+        # render as e.g. "any | any | any".
+        return " | ".join(dict.fromkeys(_branch_name(branch) for branch in branches))
 
-    t = schema.get("type")
-    if isinstance(t, list):
-        return " | ".join(sorted(t))
-    if t:
+    if t := schema.get("type"):
+        if t == "array" and "prefixItems" in schema:
+            return "tuple"
         return t
     if "enum" in schema:
         return "enum"
     if "const" in schema:
         return "const"
-    return "unknown"
+    return "any"
 
 
-def _diff_union(old: dict, new: dict, prefix: str) -> list[str]:
-    """Diff two union schemas by branch name. Returns lines describing added/removed variants."""
-    old_names = {_branch_name(b) for b in _union_branches(old) or []}
-    new_names = {_branch_name(b) for b in _union_branches(new) or []}
-    added = [f"{prefix}: added variant `{added}`" for added in sorted(new_names - old_names)]
-    removed = [f"{prefix}: removed variant `{removed}`" for removed in sorted(old_names - new_names)]
-    return added + removed
+def _format_value(value) -> str | None:
+    """Render an enum/const/default value for a changelog line; None if too long to inline."""
+    rendered = json.dumps(value)
+    if len(rendered) > _MAX_RENDERED_VALUE_LENGTH:
+        return None
+    return rendered
 
 
-def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
-    """Diff top-level properties of two object schemas. `label` is e.g. `parameter` or `field`."""
-    old_props = old.get("properties", {})
-    new_props = new.get("properties", {})
-    return [
-        f"added {label} `{name}`"
-        for name in sorted(set(new_props) - set(old_props))
-    ] + [
-        f"removed {label} `{name}`"
-        for name in sorted(set(old_props) - set(new_props))
-    ] + [
-        f"{label} `{name}` type changed ({old_type} → {new_type})"
-        for name in sorted(set(old_props) & set(new_props))
-        if (old_type := _type_summary(old_props[name])) != (new_type := _type_summary(new_props[name]))
-    ]
+def _join(path: str, key: str) -> str:
+    return f"{path}.{key}" if path else key
+
+
+def _map_value_schema(schema: dict) -> dict | None:
+    """Schema for an object's undeclared (map) properties; None if they are disallowed.
+
+    Absent `additionalProperties` and `true` both mean "any value" and normalize to the
+    bare-any schema `{}` so that flipping between those representations is no change.
+    """
+    extra = schema.get("additionalProperties", True)
+    if extra is False:
+        return None
+    if extra is True:
+        return {}
+    return extra
+
+
+def _group_branches(branches: list[dict]) -> dict[str, list[dict]]:
+    """Group union branches by name, preserving order — duplicate names do occur."""
+    groups: dict[str, list[dict]] = {}
+    for branch in branches:
+        groups.setdefault(_branch_name(branch), []).append(branch)
+    return groups
+
+
+class _SchemaDiffer:
+    """Recursive schema diff for one tree (the return value or a single call parameter).
+
+    Accumulates change lines in `self.lines`. Lines about the root node itself are
+    labeled with `root_label` (empty for the return value, whose label is supplied by
+    the renderer); lines about nested nodes are labeled ``field `<path>```.
+    """
+
+    def __init__(self, root_path: str, root_label: str):
+        self.root_path = root_path
+        self.root_label = root_label
+        self.lines: list[str] = []
+
+    def _emit(self, path: str, text: str, sep: str = " "):
+        label = self.root_label if path == self.root_path else f"field `{path}`"
+        self.lines.append(f"{label}{sep}{text}" if label else text)
+
+    def diff(self, old: dict, new: dict, path: str):
+        if old == new:
+            return
+
+        old_branches = _union_branches(old)
+        new_branches = _union_branches(new)
+        if old_branches is not None and new_branches is not None:
+            self._diff_union(old, new, old_branches, new_branches, path)
+        else:
+            old_summary = _type_summary(old)
+            new_summary = _type_summary(new)
+            if old_summary != new_summary:
+                # The node changed kind; its new contents are not worth itemizing.
+                self._emit(path, f"type changed ({old_summary} → {new_summary})")
+                return
+
+            self._diff_enum(old, new, path)
+            self._diff_const(old, new, path)
+            # Key on `type`, not the summary: a union whose branches summarize alike
+            # (e.g. anyOf of two untitled objects) has the same summary as a plain node
+            # but must not be recursed into as one.
+            if (node_type := old.get("type")) == new.get("type"):
+                if node_type == "object":
+                    self._diff_object(old, new, path)
+                elif node_type == "array":
+                    self._diff_array(old, new, path)
+
+        self._diff_default(old, new, path)
+
+    def _diff_union(self, old: dict, new: dict, old_branches: list[dict], new_branches: list[dict], path: str):
+        old_groups = _group_branches(old_branches)
+        new_groups = _group_branches(new_branches)
+
+        titled = any(
+            "title" in branch
+            for branches in (*old_groups.values(), *new_groups.values())
+            for branch in branches
+        )
+        if titled:
+            for name in sorted(new_groups.keys() - old_groups.keys()):
+                self._emit(path, f"added variant `{name}`", sep=": ")
+            for name in sorted(old_groups.keys() - new_groups.keys()):
+                self._emit(path, f"removed variant `{name}`", sep=": ")
+        else:
+            # A union of unnamed alternatives (typically a nullable wrapper) reads better
+            # as a single type change: e.g. (string → string | null).
+            old_summary = _type_summary(old)
+            new_summary = _type_summary(new)
+            if old_summary != new_summary:
+                self._emit(path, f"type changed ({old_summary} → {new_summary})")
+
+        for name in sorted(old_groups.keys() & new_groups.keys()):
+            old_branches = old_groups[name]
+            new_branches = new_groups[name]
+            for old_branch, new_branch in zip(old_branches, new_branches):
+                branch_path = _join(path, name) if "title" in old_branch or "title" in new_branch else path
+                self.diff(old_branch, new_branch, branch_path)
+            if titled and len(old_branches) != len(new_branches):
+                action = "added" if len(new_branches) > len(old_branches) else "removed"
+                for _ in range(abs(len(new_branches) - len(old_branches))):
+                    self._emit(path, f"{action} variant `{name}`", sep=": ")
+
+    def _diff_enum(self, old: dict, new: dict, path: str):
+        if "enum" not in old and "enum" not in new:
+            return
+        # Compare values as JSON renderings: hashable, and `0`/`false` stay distinct.
+        old_values = {json.dumps(value) for value in old.get("enum", ())}
+        new_values = {json.dumps(value) for value in new.get("enum", ())}
+        for value in sorted(new_values - old_values):
+            self._emit(path, f"added enum value {value}", sep=": ")
+        for value in sorted(old_values - new_values):
+            self._emit(path, f"removed enum value {value}", sep=": ")
+
+    def _diff_const(self, old: dict, new: dict, path: str):
+        old_const = old.get("const", _MISSING)
+        new_const = new.get("const", _MISSING)
+        if old_const == new_const:
+            return
+        if old_const is _MISSING:
+            self._emit(path, f"value restricted to constant {json.dumps(new_const)}", sep=": ")
+        elif new_const is _MISSING:
+            self._emit(path, f"constant value restriction removed (was {json.dumps(old_const)})", sep=": ")
+        else:
+            self._emit(path, f"const value changed ({json.dumps(old_const)} → {json.dumps(new_const)})")
+
+    def _diff_object(self, old: dict, new: dict, path: str):
+        old_required = set(old.get("required", ()))
+        new_required = set(new.get("required", ()))
+        old_props = old.get("properties", {})
+        new_props = new.get("properties", {})
+
+        for name in sorted(new_props.keys() - old_props.keys()):
+            suffix = " (required)" if name in new_required else ""
+            self.lines.append(f"added field `{_join(path, name)}`{suffix}")
+        for name in sorted(old_props.keys() - new_props.keys()):
+            self.lines.append(f"removed field `{_join(path, name)}`")
+        for name in sorted(old_props.keys() & new_props.keys()):
+            field_path = _join(path, name)
+            # `required` is compared as a set: real dumps reorder it with identical content.
+            if name in new_required and name not in old_required:
+                self.lines.append(f"field `{field_path}` became required")
+            elif name in old_required and name not in new_required:
+                self.lines.append(f"field `{field_path}` became optional")
+            self.diff(old_props[name], new_props[name], field_path)
+
+        old_extra = _map_value_schema(old)
+        new_extra = _map_value_schema(new)
+        if old_extra is not None and new_extra is not None:
+            self.diff(old_extra, new_extra, path + "[*]")
+        elif new_extra is not None:
+            self._emit(path, "additional properties now allowed", sep=": ")
+        elif old_extra is not None:
+            self._emit(path, "additional properties no longer allowed", sep=": ")
+
+        old_patterns = old.get("patternProperties", {})
+        new_patterns = new.get("patternProperties", {})
+        for pattern in sorted(new_patterns.keys() - old_patterns.keys()):
+            self._emit(path, f"added properties matching pattern `{pattern}`", sep=": ")
+        for pattern in sorted(old_patterns.keys() - new_patterns.keys()):
+            self._emit(path, f"removed properties matching pattern `{pattern}`", sep=": ")
+        for pattern in sorted(old_patterns.keys() & new_patterns.keys()):
+            self.diff(old_patterns[pattern], new_patterns[pattern], path + "[*]")
+
+        if (old_names := old.get("propertyNames")) != (new_names := new.get("propertyNames")):
+            self.diff(old_names or {}, new_names or {}, path + "[*:keys]")
+
+    def _diff_array(self, old: dict, new: dict, path: str):
+        if "prefixItems" in old:
+            # Fixed tuple (only core.download's return in practice). A list ↔ tuple
+            # change never reaches here: the type summaries differ ("array" vs "tuple").
+            old_members = old["prefixItems"]
+            new_members = new["prefixItems"]
+            if len(old_members) != len(new_members):
+                self._emit(path, f"tuple length changed ({len(old_members)} → {len(new_members)})")
+            for i, (old_member, new_member) in enumerate(zip(old_members, new_members)):
+                self.diff(old_member, new_member, f"{path}[{i}]")
+        else:
+            self.diff(old["items"], new["items"], path + "[]")
+
+    def _diff_default(self, old: dict, new: dict, path: str):
+        old_default = old.get("default", _MISSING)
+        new_default = new.get("default", _MISSING)
+        if old_default == new_default:
+            return
+        if old_default is _MISSING:
+            detail = _format_value(new_default)
+            self._emit(path, f"default value added ({detail})" if detail else "default value added")
+        elif new_default is _MISSING:
+            self._emit(path, "default value removed")
+        else:
+            old_detail = _format_value(old_default)
+            new_detail = _format_value(new_default)
+            if old_detail and new_detail:
+                self._emit(path, f"default value changed ({old_detail} → {new_detail})")
+            else:
+                self._emit(path, "default value changed")
 
 
 def _diff_call_parameters(old: dict, new: dict) -> list[str]:
-    """Brief top-level diff of the `Call parameters` array schema."""
-    old_by_name = {item["title"]: item for item in old["prefixItems"]}
-    new_by_name = {item["title"]: item for item in new["prefixItems"]}
+    """Diff the `Call parameters` schemas. Parameters are keyed by title; positions matter."""
+    old_params = {param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])}
+    new_params = {param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])}
+    added = new_params.keys() - old_params.keys()
+    removed = old_params.keys() - new_params.keys()
 
-    lines = [
-        f"added parameter `{name}`"
-        for name in sorted(new_by_name.keys() - old_by_name.keys())
-    ] + [
-        f"removed parameter `{name}`"
-        for name in sorted(old_by_name.keys() - new_by_name.keys())
-    ]
+    # A removed and an added parameter occupying the same position is a rename, not an
+    # (alarming, wire-incompatible-looking) removal plus addition.
+    renames = {}
+    added_by_index = {new_params[title][0]: title for title in added}
+    for title in sorted(removed):
+        if (new_title := added_by_index.get(old_params[title][0])) is not None:
+            renames[title] = new_title
+    added -= set(renames.values())
+    removed -= renames.keys()
 
-    for name in sorted(new_by_name.keys() & old_by_name.keys()):
-        old_param = old_by_name[name]
-        new_param = new_by_name[name]
-        if _union_branches(old_param) is not None and _union_branches(new_param) is not None:
-            union_lines = _diff_union(old_param, new_param, f"parameter `{name}`")
-            if union_lines:
-                lines.extend(union_lines)
-                continue
+    lines = []
+    for title in sorted(added):
+        kind = "optional" if "default" in new_params[title][1] else "required"
+        lines.append(f"added parameter `{title}` ({kind})")
+    for title in sorted(removed):
+        lines.append(f"removed parameter `{title}`")
 
-        old_type = _type_summary(old_param)
-        new_type = _type_summary(new_param)
-        if old_type != new_type:
-            lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
+    pairs = [(title, title) for title in old_params.keys() & new_params.keys()] + list(renames.items())
+    for old_title, new_title in sorted(pairs, key=lambda pair: pair[1]):
+        old_index, old_param = old_params[old_title]
+        new_index, new_param = new_params[new_title]
+        if old_title != new_title:
+            lines.append(f"parameter `{old_title}` renamed to `{new_title}`")
+        elif old_index != new_index:
+            # Positions are 0-based, matching the "Parameter N" headings on method pages.
+            lines.append(f"parameter `{new_title}` moved from position {old_index} to {new_index}")
+
+        had_default = "default" in old_param
+        has_default = "default" in new_param
+        if had_default != has_default:
+            lines.append(f"parameter `{new_title}` became {'required' if had_default else 'optional'}")
+            # The presence transition says it all; don't also report it as a default change.
+            old_param = {key: value for key, value in old_param.items() if key != "default"}
+            new_param = {key: value for key, value in new_param.items() if key != "default"}
+
+        differ = _SchemaDiffer(root_path=new_title, root_label=f"parameter `{new_title}`")
+        differ.diff(old_param, new_param, new_title)
+        lines.extend(differ.lines)
 
     return lines
 
 
 def _diff_return_value(old: dict, new: dict) -> list[str]:
-    """Brief top-level diff of the `Return value` schema."""
-    if _union_branches(old) is not None and _union_branches(new) is not None:
-        union_lines = _diff_union(old, new, "return value")
-        if union_lines:
-            return union_lines
-
-    old_type = _type_summary(old)
-    new_type = _type_summary(new)
-    if old_type != new_type:
-        return [f"return value type changed ({old_type} → {new_type})"]
-    if old.get("type") == "object":
-        return _diff_object_properties(old, new, "field")
-
-    return []
+    """Diff the `Return value` schemas. Root lines are bare; the renderer labels them."""
+    differ = _SchemaDiffer(root_path="", root_label="")
+    differ.diff(old, new, "")
+    return differ.lines
 
 
 def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
-    """Compare two method/event schemas. Returns (call_params_diff, return_value_diff)."""
+    """Compare two method schemas. Returns (call_params_diff, return_value_diff).
+
+    Both lists empty means the schemas differ only cosmetically (or not at all).
+    """
     if old == new:
         return [], []
 
     old_props = old["properties"]
     new_props = new["properties"]
-
-    call_diff = _diff_call_parameters(
-        old_props["Call parameters"],
-        new_props["Call parameters"],
+    return (
+        _diff_call_parameters(old_props["Call parameters"], new_props["Call parameters"]),
+        _diff_return_value(old_props["Return value"], new_props["Return value"]),
     )
-    return_diff = _diff_return_value(
-        old_props["Return value"],
-        new_props["Return value"],
-    )
-
-    return call_diff, return_diff
 
 
 def _diff_items(
@@ -169,23 +386,19 @@ def _diff_items(
     prev_by_name = {item.name: item for item in previous}
     cur_by_name = {item.name: item for item in current}
 
-    added = sorted(set(cur_by_name) - set(prev_by_name))
-    removed = sorted(set(prev_by_name) - set(cur_by_name))
+    added = sorted(cur_by_name.keys() - prev_by_name.keys())
+    removed = sorted(prev_by_name.keys() - cur_by_name.keys())
     changed = []
-    for name in sorted(set(cur_by_name) & set(prev_by_name)):
+    for name in sorted(cur_by_name.keys() & prev_by_name.keys()):
         old_schemas = prev_by_name[name].schemas
         new_schemas = cur_by_name[name].schemas
         if old_schemas == new_schemas:
             continue
 
         call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
-        if not call_diff and not return_diff:
-            # The schemas differ but our shallow diff couldn't surface anything meaningful
-            # (e.g. nested-only change). Record the method as changed with a generic note.
-            call_diff = []
-            return_diff = ["schema changed (see method page for details)"]
-
-        changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
+        if call_diff or return_diff:
+            # No lines means the difference is cosmetic-only; the method is omitted.
+            changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
 
     return added, removed, changed
 

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -36,8 +36,6 @@ class Changelog:
 
 def _union_branches(schema: dict) -> list[dict] | None:
     """If `schema` is a oneOf/anyOf, return its branches; else None."""
-    if not isinstance(schema, dict):
-        return
     for combiner in ("oneOf", "anyOf"):
         if combiner in schema:
             return schema[combiner]
@@ -45,7 +43,7 @@ def _union_branches(schema: dict) -> list[dict] | None:
 
 def _branch_name(branch: dict) -> str:
     """Best-effort name for a union branch — prefer Pydantic's `title`, fall back to type."""
-    if isinstance(branch, dict) and (title := branch.get("title")):
+    if title := branch.get("title"):
         return title
     return _type_summary(branch)
 
@@ -82,34 +80,35 @@ def _diff_union(old: dict, new: dict, prefix: str) -> list[str]:
 
 def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
     """Diff top-level properties of two object schemas. `label` is e.g. `parameter` or `field`."""
-    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
-    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
-    lines = []
-    for name in sorted(set(new_props) - set(old_props)):
-        lines.append(f"added {label} `{name}`")
-    for name in sorted(set(old_props) - set(new_props)):
-        lines.append(f"removed {label} `{name}`")
-    for name in sorted(set(old_props) & set(new_props)):
-        old_type = _type_summary(old_props[name])
-        new_type = _type_summary(new_props[name])
-        if old_type != new_type:
-            lines.append(f"{label} `{name}` type changed ({old_type} → {new_type})")
-    return lines
+    old_props = old.get("properties", {})
+    new_props = new.get("properties", {})
+    return [
+        f"added {label} `{name}`"
+        for name in sorted(set(new_props) - set(old_props))
+    ] + [
+        f"removed {label} `{name}`"
+        for name in sorted(set(old_props) - set(new_props))
+    ] + [
+        f"{label} `{name}` type changed ({old_type} → {new_type})"
+        for name in sorted(set(old_props) & set(new_props))
+        if (old_type := _type_summary(old_props[name])) != (new_type := _type_summary(new_props[name]))
+    ]
 
 
 def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     """Brief top-level diff of the `Call parameters` array schema."""
-    old_items = old.get("prefixItems", []) if isinstance(old, dict) else []
-    new_items = new.get("prefixItems", []) if isinstance(new, dict) else []
-    old_by_name = {item.get("title"): item for item in old_items if isinstance(item, dict)}
-    new_by_name = {item.get("title"): item for item in new_items if isinstance(item, dict)}
+    old_by_name = {item["title"]: item for item in old["prefixItems"]}
+    new_by_name = {item["title"]: item for item in new["prefixItems"]}
 
-    lines = []
-    for name in sorted(k for k in new_by_name if k not in old_by_name and k is not None):
-        lines.append(f"added parameter `{name}`")
-    for name in sorted(k for k in old_by_name if k not in new_by_name and k is not None):
-        lines.append(f"removed parameter `{name}`")
-    for name in sorted(k for k in new_by_name if k in old_by_name and k is not None):
+    lines = [
+        f"added parameter `{name}`"
+        for name in sorted(new_by_name.keys() - old_by_name.keys())
+    ] + [
+        f"removed parameter `{name}`"
+        for name in sorted(old_by_name.keys() - new_by_name.keys())
+    ]
+
+    for name in sorted(new_by_name.keys() & old_by_name.keys()):
         old_param = old_by_name[name]
         new_param = new_by_name[name]
         if _union_branches(old_param) is not None and _union_branches(new_param) is not None:
@@ -117,10 +116,12 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
             if union_lines:
                 lines.extend(union_lines)
                 continue
+
         old_type = _type_summary(old_param)
         new_type = _type_summary(new_param)
         if old_type != new_type:
             lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
+
     return lines
 
 
@@ -130,12 +131,14 @@ def _diff_return_value(old: dict, new: dict) -> list[str]:
         union_lines = _diff_union(old, new, "return value")
         if union_lines:
             return union_lines
-    old_type = _type_summary(old) if isinstance(old, dict) else "unknown"
-    new_type = _type_summary(new) if isinstance(new, dict) else "unknown"
+
+    old_type = _type_summary(old)
+    new_type = _type_summary(new)
     if old_type != new_type:
         return [f"return value type changed ({old_type} → {new_type})"]
-    if isinstance(old, dict) and isinstance(new, dict) and old.get("type") == "object":
+    if old.get("type") == "object":
         return _diff_object_properties(old, new, "field")
+
     return []
 
 
@@ -144,17 +147,18 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
     if old == new:
         return [], []
 
-    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
-    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
+    old_props = old["properties"]
+    new_props = new["properties"]
 
     call_diff = _diff_call_parameters(
-        old_props.get("Call parameters", {}),
-        new_props.get("Call parameters", {}),
+        old_props["Call parameters"],
+        new_props["Call parameters"],
     )
     return_diff = _diff_return_value(
-        old_props.get("Return value", {}),
-        new_props.get("Return value", {}),
+        old_props["Return value"],
+        new_props["Return value"],
     )
+
     return call_diff, return_diff
 
 
@@ -173,12 +177,14 @@ def _diff_items(
         new_schemas = cur_by_name[name].schemas
         if old_schemas == new_schemas:
             continue
+
         call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
         if not call_diff and not return_diff:
             # The schemas differ but our shallow diff couldn't surface anything meaningful
             # (e.g. nested-only change). Record the method as changed with a generic note.
             call_diff = []
             return_diff = ["schema changed (see method page for details)"]
+
         changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
 
     return added, removed, changed

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -1,32 +1,10 @@
 # -*- coding=utf-8 -*-
 """Cross-version API changelog computation.
 
-Given two :class:`APIDump` objects — any two versions, not necessarily adjacent —
-produce a :class:`Changelog` describing which methods were added, removed, or had
-their schemas changed. Every schema change is reported exactly, at any nesting
-depth, as a human-readable line addressing the changed node by path:
-
-- object fields join with dots (``options.force``), array items append ``[]``
-  (``apps[].options``), map values (an ``additionalProperties``/``patternProperties``
-  schema) append ``[*]``, fixed tuple members append ``[i]``, and titled union
-  branches join like fields (``AppQueryResultItem.action_required``); untitled
-  union branches (e.g. nullable wrappers) are descended in place.
-- union variants are identified by their Pydantic-generated branch title, falling
-  back to a type summary for untitled branches.
-
-The diff is semantic, not cosmetic. It reads only the schema keys ``type``,
-``enum``, ``const``, ``default``, ``required``, ``properties``, ``items``,
-``prefixItems``, ``additionalProperties``, ``patternProperties``, ``propertyNames``,
-``anyOf``, ``oneOf``, and ``title`` (the latter only to identify call parameters
-and union branches). Description/example wording and validation-constraint keys
-(``minLength``, ``pattern``, ...) are never read, so changes to them produce no
-changelog entry. Ignored keys are skipped by never reading them — NOT by stripping
-them from the schemas first: API models contain *fields* named ``description``,
-``type``, or ``default``, and deleting keys by name would corrupt them.
-
-The schemas are trusted to follow SCHEMA_RULES.md (formalized in
-api_dump.schema.json), which is why this module indexes into them without
-defensive checks.
+The diff is semantic, not cosmetic. Description/example wording and
+validation-constraint keys (``minLength``, ``pattern``, ...) are never read, so
+changes to them produce no changelog entry. The schemas are trusted to follow the
+structural rules of the `--dump-api` output.
 """
 from __future__ import annotations
 

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -115,7 +115,7 @@ class _SchemaDiffer:
 
     Accumulates change lines in `self.lines`. Lines about the root node itself are
     labeled with `root_label` (empty for the return value, whose label is supplied by
-    the renderer); lines about nested nodes are labeled ``field `<path>```.
+    the renderer); lines about nested nodes are labeled with their `` `<path>` ``.
     """
 
     def __init__(self, root_path: str, root_label: str):
@@ -124,7 +124,7 @@ class _SchemaDiffer:
         self.lines: list[str] = []
 
     def _emit(self, path: str, text: str, sep: str = " "):
-        label = self.root_label if path == self.root_path else f"field `{path}`"
+        label = self.root_label if path == self.root_path else f"`{path}`"
         self.lines.append(f"{label}{sep}{text}" if label else text)
 
     def diff(self, old: dict, new: dict, path: str):
@@ -220,16 +220,16 @@ class _SchemaDiffer:
 
         for name in sorted(new_props.keys() - old_props.keys()):
             suffix = " (required)" if name in new_required else ""
-            self.lines.append(f"added field `{_join(path, name)}`{suffix}")
+            self.lines.append(f"added `{_join(path, name)}`{suffix}")
         for name in sorted(old_props.keys() - new_props.keys()):
-            self.lines.append(f"removed field `{_join(path, name)}`")
+            self.lines.append(f"removed `{_join(path, name)}`")
         for name in sorted(old_props.keys() & new_props.keys()):
             field_path = _join(path, name)
             # `required` is compared as a set: real dumps reorder it with identical content.
             if name in new_required and name not in old_required:
-                self.lines.append(f"field `{field_path}` became required")
+                self.lines.append(f"`{field_path}` became required")
             elif name in old_required and name not in new_required:
-                self.lines.append(f"field `{field_path}` became optional")
+                self.lines.append(f"`{field_path}` became optional")
             self.diff(old_props[name], new_props[name], field_path)
 
         old_extra = _map_value_schema(old)

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -1,0 +1,168 @@
+# -*- coding=utf-8 -*-
+"""Cross-version API changelog computation.
+
+Given two adjacent :class:`APIDump` objects, produce a :class:`Changelog`
+describing which methods/events were added, removed, or had their schemas
+changed. The schema diff is intentionally shallow (top-level call parameters
+and return value) — deeper changes are surfaced as a generic note pointing the
+reader at the per-method page.
+"""
+from __future__ import annotations
+
+import dataclasses
+import typing
+
+if typing.TYPE_CHECKING:
+    from middlewared.api.base.server.doc import APIDump, APIDumpMethod, APIDumpEvent
+
+
+@dataclasses.dataclass
+class SchemaChange:
+    name: str
+    call_params_diff: list[str]
+    return_value_diff: list[str]
+
+
+@dataclasses.dataclass
+class Changelog:
+    previous_version: str
+    methods_added: list[str] = dataclasses.field(default_factory=list)
+    methods_removed: list[str] = dataclasses.field(default_factory=list)
+    methods_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
+    events_added: list[str] = dataclasses.field(default_factory=list)
+    events_removed: list[str] = dataclasses.field(default_factory=list)
+    events_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (
+            self.methods_added or self.methods_removed or self.methods_changed or
+            self.events_added or self.events_removed or self.events_changed
+        )
+
+
+def _type_summary(schema: dict) -> str:
+    """Render a brief human-readable type summary for a JSON-Schema fragment."""
+    if not isinstance(schema, dict):
+        return "unknown"
+
+    for combiner in ("anyOf", "oneOf"):
+        if combiner in schema:
+            return " | ".join(_type_summary(s) for s in schema[combiner])
+
+    t = schema.get("type")
+    if isinstance(t, list):
+        return " | ".join(t)
+    if t:
+        return t
+    if "enum" in schema:
+        return "enum"
+    if "const" in schema:
+        return "const"
+    return "unknown"
+
+
+def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
+    """Diff top-level properties of two object schemas. `label` is e.g. `parameter` or `field`."""
+    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
+    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
+    lines = []
+    for name in sorted(set(new_props) - set(old_props)):
+        lines.append(f"added {label} `{name}`")
+    for name in sorted(set(old_props) - set(new_props)):
+        lines.append(f"removed {label} `{name}`")
+    for name in sorted(set(old_props) & set(new_props)):
+        old_type = _type_summary(old_props[name])
+        new_type = _type_summary(new_props[name])
+        if old_type != new_type:
+            lines.append(f"{label} `{name}` type changed ({old_type} → {new_type})")
+    return lines
+
+
+def _diff_call_parameters(old: dict, new: dict) -> list[str]:
+    """Brief top-level diff of the `Call parameters` array schema."""
+    old_items = old.get("prefixItems", []) if isinstance(old, dict) else []
+    new_items = new.get("prefixItems", []) if isinstance(new, dict) else []
+    old_by_name = {item.get("title"): item for item in old_items if isinstance(item, dict)}
+    new_by_name = {item.get("title"): item for item in new_items if isinstance(item, dict)}
+
+    lines = []
+    for name in sorted(k for k in new_by_name if k not in old_by_name and k is not None):
+        lines.append(f"added parameter `{name}`")
+    for name in sorted(k for k in old_by_name if k not in new_by_name and k is not None):
+        lines.append(f"removed parameter `{name}`")
+    for name in sorted(k for k in new_by_name if k in old_by_name and k is not None):
+        old_type = _type_summary(old_by_name[name])
+        new_type = _type_summary(new_by_name[name])
+        if old_type != new_type:
+            lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
+    return lines
+
+
+def _diff_return_value(old: dict, new: dict) -> list[str]:
+    """Brief top-level diff of the `Return value` schema."""
+    old_type = _type_summary(old) if isinstance(old, dict) else "unknown"
+    new_type = _type_summary(new) if isinstance(new, dict) else "unknown"
+    if old_type != new_type:
+        return [f"return value type changed ({old_type} → {new_type})"]
+    if isinstance(old, dict) and isinstance(new, dict) and old.get("type") == "object":
+        return _diff_object_properties(old, new, "field")
+    return []
+
+
+def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
+    """Compare two method/event schemas. Returns (call_params_diff, return_value_diff)."""
+    if old == new:
+        return [], []
+
+    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
+    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
+
+    call_diff = _diff_call_parameters(
+        old_props.get("Call parameters", {}),
+        new_props.get("Call parameters", {}),
+    )
+    return_diff = _diff_return_value(
+        old_props.get("Return value", {}),
+        new_props.get("Return value", {}),
+    )
+    return call_diff, return_diff
+
+
+def _diff_items(
+    previous: typing.Iterable[APIDumpMethod | APIDumpEvent], current: typing.Iterable[APIDumpMethod | APIDumpEvent],
+) -> tuple[list[str], list[str], list[SchemaChange]]:
+    """Compute added/removed/changed for a list of APIDumpMethod or APIDumpEvent."""
+    prev_by_name = {item.name: item for item in previous}
+    cur_by_name = {item.name: item for item in current}
+
+    added = sorted(set(cur_by_name) - set(prev_by_name))
+    removed = sorted(set(prev_by_name) - set(cur_by_name))
+    changed = []
+    for name in sorted(set(cur_by_name) & set(prev_by_name)):
+        old_schemas = prev_by_name[name].schemas
+        new_schemas = cur_by_name[name].schemas
+        if old_schemas == new_schemas:
+            continue
+        call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
+        if not call_diff and not return_diff:
+            # The schemas differ but our shallow diff couldn't surface anything meaningful
+            # (e.g. nested-only change). Record the method as changed with a generic note.
+            call_diff = []
+            return_diff = ["schema changed (see method page for details)"]
+        changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
+
+    return added, removed, changed
+
+
+def compute_changelog(previous: APIDump, current: APIDump) -> Changelog:
+    methods_added, methods_removed, methods_changed = _diff_items(previous.methods, current.methods)
+    events_added, events_removed, events_changed = _diff_items(previous.events, current.events)
+    return Changelog(
+        previous_version=previous.version,
+        methods_added=methods_added,
+        methods_removed=methods_removed,
+        methods_changed=methods_changed,
+        events_added=events_added,
+        events_removed=events_removed,
+        events_changed=events_changed,
+    )

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -6,6 +6,7 @@ validation-constraint keys (``minLength``, ``pattern``, ...) are never read, so
 changes to them produce no changelog entry. The schemas are trusted to follow the
 structural rules of the `--dump-api` output.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -156,7 +157,14 @@ class _SchemaDiffer:
 
         self._diff_default(old, new, path)
 
-    def _diff_union(self, old: dict, new: dict, old_branches: list[dict], new_branches: list[dict], path: str):
+    def _diff_union(
+        self,
+        old: dict,
+        new: dict,
+        old_branches: list[dict],
+        new_branches: list[dict],
+        path: str,
+    ):
         old_groups = _group_branches(old_branches)
         new_groups = _group_branches(new_branches)
 
@@ -182,7 +190,11 @@ class _SchemaDiffer:
             old_branches = old_groups[name]
             new_branches = new_groups[name]
             for old_branch, new_branch in zip(old_branches, new_branches):
-                branch_path = _join(path, name) if "title" in old_branch or "title" in new_branch else path
+                branch_path = (
+                    _join(path, name)
+                    if "title" in old_branch or "title" in new_branch
+                    else path
+                )
                 self.diff(old_branch, new_branch, branch_path)
             if titled and len(old_branches) != len(new_branches):
                 action = "added" if len(new_branches) > len(old_branches) else "removed"
@@ -206,11 +218,20 @@ class _SchemaDiffer:
         if old_const == new_const:
             return
         if old_const is _MISSING:
-            self._emit(path, f"value restricted to constant {json.dumps(new_const)}", sep=": ")
+            self._emit(
+                path, f"value restricted to constant {json.dumps(new_const)}", sep=": "
+            )
         elif new_const is _MISSING:
-            self._emit(path, f"constant value restriction removed (was {json.dumps(old_const)})", sep=": ")
+            self._emit(
+                path,
+                f"constant value restriction removed (was {json.dumps(old_const)})",
+                sep=": ",
+            )
         else:
-            self._emit(path, f"const value changed ({json.dumps(old_const)} → {json.dumps(new_const)})")
+            self._emit(
+                path,
+                f"const value changed ({json.dumps(old_const)} → {json.dumps(new_const)})",
+            )
 
     def _diff_object(self, old: dict, new: dict, path: str):
         old_required = set(old.get("required", ()))
@@ -232,11 +253,19 @@ class _SchemaDiffer:
                 self.lines.append(f"`{field_path}` became required")
                 if "default" in old_field and "default" not in new_field:
                     # Losing the default is implied by becoming required.
-                    old_field = {key: value for key, value in old_field.items() if key != "default"}
+                    old_field = {
+                        key: value
+                        for key, value in old_field.items()
+                        if key != "default"
+                    }
             elif name in old_required and name not in new_required:
                 self.lines.append(f"`{field_path}` became optional")
                 if "default" in new_field and "default" not in old_field:
-                    new_field = {key: value for key, value in new_field.items() if key != "default"}
+                    new_field = {
+                        key: value
+                        for key, value in new_field.items()
+                        if key != "default"
+                    }
             self.diff(old_field, new_field, field_path)
 
         old_extra = _map_value_schema(old)
@@ -253,11 +282,15 @@ class _SchemaDiffer:
         for pattern in sorted(new_patterns.keys() - old_patterns.keys()):
             self._emit(path, f"added properties matching pattern `{pattern}`", sep=": ")
         for pattern in sorted(old_patterns.keys() - new_patterns.keys()):
-            self._emit(path, f"removed properties matching pattern `{pattern}`", sep=": ")
+            self._emit(
+                path, f"removed properties matching pattern `{pattern}`", sep=": "
+            )
         for pattern in sorted(old_patterns.keys() & new_patterns.keys()):
             self.diff(old_patterns[pattern], new_patterns[pattern], path + "[*]")
 
-        if (old_names := old.get("propertyNames")) != (new_names := new.get("propertyNames")):
+        if (old_names := old.get("propertyNames")) != (
+            new_names := new.get("propertyNames")
+        ):
             self.diff(old_names or {}, new_names or {}, path + "[*:keys]")
 
     def _diff_array(self, old: dict, new: dict, path: str):
@@ -267,7 +300,10 @@ class _SchemaDiffer:
             old_members = old["prefixItems"]
             new_members = new["prefixItems"]
             if len(old_members) != len(new_members):
-                self._emit(path, f"tuple length changed ({len(old_members)} → {len(new_members)})")
+                self._emit(
+                    path,
+                    f"tuple length changed ({len(old_members)} → {len(new_members)})",
+                )
             for i, (old_member, new_member) in enumerate(zip(old_members, new_members)):
                 self.diff(old_member, new_member, f"{path}[{i}]")
         else:
@@ -280,7 +316,10 @@ class _SchemaDiffer:
             return
         if old_default is _MISSING:
             detail = _format_value(new_default)
-            self._emit(path, f"default value added ({detail})" if detail else "default value added")
+            self._emit(
+                path,
+                f"default value added ({detail})" if detail else "default value added",
+            )
         elif new_default is _MISSING:
             self._emit(path, "default value removed")
         else:
@@ -294,8 +333,12 @@ class _SchemaDiffer:
 
 def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     """Diff the `Call parameters` schemas. Parameters are keyed by title; positions matter."""
-    old_params = {param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])}
-    new_params = {param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])}
+    old_params = {
+        param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])
+    }
+    new_params = {
+        param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])
+    }
     added = new_params.keys() - old_params.keys()
     removed = old_params.keys() - new_params.keys()
 
@@ -316,7 +359,9 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     for title in sorted(removed):
         lines.append(f"removed parameter `{title}`")
 
-    pairs = [(title, title) for title in old_params.keys() & new_params.keys()] + list(renames.items())
+    pairs = [(title, title) for title in old_params.keys() & new_params.keys()] + list(
+        renames.items()
+    )
     for old_title, new_title in sorted(pairs, key=lambda pair: pair[1]):
         old_index, old_param = old_params[old_title]
         new_index, new_param = new_params[new_title]
@@ -324,17 +369,27 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
             lines.append(f"parameter `{old_title}` renamed to `{new_title}`")
         elif old_index != new_index:
             # Positions are 0-based, matching the "Parameter N" headings on method pages.
-            lines.append(f"parameter `{new_title}` moved from position {old_index} to {new_index}")
+            lines.append(
+                f"parameter `{new_title}` moved from position {old_index} to {new_index}"
+            )
 
         had_default = "default" in old_param
         has_default = "default" in new_param
         if had_default != has_default:
-            lines.append(f"parameter `{new_title}` became {'required' if had_default else 'optional'}")
+            lines.append(
+                f"parameter `{new_title}` became {'required' if had_default else 'optional'}"
+            )
             # The presence transition says it all; don't also report it as a default change.
-            old_param = {key: value for key, value in old_param.items() if key != "default"}
-            new_param = {key: value for key, value in new_param.items() if key != "default"}
+            old_param = {
+                key: value for key, value in old_param.items() if key != "default"
+            }
+            new_param = {
+                key: value for key, value in new_param.items() if key != "default"
+            }
 
-        differ = _SchemaDiffer(root_path=new_title, root_label=f"parameter `{new_title}`")
+        differ = _SchemaDiffer(
+            root_path=new_title, root_label=f"parameter `{new_title}`"
+        )
         differ.diff(old_param, new_param, new_title)
         lines.extend(differ.lines)
 
@@ -359,13 +414,16 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
     old_props = old["properties"]
     new_props = new["properties"]
     return (
-        _diff_call_parameters(old_props["Call parameters"], new_props["Call parameters"]),
+        _diff_call_parameters(
+            old_props["Call parameters"], new_props["Call parameters"]
+        ),
         _diff_return_value(old_props["Return value"], new_props["Return value"]),
     )
 
 
 def _diff_items(
-    old: typing.Iterable[APIDumpMethod], new: typing.Iterable[APIDumpMethod],
+    old: typing.Iterable[APIDumpMethod],
+    new: typing.Iterable[APIDumpMethod],
 ) -> tuple[list[str], list[str], list[SchemaChange]]:
     """Compute added/removed/changed for a list of APIDumpMethod."""
     old_by_name = {item.name: item for item in old}
@@ -383,13 +441,19 @@ def _diff_items(
         call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
         if call_diff or return_diff:
             # No lines means the difference is cosmetic-only; the method is omitted.
-            changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
+            changed.append(
+                SchemaChange(
+                    name=name, call_params_diff=call_diff, return_value_diff=return_diff
+                )
+            )
 
     return added, removed, changed
 
 
 def compute_changelog(old: APIDump, new: APIDump) -> Changelog:
-    methods_added, methods_removed, methods_changed = _diff_items(old.methods, new.methods)
+    methods_added, methods_removed, methods_changed = _diff_items(
+        old.methods, new.methods
+    )
     return Changelog(
         old_version=old.version,
         methods_added=methods_added,

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -225,12 +225,19 @@ class _SchemaDiffer:
             self.lines.append(f"removed `{_join(path, name)}`")
         for name in sorted(old_props.keys() & new_props.keys()):
             field_path = _join(path, name)
+            old_field = old_props[name]
+            new_field = new_props[name]
             # `required` is compared as a set: real dumps reorder it with identical content.
             if name in new_required and name not in old_required:
                 self.lines.append(f"`{field_path}` became required")
+                if "default" in old_field and "default" not in new_field:
+                    # Losing the default is implied by becoming required.
+                    old_field = {key: value for key, value in old_field.items() if key != "default"}
             elif name in old_required and name not in new_required:
                 self.lines.append(f"`{field_path}` became optional")
-            self.diff(old_props[name], new_props[name], field_path)
+                if "default" in new_field and "default" not in old_field:
+                    new_field = {key: value for key, value in new_field.items() if key != "default"}
+            self.diff(old_field, new_field, field_path)
 
         old_extra = _map_value_schema(old)
         new_extra = _map_value_schema(new)

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -34,18 +34,34 @@ class Changelog:
         return not (self.methods_added or self.methods_removed or self.methods_changed)
 
 
+def _union_branches(schema: dict) -> list[dict] | None:
+    """If `schema` is a oneOf/anyOf, return its branches; else None."""
+    if not isinstance(schema, dict):
+        return
+    for combiner in ("oneOf", "anyOf"):
+        if combiner in schema:
+            return schema[combiner]
+
+
+def _branch_name(branch: dict) -> str:
+    """Best-effort name for a union branch — prefer Pydantic's `title`, fall back to type."""
+    if isinstance(branch, dict) and (title := branch.get("title")):
+        return title
+    return _type_summary(branch)
+
+
 def _type_summary(schema: dict) -> str:
     """Render a brief human-readable type summary for a JSON-Schema fragment."""
     if not isinstance(schema, dict):
         return "unknown"
 
-    for combiner in ("anyOf", "oneOf"):
-        if combiner in schema:
-            return " | ".join(_type_summary(s) for s in schema[combiner])
+    branches = _union_branches(schema)
+    if branches is not None:
+        return " | ".join(_branch_name(b) for b in branches)
 
     t = schema.get("type")
     if isinstance(t, list):
-        return " | ".join(t)
+        return " | ".join(sorted(t))
     if t:
         return t
     if "enum" in schema:
@@ -53,6 +69,15 @@ def _type_summary(schema: dict) -> str:
     if "const" in schema:
         return "const"
     return "unknown"
+
+
+def _diff_union(old: dict, new: dict, prefix: str) -> list[str]:
+    """Diff two union schemas by branch name. Returns lines describing added/removed variants."""
+    old_names = {_branch_name(b) for b in _union_branches(old) or []}
+    new_names = {_branch_name(b) for b in _union_branches(new) or []}
+    added = [f"{prefix}: added variant `{added}`" for added in sorted(new_names - old_names)]
+    removed = [f"{prefix}: removed variant `{removed}`" for removed in sorted(old_names - new_names)]
+    return added + removed
 
 
 def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
@@ -85,8 +110,15 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     for name in sorted(k for k in old_by_name if k not in new_by_name and k is not None):
         lines.append(f"removed parameter `{name}`")
     for name in sorted(k for k in new_by_name if k in old_by_name and k is not None):
-        old_type = _type_summary(old_by_name[name])
-        new_type = _type_summary(new_by_name[name])
+        old_param = old_by_name[name]
+        new_param = new_by_name[name]
+        if _union_branches(old_param) is not None and _union_branches(new_param) is not None:
+            union_lines = _diff_union(old_param, new_param, f"parameter `{name}`")
+            if union_lines:
+                lines.extend(union_lines)
+                continue
+        old_type = _type_summary(old_param)
+        new_type = _type_summary(new_param)
         if old_type != new_type:
             lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
     return lines
@@ -94,6 +126,10 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
 
 def _diff_return_value(old: dict, new: dict) -> list[str]:
     """Brief top-level diff of the `Return value` schema."""
+    if _union_branches(old) is not None and _union_branches(new) is not None:
+        union_lines = _diff_union(old, new, "return value")
+        if union_lines:
+            return union_lines
     old_type = _type_summary(old) if isinstance(old, dict) else "unknown"
     new_type = _type_summary(new) if isinstance(new, dict) else "unknown"
     if old_type != new_type:

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -29,7 +29,7 @@ class SchemaChange:
 
 @dataclasses.dataclass
 class Changelog:
-    previous_version: str
+    old_version: str
     methods_added: list[str] = dataclasses.field(default_factory=list)
     methods_removed: list[str] = dataclasses.field(default_factory=list)
     methods_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
@@ -365,18 +365,18 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
 
 
 def _diff_items(
-    previous: typing.Iterable[APIDumpMethod], current: typing.Iterable[APIDumpMethod],
+    old: typing.Iterable[APIDumpMethod], new: typing.Iterable[APIDumpMethod],
 ) -> tuple[list[str], list[str], list[SchemaChange]]:
     """Compute added/removed/changed for a list of APIDumpMethod."""
-    prev_by_name = {item.name: item for item in previous}
-    cur_by_name = {item.name: item for item in current}
+    old_by_name = {item.name: item for item in old}
+    new_by_name = {item.name: item for item in new}
 
-    added = sorted(cur_by_name.keys() - prev_by_name.keys())
-    removed = sorted(prev_by_name.keys() - cur_by_name.keys())
+    added = sorted(new_by_name.keys() - old_by_name.keys())
+    removed = sorted(old_by_name.keys() - new_by_name.keys())
     changed = []
-    for name in sorted(cur_by_name.keys() & prev_by_name.keys()):
-        old_schemas = prev_by_name[name].schemas
-        new_schemas = cur_by_name[name].schemas
+    for name in sorted(new_by_name.keys() & old_by_name.keys()):
+        old_schemas = old_by_name[name].schemas
+        new_schemas = new_by_name[name].schemas
         if old_schemas == new_schemas:
             continue
 
@@ -388,10 +388,10 @@ def _diff_items(
     return added, removed, changed
 
 
-def compute_changelog(previous: APIDump, current: APIDump) -> Changelog:
-    methods_added, methods_removed, methods_changed = _diff_items(previous.methods, current.methods)
+def compute_changelog(old: APIDump, new: APIDump) -> Changelog:
+    methods_added, methods_removed, methods_changed = _diff_items(old.methods, new.methods)
     return Changelog(
-        previous_version=previous.version,
+        old_version=old.version,
         methods_added=methods_added,
         methods_removed=methods_removed,
         methods_changed=methods_changed,

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -2,10 +2,10 @@
 """Cross-version API changelog computation.
 
 Given two adjacent :class:`APIDump` objects, produce a :class:`Changelog`
-describing which methods/events were added, removed, or had their schemas
-changed. The schema diff is intentionally shallow (top-level call parameters
-and return value) — deeper changes are surfaced as a generic note pointing the
-reader at the per-method page.
+describing which methods were added, removed, or had their schemas changed.
+The schema diff is intentionally shallow (top-level call parameters and return
+value) — deeper changes are surfaced as a generic note pointing the reader at
+the per-method page.
 """
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import dataclasses
 import typing
 
 if typing.TYPE_CHECKING:
-    from middlewared.api.base.server.doc import APIDump, APIDumpMethod, APIDumpEvent
+    from middlewared.api.base.server.doc import APIDump, APIDumpMethod
 
 
 @dataclasses.dataclass
@@ -29,15 +29,9 @@ class Changelog:
     methods_added: list[str] = dataclasses.field(default_factory=list)
     methods_removed: list[str] = dataclasses.field(default_factory=list)
     methods_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
-    events_added: list[str] = dataclasses.field(default_factory=list)
-    events_removed: list[str] = dataclasses.field(default_factory=list)
-    events_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
 
     def is_empty(self) -> bool:
-        return not (
-            self.methods_added or self.methods_removed or self.methods_changed or
-            self.events_added or self.events_removed or self.events_changed
-        )
+        return not (self.methods_added or self.methods_removed or self.methods_changed)
 
 
 def _type_summary(schema: dict) -> str:
@@ -129,9 +123,9 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
 
 
 def _diff_items(
-    previous: typing.Iterable[APIDumpMethod | APIDumpEvent], current: typing.Iterable[APIDumpMethod | APIDumpEvent],
+    previous: typing.Iterable[APIDumpMethod], current: typing.Iterable[APIDumpMethod],
 ) -> tuple[list[str], list[str], list[SchemaChange]]:
-    """Compute added/removed/changed for a list of APIDumpMethod or APIDumpEvent."""
+    """Compute added/removed/changed for a list of APIDumpMethod."""
     prev_by_name = {item.name: item for item in previous}
     cur_by_name = {item.name: item for item in current}
 
@@ -156,13 +150,9 @@ def _diff_items(
 
 def compute_changelog(previous: APIDump, current: APIDump) -> Changelog:
     methods_added, methods_removed, methods_changed = _diff_items(previous.methods, current.methods)
-    events_added, events_removed, events_changed = _diff_items(previous.events, current.events)
     return Changelog(
         previous_version=previous.version,
         methods_added=methods_added,
         methods_removed=methods_removed,
         methods_changed=methods_changed,
-        events_added=events_added,
-        events_removed=events_removed,
-        events_changed=events_changed,
     )

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -49,6 +49,7 @@ def _union_branches(schema: dict) -> list[dict] | None:
     for combiner in ("oneOf", "anyOf"):
         if combiner in schema:
             return schema[combiner]
+    return None
 
 
 def _branch_name(branch: dict) -> str:
@@ -169,9 +170,7 @@ class _SchemaDiffer:
         new_groups = _group_branches(new_branches)
 
         titled = any(
-            "title" in branch
-            for branches in (*old_groups.values(), *new_groups.values())
-            for branch in branches
+            "title" in branch for branches in (*old_groups.values(), *new_groups.values()) for branch in branches
         )
         if titled:
             for name in sorted(new_groups.keys() - old_groups.keys()):
@@ -190,11 +189,7 @@ class _SchemaDiffer:
             old_branches = old_groups[name]
             new_branches = new_groups[name]
             for old_branch, new_branch in zip(old_branches, new_branches):
-                branch_path = (
-                    _join(path, name)
-                    if "title" in old_branch or "title" in new_branch
-                    else path
-                )
+                branch_path = _join(path, name) if "title" in old_branch or "title" in new_branch else path
                 self.diff(old_branch, new_branch, branch_path)
             if titled and len(old_branches) != len(new_branches):
                 action = "added" if len(new_branches) > len(old_branches) else "removed"
@@ -218,9 +213,7 @@ class _SchemaDiffer:
         if old_const == new_const:
             return
         if old_const is _MISSING:
-            self._emit(
-                path, f"value restricted to constant {json.dumps(new_const)}", sep=": "
-            )
+            self._emit(path, f"value restricted to constant {json.dumps(new_const)}", sep=": ")
         elif new_const is _MISSING:
             self._emit(
                 path,
@@ -253,19 +246,11 @@ class _SchemaDiffer:
                 self.lines.append(f"`{field_path}` became required")
                 if "default" in old_field and "default" not in new_field:
                     # Losing the default is implied by becoming required.
-                    old_field = {
-                        key: value
-                        for key, value in old_field.items()
-                        if key != "default"
-                    }
+                    old_field = {key: value for key, value in old_field.items() if key != "default"}
             elif name in old_required and name not in new_required:
                 self.lines.append(f"`{field_path}` became optional")
                 if "default" in new_field and "default" not in old_field:
-                    new_field = {
-                        key: value
-                        for key, value in new_field.items()
-                        if key != "default"
-                    }
+                    new_field = {key: value for key, value in new_field.items() if key != "default"}
             self.diff(old_field, new_field, field_path)
 
         old_extra = _map_value_schema(old)
@@ -282,15 +267,11 @@ class _SchemaDiffer:
         for pattern in sorted(new_patterns.keys() - old_patterns.keys()):
             self._emit(path, f"added properties matching pattern `{pattern}`", sep=": ")
         for pattern in sorted(old_patterns.keys() - new_patterns.keys()):
-            self._emit(
-                path, f"removed properties matching pattern `{pattern}`", sep=": "
-            )
+            self._emit(path, f"removed properties matching pattern `{pattern}`", sep=": ")
         for pattern in sorted(old_patterns.keys() & new_patterns.keys()):
             self.diff(old_patterns[pattern], new_patterns[pattern], path + "[*]")
 
-        if (old_names := old.get("propertyNames")) != (
-            new_names := new.get("propertyNames")
-        ):
+        if (old_names := old.get("propertyNames")) != (new_names := new.get("propertyNames")):
             self.diff(old_names or {}, new_names or {}, path + "[*:keys]")
 
     def _diff_array(self, old: dict, new: dict, path: str):
@@ -333,12 +314,8 @@ class _SchemaDiffer:
 
 def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     """Diff the `Call parameters` schemas. Parameters are keyed by title; positions matter."""
-    old_params = {
-        param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])
-    }
-    new_params = {
-        param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])
-    }
+    old_params = {param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])}
+    new_params = {param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])}
     added = new_params.keys() - old_params.keys()
     removed = old_params.keys() - new_params.keys()
 
@@ -359,9 +336,7 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     for title in sorted(removed):
         lines.append(f"removed parameter `{title}`")
 
-    pairs = [(title, title) for title in old_params.keys() & new_params.keys()] + list(
-        renames.items()
-    )
+    pairs = [(title, title) for title in old_params.keys() & new_params.keys()] + list(renames.items())
     for old_title, new_title in sorted(pairs, key=lambda pair: pair[1]):
         old_index, old_param = old_params[old_title]
         new_index, new_param = new_params[new_title]
@@ -369,27 +344,17 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
             lines.append(f"parameter `{old_title}` renamed to `{new_title}`")
         elif old_index != new_index:
             # Positions are 0-based, matching the "Parameter N" headings on method pages.
-            lines.append(
-                f"parameter `{new_title}` moved from position {old_index} to {new_index}"
-            )
+            lines.append(f"parameter `{new_title}` moved from position {old_index} to {new_index}")
 
         had_default = "default" in old_param
         has_default = "default" in new_param
         if had_default != has_default:
-            lines.append(
-                f"parameter `{new_title}` became {'required' if had_default else 'optional'}"
-            )
+            lines.append(f"parameter `{new_title}` became {'required' if had_default else 'optional'}")
             # The presence transition says it all; don't also report it as a default change.
-            old_param = {
-                key: value for key, value in old_param.items() if key != "default"
-            }
-            new_param = {
-                key: value for key, value in new_param.items() if key != "default"
-            }
+            old_param = {key: value for key, value in old_param.items() if key != "default"}
+            new_param = {key: value for key, value in new_param.items() if key != "default"}
 
-        differ = _SchemaDiffer(
-            root_path=new_title, root_label=f"parameter `{new_title}`"
-        )
+        differ = _SchemaDiffer(root_path=new_title, root_label=f"parameter `{new_title}`")
         differ.diff(old_param, new_param, new_title)
         lines.extend(differ.lines)
 
@@ -414,9 +379,7 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
     old_props = old["properties"]
     new_props = new["properties"]
     return (
-        _diff_call_parameters(
-            old_props["Call parameters"], new_props["Call parameters"]
-        ),
+        _diff_call_parameters(old_props["Call parameters"], new_props["Call parameters"]),
         _diff_return_value(old_props["Return value"], new_props["Return value"]),
     )
 
@@ -441,19 +404,13 @@ def _diff_items(
         call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
         if call_diff or return_diff:
             # No lines means the difference is cosmetic-only; the method is omitted.
-            changed.append(
-                SchemaChange(
-                    name=name, call_params_diff=call_diff, return_value_diff=return_diff
-                )
-            )
+            changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
 
     return added, removed, changed
 
 
 def compute_changelog(old: APIDump, new: APIDump) -> Changelog:
-    methods_added, methods_removed, methods_changed = _diff_items(
-        old.methods, new.methods
-    )
+    methods_added, methods_removed, methods_changed = _diff_items(old.methods, new.methods)
     return Changelog(
         old_version=old.version,
         methods_added=methods_added,

--- a/src/middlewared_docs/changelog.py
+++ b/src/middlewared_docs/changelog.py
@@ -10,6 +10,7 @@ structural rules of the `--dump-api` output.
 from __future__ import annotations
 
 import dataclasses
+import enum
 import json
 import typing
 
@@ -19,6 +20,29 @@ if typing.TYPE_CHECKING:
 _MISSING = object()
 # Defaults longer than this are reported without their values.
 _MAX_RENDERED_VALUE_LENGTH = 50
+
+
+class SchemaKey(enum.StrEnum):
+    """JSON field names read from `--dump-api` method schemas."""
+
+    # Method-schema envelope (the two top-level `properties` of every method schema).
+    CALL_PARAMETERS = "Call parameters"
+    RETURN_VALUE = "Return value"
+    # Structural keywords.
+    TYPE = "type"
+    TITLE = "title"
+    DEFAULT = "default"
+    ENUM = "enum"
+    CONST = "const"
+    PROPERTIES = "properties"
+    REQUIRED = "required"
+    ADDITIONAL_PROPERTIES = "additionalProperties"
+    PATTERN_PROPERTIES = "patternProperties"
+    PROPERTY_NAMES = "propertyNames"
+    ITEMS = "items"
+    PREFIX_ITEMS = "prefixItems"
+    ANY_OF = "anyOf"
+    ONE_OF = "oneOf"
 
 
 @dataclasses.dataclass
@@ -46,7 +70,7 @@ def _union_branches(schema: dict) -> list[dict] | None:
     union) accepts the same payloads as the equivalent anyOf, so flipping between them
     is not a reportable change.
     """
-    for combiner in ("oneOf", "anyOf"):
+    for combiner in (SchemaKey.ONE_OF, SchemaKey.ANY_OF):
         if combiner in schema:
             return schema[combiner]
     return None
@@ -54,7 +78,7 @@ def _union_branches(schema: dict) -> list[dict] | None:
 
 def _branch_name(branch: dict) -> str:
     """Best-effort name for a union branch — prefer Pydantic's `title`, fall back to type."""
-    if title := branch.get("title"):
+    if title := branch.get(SchemaKey.TITLE):
         return title
     return _type_summary(branch)
 
@@ -67,13 +91,13 @@ def _type_summary(schema: dict) -> str:
         # render as e.g. "any | any | any".
         return " | ".join(dict.fromkeys(_branch_name(branch) for branch in branches))
 
-    if t := schema.get("type"):
-        if t == "array" and "prefixItems" in schema:
+    if t := schema.get(SchemaKey.TYPE):
+        if t == "array" and SchemaKey.PREFIX_ITEMS in schema:
             return "tuple"
         return t
-    if "enum" in schema:
+    if SchemaKey.ENUM in schema:
         return "enum"
-    if "const" in schema:
+    if SchemaKey.CONST in schema:
         return "const"
     return "any"
 
@@ -96,7 +120,7 @@ def _map_value_schema(schema: dict) -> dict | None:
     Absent `additionalProperties` and `true` both mean "any value" and normalize to the
     bare-any schema `{}` so that flipping between those representations is no change.
     """
-    extra = schema.get("additionalProperties", True)
+    extra = schema.get(SchemaKey.ADDITIONAL_PROPERTIES, True)
     if extra is False:
         return None
     if extra is True:
@@ -150,7 +174,7 @@ class _SchemaDiffer:
             # Key on `type`, not the summary: a union whose branches summarize alike
             # (e.g. anyOf of two untitled objects) has the same summary as a plain node
             # but must not be recursed into as one.
-            if (node_type := old.get("type")) == new.get("type"):
+            if (node_type := old.get(SchemaKey.TYPE)) == new.get(SchemaKey.TYPE):
                 if node_type == "object":
                     self._diff_object(old, new, path)
                 elif node_type == "array":
@@ -170,7 +194,9 @@ class _SchemaDiffer:
         new_groups = _group_branches(new_branches)
 
         titled = any(
-            "title" in branch for branches in (*old_groups.values(), *new_groups.values()) for branch in branches
+            SchemaKey.TITLE in branch
+            for branches in (*old_groups.values(), *new_groups.values())
+            for branch in branches
         )
         if titled:
             for name in sorted(new_groups.keys() - old_groups.keys()):
@@ -189,7 +215,8 @@ class _SchemaDiffer:
             old_branches = old_groups[name]
             new_branches = new_groups[name]
             for old_branch, new_branch in zip(old_branches, new_branches):
-                branch_path = _join(path, name) if "title" in old_branch or "title" in new_branch else path
+                titled_branch = SchemaKey.TITLE in old_branch or SchemaKey.TITLE in new_branch
+                branch_path = _join(path, name) if titled_branch else path
                 self.diff(old_branch, new_branch, branch_path)
             if titled and len(old_branches) != len(new_branches):
                 action = "added" if len(new_branches) > len(old_branches) else "removed"
@@ -197,19 +224,19 @@ class _SchemaDiffer:
                     self._emit(path, f"{action} variant `{name}`", sep=": ")
 
     def _diff_enum(self, old: dict, new: dict, path: str):
-        if "enum" not in old and "enum" not in new:
+        if SchemaKey.ENUM not in old and SchemaKey.ENUM not in new:
             return
         # Compare values as JSON renderings: hashable, and `0`/`false` stay distinct.
-        old_values = {json.dumps(value) for value in old.get("enum", ())}
-        new_values = {json.dumps(value) for value in new.get("enum", ())}
+        old_values = {json.dumps(value) for value in old.get(SchemaKey.ENUM, ())}
+        new_values = {json.dumps(value) for value in new.get(SchemaKey.ENUM, ())}
         for value in sorted(new_values - old_values):
             self._emit(path, f"added enum value {value}", sep=": ")
         for value in sorted(old_values - new_values):
             self._emit(path, f"removed enum value {value}", sep=": ")
 
     def _diff_const(self, old: dict, new: dict, path: str):
-        old_const = old.get("const", _MISSING)
-        new_const = new.get("const", _MISSING)
+        old_const = old.get(SchemaKey.CONST, _MISSING)
+        new_const = new.get(SchemaKey.CONST, _MISSING)
         if old_const == new_const:
             return
         if old_const is _MISSING:
@@ -227,10 +254,10 @@ class _SchemaDiffer:
             )
 
     def _diff_object(self, old: dict, new: dict, path: str):
-        old_required = set(old.get("required", ()))
-        new_required = set(new.get("required", ()))
-        old_props = old.get("properties", {})
-        new_props = new.get("properties", {})
+        old_required = set(old.get(SchemaKey.REQUIRED, ()))
+        new_required = set(new.get(SchemaKey.REQUIRED, ()))
+        old_props = old.get(SchemaKey.PROPERTIES, {})
+        new_props = new.get(SchemaKey.PROPERTIES, {})
 
         for name in sorted(new_props.keys() - old_props.keys()):
             suffix = " (required)" if name in new_required else ""
@@ -244,13 +271,13 @@ class _SchemaDiffer:
             # `required` is compared as a set: real dumps reorder it with identical content.
             if name in new_required and name not in old_required:
                 self.lines.append(f"`{field_path}` became required")
-                if "default" in old_field and "default" not in new_field:
+                if SchemaKey.DEFAULT in old_field and SchemaKey.DEFAULT not in new_field:
                     # Losing the default is implied by becoming required.
-                    old_field = {key: value for key, value in old_field.items() if key != "default"}
+                    old_field = {key: value for key, value in old_field.items() if key != SchemaKey.DEFAULT}
             elif name in old_required and name not in new_required:
                 self.lines.append(f"`{field_path}` became optional")
-                if "default" in new_field and "default" not in old_field:
-                    new_field = {key: value for key, value in new_field.items() if key != "default"}
+                if SchemaKey.DEFAULT in new_field and SchemaKey.DEFAULT not in old_field:
+                    new_field = {key: value for key, value in new_field.items() if key != SchemaKey.DEFAULT}
             self.diff(old_field, new_field, field_path)
 
         old_extra = _map_value_schema(old)
@@ -262,8 +289,8 @@ class _SchemaDiffer:
         elif old_extra is not None:
             self._emit(path, "additional properties no longer allowed", sep=": ")
 
-        old_patterns = old.get("patternProperties", {})
-        new_patterns = new.get("patternProperties", {})
+        old_patterns = old.get(SchemaKey.PATTERN_PROPERTIES, {})
+        new_patterns = new.get(SchemaKey.PATTERN_PROPERTIES, {})
         for pattern in sorted(new_patterns.keys() - old_patterns.keys()):
             self._emit(path, f"added properties matching pattern `{pattern}`", sep=": ")
         for pattern in sorted(old_patterns.keys() - new_patterns.keys()):
@@ -271,15 +298,15 @@ class _SchemaDiffer:
         for pattern in sorted(old_patterns.keys() & new_patterns.keys()):
             self.diff(old_patterns[pattern], new_patterns[pattern], path + "[*]")
 
-        if (old_names := old.get("propertyNames")) != (new_names := new.get("propertyNames")):
+        if (old_names := old.get(SchemaKey.PROPERTY_NAMES)) != (new_names := new.get(SchemaKey.PROPERTY_NAMES)):
             self.diff(old_names or {}, new_names or {}, path + "[*:keys]")
 
     def _diff_array(self, old: dict, new: dict, path: str):
-        if "prefixItems" in old:
+        if SchemaKey.PREFIX_ITEMS in old:
             # Fixed tuple (only core.download's return in practice). A list ↔ tuple
             # change never reaches here: the type summaries differ ("array" vs "tuple").
-            old_members = old["prefixItems"]
-            new_members = new["prefixItems"]
+            old_members = old[SchemaKey.PREFIX_ITEMS]
+            new_members = new[SchemaKey.PREFIX_ITEMS]
             if len(old_members) != len(new_members):
                 self._emit(
                     path,
@@ -288,11 +315,11 @@ class _SchemaDiffer:
             for i, (old_member, new_member) in enumerate(zip(old_members, new_members)):
                 self.diff(old_member, new_member, f"{path}[{i}]")
         else:
-            self.diff(old["items"], new["items"], path + "[]")
+            self.diff(old[SchemaKey.ITEMS], new[SchemaKey.ITEMS], path + "[]")
 
     def _diff_default(self, old: dict, new: dict, path: str):
-        old_default = old.get("default", _MISSING)
-        new_default = new.get("default", _MISSING)
+        old_default = old.get(SchemaKey.DEFAULT, _MISSING)
+        new_default = new.get(SchemaKey.DEFAULT, _MISSING)
         if old_default == new_default:
             return
         if old_default is _MISSING:
@@ -314,8 +341,8 @@ class _SchemaDiffer:
 
 def _diff_call_parameters(old: dict, new: dict) -> list[str]:
     """Diff the `Call parameters` schemas. Parameters are keyed by title; positions matter."""
-    old_params = {param["title"]: (i, param) for i, param in enumerate(old["prefixItems"])}
-    new_params = {param["title"]: (i, param) for i, param in enumerate(new["prefixItems"])}
+    old_params = {param[SchemaKey.TITLE]: (i, param) for i, param in enumerate(old[SchemaKey.PREFIX_ITEMS])}
+    new_params = {param[SchemaKey.TITLE]: (i, param) for i, param in enumerate(new[SchemaKey.PREFIX_ITEMS])}
     added = new_params.keys() - old_params.keys()
     removed = old_params.keys() - new_params.keys()
 
@@ -331,7 +358,7 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
 
     lines = []
     for title in sorted(added):
-        kind = "optional" if "default" in new_params[title][1] else "required"
+        kind = "optional" if SchemaKey.DEFAULT in new_params[title][1] else "required"
         lines.append(f"added parameter `{title}` ({kind})")
     for title in sorted(removed):
         lines.append(f"removed parameter `{title}`")
@@ -346,13 +373,13 @@ def _diff_call_parameters(old: dict, new: dict) -> list[str]:
             # Positions are 0-based, matching the "Parameter N" headings on method pages.
             lines.append(f"parameter `{new_title}` moved from position {old_index} to {new_index}")
 
-        had_default = "default" in old_param
-        has_default = "default" in new_param
+        had_default = SchemaKey.DEFAULT in old_param
+        has_default = SchemaKey.DEFAULT in new_param
         if had_default != has_default:
             lines.append(f"parameter `{new_title}` became {'required' if had_default else 'optional'}")
             # The presence transition says it all; don't also report it as a default change.
-            old_param = {key: value for key, value in old_param.items() if key != "default"}
-            new_param = {key: value for key, value in new_param.items() if key != "default"}
+            old_param = {key: value for key, value in old_param.items() if key != SchemaKey.DEFAULT}
+            new_param = {key: value for key, value in new_param.items() if key != SchemaKey.DEFAULT}
 
         differ = _SchemaDiffer(root_path=new_title, root_label=f"parameter `{new_title}`")
         differ.diff(old_param, new_param, new_title)
@@ -376,11 +403,11 @@ def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
     if old == new:
         return [], []
 
-    old_props = old["properties"]
-    new_props = new["properties"]
+    old_props = old[SchemaKey.PROPERTIES]
+    new_props = new[SchemaKey.PROPERTIES]
     return (
-        _diff_call_parameters(old_props["Call parameters"], new_props["Call parameters"]),
-        _diff_return_value(old_props["Return value"], new_props["Return value"]),
+        _diff_call_parameters(old_props[SchemaKey.CALL_PARAMETERS], new_props[SchemaKey.CALL_PARAMETERS]),
+        _diff_return_value(old_props[SchemaKey.RETURN_VALUE], new_props[SchemaKey.RETURN_VALUE]),
     )
 
 

--- a/src/middlewared_docs/docs/index.rst
+++ b/src/middlewared_docs/docs/index.rst
@@ -5,6 +5,7 @@ Contents
    :maxdepth: 1
 
    jsonrpc.rst
+$CHANGELOG_ENTRY
    api_methods.rst
    api_events.rst
    jobs.rst

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -84,22 +84,6 @@ class DocumentationGenerator:
             "api_methods",
             changelog.methods_changed,
         )
-        result += self._render_changelog_section(
-            "Events Added",
-            "api_events",
-            changelog.events_added,
-        )
-        result += self._render_changelog_section(
-            "Events Removed",
-            "api_events",
-            changelog.events_removed,
-            removed=True,
-        )
-        result += self._render_schema_changes_section(
-            "Events with Schema Changes",
-            "api_events",
-            changelog.events_changed,
-        )
 
         with open(f"{self.output_dir}/changelog.rst", "w") as f:
             f.write(result)

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -75,8 +75,9 @@ class DocumentationGenerator:
         )
         result += self._render_changelog_section(
             "Methods Removed",
-            None,
+            "api_methods",
             changelog.methods_removed,
+            removed=True,
         )
         result += self._render_schema_changes_section(
             "Methods with Schema Changes",
@@ -90,8 +91,9 @@ class DocumentationGenerator:
         )
         result += self._render_changelog_section(
             "Events Removed",
-            None,
+            "api_events",
             changelog.events_removed,
+            removed=True,
         )
         result += self._render_schema_changes_section(
             "Events with Schema Changes",
@@ -102,17 +104,23 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/changelog.rst", "w") as f:
             f.write(result)
 
-    def _render_changelog_section(self, title: str, doc_prefix: str | None, names: list[str]) -> str:
+    def _render_changelog_section(self, title: str, doc_prefix: str, names: list[str],
+                                  removed: bool = False) -> str:
         if not names:
             return ""
         out = f"{title}\n{'-' * len(title)}\n\n"
         for plugin, plugin_names in self._group_by_plugin(names):
             out += f"**{plugin}**\n\n"
             for name in plugin_names:
-                if doc_prefix:
-                    out += f"- :doc:`{name} <{doc_prefix}_{name}>`\n"
+                if removed:
+                    # The method/event no longer exists in this version's build, so link to its
+                    # page in the previous version's sibling Sphinx site via a relative URL.
+                    changelog = self.changelog
+                    assert changelog is not None
+                    url = f"../{changelog.previous_version}/{doc_prefix}_{name}.html"
+                    out += f"- `{name} <{url}>`__\n"
                 else:
-                    out += f"- ``{name}``\n"
+                    out += f"- :doc:`{name} <{doc_prefix}_{name}>`\n"
             out += "\n"
         return out
 

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -124,12 +124,20 @@ class DocumentationGenerator:
         for plugin in sorted(by_plugin):
             out += f"**{plugin}**\n\n"
             for change in sorted(by_plugin[plugin], key=lambda c: c.name):
+                # The blank lines around each nested list are required: without them,
+                # docutils parses the construct as a definition list and renders the
+                # would-be parent item as a bold term instead of a list item.
                 out += f"- :doc:`{change.name} <{doc_prefix}_{change.name}>`\n\n"
-                for line in change.call_params_diff:
-                    out += f"  - Call parameters: {line}\n"
-                for line in change.return_value_diff:
-                    out += f"  - Return value: {line}\n"
-                out += "\n"
+                for label, lines in (
+                    ("Call parameters", change.call_params_diff),
+                    ("Return value", change.return_value_diff),
+                ):
+                    if not lines:
+                        continue
+                    out += f"  - {label}:\n\n"
+                    for line in lines:
+                        out += f"    - {line}\n"
+                    out += "\n"
         return out
 
     def _group_by_plugin(self, names: list[str]) -> list[tuple[str, list[str]]]:

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -12,11 +12,12 @@ import tempfile
 import textwrap
 import typing
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from json_schema_for_humans.generate import generate_from_filename
 from json_schema_for_humans.generation_configuration import GenerationConfiguration
 
 from middlewared.fake_env import setup_fake_middleware_env
+
 setup_fake_middleware_env()
 
 from middlewared.api.base.server.doc import APIDump, APIDumpMethod, APIDumpEvent
@@ -68,9 +69,7 @@ class DocumentationGenerator:
         if changelog.is_empty():
             result += f"No API schema changes since version {changelog.old_version}.\n"
         else:
-            result += (
-                f"Summary of API changes since version {changelog.old_version}.\n\n"
-            )
+            result += f"Summary of API changes since version {changelog.old_version}.\n\n"
 
             result += self._render_changelog_section(
                 "Methods Added",
@@ -92,8 +91,7 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/changelog.rst", "w") as f:
             f.write(result)
 
-    def _render_changelog_section(self, title: str, doc_prefix: str, names: list[str],
-                                  removed: bool = False) -> str:
+    def _render_changelog_section(self, title: str, doc_prefix: str, names: list[str], removed: bool = False) -> str:
         if not names:
             return ""
         out = f"{title}\n{'-' * len(title)}\n\n"
@@ -113,8 +111,7 @@ class DocumentationGenerator:
             out += "\n"
         return out
 
-    def _render_schema_changes_section(self, title: str, doc_prefix: str,
-                                       changes: list[SchemaChange]) -> str:
+    def _render_schema_changes_section(self, title: str, doc_prefix: str, changes: list[SchemaChange]) -> str:
         if not changes:
             return ""
         out = f"{title}\n{'-' * len(title)}\n\n"
@@ -164,23 +161,24 @@ class DocumentationGenerator:
             self._api_event_html_process,
         )
 
-    def _write_api_index(self, filename: str, title: str, items: list[APIDumpMethod | APIDumpEvent],
-                         html_process: typing.Callable[[BeautifulSoup], None]):
+    def _write_api_index(
+        self,
+        filename: str,
+        title: str,
+        items: list[APIDumpMethod | APIDumpEvent],
+        html_process: typing.Callable[[BeautifulSoup], None],
+    ):
         plugins = sorted({method.name.rsplit(".", 1)[0] for method in items})
 
         index = textwrap.dedent(f"""\
             {title}
-            {'-' * len(title)}
+            {"-" * len(title)}
 
             .. toctree::
 
         """)
         for plugin in plugins:
-            plugin_items = [
-                item
-                for item in items
-                if item.name.rsplit(".", 1)[0] == plugin
-            ]
+            plugin_items = [item for item in items if item.name.rsplit(".", 1)[0] == plugin]
             if not plugin_items:
                 continue
 
@@ -191,11 +189,16 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/{filename}.rst", "w") as f:
             f.write(index)
 
-    def _write_plugin(self, prefix: str, plugin: str, items: list[APIDumpMethod | APIDumpEvent],
-                      html_process: typing.Callable[[BeautifulSoup], None]):
+    def _write_plugin(
+        self,
+        prefix: str,
+        plugin: str,
+        items: list[APIDumpMethod | APIDumpEvent],
+        html_process: typing.Callable[[BeautifulSoup], None],
+    ):
         index = textwrap.dedent(f"""\
             {plugin}
-            {'-' * len(plugin)}
+            {"-" * len(plugin)}
 
             .. toctree::
 
@@ -210,8 +213,9 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/{prefix}_{plugin}.rst", "w") as f:
             f.write(index)
 
-    def _generate_item_schemas_html(self, prefix: str, item: APIDumpMethod | APIDumpEvent,
-                                    process: typing.Callable[[BeautifulSoup], None]) -> str:
+    def _generate_item_schemas_html(
+        self, prefix: str, item: APIDumpMethod | APIDumpEvent, process: typing.Callable[[BeautifulSoup], None]
+    ) -> str:
         json_path = f"{self.output_dir}/{prefix}_{item.name}.json"
         try:
             with open(json_path, "w") as f:
@@ -254,14 +258,16 @@ class DocumentationGenerator:
                     except ValueError:
                         continue
 
-                    new_default_value_value = soup.new_tag("div", **{"class": "value"})
+                    new_default_value_value = soup.new_tag("div", attrs={"class": "value"})
                     new_default_value_value.string = json.dumps(value_decoded, indent=2)
-                    new_default_value = soup.new_tag("div", **{"class": "json-default-value"})
+                    new_default_value = soup.new_tag("div", attrs={"class": "json-default-value"})
                     new_default_value.string = "Default:"
                     new_default_value.insert(1, new_default_value_value)
                     default_value.replace_with(new_default_value)
 
-            return soup.find("body").decode_contents()
+            body = soup.find("body")
+            assert isinstance(body, Tag)
+            return body.decode_contents()
         finally:
             os.unlink(json_path)
 
@@ -277,10 +283,7 @@ class DocumentationGenerator:
         if isinstance(item, APIDumpMethod):
             if item.name == "core.download":
                 # Add downloadable jobs list for core.download
-                downloadable_jobs = [
-                    m for m in self.api.methods
-                    if m.output_pipes
-                ]
+                downloadable_jobs = [m for m in self.api.methods if m.output_pipes]
                 if downloadable_jobs:
                     result += "**Jobs that can be downloaded:**\n\n"
                     for job in sorted(downloadable_jobs, key=lambda m: m.name):
@@ -296,25 +299,27 @@ class DocumentationGenerator:
                     result += f"*This job {modal} be used with* :doc:`core.download <api_methods_core.download>`.\n\n"
 
         result += ".. raw:: html\n\n"
-        result += textwrap.indent(
-            "<div id=\"json-schema\">" + schemas_html + "</div><br><br>", " " * 4
-        ) + "\n\n"
+        result += textwrap.indent('<div id="json-schema">' + schemas_html + "</div><br><br>", " " * 4) + "\n\n"
 
         result += "*Required roles:* " + " | ".join(item.roles) + "\n\n"
 
         return result
 
     def _api_method_html_process(self, soup: BeautifulSoup):
-        for h5 in soup.find("div", {"id": "Call_parameters"}).find().find_all("h5", recursive=False):
+        call_parameters = soup.find("div", {"id": "Call_parameters"})
+        assert isinstance(call_parameters, Tag)
+        inner = call_parameters.find()
+        assert isinstance(inner, Tag)
+        for h5 in inner.find_all("h5", recursive=False):
             if m := re.match("Item at ([0-9]+) must be:", h5.text):
                 number = int(m.group(1))
 
-                next_sibling = h5.next_sibling
-                while next_sibling and next_sibling.name is None:
-                    next_sibling = next_sibling.next_sibling
-
-                name = next_sibling.find("h4").text
-                h5.string = f"Parameter {number}: {name}"
+                # The parameter's heading is the next sibling element (skipping text nodes).
+                sibling = h5.find_next_sibling()
+                assert isinstance(sibling, Tag)
+                heading = sibling.find("h4")
+                assert isinstance(heading, Tag)
+                h5.string = f"Parameter {number}: {heading.text}"
 
     def _api_event_html_process(self, soup: BeautifulSoup):
         pass
@@ -377,7 +382,8 @@ def build_api(output_dir: str, api_and_changelog: tuple[APIDump, Changelog | Non
     subprocess.run(
         [
             os.path.join(os.path.dirname(sys.executable), "sphinx-build"),
-            "-M", "html",
+            "-M",
+            "html",
             rst_dir,
             build_dir,
         ],
@@ -423,18 +429,18 @@ def main(output_dir):
         cwd = f"{output_dir}/{version}"
         version_switch = [
             (
-                f'<option value="{api.version}" {"selected" if api.version == version else ""}>' +
-                f'{api.version_title}' +
-                '</option>'
+                f'<option value="{api.version}" {"selected" if api.version == version else ""}>'
+                + f"{api.version_title}"
+                + "</option>"
             )
             for api in apis_sorted
         ]
         version_switch = (
             '<form class="form-inline">'
-            '<select class="form-control" onchange="navigateToVersion(this.value);">' +
-            ''.join(version_switch) +
-            '</select>'
-            '</form>'
+            '<select class="form-control" onchange="navigateToVersion(this.value);">'
+            + "".join(version_switch)
+            + "</select>"
+            "</form>"
         )
 
         for root, dirs, files in os.walk(cwd):

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -66,10 +66,10 @@ class DocumentationGenerator:
         title = "Changelog"
         result = f"{title}\n{'=' * len(title)}\n\n"
         if changelog.is_empty():
-            result += f"No API schema changes since version {changelog.previous_version}.\n"
+            result += f"No API schema changes since version {changelog.old_version}.\n"
         else:
             result += (
-                f"Summary of API changes since version {changelog.previous_version}.\n\n"
+                f"Summary of API changes since version {changelog.old_version}.\n\n"
             )
 
             result += self._render_changelog_section(
@@ -102,10 +102,11 @@ class DocumentationGenerator:
             for name in plugin_names:
                 if removed:
                     # The method/event no longer exists in this version's build, so link to its
-                    # page in the previous version's sibling Sphinx site via a relative URL.
+                    # page in the sibling Sphinx site of the version this changelog was computed
+                    # against
                     changelog = self.changelog
                     assert changelog is not None
-                    url = f"../{changelog.previous_version}/{doc_prefix}_{name}.html"
+                    url = f"../{changelog.old_version}/{doc_prefix}_{name}.html"
                     out += f"- `{name} <{url}>`__\n"
                 else:
                     out += f"- :doc:`{name} <{doc_prefix}_{name}>`\n"

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -1,5 +1,4 @@
 # -*- coding=utf-8 -*-
-import dataclasses
 import functools
 import json
 import logging
@@ -22,157 +21,9 @@ setup_fake_middleware_env()
 
 from middlewared.api.base.server.doc import APIDump, APIDumpMethod, APIDumpEvent
 
+from changelog import Changelog, SchemaChange, compute_changelog
+
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class SchemaChange:
-    name: str
-    call_params_diff: list[str]
-    return_value_diff: list[str]
-
-
-@dataclasses.dataclass
-class Changelog:
-    previous_version: str
-    methods_added: list[str] = dataclasses.field(default_factory=list)
-    methods_removed: list[str] = dataclasses.field(default_factory=list)
-    methods_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
-    events_added: list[str] = dataclasses.field(default_factory=list)
-    events_removed: list[str] = dataclasses.field(default_factory=list)
-    events_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
-
-    def is_empty(self) -> bool:
-        return not (
-            self.methods_added or self.methods_removed or self.methods_changed or
-            self.events_added or self.events_removed or self.events_changed
-        )
-
-
-def _type_summary(schema: dict) -> str:
-    """Render a brief human-readable type summary for a JSON-Schema fragment."""
-    if not isinstance(schema, dict):
-        return "unknown"
-
-    for combiner in ("anyOf", "oneOf"):
-        if combiner in schema:
-            return " | ".join(_type_summary(s) for s in schema[combiner])
-
-    t = schema.get("type")
-    if isinstance(t, list):
-        return " | ".join(t)
-    if t:
-        return t
-    if "enum" in schema:
-        return "enum"
-    if "const" in schema:
-        return "const"
-    return "unknown"
-
-
-def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
-    """Diff top-level properties of two object schemas. `label` is e.g. `parameter` or `field`."""
-    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
-    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
-    lines = []
-    for name in sorted(set(new_props) - set(old_props)):
-        lines.append(f"added {label} `{name}`")
-    for name in sorted(set(old_props) - set(new_props)):
-        lines.append(f"removed {label} `{name}`")
-    for name in sorted(set(old_props) & set(new_props)):
-        old_type = _type_summary(old_props[name])
-        new_type = _type_summary(new_props[name])
-        if old_type != new_type:
-            lines.append(f"{label} `{name}` type changed ({old_type} → {new_type})")
-    return lines
-
-
-def _diff_call_parameters(old: dict, new: dict) -> list[str]:
-    """Brief top-level diff of the `Call parameters` array schema."""
-    old_items = old.get("prefixItems", []) if isinstance(old, dict) else []
-    new_items = new.get("prefixItems", []) if isinstance(new, dict) else []
-    old_by_name = {item.get("title"): item for item in old_items if isinstance(item, dict)}
-    new_by_name = {item.get("title"): item for item in new_items if isinstance(item, dict)}
-
-    lines = []
-    for name in sorted(k for k in new_by_name if k not in old_by_name and k is not None):
-        lines.append(f"added parameter `{name}`")
-    for name in sorted(k for k in old_by_name if k not in new_by_name and k is not None):
-        lines.append(f"removed parameter `{name}`")
-    for name in sorted(k for k in new_by_name if k in old_by_name and k is not None):
-        old_type = _type_summary(old_by_name[name])
-        new_type = _type_summary(new_by_name[name])
-        if old_type != new_type:
-            lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
-    return lines
-
-
-def _diff_return_value(old: dict, new: dict) -> list[str]:
-    """Brief top-level diff of the `Return value` schema."""
-    old_type = _type_summary(old) if isinstance(old, dict) else "unknown"
-    new_type = _type_summary(new) if isinstance(new, dict) else "unknown"
-    if old_type != new_type:
-        return [f"return value type changed ({old_type} → {new_type})"]
-    if isinstance(old, dict) and isinstance(new, dict) and old.get("type") == "object":
-        return _diff_object_properties(old, new, "field")
-    return []
-
-
-def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
-    """Compare two method/event schemas. Returns (call_params_diff, return_value_diff)."""
-    if old == new:
-        return [], []
-
-    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
-    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
-
-    call_diff = _diff_call_parameters(
-        old_props.get("Call parameters", {}),
-        new_props.get("Call parameters", {}),
-    )
-    return_diff = _diff_return_value(
-        old_props.get("Return value", {}),
-        new_props.get("Return value", {}),
-    )
-    return call_diff, return_diff
-
-
-def _diff_items(previous: list, current: list) -> tuple[list[str], list[str], list[SchemaChange]]:
-    """Compute added/removed/changed for a list of APIDumpMethod or APIDumpEvent."""
-    prev_by_name = {item.name: item for item in previous}
-    cur_by_name = {item.name: item for item in current}
-
-    added = sorted(set(cur_by_name) - set(prev_by_name))
-    removed = sorted(set(prev_by_name) - set(cur_by_name))
-    changed = []
-    for name in sorted(set(cur_by_name) & set(prev_by_name)):
-        old_schemas = prev_by_name[name].schemas
-        new_schemas = cur_by_name[name].schemas
-        if old_schemas == new_schemas:
-            continue
-        call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
-        if not call_diff and not return_diff:
-            # The schemas differ but our shallow diff couldn't surface anything meaningful
-            # (e.g. nested-only change). Record the method as changed with a generic note.
-            call_diff = []
-            return_diff = ["schema changed (see method page for details)"]
-        changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
-
-    return added, removed, changed
-
-
-def compute_changelog(previous: APIDump, current: APIDump) -> Changelog:
-    methods_added, methods_removed, methods_changed = _diff_items(previous.methods, current.methods)
-    events_added, events_removed, events_changed = _diff_items(previous.events, current.events)
-    return Changelog(
-        previous_version=previous.version,
-        methods_added=methods_added,
-        methods_removed=methods_removed,
-        methods_changed=methods_changed,
-        events_added=events_added,
-        events_removed=events_removed,
-        events_changed=events_changed,
-    )
 
 
 class DocumentationGenerator:
@@ -496,6 +347,7 @@ def build_api(output_dir: str, api_and_changelog: tuple[APIDump, Changelog | Non
 
 
 def main(output_dir):
+    # Load API models
     data = json.loads(
         subprocess.run(
             ["middlewared", "--dump-api"],
@@ -507,9 +359,13 @@ def main(output_dir):
     )
     apis = [APIDump.model_validate(api_dump) for api_dump in data["versions"]]
     apis_sorted = sorted(apis, key=lambda api: api.version)
+
+    # Compute changelogs between versions
     changelogs: dict[str, Changelog | None] = {apis_sorted[0].version: None}
     for previous, current in zip(apis_sorted, apis_sorted[1:]):
         changelogs[current.version] = compute_changelog(previous, current)
+
+    # Generate docs pages
     work_items = [(api, changelogs[api.version]) for api in apis]
     with multiprocessing.Pool() as p:
         p.map(functools.partial(build_api, output_dir), work_items)
@@ -517,39 +373,39 @@ def main(output_dir):
     shutil.rmtree(f"{output_dir}/rst")
     shutil.rmtree(f"{output_dir}/html")
 
+    apis_sorted.reverse()
     for version in os.listdir(output_dir):
         cwd = f"{output_dir}/{version}"
+        version_switch = [
+            (
+                f'<option value="{api.version}" {"selected" if api.version == version else ""}>' +
+                f'{api.version_title}' +
+                '</option>'
+            )
+            for api in apis_sorted
+        ]
+        version_switch = (
+            '<form class="form-inline">'
+            '<select class="form-control" onchange="navigateToVersion(this.value);">' +
+            ''.join(version_switch) +
+            '</select>'
+            '</form>'
+        )
 
         for root, dirs, files in os.walk(cwd):
-            for filename in files:
-                if filename.endswith(".html"):
-                    with open(f"{root}/{filename}") as f:
-                        contents = f.read()
+            for filename in filter(lambda fname: fname.endswith(".html"), files):
+                with open(f"{root}/{filename}") as f:
+                    contents = f.read()
 
-                    # Version switch
-                    version_switch = [
-                        (
-                            f'<option value="{api.version}" {"selected" if api.version == version else ""}>' +
-                            f'{api.version_title}' +
-                            '</option>'
-                        )
-                        for api in sorted(apis, key=lambda api: api.version, reverse=True)
-                    ]
-                    version_switch = (
-                        '<form class="form-inline">'
-                        '<select class="form-control" onchange="navigateToVersion(this.value);">' +
-                        ''.join(version_switch) +
-                        '</select>'
-                        '</form>'
-                    )
-                    navbar = '<ul class="navbar-nav mr-auto">'
-                    contents = contents.replace(navbar, version_switch + navbar)
+                # Version switch
+                navbar = '<ul class="navbar-nav mr-auto">'
+                contents = contents.replace(navbar, version_switch + navbar)
 
-                    # Make sphinx show a summary of the search result (sphinxbootstrap4theme breaks this)
-                    contents = contents.replace('<div class="bodywrapper">', '<div class="bodywrapper" role="main">')
+                # Make sphinx show a summary of the search result (sphinxbootstrap4theme breaks this)
+                contents = contents.replace('<div class="bodywrapper">', '<div class="bodywrapper" role="main">')
 
-                    with open(f"{root}/{filename}", "w") as f:
-                        f.write(contents)
+                with open(f"{root}/{filename}", "w") as f:
+                    f.write(contents)
 
         with tempfile.NamedTemporaryFile() as tf:
             shutil.make_archive(tf.name, "zip", cwd)

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -319,6 +319,42 @@ class DocumentationGenerator:
         pass
 
 
+def collapse_changelog_schema_changes(html_path: str):
+    """Collapse each method's diff list in "Methods with Schema Changes" into an accordion.
+
+    Operates on the built HTML: each method list item there holds the method link
+    followed by the nested diff list, which become the `<summary>` and the collapsed
+    body of a native `<details>` element.
+    """
+    with open(html_path) as f:
+        soup = BeautifulSoup(f.read())
+
+    section = soup.find(id="methods-with-schema-changes")
+    if section is None:
+        return
+
+    for li in section.find_all("li"):
+        p = li.find("p", recursive=False)
+        ul = li.find("ul", recursive=False)
+        if p is None or ul is None or p.find("a") is None:
+            # Not a method item: either a diff line, or a "Call parameters:"/
+            # "Return value:" label (which has a nested list but no link).
+            continue
+
+        summary = soup.new_tag("summary")
+        for child in list(p.children):
+            summary.append(child.extract())
+        details = soup.new_tag("details")
+        details.append(summary)
+        details.append(ul.extract())
+        p.replace_with(details)
+        # The <summary> disclosure triangle replaces the bullet.
+        li["style"] = "list-style: none"
+
+    with open(html_path, "w") as f:
+        f.write(str(soup))
+
+
 def docs_filename(version: str):
     return f"truenas-{version}-docs.zip"
 
@@ -348,6 +384,10 @@ def build_api(output_dir: str, api_and_changelog: tuple[APIDump, Changelog | Non
     )
 
     shutil.move(f"{build_dir}/html", f"{output_dir}/{api.version}")
+
+    changelog_path = f"{output_dir}/{api.version}/changelog.html"
+    if os.path.exists(changelog_path):
+        collapse_changelog_schema_changes(changelog_path)
 
 
 def main(output_dir):

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -46,9 +46,10 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/index.rst") as f:
             index = f.read()
 
-        if self.changelog is not None and not self.changelog.is_empty():
+        if self.changelog is not None:
             index = index.replace("$CHANGELOG_ENTRY\n", "   changelog.rst\n")
         else:
+            # The oldest documented version has no predecessor to compare against.
             index = index.replace("$CHANGELOG_ENTRY\n", "")
 
         with open(f"{self.output_dir}/index.rst", "w") as f:
@@ -56,7 +57,7 @@ class DocumentationGenerator:
 
         self._write_api_methods()
         self._write_api_events()
-        if self.changelog is not None and not self.changelog.is_empty():
+        if self.changelog is not None:
             self._write_changelog()
 
     def _write_changelog(self):
@@ -64,26 +65,29 @@ class DocumentationGenerator:
         assert changelog is not None
         title = "Changelog"
         result = f"{title}\n{'=' * len(title)}\n\n"
-        result += (
-            f"Summary of API changes since version {changelog.previous_version}.\n\n"
-        )
+        if changelog.is_empty():
+            result += f"No API schema changes since version {changelog.previous_version}.\n"
+        else:
+            result += (
+                f"Summary of API changes since version {changelog.previous_version}.\n\n"
+            )
 
-        result += self._render_changelog_section(
-            "Methods Added",
-            "api_methods",
-            changelog.methods_added,
-        )
-        result += self._render_changelog_section(
-            "Methods Removed",
-            "api_methods",
-            changelog.methods_removed,
-            removed=True,
-        )
-        result += self._render_schema_changes_section(
-            "Methods with Schema Changes",
-            "api_methods",
-            changelog.methods_changed,
-        )
+            result += self._render_changelog_section(
+                "Methods Added",
+                "api_methods",
+                changelog.methods_added,
+            )
+            result += self._render_changelog_section(
+                "Methods Removed",
+                "api_methods",
+                changelog.methods_removed,
+                removed=True,
+            )
+            result += self._render_schema_changes_section(
+                "Methods with Schema Changes",
+                "api_methods",
+                changelog.methods_changed,
+            )
 
         with open(f"{self.output_dir}/changelog.rst", "w") as f:
             f.write(result)

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -124,12 +124,12 @@ class DocumentationGenerator:
         for plugin in sorted(by_plugin):
             out += f"**{plugin}**\n\n"
             for change in sorted(by_plugin[plugin], key=lambda c: c.name):
-                out += f"- :doc:`{change.name} <{doc_prefix}_{change.name}>`\n"
+                out += f"- :doc:`{change.name} <{doc_prefix}_{change.name}>`\n\n"
                 for line in change.call_params_diff:
-                    out += f"   - Call parameters: {line}\n"
+                    out += f"  - Call parameters: {line}\n"
                 for line in change.return_value_diff:
-                    out += f"   - Return value: {line}\n"
-            out += "\n"
+                    out += f"  - Return value: {line}\n"
+                out += "\n"
         return out
 
     def _group_by_plugin(self, names: list[str]) -> list[tuple[str, list[str]]]:

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -336,13 +336,13 @@ def collapse_changelog_schema_changes(html_path: str):
         soup = BeautifulSoup(f.read())
 
     section = soup.find(id="methods-with-schema-changes")
-    if section is None:
+    if not isinstance(section, Tag):
         return
 
     for li in section.find_all("li"):
         p = li.find("p", recursive=False)
         ul = li.find("ul", recursive=False)
-        if p is None or ul is None or p.find("a") is None:
+        if not isinstance(p, Tag) or not isinstance(ul, Tag) or p.find("a") is None:
             # Not a method item: either a diff line, or a "Call parameters:"/
             # "Return value:" label (which has a nested list but no link).
             continue

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -1,4 +1,5 @@
 # -*- coding=utf-8 -*-
+import dataclasses
 import functools
 import json
 import logging
@@ -24,10 +25,161 @@ from middlewared.api.base.server.doc import APIDump, APIDumpMethod, APIDumpEvent
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass
+class SchemaChange:
+    name: str
+    call_params_diff: list[str]
+    return_value_diff: list[str]
+
+
+@dataclasses.dataclass
+class Changelog:
+    previous_version: str
+    methods_added: list[str] = dataclasses.field(default_factory=list)
+    methods_removed: list[str] = dataclasses.field(default_factory=list)
+    methods_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
+    events_added: list[str] = dataclasses.field(default_factory=list)
+    events_removed: list[str] = dataclasses.field(default_factory=list)
+    events_changed: list[SchemaChange] = dataclasses.field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (
+            self.methods_added or self.methods_removed or self.methods_changed or
+            self.events_added or self.events_removed or self.events_changed
+        )
+
+
+def _type_summary(schema: dict) -> str:
+    """Render a brief human-readable type summary for a JSON-Schema fragment."""
+    if not isinstance(schema, dict):
+        return "unknown"
+
+    for combiner in ("anyOf", "oneOf"):
+        if combiner in schema:
+            return " | ".join(_type_summary(s) for s in schema[combiner])
+
+    t = schema.get("type")
+    if isinstance(t, list):
+        return " | ".join(t)
+    if t:
+        return t
+    if "enum" in schema:
+        return "enum"
+    if "const" in schema:
+        return "const"
+    return "unknown"
+
+
+def _diff_object_properties(old: dict, new: dict, label: str) -> list[str]:
+    """Diff top-level properties of two object schemas. `label` is e.g. `parameter` or `field`."""
+    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
+    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
+    lines = []
+    for name in sorted(set(new_props) - set(old_props)):
+        lines.append(f"added {label} `{name}`")
+    for name in sorted(set(old_props) - set(new_props)):
+        lines.append(f"removed {label} `{name}`")
+    for name in sorted(set(old_props) & set(new_props)):
+        old_type = _type_summary(old_props[name])
+        new_type = _type_summary(new_props[name])
+        if old_type != new_type:
+            lines.append(f"{label} `{name}` type changed ({old_type} → {new_type})")
+    return lines
+
+
+def _diff_call_parameters(old: dict, new: dict) -> list[str]:
+    """Brief top-level diff of the `Call parameters` array schema."""
+    old_items = old.get("prefixItems", []) if isinstance(old, dict) else []
+    new_items = new.get("prefixItems", []) if isinstance(new, dict) else []
+    old_by_name = {item.get("title"): item for item in old_items if isinstance(item, dict)}
+    new_by_name = {item.get("title"): item for item in new_items if isinstance(item, dict)}
+
+    lines = []
+    for name in sorted(k for k in new_by_name if k not in old_by_name and k is not None):
+        lines.append(f"added parameter `{name}`")
+    for name in sorted(k for k in old_by_name if k not in new_by_name and k is not None):
+        lines.append(f"removed parameter `{name}`")
+    for name in sorted(k for k in new_by_name if k in old_by_name and k is not None):
+        old_type = _type_summary(old_by_name[name])
+        new_type = _type_summary(new_by_name[name])
+        if old_type != new_type:
+            lines.append(f"parameter `{name}` type changed ({old_type} → {new_type})")
+    return lines
+
+
+def _diff_return_value(old: dict, new: dict) -> list[str]:
+    """Brief top-level diff of the `Return value` schema."""
+    old_type = _type_summary(old) if isinstance(old, dict) else "unknown"
+    new_type = _type_summary(new) if isinstance(new, dict) else "unknown"
+    if old_type != new_type:
+        return [f"return value type changed ({old_type} → {new_type})"]
+    if isinstance(old, dict) and isinstance(new, dict) and old.get("type") == "object":
+        return _diff_object_properties(old, new, "field")
+    return []
+
+
+def compute_schema_diff(old: dict, new: dict) -> tuple[list[str], list[str]]:
+    """Compare two method/event schemas. Returns (call_params_diff, return_value_diff)."""
+    if old == new:
+        return [], []
+
+    old_props = old.get("properties", {}) if isinstance(old, dict) else {}
+    new_props = new.get("properties", {}) if isinstance(new, dict) else {}
+
+    call_diff = _diff_call_parameters(
+        old_props.get("Call parameters", {}),
+        new_props.get("Call parameters", {}),
+    )
+    return_diff = _diff_return_value(
+        old_props.get("Return value", {}),
+        new_props.get("Return value", {}),
+    )
+    return call_diff, return_diff
+
+
+def _diff_items(previous: list, current: list) -> tuple[list[str], list[str], list[SchemaChange]]:
+    """Compute added/removed/changed for a list of APIDumpMethod or APIDumpEvent."""
+    prev_by_name = {item.name: item for item in previous}
+    cur_by_name = {item.name: item for item in current}
+
+    added = sorted(set(cur_by_name) - set(prev_by_name))
+    removed = sorted(set(prev_by_name) - set(cur_by_name))
+    changed = []
+    for name in sorted(set(cur_by_name) & set(prev_by_name)):
+        old_schemas = prev_by_name[name].schemas
+        new_schemas = cur_by_name[name].schemas
+        if old_schemas == new_schemas:
+            continue
+        call_diff, return_diff = compute_schema_diff(old_schemas, new_schemas)
+        if not call_diff and not return_diff:
+            # The schemas differ but our shallow diff couldn't surface anything meaningful
+            # (e.g. nested-only change). Record the method as changed with a generic note.
+            call_diff = []
+            return_diff = ["schema changed (see method page for details)"]
+        changed.append(SchemaChange(name=name, call_params_diff=call_diff, return_value_diff=return_diff))
+
+    return added, removed, changed
+
+
+def compute_changelog(previous: APIDump, current: APIDump) -> Changelog:
+    methods_added, methods_removed, methods_changed = _diff_items(previous.methods, current.methods)
+    events_added, events_removed, events_changed = _diff_items(previous.events, current.events)
+    return Changelog(
+        previous_version=previous.version,
+        methods_added=methods_added,
+        methods_removed=methods_removed,
+        methods_changed=methods_changed,
+        events_added=events_added,
+        events_removed=events_removed,
+        events_changed=events_changed,
+    )
+
+
 class DocumentationGenerator:
-    def __init__(self, api: APIDump, output_dir: str):
+    def __init__(self, api: APIDump, output_dir: str, changelog: Changelog | None = None):
         self.api = api
         self.output_dir = output_dir
+        self.changelog = changelog
 
     def generate(self):
         shutil.copytree("docs", self.output_dir, dirs_exist_ok=True)
@@ -40,8 +192,105 @@ class DocumentationGenerator:
         with open(f"{self.output_dir}/conf.py", "w") as f:
             f.write(conf)
 
+        with open(f"{self.output_dir}/index.rst") as f:
+            index = f.read()
+
+        if self.changelog is not None and not self.changelog.is_empty():
+            index = index.replace("$CHANGELOG_ENTRY\n", "   changelog.rst\n")
+        else:
+            index = index.replace("$CHANGELOG_ENTRY\n", "")
+
+        with open(f"{self.output_dir}/index.rst", "w") as f:
+            f.write(index)
+
         self._write_api_methods()
         self._write_api_events()
+        if self.changelog is not None and not self.changelog.is_empty():
+            self._write_changelog()
+
+    def _write_changelog(self):
+        changelog = self.changelog
+        assert changelog is not None
+        title = "Changelog"
+        result = f"{title}\n{'=' * len(title)}\n\n"
+        result += (
+            f"Summary of API changes since version {changelog.previous_version}.\n\n"
+        )
+
+        result += self._render_changelog_section(
+            "Methods Added",
+            "api_methods",
+            changelog.methods_added,
+        )
+        result += self._render_changelog_section(
+            "Methods Removed",
+            None,
+            changelog.methods_removed,
+        )
+        result += self._render_schema_changes_section(
+            "Methods with Schema Changes",
+            "api_methods",
+            changelog.methods_changed,
+        )
+        result += self._render_changelog_section(
+            "Events Added",
+            "api_events",
+            changelog.events_added,
+        )
+        result += self._render_changelog_section(
+            "Events Removed",
+            None,
+            changelog.events_removed,
+        )
+        result += self._render_schema_changes_section(
+            "Events with Schema Changes",
+            "api_events",
+            changelog.events_changed,
+        )
+
+        with open(f"{self.output_dir}/changelog.rst", "w") as f:
+            f.write(result)
+
+    def _render_changelog_section(self, title: str, doc_prefix: str | None, names: list[str]) -> str:
+        if not names:
+            return ""
+        out = f"{title}\n{'-' * len(title)}\n\n"
+        for plugin, plugin_names in self._group_by_plugin(names):
+            out += f"**{plugin}**\n\n"
+            for name in plugin_names:
+                if doc_prefix:
+                    out += f"- :doc:`{name} <{doc_prefix}_{name}>`\n"
+                else:
+                    out += f"- ``{name}``\n"
+            out += "\n"
+        return out
+
+    def _render_schema_changes_section(self, title: str, doc_prefix: str,
+                                       changes: list[SchemaChange]) -> str:
+        if not changes:
+            return ""
+        out = f"{title}\n{'-' * len(title)}\n\n"
+        by_plugin: dict[str, list[SchemaChange]] = {}
+        for change in changes:
+            plugin = change.name.rsplit(".", 1)[0]
+            by_plugin.setdefault(plugin, []).append(change)
+        for plugin in sorted(by_plugin):
+            out += f"**{plugin}**\n\n"
+            for change in sorted(by_plugin[plugin], key=lambda c: c.name):
+                out += f"- :doc:`{change.name} <{doc_prefix}_{change.name}>`\n"
+                for line in change.call_params_diff:
+                    out += f"   - Call parameters: {line}\n"
+                for line in change.return_value_diff:
+                    out += f"   - Return value: {line}\n"
+            out += "\n"
+        return out
+
+    def _group_by_plugin(self, names: list[str]) -> list[tuple[str, list[str]]]:
+        groups: dict[str, list[str]] = {}
+        for name in names:
+            plugin = name.rsplit(".", 1)[0]
+            groups.setdefault(plugin, []).append(name)
+        return [(plugin, sorted(groups[plugin])) for plugin in sorted(groups)]
 
     def _write_api_methods(self):
         return self._write_api_index(
@@ -219,9 +468,10 @@ def docs_filename(version: str):
     return f"truenas-{version}-docs.zip"
 
 
-def build_api(output_dir: str, api: APIDump):
+def build_api(output_dir: str, api_and_changelog: tuple[APIDump, Changelog | None]):
+    api, changelog = api_and_changelog
     rst_dir = f"{output_dir}/rst/{api.version}"
-    DocumentationGenerator(api, rst_dir).generate()
+    DocumentationGenerator(api, rst_dir, changelog).generate()
 
     with open(f"{rst_dir}/index.rst") as f:
         index = f.read()
@@ -256,8 +506,13 @@ def main(output_dir):
         ).stdout
     )
     apis = [APIDump.model_validate(api_dump) for api_dump in data["versions"]]
+    apis_sorted = sorted(apis, key=lambda api: api.version)
+    changelogs: dict[str, Changelog | None] = {apis_sorted[0].version: None}
+    for previous, current in zip(apis_sorted, apis_sorted[1:]):
+        changelogs[current.version] = compute_changelog(previous, current)
+    work_items = [(api, changelogs[api.version]) for api in apis]
     with multiprocessing.Pool() as p:
-        p.map(functools.partial(build_api, output_dir), apis)
+        p.map(functools.partial(build_api, output_dir), work_items)
 
     shutil.rmtree(f"{output_dir}/rst")
     shutil.rmtree(f"{output_dir}/html")

--- a/src/middlewared_docs/ruff.toml
+++ b/src/middlewared_docs/ruff.toml
@@ -1,0 +1,10 @@
+# Inherit the middlewared rule set (line length, target version, select, banned-api).
+extend = "../middlewared/pyproject.toml"
+
+[lint.isort]
+force-sort-within-sections = true
+known-first-party = ["changelog"]
+
+[lint.per-file-ignores]
+# setup_fake_middleware_env() must run before the middlewared imports it enables.
+"generate_docs.py" = ["E402", "I001"]

--- a/src/middlewared_docs/test_changelog.py
+++ b/src/middlewared_docs/test_changelog.py
@@ -1,0 +1,283 @@
+# -*- coding=utf-8 -*-
+"""Unit tests for the cross-version API changelog diff (`changelog.py`)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import changelog as cl
+
+
+# --- builders for the canonical `--dump-api` schema shape ------------------------------
+
+def method_schemas(call_params=None, return_value=None):
+    """A method schema as it appears in the dump: object with Call parameters + Return value."""
+    return {
+        "type": "object",
+        "properties": {
+            "Call parameters": {
+                "type": "array",
+                "prefixItems": list(call_params or []),
+                "items": False,
+            },
+            "Return value": {} if return_value is None else return_value,
+        },
+    }
+
+
+def param(title, **extra):
+    """A single positional call parameter (every parameter has a unique title)."""
+    return {"title": title, "type": "string", **extra}
+
+
+def obj(properties, required=()):
+    return {"type": "object", "properties": properties, "required": list(required)}
+
+
+def call_diff(old_params, new_params):
+    return cl.compute_schema_diff(method_schemas(call_params=old_params),
+                                  method_schemas(call_params=new_params))[0]
+
+
+def return_diff(old_rv, new_rv):
+    return cl.compute_schema_diff(method_schemas(return_value=old_rv),
+                                  method_schemas(return_value=new_rv))[1]
+
+
+# --- whole-schema short-circuits -------------------------------------------------------
+
+def test_identical_schemas_produce_no_diff():
+    schema = method_schemas([param("x")], obj({"a": {"type": "string"}}))
+    assert cl.compute_schema_diff(schema, schema) == ([], [])
+
+
+def test_cosmetic_only_change_is_ignored():
+    # Description/title wording is never read, so it is not a reportable change.
+    old = method_schemas(return_value={"type": "string", "description": "old words"})
+    new = method_schemas(return_value={"type": "string", "description": "new words"})
+    assert cl.compute_schema_diff(old, new) == ([], [])
+
+
+# --- call parameters -------------------------------------------------------------------
+
+CALL_PARAM_CASES = [
+    pytest.param(
+        [param("a")], [param("a"), param("b")],
+        ["added parameter `b` (required)"],
+        id="added-required-param",
+    ),
+    pytest.param(
+        [param("a")], [param("a"), param("b", default="x")],
+        ["added parameter `b` (optional)"],
+        id="added-optional-param",
+    ),
+    pytest.param(
+        [param("a"), param("b")], [param("a")],
+        ["removed parameter `b`"],
+        id="removed-param",
+    ),
+    pytest.param(
+        [param("old_name")], [param("new_name")],
+        ["parameter `old_name` renamed to `new_name`"],
+        id="same-position-rename",
+    ),
+    pytest.param(
+        [param("a"), param("b")], [param("b"), param("a")],
+        ["parameter `a` moved from position 0 to 1", "parameter `b` moved from position 1 to 0"],
+        id="position-move",
+    ),
+    pytest.param(
+        [param("a", default="x")], [param("a")],
+        ["parameter `a` became required"],
+        id="param-became-required-suppresses-default-removed",
+    ),
+    pytest.param(
+        [param("a")], [param("a", default="x")],
+        ["parameter `a` became optional"],
+        id="param-became-optional-suppresses-default-added",
+    ),
+    pytest.param(
+        [param("a", type="string")], [param("a", type="integer")],
+        ["parameter `a` type changed (string → integer)"],
+        id="param-type-change",
+    ),
+]
+
+
+@pytest.mark.parametrize("old_params,new_params,expected", CALL_PARAM_CASES)
+def test_call_parameter_diff(old_params, new_params, expected):
+    assert call_diff(old_params, new_params) == expected
+
+
+# --- return value: objects, fields, transitions ----------------------------------------
+
+RETURN_VALUE_CASES = [
+    pytest.param(
+        obj({"a": {"type": "string"}}),
+        obj({"a": {"type": "string"}, "b": {"type": "string"}}, required=["b"]),
+        ["added `b` (required)"],
+        id="added-required-field",
+    ),
+    pytest.param(
+        obj({"a": {"type": "string"}, "b": {"type": "string"}}),
+        obj({"a": {"type": "string"}}),
+        ["removed `b`"],
+        id="removed-field",
+    ),
+    pytest.param(
+        obj({"a": {"type": "string", "default": "x"}}),
+        obj({"a": {"type": "string"}}, required=["a"]),
+        ["`a` became required"],
+        id="field-became-required-suppresses-default-removed",
+    ),
+    pytest.param(
+        obj({"a": {"type": "string"}}, required=["a"]),
+        obj({"a": {"type": "string", "default": "x"}}),
+        ["`a` became optional"],
+        id="field-became-optional-suppresses-default-added",
+    ),
+    pytest.param(
+        obj({"a": {"type": "string"}, "b": {"type": "string"}}, required=["a", "b"]),
+        obj({"a": {"type": "string"}, "b": {"type": "string"}}, required=["b", "a"]),
+        [],
+        id="required-reordering-is-not-a-change",
+    ),
+    pytest.param(
+        {"type": "string"}, {"type": "integer"},
+        ["type changed (string → integer)"],
+        id="root-type-change",
+    ),
+    pytest.param(
+        {"type": "string"},
+        {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        ["type changed (string → string | null)"],
+        id="became-nullable",
+    ),
+    pytest.param(
+        {"enum": ["a", "b"]}, {"enum": ["b", "c"]},
+        ['added enum value "c"', 'removed enum value "a"'],
+        id="enum-values",
+    ),
+    pytest.param(
+        obj({"a": {"type": "string"}}),
+        obj({"a": {"type": "string", "const": "x"}}),
+        ['`a`: value restricted to constant "x"'],
+        id="const-added",
+    ),
+    pytest.param(
+        obj({"a": {"type": "integer", "default": 1}}),
+        obj({"a": {"type": "integer", "default": 2}}),
+        ["`a` default value changed (1 → 2)"],
+        id="default-changed",
+    ),
+    pytest.param(
+        obj({"a": {"type": "integer"}}),
+        obj({"a": {"type": "integer", "default": 5}}),
+        ["`a` default value added (5)"],
+        id="default-added",
+    ),
+    pytest.param(
+        obj({"a": {"type": "array", "items": {"type": "string"}}}),
+        obj({"a": {"type": "array", "items": {"type": "integer"}}}),
+        ["`a[]` type changed (string → integer)"],
+        id="array-item-type-change",
+    ),
+    pytest.param(
+        {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}]},
+        {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}, {"type": "boolean"}]},
+        ["tuple length changed (2 → 3)"],
+        id="tuple-length-change",
+    ),
+    pytest.param(
+        {"type": "object", "properties": {}},
+        {"type": "object", "properties": {}, "additionalProperties": False},
+        ["additional properties no longer allowed"],
+        id="additional-properties-disallowed",
+    ),
+    pytest.param(
+        {"type": "object", "properties": {}, "additionalProperties": True},
+        {"type": "object", "properties": {}},
+        [],
+        id="additional-properties-true-equals-absent",
+    ),
+]
+
+
+@pytest.mark.parametrize("old_rv,new_rv,expected", RETURN_VALUE_CASES)
+def test_return_value_diff(old_rv, new_rv, expected):
+    assert return_diff(old_rv, new_rv) == expected
+
+
+# --- unions ----------------------------------------------------------------------------
+
+def test_titled_union_added_and_removed_variant():
+    old = {"anyOf": [obj({"a": {"type": "string"}}) | {"title": "A"},
+                     obj({"b": {"type": "string"}}) | {"title": "B"}]}
+    new = {"anyOf": [obj({"a": {"type": "string"}}) | {"title": "A"},
+                     obj({"c": {"type": "string"}}) | {"title": "C"}]}
+    assert return_diff(old, new) == ["added variant `C`", "removed variant `B`"]
+
+
+def test_anyof_and_oneof_are_interchangeable():
+    branches = [obj({"a": {"type": "string"}}) | {"title": "A"},
+                obj({"b": {"type": "string"}}) | {"title": "B"}]
+    assert return_diff({"anyOf": branches}, {"oneOf": list(branches)}) == []
+
+
+def test_union_recurses_into_same_named_branch():
+    old = {"anyOf": [obj({"a": {"type": "string"}}) | {"title": "A"}]}
+    new = {"anyOf": [obj({"a": {"type": "integer"}}) | {"title": "A"}]}
+    assert return_diff(old, new) == ["`A.a` type changed (string → integer)"]
+
+
+# --- nested dot-notation paths ---------------------------------------------------------
+
+def test_nested_field_path_uses_dot_notation():
+    old = obj({"outer": obj({"inner": {"type": "string"}})})
+    new = obj({"outer": obj({"inner": {"type": "integer"}})})
+    assert return_diff(old, new) == ["`outer.inner` type changed (string → integer)"]
+
+
+# --- compute_changelog over method lists (stubbed APIDump) -----------------------------
+
+class _Method:
+    def __init__(self, name, schemas):
+        self.name = name
+        self.schemas = schemas
+
+
+class _Dump:
+    def __init__(self, version, methods):
+        self.version = version
+        self.methods = methods
+
+
+def test_compute_changelog_partitions_methods():
+    unchanged = method_schemas([param("x")])
+    old = _Dump("25.10.0", [
+        _Method("svc.kept", unchanged),
+        _Method("svc.gone", method_schemas([param("x")])),
+        _Method("svc.touched", method_schemas([param("x")])),
+    ])
+    new = _Dump("26.0.0", [
+        _Method("svc.kept", unchanged),
+        _Method("svc.fresh", method_schemas([param("x")])),
+        _Method("svc.touched", method_schemas([param("x"), param("y")])),
+    ])
+
+    log = cl.compute_changelog(old, new)  # type: ignore[arg-type]
+
+    assert log.old_version == "25.10.0"
+    assert log.methods_added == ["svc.fresh"]
+    assert log.methods_removed == ["svc.gone"]
+    assert [c.name for c in log.methods_changed] == ["svc.touched"]
+    assert log.methods_changed[0].call_params_diff == ["added parameter `y` (required)"]
+    assert log.methods_changed[0].return_value_diff == []
+    assert not log.is_empty()
+
+
+def test_compute_changelog_empty_when_nothing_changed():
+    methods = [_Method("svc.kept", method_schemas([param("x")]))]
+    log = cl.compute_changelog(_Dump("a", methods), _Dump("b", list(methods)))  # type: ignore[arg-type]
+    assert log.is_empty()

--- a/src/middlewared_docs/test_changelog.py
+++ b/src/middlewared_docs/test_changelog.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
 """Unit tests for the cross-version API changelog diff (`changelog.py`)."""
+
 import os
 import sys
 
@@ -10,6 +11,7 @@ import changelog as cl
 
 
 # --- builders for the canonical `--dump-api` schema shape ------------------------------
+
 
 def method_schemas(call_params=None, return_value=None):
     """A method schema as it appears in the dump: object with Call parameters + Return value."""
@@ -36,16 +38,19 @@ def obj(properties, required=()):
 
 
 def call_diff(old_params, new_params):
-    return cl.compute_schema_diff(method_schemas(call_params=old_params),
-                                  method_schemas(call_params=new_params))[0]
+    return cl.compute_schema_diff(
+        method_schemas(call_params=old_params), method_schemas(call_params=new_params)
+    )[0]
 
 
 def return_diff(old_rv, new_rv):
-    return cl.compute_schema_diff(method_schemas(return_value=old_rv),
-                                  method_schemas(return_value=new_rv))[1]
+    return cl.compute_schema_diff(
+        method_schemas(return_value=old_rv), method_schemas(return_value=new_rv)
+    )[1]
 
 
 # --- whole-schema short-circuits -------------------------------------------------------
+
 
 def test_identical_schemas_produce_no_diff():
     schema = method_schemas([param("x")], obj({"a": {"type": "string"}}))
@@ -63,42 +68,53 @@ def test_cosmetic_only_change_is_ignored():
 
 CALL_PARAM_CASES = [
     pytest.param(
-        [param("a")], [param("a"), param("b")],
+        [param("a")],
+        [param("a"), param("b")],
         ["added parameter `b` (required)"],
         id="added-required-param",
     ),
     pytest.param(
-        [param("a")], [param("a"), param("b", default="x")],
+        [param("a")],
+        [param("a"), param("b", default="x")],
         ["added parameter `b` (optional)"],
         id="added-optional-param",
     ),
     pytest.param(
-        [param("a"), param("b")], [param("a")],
+        [param("a"), param("b")],
+        [param("a")],
         ["removed parameter `b`"],
         id="removed-param",
     ),
     pytest.param(
-        [param("old_name")], [param("new_name")],
+        [param("old_name")],
+        [param("new_name")],
         ["parameter `old_name` renamed to `new_name`"],
         id="same-position-rename",
     ),
     pytest.param(
-        [param("a"), param("b")], [param("b"), param("a")],
-        ["parameter `a` moved from position 0 to 1", "parameter `b` moved from position 1 to 0"],
+        [param("a"), param("b")],
+        [param("b"), param("a")],
+        [
+            "parameter `a` moved from position 0 to 1",
+            "parameter `b` moved from position 1 to 0",
+        ],
         id="position-move",
     ),
     pytest.param(
-        [param("a", default="x")], [param("a")],
+        [param("a", default="x")],
+        [param("a")],
         ["parameter `a` became required"],
         id="param-became-required-suppresses-default-removed",
     ),
     pytest.param(
-        [param("a")], [param("a", default="x")],
+        [param("a")],
+        [param("a", default="x")],
         ["parameter `a` became optional"],
         id="param-became-optional-suppresses-default-added",
     ),
     pytest.param(
-        [param("a", type="string")], [param("a", type="integer")],
+        [param("a", type="string")],
+        [param("a", type="integer")],
         ["parameter `a` type changed (string → integer)"],
         id="param-type-change",
     ),
@@ -144,7 +160,8 @@ RETURN_VALUE_CASES = [
         id="required-reordering-is-not-a-change",
     ),
     pytest.param(
-        {"type": "string"}, {"type": "integer"},
+        {"type": "string"},
+        {"type": "integer"},
         ["type changed (string → integer)"],
         id="root-type-change",
     ),
@@ -155,7 +172,8 @@ RETURN_VALUE_CASES = [
         id="became-nullable",
     ),
     pytest.param(
-        {"enum": ["a", "b"]}, {"enum": ["b", "c"]},
+        {"enum": ["a", "b"]},
+        {"enum": ["b", "c"]},
         ['added enum value "c"', 'removed enum value "a"'],
         id="enum-values",
     ),
@@ -185,7 +203,14 @@ RETURN_VALUE_CASES = [
     ),
     pytest.param(
         {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}]},
-        {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}, {"type": "boolean"}]},
+        {
+            "type": "array",
+            "prefixItems": [
+                {"type": "string"},
+                {"type": "integer"},
+                {"type": "boolean"},
+            ],
+        },
         ["tuple length changed (2 → 3)"],
         id="tuple-length-change",
     ),
@@ -211,17 +236,28 @@ def test_return_value_diff(old_rv, new_rv, expected):
 
 # --- unions ----------------------------------------------------------------------------
 
+
 def test_titled_union_added_and_removed_variant():
-    old = {"anyOf": [obj({"a": {"type": "string"}}) | {"title": "A"},
-                     obj({"b": {"type": "string"}}) | {"title": "B"}]}
-    new = {"anyOf": [obj({"a": {"type": "string"}}) | {"title": "A"},
-                     obj({"c": {"type": "string"}}) | {"title": "C"}]}
+    old = {
+        "anyOf": [
+            obj({"a": {"type": "string"}}) | {"title": "A"},
+            obj({"b": {"type": "string"}}) | {"title": "B"},
+        ]
+    }
+    new = {
+        "anyOf": [
+            obj({"a": {"type": "string"}}) | {"title": "A"},
+            obj({"c": {"type": "string"}}) | {"title": "C"},
+        ]
+    }
     assert return_diff(old, new) == ["added variant `C`", "removed variant `B`"]
 
 
 def test_anyof_and_oneof_are_interchangeable():
-    branches = [obj({"a": {"type": "string"}}) | {"title": "A"},
-                obj({"b": {"type": "string"}}) | {"title": "B"}]
+    branches = [
+        obj({"a": {"type": "string"}}) | {"title": "A"},
+        obj({"b": {"type": "string"}}) | {"title": "B"},
+    ]
     assert return_diff({"anyOf": branches}, {"oneOf": list(branches)}) == []
 
 
@@ -233,6 +269,7 @@ def test_union_recurses_into_same_named_branch():
 
 # --- nested dot-notation paths ---------------------------------------------------------
 
+
 def test_nested_field_path_uses_dot_notation():
     old = obj({"outer": obj({"inner": {"type": "string"}})})
     new = obj({"outer": obj({"inner": {"type": "integer"}})})
@@ -240,6 +277,7 @@ def test_nested_field_path_uses_dot_notation():
 
 
 # --- compute_changelog over method lists (stubbed APIDump) -----------------------------
+
 
 class _Method:
     def __init__(self, name, schemas):
@@ -255,16 +293,22 @@ class _Dump:
 
 def test_compute_changelog_partitions_methods():
     unchanged = method_schemas([param("x")])
-    old = _Dump("25.10.0", [
-        _Method("svc.kept", unchanged),
-        _Method("svc.gone", method_schemas([param("x")])),
-        _Method("svc.touched", method_schemas([param("x")])),
-    ])
-    new = _Dump("26.0.0", [
-        _Method("svc.kept", unchanged),
-        _Method("svc.fresh", method_schemas([param("x")])),
-        _Method("svc.touched", method_schemas([param("x"), param("y")])),
-    ])
+    old = _Dump(
+        "25.10.0",
+        [
+            _Method("svc.kept", unchanged),
+            _Method("svc.gone", method_schemas([param("x")])),
+            _Method("svc.touched", method_schemas([param("x")])),
+        ],
+    )
+    new = _Dump(
+        "26.0.0",
+        [
+            _Method("svc.kept", unchanged),
+            _Method("svc.fresh", method_schemas([param("x")])),
+            _Method("svc.touched", method_schemas([param("x"), param("y")])),
+        ],
+    )
 
     log = cl.compute_changelog(old, new)  # type: ignore[arg-type]
 

--- a/src/middlewared_docs/tests/conftest.py
+++ b/src/middlewared_docs/tests/conftest.py
@@ -1,0 +1,6 @@
+# -*- coding=utf-8 -*-
+import os
+import sys
+
+# Make the package modules (changelog.py, ...) importable without installing the package.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/src/middlewared_docs/tests/test_changelog.py
+++ b/src/middlewared_docs/tests/test_changelog.py
@@ -1,14 +1,16 @@
 # -*- coding=utf-8 -*-
-"""Unit tests for the cross-version API changelog diff (`changelog.py`)."""
+"""Unit tests for the cross-version API changelog diff (`changelog.py`).
 
-import os
-import sys
+`changelog.py` is made importable by tests/conftest.py, which puts the package dir on
+sys.path. This package is not part of the middlewared unit-test suite and the module
+imports nothing from middlewared at runtime, so the tests run standalone:
+
+    pytest src/middlewared_docs/tests/
+"""
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import changelog as cl
-
 
 # --- builders for the canonical `--dump-api` schema shape ------------------------------
 
@@ -38,15 +40,11 @@ def obj(properties, required=()):
 
 
 def call_diff(old_params, new_params):
-    return cl.compute_schema_diff(
-        method_schemas(call_params=old_params), method_schemas(call_params=new_params)
-    )[0]
+    return cl.compute_schema_diff(method_schemas(call_params=old_params), method_schemas(call_params=new_params))[0]
 
 
 def return_diff(old_rv, new_rv):
-    return cl.compute_schema_diff(
-        method_schemas(return_value=old_rv), method_schemas(return_value=new_rv)
-    )[1]
+    return cl.compute_schema_diff(method_schemas(return_value=old_rv), method_schemas(return_value=new_rv))[1]
 
 
 # --- whole-schema short-circuits -------------------------------------------------------


### PR DESCRIPTION
## Summary

This branch adds an automatically generated Changelog page to the API documentation site. For each documented API version, it computes a semantic diff against the immediately preceding version and renders a per-version page summarizing what changed in the API surface: methods added, methods removed, and methods whose call-parameter or return-value schemas changed.

The diff is semantic, not cosmetic. It reads the structural shape of each method's JSON Schema (from middlewared --dump-api) and ignores description/example wording and validation-constraint keys (minLength, pattern, etc.). A method whose only change is reworded docs or a tweaked regex produces no changelog entry.

## What's included

- **src/middlewared_docs/changelog.py** (new) — the diff engine. Compares two APIDumps and produces a Changelog(added/removed/changed methods). The recursive_SchemaDiffer walks objects, arrays/tuples, unions (oneOf/anyOf), enums, consts, defaults, and map/pattern properties, emitting human-readable change lines keyed by field path.
- **src/middlewared_docs/generate_docs.py** (modified) — wires the changelog into doc generation:
  - Computes a changelog for each version against its predecessor (the oldest version has none).
  - Renders a changelog.rst page grouped by plugin, with links to method pages (removed methods link into the sibling docs site of the prior version, since they no longer exist in the current build).
  - Post-processes the built HTML to collapse each method's schema-change diff into an accordion.
  - Refactors the version-switch HTML injection out of the per-file loop (computed once per version).
- **src/middlewared_docs/docs/index.rst** (modified) — adds a $CHANGELOG_ENTRY placeholder in the toctree that is substituted with changelog.rst when a changelog exists, or removed otherwise.
- **src/middlewared_docs/test_changelog.py** (new) — unit tests covering the diff engine across parameter add/remove/rename/reorder, required↔optional transitions, default changes, union variants, enum/const changes, nested objects, arrays/tuples, and map/pattern properties.
- **.github/workflows/unittests.yml** (modified) — runs the new changelog tests in CI.

Original PR: https://github.com/truenas/middleware/pull/19140
