### PR TITLE
NAS-141434 / 27.0.0-BETA.1 / map known exit codes to `exited` instead of `crashed`

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -15,7 +15,7 @@ from .path import get_app_parent_config_path
 from .utils import PROJECT_PREFIX, AppState, ContainerState, get_app_name_from_project_name
 
 COMPOSE_SERVICE_KEY: str = 'com.docker.compose.service'
-KNOWN_EXIT_CODES: tuple[int, ...] = (
+KNOWN_NORMAL_EXIT_CODES: tuple[int, ...] = (
     0,    # Normal exit
     129,  # SIGHUP
     130,  # SIGINT
@@ -279,7 +279,7 @@ def translate_resources_to_desired_workflow(app_resources: dict[str, Any]) -> di
                 state = ContainerState.RUNNING.value
         elif container['State']['Status'].lower() == 'created':
             state = ContainerState.CREATED.value
-        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] not in KNOWN_EXIT_CODES:
+        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] not in KNOWN_NORMAL_EXIT_CODES:
             state = ContainerState.CRASHED.value
         else:
             state = ContainerState.EXITED.value

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -15,6 +15,12 @@ from .path import get_app_parent_config_path
 from .utils import PROJECT_PREFIX, AppState, ContainerState, get_app_name_from_project_name
 
 COMPOSE_SERVICE_KEY: str = 'com.docker.compose.service'
+KNOWN_EXIT_CODES: tuple[int, ...] = (
+    0,    # Normal exit
+    130,  # SIGINT
+    137,  # SIGKILL
+    143,  # SIGTERM
+)
 
 
 @dataclass(frozen=True, eq=True)
@@ -272,10 +278,10 @@ def translate_resources_to_desired_workflow(app_resources: dict[str, Any]) -> di
                 state = ContainerState.RUNNING.value
         elif container['State']['Status'].lower() == 'created':
             state = ContainerState.CREATED.value
-        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] != 0:
+        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] not in KNOWN_EXIT_CODES:
             state = ContainerState.CRASHED.value
         else:
-            state = 'exited'
+            state = ContainerState.EXITED.value
 
         workloads['container_details'].append({
             'service_name': service_name,

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -269,7 +269,8 @@ def translate_resources_to_desired_workflow(app_resources: dict[str, Any]) -> di
                 type='bind' if volume_mount['Type'] == 'bind' else 'volume',
             ))
 
-        if container['State']['Status'].lower() == 'running':
+        container_status = container['State']['Status'].lower()
+        if container_status == 'running':
             if health_config := container['State'].get('Health'):
                 if health_config['Status'] == 'healthy':
                     state = ContainerState.RUNNING.value
@@ -277,9 +278,9 @@ def translate_resources_to_desired_workflow(app_resources: dict[str, Any]) -> di
                     state = ContainerState.STARTING.value
             else:
                 state = ContainerState.RUNNING.value
-        elif container['State']['Status'].lower() == 'created':
+        elif container_status == 'created':
             state = ContainerState.CREATED.value
-        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] not in KNOWN_NORMAL_EXIT_CODES:
+        elif container_status == 'exited' and container['State']['ExitCode'] not in KNOWN_NORMAL_EXIT_CODES:
             state = ContainerState.CRASHED.value
         else:
             state = ContainerState.EXITED.value

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -17,6 +17,7 @@ from .utils import PROJECT_PREFIX, AppState, ContainerState, get_app_name_from_p
 COMPOSE_SERVICE_KEY: str = 'com.docker.compose.service'
 KNOWN_EXIT_CODES: tuple[int, ...] = (
     0,    # Normal exit
+    129,  # SIGHUP
     130,  # SIGINT
     137,  # SIGKILL
     143,  # SIGTERM


### PR DESCRIPTION
This will correctly reflect the app "state" **when a container uses correct exit codes**.

For containers that use those exit codes incorrectly, ie uses 143 for crashing, it will result in state being `stopped` instead of `crashed`

