### PR TITLE
NAS-141425 / 27.0.0-BETA.1 / fix ftp and boot test

### DIFF
--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -50,7 +50,7 @@ def ftp_init_db_dflt(confirm_test_config):
     # Get the 'default' settings from FTPModel
     ftpconf_script = '#!/usr/bin/python3\n'
     ftpconf_script += 'import json\n'
-    ftpconf_script += 'from middlewared.plugins.ftp import FTPModel\n'
+    ftpconf_script += 'from middlewared.plugins.ftp.config import FTPModel\n'
     ftpconf_script += 'FTPModel_defaults = {}\n'
     ftpconf_script += 'for attrib in FTPModel.__dict__.keys():\n'
     ftpconf_script += '    if attrib[:4] == "ftp_":\n'

--- a/tests/api2/test_boot_attach_replace_detach.py
+++ b/tests/api2/test_boot_attach_replace_detach.py
@@ -10,6 +10,7 @@ if not ha:
     # we have to skip this test since it will fail
     # 100% of the time on HA VMs.
 
+    @pytest.mark.skip(reason="Skip until IT can provide larger disks (current disks lack space for boot partitions)")
     @pytest.mark.timeout(600)
     def test_boot_attach_replace_detach():
         existing_disks = call("boot.get_disks")


### PR DESCRIPTION
test_200_ftp: FTPModel moved to ftp.config submodule when the plugin was converted to the typesafe pattern; update the generated script's import accordingly.

test_boot_attach_replace_detach: skip until we have larger disks; current disks lack space for the required boot partitions.