### PR TITLE
NAS-141350 / 27.0.0-BETA.1 / Reject and normalize non-colon NIC MAC addresses

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-06-16_12-00_normalize_nic_mac.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-06-16_12-00_normalize_nic_mac.py
@@ -1,0 +1,65 @@
+"""Normalize NIC MAC addresses to libvirt's colon-separated form
+
+Revision ID: 4a7e1c9b2f30
+Revises: de51ca6f583a
+Create Date: 2026-06-16 12:00:00.000000+00:00
+
+"""
+import json
+import random
+import re
+
+from alembic import op
+from sqlalchemy import text
+
+from middlewared.utils.pwenc import decrypt, encrypt
+
+
+# revision identifiers, used by Alembic.
+revision = '4a7e1c9b2f30'
+down_revision = 'de51ca6f583a'
+branch_labels = None
+depends_on = None
+
+
+def random_mac() -> str:
+    mac_address = [
+        0x00, 0xa0, 0x98, random.randint(0x00, 0x7f), random.randint(0x00, 0xff), random.randint(0x00, 0xff)
+    ]
+    return ':'.join(['%02x' % x for x in mac_address])
+
+
+def normalize_mac(mac: str) -> str:
+    # libvirt's defineXML only parses colon-separated MACs. Older releases stored dash, no-separator,
+    # mixed and uppercase forms; collapse anything that carries a valid 48-bit address to the canonical
+    # lowercase colon form, and regenerate the rare value that isn't a MAC at all.
+    hexed = re.sub(r'[:-]', '', mac).lower()
+    if re.fullmatch(r'[0-9a-f]{12}', hexed):
+        return ':'.join(hexed[i:i + 2] for i in range(0, 12, 2))
+    return random_mac()
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for table in ('vm_device', 'container_device'):
+        for row in conn.execute(text(f"SELECT * FROM {table}")).mappings().all():
+            if not (decrypted := decrypt(row['attributes'])):
+                continue
+
+            attributes = json.loads(decrypted)
+
+            if attributes.get('dtype') != 'NIC' or not attributes.get('mac'):
+                continue
+
+            normalized = normalize_mac(attributes['mac'])
+            if normalized != attributes['mac']:
+                attributes['mac'] = normalized
+                conn.execute(
+                    text(f"UPDATE {table} SET attributes = :attrs WHERE id = :id"),
+                    {"attrs": encrypt(json.dumps(attributes)), "id": row['id']}
+                )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -84,8 +84,8 @@ Domain = Annotated[str, AfterValidator(match_validator(
     "Domain can only contain letters, numbers, periods, and dashes"
 ))]
 MACAddress = Annotated[str, AfterValidator(match_validator(
-    re.compile(r"^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$"),
-    'MAC address is not valid.'
+    re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
+    'MAC address must be a colon-separated hexadecimal value (e.g. 00:a0:99:7e:bb:8a).'
 ))]
 IPv4Address = Annotated[str, AfterValidator(_validate_ipv4_address)]
 IPv6Address = Annotated[str, AfterValidator(_validate_ipv6_address)]

--- a/src/middlewared/middlewared/api/v27_0_0/container_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/container_device.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    MACAddress,
     NonEmptyString,
     excluded_field,
 )
@@ -53,9 +54,8 @@ class ContainerNICDevice(BaseModel):
         default=None,
         description="Host network interface or bridge to attach to. `null` for no attachment.",
     )
-    mac: str | None = Field(
+    mac: MACAddress | None = Field(
         default=None,
-        pattern='^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$',
         description="MAC address for the virtual network interface. `null` for auto-generation.",
     )
 

--- a/src/middlewared/middlewared/api/v27_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm_device.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    MACAddress,
     NonEmptyString,
     excluded_field,
 )
@@ -75,9 +76,8 @@ class VMNICDevice(BaseModel):
         default=None,
         description="Host network interface or bridge to attach to. `null` for no attachment.",
     )
-    mac: str | None = Field(
+    mac: MACAddress | None = Field(
         default=None,
-        pattern='^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$',
         description="MAC address for the virtual network interface. `null` for auto-generation.",
     )
 

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_mac_address.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_mac_address.py
@@ -1,0 +1,57 @@
+import pydantic
+import pytest
+
+from middlewared.api.base import BaseModel, MACAddress
+from middlewared.api.base.handler.accept import accept_params
+from middlewared.api.v27_0_0.container_device import ContainerNICDevice
+from middlewared.api.v27_0_0.vm_device import VMNICDevice
+from middlewared.service_exception import ValidationErrors
+
+
+class MACAddressModel(BaseModel):
+    mac: MACAddress
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "00:a0:99:7e:bb:8a",  # canonical lowercase
+        "00:A0:99:7E:BB:8A",  # uppercase colon (libvirt accepts and lowercases)
+    ],
+)
+def test_mac_address_accepts_colon(value):
+    assert accept_params(MACAddressModel, [value]) == [value]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "10-66-6a-1f-f1-b1",  # dash separators
+        "10-66-6A-1F-F1-B1",  # dash separators, uppercase
+        "00a0997ebb8a",  # no separators
+        "00:a0-99:7e-bb:8a",  # mixed separators
+        "00:a0:99:7e:bb",  # too short
+        "gg:gg:gg:gg:gg:gg",  # colon-separated but non-hex
+    ],
+)
+def test_mac_address_rejects_non_colon(value):
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(MACAddressModel, [value])
+
+    assert "colon-separated" in ve.value.errors[0].errmsg
+
+
+@pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
+def test_nic_device_mac_accepts_colon(model):
+    assert model(dtype="NIC", mac="00:a0:99:7e:bb:8a").mac == "00:a0:99:7e:bb:8a"
+
+
+@pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
+def test_nic_device_mac_allows_null(model):
+    assert model(dtype="NIC", mac=None).mac is None
+
+
+@pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
+def test_nic_device_mac_rejects_dash(model):
+    with pytest.raises(pydantic.ValidationError):
+        model(dtype="NIC", mac="10-66-6a-1f-f1-b1")


### PR DESCRIPTION
## Problem
A custom NIC MAC entered with dash, no-separator, or mixed separators (e.g. `10-66-6A-1F-F1-B1`) passed the permissive `mac` pattern but libvirt's `defineXML` only parses colon-separated MACs, so the container/VM saved fine and then failed to start with `XML error: unable to parse mac address`. The colon-only `MACAddr(separator=':')` guard the VM plugin used through electriceel was dropped when devices moved to the pydantic models at fangtooth, and containers (26.0+) never had it, so these values can already be sitting in `vm_device` and `container_device`.

## Solution
- Tightened the shared `MACAddress` type to colon-only with a clear message, and switched the v27 VM and Container NIC `mac` fields to use it (removing the duplicated permissive inline pattern). Frozen API versions are left as-is.
- Added a migration that normalizes existing NIC MACs in both `vm_device` and `container_device` to libvirt's canonical lowercase colon form, regenerating the rare value that isn't a real MAC. This is required because `*.device.query` re-validates rows through the model, so an un-normalized non-colon MAC would otherwise make `query` fail once the pattern is tightened. Normalization preserves the user's intended address and heals instances that were stuck failing to start.