### PR TITLE
NAS-141386 / 27.0.0-BETA.1 / prevent dhcpcd added ipv6 addrs

### DIFF
--- a/debian/debian/ix-dhcpcd@.service
+++ b/debian/debian/ix-dhcpcd@.service
@@ -11,6 +11,7 @@ Documentation=man:dhcpcd(8)
 Type=forking
 PIDFile=/run/dhcpcd/%I.pid
 ExecStart=/usr/sbin/dhcpcd -q -w %I
+ExecReload=/usr/sbin/dhcpcd -n %I
 ExecStop=/usr/sbin/dhcpcd -x %I
 Restart=always
 

--- a/src/middlewared/middlewared/etc_files/dhcpcd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/dhcpcd.conf.mako
@@ -7,6 +7,9 @@
         hostname = f"{gc['hostname']}.{gc['domain']}"
 
     nameservers = ' '.join([gc[f'nameserver{i}'] for i in range(1, 4) if gc[f'nameserver{i}']]) or None
+
+    interfaces = middleware.call_sync('datastore.query', 'network.interfaces', [], {'prefix': 'int_'})
+    no_autoconf = [i['interface'] for i in interfaces if not i['ipv6auto']]
 %>
 # TrueNAS dhcpcd configuration
 # Generated automatically, do not edit
@@ -43,3 +46,14 @@ static domain_name_servers=${nameservers}
 
 # Disable IPv4LL (169.254.x.x addresses)
 noipv4ll
+
+# Per-interface IPv6 autoconfiguration ("Autoconfigure IPv6") control.
+# dhcpcd does SLAAC in userspace by default, independent of the
+# net.ipv6.conf.<if>.autoconf sysctl, so disabling it via sysctl has no
+# effect on dhcpcd-managed interfaces. Suppress Router Solicitation here
+# instead so neither dhcpcd nor the kernel assigns a SLAAC address or an
+# RA-derived default route when autoconf is disabled.
+% for iface in no_autoconf:
+interface ${iface}
+    noipv6rs
+% endfor

--- a/src/middlewared/middlewared/plugins/interface/dhcp.py
+++ b/src/middlewared/middlewared/plugins/interface/dhcp.py
@@ -8,7 +8,7 @@ import struct
 
 from middlewared.plugins.service_.services.dbus_router import system_dbus
 
-__all__ = ("DHCPLease", "DHCPStatus", "dhcp_leases", "dhcp_start", "dhcp_status", "dhcp_stop")
+__all__ = ("DHCPLease", "DHCPStatus", "dhcp_leases", "dhcp_reload", "dhcp_start", "dhcp_status", "dhcp_stop")
 
 
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
@@ -132,6 +132,26 @@ async def dhcp_stop(interface: str) -> None:
     """
     unit_name = f"ix-dhcpcd@{interface}.service"
     await system_dbus.call_unit_action_and_wait(unit_name, "Stop")
+
+
+async def dhcp_reload(interface: str) -> None:
+    """Reload dhcpcd's configuration for an interface via systemd (D-Bus).
+
+    Triggers the ix-dhcpcd@{interface}.service ExecReload, which runs
+    `dhcpcd -n` (SIGHUP). dhcpcd re-reads dhcpcd.conf and re-applies it,
+    picking up per-interface changes such as the noipv6rs ("Autoconfigure
+    IPv6") option and dropping a SLAAC address that is no longer permitted,
+    without releasing the existing DHCPv4 lease.
+
+    NOTE: a reload (SIGHUP) is required for config changes to take effect. The
+    dhcpcd control-socket "--rebind" command performs only a DHCP-level rebind
+    and does NOT reload the configuration (verified against dhcpcd 10.x).
+
+    Raises if the unit is not active, so callers should only reload interfaces
+    that are running (or handle the error).
+    """
+    unit_name = f"ix-dhcpcd@{interface}.service"
+    await system_dbus.call_unit_action_and_wait(unit_name, "Reload")
 
 
 def dhcp_leases(interface: str) -> DHCPLease | None:

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -57,7 +57,7 @@ from middlewared.api.current import (
     InterfaceXmitHashPolicyChoicesArgs,
     InterfaceXmitHashPolicyChoicesResult,
 )
-from middlewared.plugins.interface.dhcp import dhcp_start
+from middlewared.plugins.interface.dhcp import dhcp_reload, dhcp_start
 from middlewared.service import CallError, CRUDService, ServiceContext, ValidationErrors, filterable_api_method, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils.filter_list import filter_list
@@ -1698,13 +1698,32 @@ class InterfaceService(CRUDService):
 
         interfaces = list(iface_configs.keys())
 
-        if run_dhcp:
-            # update dhcpcd.conf before we run dhcpcd to ensure the hostname/fqdn
-            # and/or the static routers config options are set properly
+        # DHCP-enabled interfaces that are already running (not freshly started
+        # below) need their dhcpcd.conf reloaded so config changes -- e.g.
+        # toggling "Autoconfigure IPv6" (the per-interface noipv6rs option) --
+        # take effect without releasing the lease.
+        run_dhcp_set = set(run_dhcp)
+        reload_dhcp = [
+            name for name, cfg in iface_configs.items()
+            if cfg['interface']['int_dhcp'] and name not in run_dhcp_set
+        ]
+
+        if run_dhcp or reload_dhcp:
+            # update dhcpcd.conf before we (re)start/reload dhcpcd to ensure the
+            # hostname/fqdn, static routers, and per-interface IPv6 autoconf
+            # options are set properly
             await self.middleware.call('etc.generate', 'dhcpcd')
+
+        if run_dhcp:
             await asyncio.wait([
                 self.middleware.create_task(self.run_dhcp(interface, wait_dhcp)) for interface in run_dhcp
             ])
+
+        for name in reload_dhcp:
+            try:
+                await dhcp_reload(name)
+            except Exception:
+                self.logger.error('Failed to reload dhcpcd for %s', name, exc_info=True)
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 


### PR DESCRIPTION
Migration to Trixie and subsequently dhcpcd from dhclient exposed issues with our ipv6 auto address configuration logic. dhcpcd does all things ipv6 in userspace and ignored kernel sysctls. The API toggled the sysctl values to disable SLAAC on an interface but dhcpcd ignored it and configured the interface accordingly. This changes it so that dhcpcd is configured to ignore ipv6 addresses if the user configures it as so.