### PR TITLE
NAS-141435 / 27.0.0-BETA.1 / Fix public API method docstrings (RST, doc references, JSON-RPC examples)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,17 @@ async def do_create(self, app, data):
 ```
 
 **API Model Field Descriptions**:
-- Every field in API models (`Args`, `Result`, `Entry` classes) **must** have a description, either as a docstring or via `Field(description=...)`.
+- Every field in API models (`Args`, `Result`, `Entry` classes) **must** have a description via `Field(description=...)`.
 - This is enforced by `test_api_docstrings` in the unit test suite.
+- Description can be formatted with Markdown.
+
+**Method Docstrings**:
+- Every public API method (decorated with `@api_method`) **must** have a docstring.
+- The docstring is a description of the method, formatted with reStructuredText (RST).
+- Do **not** use Google- or NumPy-style docstrings (no `Args:`/`Returns:`/`Parameters` sections).
+- Do **not** document parameters or return values in the method docstring; those descriptions belong only in the API models (see **API Model Field Descriptions** above).
+- Every mention of another API method (or the method itself) **must** be a doc reference, e.g. ``:doc:`core.bulk <api_methods_core.bulk>` ``.
+- If the description includes example code, it **must** be JSON-RPC (as passed by the API client), not Python.
 
 **API Versioning**:
 - Multiple API versions maintained in parallel (`src/middlewared/middlewared/api/v*/`)
@@ -227,92 +236,26 @@ Common test patterns:
 
 ## Logging Guidelines
 
-The middleware follows a philosophy of **logging problems and state changes, not routine success**. The absence of error messages indicates successful operation.
+Log **problems and state changes, not routine success** — absence of error messages means things worked. Use `self.logger`.
 
-### When TO Log
+**Levels:**
+- **ERROR** — operation failures, unexpected exceptions (always `exc_info=True`), service state problems, data inconsistencies.
+- **WARNING** — recoverable/degraded conditions, non-critical config issues, failed non-critical cleanup, unexpected-but-handled data.
+- **INFO** — significant state changes and milestones (pool imports, service starts, setup completion).
+- **DEBUG** — flow through complex multi-step operations, significant code-path entry/exit, race-condition workarounds.
 
-**ERROR level** (`self.logger.error`):
-- Operation failures that prevent functionality
-- Unexpected exceptions (always use `exc_info=True`)
-- Service state problems
-- Critical configuration errors
-- Data inconsistencies
+**Do NOT log:** routine reads/queries/`get_instance`, datastore lookups and config retrieval, successful routine CRUD, internal helper calls, data transforms, cache hits, or anything sensitive (credentials, keys, passwords). For input validation raise `ValidationError`; for permission/operational failures raise `CallError` — don't log instead of raising.
+
+**Conventions:**
+- Include a resource identifier in every message; use the `'resource: description'` format.
+- Pass `exc_info=True` on all exception logs to capture the stack trace.
+- Log an error once — don't re-log the same failure at multiple levels as it propagates.
 
 ```python
-try:
-    # operation
 except Exception:
     self.logger.error('%s: failed to perform operation', resource_name, exc_info=True)
     raise
 ```
-
-**WARNING level** (`self.logger.warning`):
-- Recoverable errors or degraded functionality
-- Configuration issues that don't prevent operation
-- Missing or unexpected data that can be handled
-- Failed cleanup operations that aren't critical
-- Unexpected conditions that succeeded but shouldn't have occurred
-
-**INFO level** (`self.logger.info`):
-- Significant system state changes (pool imports, service starts)
-- Major configuration changes
-- Initialization/setup completion messages
-- Important milestones in long-running operations
-
-**DEBUG level** (`self.logger.debug`):
-- Progress tracking through complex multi-step operations
-- Entry/exit of significant code paths
-- State transitions that help trace execution flow
-- Race condition detection or workarounds applied
-
-### When NOT to Log
-
-**Do NOT log:**
-- ❌ Standard read operations (`.query()`, `.get_instance()`)
-- ❌ Database lookups and configuration retrieval
-- ❌ Input validation (raise `ValidationError` instead)
-- ❌ Permission checks (raise `CallError` instead)
-- ❌ Successful routine CRUD operations
-- ❌ Internal helper method calls
-- ❌ Data transformation/formatting operations
-- ❌ Cache lookups or simple getters/setters
-- ❌ Sensitive data (credentials, keys, passwords)
-
-### Logging Patterns
-
-```python
-# Pattern 1: Exception with context and stack trace
-try:
-    result = perform_operation()
-except Exception:
-    self.logger.error('Failed to perform operation on %r', resource_id, exc_info=True)
-    raise CallError(f'Operation failed: {error}')
-
-# Pattern 2: Warning for non-critical failures
-if not expected_condition:
-    self.logger.warning('%s: unexpected condition detected', resource_name)
-
-# Pattern 3: Debug for complex operation flow
-self.logger.debug('Starting multi-step operation on %r', resource_name)
-# ... step 1 ...
-self.logger.debug('Completed step 1, beginning step 2')
-# ... step 2 ...
-self.logger.debug('Operation completed successfully')
-
-# Pattern 4: Info for significant state changes
-self.logger.info('Pool %r imported successfully', pool_name)
-
-# Pattern 5: Structured message format
-self.logger.error('%s: %s', resource_identifier, description)
-```
-
-### Key Principles
-
-1. **Context is critical**: Always include resource identifiers (pool name, share ID, etc.)
-2. **Use `exc_info=True`**: For all exceptions to capture stack traces
-3. **Structured format**: Use `'resource: description'` pattern consistently
-4. **No success logging**: Don't log when things work as expected
-5. **Log once**: Don't log the same error at multiple levels
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ async def do_create(self, app, data):
 - The docstring is a description of the method, formatted with reStructuredText (RST).
 - Do **not** use Google- or NumPy-style docstrings (no `Args:`/`Returns:`/`Parameters` sections).
 - Do **not** document parameters or return values in the method docstring; those descriptions belong only in the API models (see **API Model Field Descriptions** above).
-- Every mention of another API method (or the method itself) **must** be a doc reference, e.g. ``:doc:`core.bulk <api_methods_core.bulk>` ``.
+- Every mention of another API method (or the method itself) **must** be a method reference, e.g. ``:method:`core.bulk` ``. The docs preprocessor expands this to the full ``:doc:`core.bulk <api_methods_core.bulk>` `` cross-reference at build time.
 - If the description includes example code, it **must** be JSON-RPC (as passed by the API client), not Python.
 
 **API Versioning**:

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -12,7 +12,6 @@ from .api import API
 from .event import Event
 from .method import Method
 
-
 _LIST_MARKER_RE = re.compile(r"([-*+]|[0-9]+\.|#\.) ")
 
 

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -41,7 +41,7 @@ def reflow_docstring(doc: str) -> str:
     out: list[str] = []
     block: list[str] = []
 
-    def flush():
+    def flush() -> None:
         if not block:
             return
         if _is_unindented_prose(block):

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -13,6 +13,56 @@ from .event import Event
 from .method import Method
 
 
+_LIST_MARKER_RE = re.compile(r"([-*+]|[0-9]+\.|#\.) ")
+
+
+def _is_unindented_prose(block: list[str]) -> bool:
+    """Whether a blank-line-delimited block is a plain prose paragraph to unwrap."""
+    # Any indentation means the block is a literal block, block quote, table, or a
+    # list/definition item with continuation lines: its line structure matters.
+    if any(line[:1].isspace() for line in block):
+        return False
+    # Directives and list items rely on their line structure too.
+    first = block[0]
+    if first.startswith(".. ") or _LIST_MARKER_RE.match(first):
+        return False
+    return True
+
+
+def reflow_docstring(doc: str) -> str:
+    """Unwrap hard-wrapped prose paragraphs while leaving RST structure intact.
+
+    Method docstrings are hard-wrapped for readability in source. A
+    blank-line-delimited block of entirely unindented prose is joined into a single
+    line so it reflows when rendered as HTML. Any block that carries indentation (a
+    literal block, block quote, table, or a list/definition item with continuation
+    lines) or that opens with a directive or list marker is left exactly as written,
+    so its structure is preserved rather than mangled.
+    """
+    out: list[str] = []
+    block: list[str] = []
+
+    def flush():
+        if not block:
+            return
+        if _is_unindented_prose(block):
+            out.append(" ".join(line.strip() for line in block))
+        else:
+            out.extend(block)
+        block.clear()
+
+    for line in doc.split("\n"):
+        if line.strip():
+            block.append(line)
+        else:
+            flush()
+            out.append("")
+
+    flush()
+
+    return "\n".join(out).strip()
+
+
 class APIDump(BaseModel):
     version: str
     version_title: str
@@ -87,7 +137,7 @@ class APIDumper:
 
         methodobj_ = method.methodobj
         if doc := inspect.getdoc(methodobj_):
-            doc = re.sub(r"(\S)\n[ ]*(\S)", r"\1 \2", doc).strip()
+            doc = reflow_docstring(doc)
 
         input_pipes, output_pipes, check_pipes = False, False, True
         if job := getattr(methodobj_, "_job", None):

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -13,6 +13,12 @@ from .event import Event
 from .method import Method
 
 _LIST_MARKER_RE = re.compile(r"([-*+]|[0-9]+\.|#\.) ")
+_METHOD_REF_RE = re.compile(r":method:`([\w.]+)`")
+
+
+def expand_method_refs(doc: str) -> str:
+    """Expand ``:method:`x``` shorthand into a full ``:doc:`` cross-reference."""
+    return _METHOD_REF_RE.sub(r":doc:`\1 <api_methods_\1>`", doc)
 
 
 def _is_unindented_prose(block: list[str]) -> bool:
@@ -37,7 +43,10 @@ def reflow_docstring(doc: str) -> str:
     literal block, block quote, table, or a list/definition item with continuation
     lines) or that opens with a directive or list marker is left exactly as written,
     so its structure is preserved rather than mangled.
+
+    ``:method:`x``` shorthand references are expanded into full ``:doc:`` cross-references.
     """
+    doc = expand_method_refs(doc)
     out: list[str] = []
     block: list[str] = []
 

--- a/src/middlewared/middlewared/api/v27_0_0/auth.py
+++ b/src/middlewared/middlewared/api/v27_0_0/auth.py
@@ -82,7 +82,9 @@ class AuthSessionsEntry(BaseModel):
 class AuthCommonOptions(BaseModel):
     user_info: bool = Field(
         default=True,
-        description="Whether to include detailed user information in the authentication response.",
+        description=(
+            "Whether to include detailed user information (the output of `auth.me`) in the authentication response."
+        ),
     )  # include auth.me in successful result
     reconnect_token: bool = Field(
         default=False,
@@ -214,7 +216,9 @@ class AuthUserInfo(UserGetUserObj):
 
 class AuthRespSuccess(BaseModel):
     response_type: Literal["SUCCESS"] = Field(description="Authentication response type indicating successful login.")
-    user_info: AuthUserInfo | None = Field(description="Authenticated user information or `null` if not available.")
+    user_info: AuthUserInfo | None = Field(
+        description="Authenticated user information (the output of `auth.me`), or `null` if not requested.",
+    )
     authenticator: Literal['LEVEL_1', 'LEVEL_2'] = Field(
         description="Authentication level achieved (LEVEL_1 for password, LEVEL_2 for two-factor).",
     )

--- a/src/middlewared/middlewared/api/v27_0_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v27_0_0/zfs_resource_crud.py
@@ -373,8 +373,9 @@ class ZFSResourceQuery(BaseModel):
 class ZFSResourceDestroyArgsData(BaseModel):
     path: NonEmptyString = Field(
         description=(
-            "Path of the zfs resource (dataset or volume) to be destroyed. Snapshot paths (containing '@') are not "
-            "accepted - use `zfs.resource.snapshot.destroy` instead."
+            "Path of the zfs resource (dataset or volume) to be destroyed. Must be of the form 'pool/name'; it cannot "
+            "be an absolute path or end with '/'. Snapshot paths (containing '@') are not accepted - use "
+            "`zfs.resource.snapshot.destroy` instead."
         ),
     )
     recursive: bool = Field(

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -784,96 +784,38 @@ class AuthService(Service):
     @api_method(AuthLoginExArgs, AuthLoginExResult, cli_private=True, authentication_required=False, pass_app=True)
     async def login_ex(self, app, data):
         """
-        Authenticate using one of a variety of mechanisms
+        Authenticate using one of a variety of mechanisms.
 
-        NOTE: mechanisms with a _PLAIN suffix indicate that they involve
-        passing plain-text passwords or password-equivalent strings and
-        should not be used on untrusted / insecure transport. Available
-        mechanisms will be expanded in future releases.
+        The mechanism is selected by the ``mechanism`` field of the request, and the set of
+        supported mechanisms will be expanded in future releases.
 
-        params:
-            This takes a single argument consistning of a JSON object with the
-            following keys:
+        .. warning::
 
-            mechanism: the mechanism by which to authenticate to the backend
-            the exact parameters to use vary by mechanism and are described
-            below
+            Mechanisms with a ``_PLAIN`` suffix involve passing plain-text passwords or
+            password-equivalent strings and should not be used over untrusted or insecure
+            transport.
 
-            PASSWORD_PLAIN
-            username: username with which to authenticate
-            password: password with which to authenticate
-            login_options: dictionary with additional authentication options
+        The ``response_type`` of the result indicates the outcome of the current authentication
+        step and whether further action is required to complete authentication:
 
-            API_KEY_PLAIN
-            username: username with which to authenticate
-            api_key: API key string
-            login_options: dictionary with additional authentication options
+        - ``SUCCESS`` -- authentication completed and a session was established.
+        - ``OTP_REQUIRED`` -- the account requires a one-time password; the client must continue
+          authentication by submitting the token via the ``OTP_TOKEN`` mechanism.
+        - ``AUTH_ERR`` -- generic authentication failure corresponding to ``PAM_AUTH_ERR`` and
+          ``PAM_USER_UNKNOWN`` from libpam. Returned when the account does not exist or the
+          credential is incorrect.
+        - ``EXPIRED`` -- the supplied credential is expired and not suitable for authentication.
+        - ``REDIRECT`` -- authentication must be performed on a different server.
 
-            AUTH_TOKEN_PLAIN
-            token: authentication token string
-            login_options: dictionary with additional authentication options
+        A JSON-RPC ``error`` response (code ``-32001``, *Method call error*) is returned instead
+        of a result in the following cases:
 
-            OTP_TOKEN
-            otp_token: one-time password token. This is only permitted if
-            a previous auth.login_ex call responded with "OTP_REQUIRED".
-
-            login_options
-            user_info: boolean - include auth.me output in successful responses.
-            reconnect_token: boolean - include a reconnect token in successful responses.
-
-        raises:
-            CallError: a middleware CallError may be raised in the following
-                circumstances.
-
-            * An multistep challenge-response authentication mechanism is being
-              used and the specified `mechanism` does not match the expected
-              next step for authentication. In this case the errno will be set
-              to EBUSY.
-
-            * OTP_TOKEN mechanism was passed without an explicit request from
-              a previous authentication step. In this case the errno will be set
-              to EINVAL.
-
-            * Current authenticator assurance level prohibits the use of the
-              specified authentication mechanism. In this case the errno will be
-              set to EOPNOTSUPP.
-
-        returns:
-            JSON object containing the following keys:
-
-            response_type: string indicating the results of the current authentication
-                mechanism. This is used to inform client of nature of authentication
-                error or whether further action will be required in order to complete
-                authentication.
-
-            <additional keys per response_type>
-
-        Notes about response types:
-
-        SUCCESS:
-
-        additional keys:
-            user_info: includes auth.me output for the resulting authenticated
-            credentials.
-            reconnect_token: token that can be used to reauthenticate if the
-            websocket session is interrupted, or null if not requested or not
-            supported by the credential type.
-
-        OTP_REQUIRED
-
-        additional key:
-            username: normalized username of user who must provide an OTP token.
-
-        AUTH_ERR
-        Generic authentication error corresponds to PAM_AUTH_ERR and PAM_USER_UNKOWN
-        from libpam. This may be returned if the account does not exist or if the
-        credential is incorrect.
-
-        EXPIRED
-        The specified credential is expired and not suitable for authentication.
-
-        REDIRECT
-        Authentication must be performed on different server.
+        - a multistep challenge-response mechanism is in progress and the supplied ``mechanism``
+          does not match the expected next step (errno ``EBUSY``)
+        - the ``OTP_TOKEN`` mechanism is used without a preceding step having requested it
+          (errno ``EINVAL``)
+        - the current authenticator assurance level prohibits the supplied mechanism
+          (errno ``EOPNOTSUPP``)
         """
         if await self.middleware.call('failover.licensed'):
             if await self.middleware.call('failover.status') == 'BACKUP':

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -330,8 +330,8 @@ class AuthService(Service):
                     "origin": "192.168.0.3:40392",
                     "credentials": "LOGIN_PASSWORD",
                     "credentials_data": {"username": "root"},
-                    "current": True,
-                    "internal": False,
+                    "current": true,
+                    "internal": false,
                     "created_at": {"$date": 1545842426070}
                 }
             ]
@@ -346,7 +346,7 @@ class AuthService(Service):
 
             [
                 [
-                    ["internal", "=", True]
+                    ["internal", "=", true]
                 ]
             ]
         """

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -322,19 +322,19 @@ class AuthService(Service):
         """
         Returns list of active auth sessions.
 
-        Example of return value:
+        Example of return value::
 
-        [
-            {
-                "id": "NyhB1J5vjPjIV82yZ6caU12HLA1boDJcZNWuVQM4hQWuiyUWMGZTz2ElDp7Yk87d",
-                "origin": "192.168.0.3:40392",
-                "credentials": "LOGIN_PASSWORD",
-                "credentials_data": {"username": "root"},
-                "current": True,
-                "internal": False,
-                "created_at": {"$date": 1545842426070}
-            }
-        ]
+            [
+                {
+                    "id": "NyhB1J5vjPjIV82yZ6caU12HLA1boDJcZNWuVQM4hQWuiyUWMGZTz2ElDp7Yk87d",
+                    "origin": "192.168.0.3:40392",
+                    "credentials": "LOGIN_PASSWORD",
+                    "credentials_data": {"username": "root"},
+                    "current": True,
+                    "internal": False,
+                    "created_at": {"$date": 1545842426070}
+                }
+            ]
 
         `credentials` can be `UNIX_SOCKET`, `ROOT_TCP_SOCKET`, `LOGIN_PASSWORD`, `API_KEY` or `TOKEN`,
         depending on what authentication method was used.
@@ -342,13 +342,13 @@ class AuthService(Service):
         For `API_KEY` corresponding `api_key` will be provided in `credentials_data`.
         For `TOKEN` its `parent` credential will be provided in `credentials_data`.
 
-        If you want to exclude all internal connections from the list, call this method with following arguments:
+        If you want to exclude all internal connections from the list, call this method with following arguments::
 
-        [
             [
-                ["internal", "=", True]
+                [
+                    ["internal", "=", True]
+                ]
             ]
-        ]
         """
         return filter_list(
             [
@@ -851,6 +851,7 @@ class AuthService(Service):
         Notes about response types:
 
         SUCCESS:
+
         additional keys:
             user_info: includes auth.me output for the resulting authenticated
             credentials.
@@ -859,6 +860,7 @@ class AuthService(Service):
             supported by the credential type.
 
         OTP_REQUIRED
+
         additional key:
             username: normalized username of user who must provide an OTP token.
 

--- a/src/middlewared/middlewared/plugins/dns_client.py
+++ b/src/middlewared/middlewared/plugins/dns_client.py
@@ -104,11 +104,12 @@ class DNSClient(Service):
     async def forward_lookup(self, data):
         """
         Rules: We can combine 'A' and 'AAAA', but 'SRV' and 'CNAME' must be singular.
-        NB1: By default record_types is ['A', 'AAAA'] and if selected will return both 'A' and 'AAAA' records
-             for hosts that support both.
-        NB2: By default raise_error is 'HOST_FAILURE', i.e. raise exception if all tests for a name fail
-        NB3: With raise_error as 'NEVER' all results are returned and resolve attempts that
-             generate an exception are returned as an empty list
+
+        - NB1: By default record_types is ['A', 'AAAA'] and if selected will return both 'A' and 'AAAA' records
+          for hosts that support both.
+        - NB2: By default raise_error is 'HOST_FAILURE', i.e. raise exception if all tests for a name fail
+        - NB3: With raise_error as 'NEVER' all results are returned and resolve attempts that
+          generate an exception are returned as an empty list
         """
         single_rtypes = ['CNAME', 'SRV']
         output = []

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -685,8 +685,7 @@ class FilesystemService(Service):
         """
         Return stats from the filesystem of a given path.
 
-        Raises:
-            CallError(ENOENT) - Path not found
+        If ``path`` does not exist, the method raises a ``CallError`` (code ``-32001``, *Method call error*).
         """
         try:
             fd = truenas_os.openat2(path, os.O_PATH, resolve=truenas_os.RESOLVE_NO_SYMLINKS)

--- a/src/middlewared/middlewared/plugins/interface/listen.py
+++ b/src/middlewared/middlewared/plugins/interface/listen.py
@@ -31,12 +31,13 @@ class InterfaceService(Service):
         """
         Returns which services will be set to listen on 0.0.0.0 (and, thus, restarted) on sync.
 
-        Example result:
-        [
-            // Samba service will be set ot listen on 0.0.0.0 and restarted because it was set up to listen on
-            // 192.168.0.1 which is being removed.
-            {"type": "SYSTEM_SERVICE", "service": "cifs", "ips": ["192.168.0.1"]},
-        ]
+        Example result::
+
+            [
+                // Samba service will be set ot listen on 0.0.0.0 and restarted because it was set up to listen on
+                // 192.168.0.1 which is being removed.
+                {"type": "SYSTEM_SERVICE", "service": "cifs", "ips": ["192.168.0.1"]},
+            ]
         """
         return [dict(await pd.delegate.repr(pd.state), ips=pd.addresses)
                 for pd in await self.listen_delegates_prepare()]

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -304,6 +304,7 @@ class iSCSITargetService(CRUDService):
     async def validate_name(self, name, existing_id):
         """
         Returns validation error for iSCSI target name
+
         :param name: name to be validated
         :param existing_id: id of an existing iSCSI target that will receive this name (or `None` if a new target
                             is being created)

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -299,7 +299,7 @@ class KeychainCredentialService(CRUDService):
         """
         Create a Keychain Credential.
 
-        The following `type`s are supported:
+        The following `type` values are supported:
          * `SSH_KEY_PAIR`
          * `SSH_CREDENTIALS`
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -458,9 +458,9 @@ class InterfaceService(CRUDService):
         This makes 2 assumptions:
 
         1. :doc:`interface.create <api_methods_interface.create>`,
-            :doc:`update <api_methods_interface.update>`, or
-            :doc:`delete <api_methods_interface.delete>` must have been called
-            before calling this method.
+           :doc:`update <api_methods_interface.update>`, or
+           :doc:`delete <api_methods_interface.delete>` must have been called
+           before calling this method.
         2. This method must be called before :doc:`interface.commit <api_methods_interface.commit>` is called.
 
         This method exists for the predominant scenario for new users:
@@ -469,16 +469,16 @@ class InterfaceService(CRUDService):
         2. All interfaces start DHCPv4 (v6 is ignored for now).
         3. One of the interfaces receives an IP address.
         4. Along with the IP, the kernel receives a default route
-            (by design, of course).
+           (by design, of course).
         5. User goes to configure this interface as having a static
-            IP address.
+           IP address.
         6. As we go through and "commit" the changes, we remove the default
-            route because it exists in the kernel FIB but doesn't exist
-            in the database.
+           route because it exists in the kernel FIB but doesn't exist
+           in the database.
         7. IF the user is connecting via layer3, then they will lose all
-            access to the TrueNAS and never be able to finalize the changes
-            to the network because we ripped out the default route which
-            is how they were communicating to begin with.
+           access to the TrueNAS and never be able to finalize the changes
+           to the network because we ripped out the default route which
+           is how they were communicating to begin with.
 
         In the above scenario, we're going to try and prevent this by doing
         the following:
@@ -488,20 +488,20 @@ class InterfaceService(CRUDService):
         3. Default route is received.
         4. User configures an interface.
         5. When user pushes "Test Changes" (:doc:`interface.commit <api_methods_interface.commit>`), WebUI will call
-            :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
-            BEFORE :doc:`interface.commit <api_methods_interface.commit>`.
+           :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
+           BEFORE :doc:`interface.commit <api_methods_interface.commit>`.
         6. If :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
-            returns any fields,
-            then webUI will open a new modal dialog that gives the end-user
-            ample warning describing the situation. Furthermore, the
-            modal will allow the user to input a default gateway and nameservers.
+           returns any fields,
+           then webUI will open a new modal dialog that gives the end-user
+           ample warning describing the situation. Furthermore, the
+           modal will allow the user to input a default gateway and nameservers.
         7. If user gives gateway, webUI will call this method providing the info
-            and we'll validate accordingly.
+           and we'll validate accordingly.
         8. OR if user doesn't give gateway, they will need to "confirm" this is
-            desired.
+           desired.
         9. The network configuration provided (gateway and nameservers) will be stored
-            in the same in-memory cache that we use for storing the interface changes
-            and will be rolled back accordingly in this plugin just like everything else.
+           in the same in-memory cache that we use for storing the interface changes
+           and will be rolled back accordingly in this plugin just like everything else.
 
         There are a few other scenarios where this is beneficial, but the one listed above
         is seen most often by end-users/support team.

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -461,7 +461,7 @@ class InterfaceService(CRUDService):
            :doc:`update <api_methods_interface.update>`, or
            :doc:`delete <api_methods_interface.delete>` must have been called
            before calling this method.
-        2. This method must be called before :doc:`interface.commit <api_methods_interface.commit>` is called.
+        2. This method must be called before :method:`interface.commit` is called.
 
         This method exists for the predominant scenario for new users:
 
@@ -487,10 +487,10 @@ class InterfaceService(CRUDService):
         2. All interfaces start DHCPv4.
         3. Default route is received.
         4. User configures an interface.
-        5. When user pushes "Test Changes" (:doc:`interface.commit <api_methods_interface.commit>`), WebUI will
-           call :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
-           BEFORE :doc:`interface.commit <api_methods_interface.commit>`.
-        6. If :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
+        5. When user pushes "Test Changes" (:method:`interface.commit`), WebUI will
+           call :method:`interface.network_config_to_be_removed`
+           BEFORE :method:`interface.commit`.
+        6. If :method:`interface.network_config_to_be_removed`
            returns any fields,
            then webUI will open a new modal dialog that gives the end-user
            ample warning describing the situation. Furthermore, the

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -457,9 +457,11 @@ class InterfaceService(CRUDService):
 
         This makes 2 assumptions:
 
-        1. `interface.create`/`update`/`delete` must have been called before
-            calling this method.
-        2. This method must be called before `interface.commit` is called.
+        1. :doc:`interface.create <api_methods_interface.create>`,
+            :doc:`update <api_methods_interface.update>`, or
+            :doc:`delete <api_methods_interface.delete>` must have been called
+            before calling this method.
+        2. This method must be called before :doc:`interface.commit <api_methods_interface.commit>` is called.
 
         This method exists for the predominant scenario for new users:
 
@@ -485,9 +487,11 @@ class InterfaceService(CRUDService):
         2. All interfaces start DHCPv4.
         3. Default route is received.
         4. User configures an interface.
-        5. When user pushes "Test Changes" (`interface.commit`), webUI will call
-            `interface.network_config_to_be_removed` BEFORE `interface.commit`.
-        6. If `interface.network_config_to_be_removed` returns any fields,
+        5. When user pushes "Test Changes" (:doc:`interface.commit <api_methods_interface.commit>`), WebUI will call
+            :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
+            BEFORE :doc:`interface.commit <api_methods_interface.commit>`.
+        6. If :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
+            returns any fields,
             then webUI will open a new modal dialog that gives the end-user
             ample warning describing the situation. Furthermore, the
             modal will allow the user to input a default gateway and nameservers.

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -487,8 +487,8 @@ class InterfaceService(CRUDService):
         2. All interfaces start DHCPv4.
         3. Default route is received.
         4. User configures an interface.
-        5. When user pushes "Test Changes" (:doc:`interface.commit <api_methods_interface.commit>`), WebUI will call
-           :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
+        5. When user pushes "Test Changes" (:doc:`interface.commit <api_methods_interface.commit>`), WebUI will
+           call :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
            BEFORE :doc:`interface.commit <api_methods_interface.commit>`.
         6. If :doc:`interface.network_config_to_be_removed <api_methods_interface.network_config_to_be_removed>`
            returns any fields,

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -456,11 +456,13 @@ class InterfaceService(CRUDService):
         that will be validated and applied to the global network configuration.
 
         This makes 2 assumptions:
+
         1. `interface.create`/`update`/`delete` must have been called before
             calling this method.
         2. This method must be called before `interface.commit` is called.
 
         This method exists for the predominant scenario for new users:
+
         1. Fresh install SCALE.
         2. All interfaces start DHCPv4 (v6 is ignored for now).
         3. One of the interfaces receives an IP address.
@@ -478,6 +480,7 @@ class InterfaceService(CRUDService):
 
         In the above scenario, we're going to try and prevent this by doing
         the following:
+
         1. Fresh install SCALE.
         2. All interfaces start DHCPv4.
         3. Default route is received.

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -122,72 +122,76 @@ class NFSService(Service):
     )
     def get_nfs4_clients(self, filters, options):
         """
-        Read information about NFSv4 clients from /proc/fs/nfsd/clients
-        Sample output:
-        [{
-            "id": "4",
-            "info": {
-                "clientid": 6273260596088110000,
-                "address": "192.168.40.247:790",
-                "status": "confirmed",
-                "seconds from last renew": 45,
-                "name": "Linux NFSv4.2 debian12-hv",
-                "minor version": 2,
-                "Implementation domain": "kernel.org",
-                "Implementation name": "Linux 6.1.0-12-amd64 #1 SMP PREEMPT_DYNAMIC"
-                                      " Debian 6.1.52-1 (2023-09-07) x86_64",
-                "Implementation time": [0, 0],
-                "callback state": "UP",
-                "callback address": "192.168.40.247:0"
-            },
-            "states": [
-                {
-                    "94850248556250062041657638912": {
-                        "type": "deleg",
-                        "access": "r",
-                        "superblock": "00:39:5",
-                        "filename": "/debian12-hv"
-                    }
+        Read information about NFSv4 clients from /proc/fs/nfsd/clients.
+
+        Sample output::
+
+            [{
+                "id": "4",
+                "info": {
+                    "clientid": 6273260596088110000,
+                    "address": "192.168.40.247:790",
+                    "status": "confirmed",
+                    "seconds from last renew": 45,
+                    "name": "Linux NFSv4.2 debian12-hv",
+                    "minor version": 2,
+                    "Implementation domain": "kernel.org",
+                    "Implementation name": "Linux 6.1.0-12-amd64 #1 SMP PREEMPT_DYNAMIC"
+                                          " Debian 6.1.52-1 (2023-09-07) x86_64",
+                    "Implementation time": [0, 0],
+                    "callback state": "UP",
+                    "callback address": "192.168.40.247:0"
                 },
-                {
-                    "94850248556250062041741524992": {
-                        "type": "open",
-                        "access": "rw",
-                        "deny": "--",
-                        "superblock": "00:39:137",
-                        "filename": "/.debian12-hv.swp",
-                        "owner": "open id:\u0000\u0000\u00008\u0000\u0000\u0000\u0000\u0000\u0000\u0014þÀ²3"
+                "states": [
+                    {
+                        "94850248556250062041657638912": {
+                            "type": "deleg",
+                            "access": "r",
+                            "superblock": "00:39:5",
+                            "filename": "/debian12-hv"
+                        }
+                    },
+                    {
+                        "94850248556250062041741524992": {
+                            "type": "open",
+                            "access": "rw",
+                            "deny": "--",
+                            "superblock": "00:39:137",
+                            "filename": "/.debian12-hv.swp",
+                            "owner": "open id:\u0000\u0000\u00008\u0000\u0000\u0000\u0000\u0000\u0000\u0014þÀ²3"
+                        }
                     }
-                }
-            ]
-        }]
-        ---- Description of the fields (all per NFS client) ----
-        'clientid': Hash generated for this client connection
-        'address':  The client IP and port. e.g. 10.20.30.40:768
+                ]
+            }]
 
-        'status':   The current client status:
-            'confirmed' An active connection.
-                        The status will convert to 'courtesy' in 90 seconds if not 'confirmed' by the client.
-            'courtesy'  A stalled connection from an inactive client.
-                        The status will convert to 'expirable' in 24hr.
-            'expirable' Waiting to be cleaned up.
+        Description of the fields (all per NFS client)::
 
-        'seconds from last renew':  The session timeout counter.  See 'status' field.
-                                    Gets reset by confirmation update from the client
+            'clientid': Hash generated for this client connection
+            'address':  The client IP and port. e.g. 10.20.30.40:768
 
-        'name': Supplied by the client.
-                Linux clients might offer something like 'Linux NFS4.2 clnt_name'.
-                FreeBSD clients might supply a UUID like name
+            'status':   The current client status:
+                'confirmed' An active connection.
+                            The status will convert to 'courtesy' in 90 seconds if not 'confirmed' by the client.
+                'courtesy'  A stalled connection from an inactive client.
+                            The status will convert to 'expirable' in 24hr.
+                'expirable' Waiting to be cleaned up.
 
-        'minor version':    The NFS4.x minor version.  E.G. '2' for NFSv4.2
+            'seconds from last renew':  The session timeout counter.  See 'status' field.
+                                        Gets reset by confirmation update from the client
 
-        'Implementation domain': NFSv4.1 info - e.g. 'kernel.org' or 'freebsd.org'.
-        'Implementation name':   NFSv4.1 info - e.g. equivalent to 'uname -a' on the client
-        'Implementation time':   NFSv4.1 info - Timestamp (time nfstime4) of client version (maybe unused?)
+            'name': Supplied by the client.
+                    Linux clients might offer something like 'Linux NFS4.2 clnt_name'.
+                    FreeBSD clients might supply a UUID like name
 
-        'callback state':   Current callback 'service' status for this client: 'UP', 'DOWN', 'FAULT' or 'UNKNOWN'
-                            Linux clients usually indicate 'UP'
-                            FreeBSD clients may indicate 'DOWN' but are still functional
+            'minor version':    The NFS4.x minor version.  E.G. '2' for NFSv4.2
+
+            'Implementation domain': NFSv4.1 info - e.g. 'kernel.org' or 'freebsd.org'.
+            'Implementation name':   NFSv4.1 info - e.g. equivalent to 'uname -a' on the client
+            'Implementation time':   NFSv4.1 info - Timestamp (time nfstime4) of client version (maybe unused?)
+
+            'callback state':   Current callback 'service' status for this client: 'UP', 'DOWN', 'FAULT' or 'UNKNOWN'
+                                Linux clients usually indicate 'UP'
+                                FreeBSD clients may indicate 'DOWN' but are still functional
         """
         clients = []
         with suppress(FileNotFoundError):

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -136,8 +136,7 @@ class NFSService(Service):
                     "name": "Linux NFSv4.2 debian12-hv",
                     "minor version": 2,
                     "Implementation domain": "kernel.org",
-                    "Implementation name": "Linux 6.1.0-12-amd64 #1 SMP PREEMPT_DYNAMIC"
-                                          " Debian 6.1.52-1 (2023-09-07) x86_64",
+                    "Implementation name": "Linux 6.1.0-12-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.52-1 x86_64",
                     "Implementation time": [0, 0],
                     "callback state": "UP",
                     "callback address": "192.168.40.247:0"

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -21,6 +21,7 @@ class PoolService(Service):
         to complete if the target is a RAIDZ vdev undergoing expansion.
 
         Locking behavior:
+
         - If another attach operation is already using the same disk, this call will fail immediately
           with EBUSY rather than queueing.
         - If another attach operation is running on the same pool (but with a different disk), this

--- a/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
@@ -23,14 +23,15 @@ class PoolDatasetService(Service):
         Responsible for telling the user whether there is a related
         share, asking for confirmation.
 
-        Example return value:
-        [
-          {
-            "type": "NFS Share",
-            "service": "nfs",
-            "attachments": ["/mnt/tank/work"]
-          }
-        ]
+        Example return value::
+
+            [
+              {
+                "type": "NFS Share",
+                "service": "nfs",
+                "attachments": ["/mnt/tank/work"]
+              }
+            ]
         """
         dataset = await self.middleware.call('pool.dataset.get_instance_quick', oid)
         if mountpoint := dataset_mountpoint(dataset):

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -78,7 +78,7 @@ class PoolDatasetService(Service):
                     "key_present_in_database": false,
                     "valid_key": false,
                     "locked": true,
-                    "unlock_error": "Child cannot be unlocked when parent \"vol/c\" is locked and provided key is invalid",
+                    "unlock_error": "Child cannot be unlocked when parent \"vol/c\" is locked and key is invalid",
                     "unlock_successful": false
                 }
             ]

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -42,45 +42,46 @@ class PoolDatasetService(Service):
 
         Keys/passphrase can be supplied to check if the keys are valid.
 
-        Example output:
-        [
-            {
-                "name": "vol",
-                "key_format": "PASSPHRASE",
-                "key_present_in_database": false,
-                "valid_key": true,
-                "locked": true,
-                "unlock_error": null,
-                "unlock_successful": true
-            },
-            {
-                "name": "vol/c1/d1",
-                "key_format": "PASSPHRASE",
-                "key_present_in_database": false,
-                "valid_key": false,
-                "locked": true,
-                "unlock_error": "Provided key is invalid",
-                "unlock_successful": false
-            },
-            {
-                "name": "vol/c",
-                "key_format": "PASSPHRASE",
-                "key_present_in_database": false,
-                "valid_key": false,
-                "locked": true,
-                "unlock_error": "Key not provided",
-                "unlock_successful": false
-            },
-            {
-                "name": "vol/c/d2",
-                "key_format": "PASSPHRASE",
-                "key_present_in_database": false,
-                "valid_key": false,
-                "locked": true,
-                "unlock_error": "Child cannot be unlocked when parent \"vol/c\" is locked and provided key is invalid",
-                "unlock_successful": false
-            }
-        ]
+        Example output::
+
+            [
+                {
+                    "name": "vol",
+                    "key_format": "PASSPHRASE",
+                    "key_present_in_database": false,
+                    "valid_key": true,
+                    "locked": true,
+                    "unlock_error": null,
+                    "unlock_successful": true
+                },
+                {
+                    "name": "vol/c1/d1",
+                    "key_format": "PASSPHRASE",
+                    "key_present_in_database": false,
+                    "valid_key": false,
+                    "locked": true,
+                    "unlock_error": "Provided key is invalid",
+                    "unlock_successful": false
+                },
+                {
+                    "name": "vol/c",
+                    "key_format": "PASSPHRASE",
+                    "key_present_in_database": false,
+                    "valid_key": false,
+                    "locked": true,
+                    "unlock_error": "Key not provided",
+                    "unlock_successful": false
+                },
+                {
+                    "name": "vol/c/d2",
+                    "key_format": "PASSPHRASE",
+                    "key_present_in_database": false,
+                    "valid_key": false,
+                    "locked": true,
+                    "unlock_error": "Child cannot be unlocked when parent \"vol/c\" is locked and provided key is invalid",
+                    "unlock_successful": false
+                }
+            ]
         """
         keys_supplied = {}
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -23,20 +23,20 @@ class PoolDatasetService(Service):
         """
         Return a list of processes using this dataset.
 
-        Example return value:
+        Example return value::
 
-        [
-          {
-            "pid": 2520,
-            "name": "smbd",
-            "service": "cifs"
-          },
-          {
-            "pid": 97778,
-            "name": "minio",
-            "cmdline": "/usr/local/bin/minio -C /usr/local/etc/minio server --address=0.0.0.0:9000 --quiet /mnt/tank/wk"
-          }
-        ]
+            [
+              {
+                "pid": 2520,
+                "name": "smbd",
+                "service": "cifs"
+              },
+              {
+                "pid": 97778,
+                "name": "minio",
+                "cmdline": "/usr/local/bin/minio -C /usr/local/etc/minio server --address=0.0.0.0:9000 --quiet /mnt/tank/wk"
+              }
+            ]
         """
         dataset = await self.middleware.call('pool.dataset.get_instance_quick', oid, {'encryption': True})
         if dataset['locked']:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -34,7 +34,7 @@ class PoolDatasetService(Service):
               {
                 "pid": 97778,
                 "name": "minio",
-                "cmdline": "/usr/local/bin/minio -C /usr/local/etc/minio server --address=0.0.0.0:9000 --quiet /mnt/tank/wk"
+                "cmdline": "/usr/local/bin/minio -C /usr/local/etc/minio server --address=0.0.0.0:9000 /mnt/tank/wk"
               }
             ]
         """

--- a/src/middlewared/middlewared/plugins/snmp.py
+++ b/src/middlewared/middlewared/plugins/snmp.py
@@ -152,6 +152,7 @@ class SNMPService(SystemServiceService):
         Update SNMP Service Configuration.
 
         --- Rules ---
+
         Enabling v3:
             requires v3_username, v3_authtype and v3_password
         Disabling v3:

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -425,9 +425,6 @@ class VMService(GenericCRUDService[VMEntry]):
     def random_mac(self) -> str:
         """
         Create a random mac address.
-
-        Returns:
-            str: with six groups of two hexadecimal digits
         """
         return random_mac()
 

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -291,11 +291,13 @@ class VMService(GenericCRUDService[VMEntry]):
         Get the current maximum amount of available memory to be allocated for VMs.
 
         In case of `overcommit` being `true`, calculations are done in the following manner:
+
         1. If a VM has requested 10G but is only consuming 5G, only 5G will be counted
         2. System will consider shrinkable ZFS ARC as free memory ( shrinkable ZFS ARC is current ZFS ARC
            minus ZFS ARC minimum )
 
         In case of `overcommit` being `false`, calculations are done in the following manner:
+
         1. Complete VM requested memory will be taken into account regardless of how much actual physical
            memory the VM is consuming
         2. System will not consider shrinkable ZFS ARC as free memory

--- a/src/middlewared/middlewared/plugins/webui/enclosure.py
+++ b/src/middlewared/middlewared/plugins/webui/enclosure.py
@@ -77,69 +77,69 @@ class WebUIEnclosureService(Service):
 
         An example of what this returns looks like the following (some redundant information cut out for brevity)::
 
-        [{
-            "name": "iX 4024Sp c205",
-            "model": "M40",
-            "controller": true,
-            "dmi": "TRUENAS-M40-HA",
-            "status": ["OK"],
-            "id": "5b0bd6d1a30714bf",
-            "vendor": "iX",
-            "product": "4024Sp",
-            "revision": "c205",
-            "bsg": "/dev/bsg/0:0:23:0",
-            "sg": "/dev/sg25",
-            "pci": "0:0:23:0",
-            "rackmount": true,
-            "top_loaded": false,
-            "front_slots": 24,
-            "rear_slots": 0,
-            "internal_slots": 0,
-            "elements": {
-                "Array Device Slot": {
-                    "1": {
-                        "descriptor": "slot00",
-                        "status": "OK",
-                        "dev": "sda",
-                        "supports_identify_light": true,
-                        "name": "sda",
-                        "size": 12000138625024,
-                        "model": "HUH721212AL4200",
-                        "serial": "XXXXX",
-                        "advpowermgmt": "DISABLED",
-                        "transfermode": "Auto",
-                        "hddstandby": "ALWAYS ON",
-                        "description": "",
-                        "rotationrate": 7200,
-                        "pool_info": {
-                            "pool_name": "test",
-                            "disk_status": "ONLINE",
-                            "disk_read_errors": 0,
-                            "disk_write_errors": 0,
-                            "disk_checksum_errors": 0,
-                            "vdev_name": "mirror-0",
-                            "vdev_type": "data",
-                            "vdev_disks": [
-                                {
-                                    "enclosure_id": "5b0bd6d1a30714bf",
-                                    "slot": 1,
-                                    "dev": "sda"
-                                },
-                                {
-                                    "enclosure_id": "5b0bd6d1a30714bf",
-                                    "slot": 2,
-                                    "dev": "sdb"
-                                },
-                                {
-                                    "enclosure_id": "5b0bd6d1a30714bf",
-                                    "slot": 3,
-                                    "dev": "sdc"
-                                }
-                            ]
+            [{
+                "name": "iX 4024Sp c205",
+                "model": "M40",
+                "controller": true,
+                "dmi": "TRUENAS-M40-HA",
+                "status": ["OK"],
+                "id": "5b0bd6d1a30714bf",
+                "vendor": "iX",
+                "product": "4024Sp",
+                "revision": "c205",
+                "bsg": "/dev/bsg/0:0:23:0",
+                "sg": "/dev/sg25",
+                "pci": "0:0:23:0",
+                "rackmount": true,
+                "top_loaded": false,
+                "front_slots": 24,
+                "rear_slots": 0,
+                "internal_slots": 0,
+                "elements": {
+                    "Array Device Slot": {
+                        "1": {
+                            "descriptor": "slot00",
+                            "status": "OK",
+                            "dev": "sda",
+                            "supports_identify_light": true,
+                            "name": "sda",
+                            "size": 12000138625024,
+                            "model": "HUH721212AL4200",
+                            "serial": "XXXXX",
+                            "advpowermgmt": "DISABLED",
+                            "transfermode": "Auto",
+                            "hddstandby": "ALWAYS ON",
+                            "description": "",
+                            "rotationrate": 7200,
+                            "pool_info": {
+                                "pool_name": "test",
+                                "disk_status": "ONLINE",
+                                "disk_read_errors": 0,
+                                "disk_write_errors": 0,
+                                "disk_checksum_errors": 0,
+                                "vdev_name": "mirror-0",
+                                "vdev_type": "data",
+                                "vdev_disks": [
+                                    {
+                                        "enclosure_id": "5b0bd6d1a30714bf",
+                                        "slot": 1,
+                                        "dev": "sda"
+                                    },
+                                    {
+                                        "enclosure_id": "5b0bd6d1a30714bf",
+                                        "slot": 2,
+                                        "dev": "sdb"
+                                    },
+                                    {
+                                        "enclosure_id": "5b0bd6d1a30714bf",
+                                        "slot": 3,
+                                        "dev": "sdc"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
-            }
-        }]
+            }]
         """
         return self.dashboard_impl()

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -454,13 +454,15 @@ class ZFSResourceService(Service):
         """
         Destroy a ZFS resource (filesystem or volume), optionally recursing into its descendants.
 
-        To destroy snapshots, use ``zfs.resource.snapshot.destroy`` instead.
+        To destroy snapshots, use
+        :doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>` instead.
 
         Invalid input is returned to the client as a JSON-RPC ``error`` response (code
         ``-32602``, *Invalid params*); each failing condition appears in the error's
         ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        - a snapshot path (containing ``@``) is supplied (use ``zfs.resource.snapshot.destroy``)
+        - a snapshot path (containing ``@``) is supplied
+          (use :doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>`)
         - the resource does not exist (``ENOENT``)
         - the resource has children and ``recursive`` is ``false`` (``EBUSY``)
         - the resource has snapshots and ``recursive`` is ``false``
@@ -487,7 +489,6 @@ class ZFSResourceService(Service):
         - Root filesystem destruction is not allowed for safety
         - Protected system paths cannot be destroyed via API
         - Datasets with snapshots require ``recursive=True``
-        - To destroy snapshots, use ``zfs.resource.snapshot.destroy``
         """
         schema = "zfs.resource.destroy"
         path = data.path
@@ -529,13 +530,13 @@ class ZFSResourceService(Service):
         resources, including their properties, hierarchical relationships, and metadata. The query
         can be customized to retrieve specific resources, properties, and control the output format.
 
-        To query snapshots, use ``zfs.resource.snapshot.query`` instead.
+        To query snapshots, use :doc:`zfs.resource.snapshot.query <api_methods_zfs.resource.snapshot.query>` instead.
 
         Invalid input is returned to the client as a JSON-RPC ``error`` response (code
         ``-32602``, *Invalid params*); each failing condition appears in the error's
         ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        - a snapshot path is supplied (use ``zfs.resource.snapshot.query``)
+        - a snapshot path is supplied (use :doc:`zfs.resource.snapshot.query <api_methods_zfs.resource.snapshot.query>`)
         - overlapping paths are supplied with ``get_children`` enabled
         - a requested path does not exist (``ENOENT``)
 

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -484,11 +484,11 @@ class ZFSResourceService(Service):
 
             {"path": "tank/parent", "recursive": true}
 
-        Notes:
+        .. note::
 
-        - Root filesystem destruction is not allowed for safety
-        - Protected system paths cannot be destroyed via API
-        - Datasets with snapshots require ``recursive`` to be ``true``
+            - Root filesystem destruction is not allowed for safety
+            - Protected system paths cannot be destroyed via API
+            - Datasets with snapshots require ``recursive`` to be ``true``
         """
         schema = "zfs.resource.destroy"
         path = data.path

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -452,48 +452,42 @@ class ZFSResourceService(Service):
     )
     def destroy(self, data: ZFSResourceDestroyArgsData) -> None:
         """
-        Destroy a ZFS resource (filesystem or volume).
+        Destroy a ZFS resource (filesystem or volume), optionally recursing into its descendants.
 
-        This method provides an interface for destroying ZFS datasets and volumes \
-        with support for recursive deletion.
+        To destroy snapshots, use ``zfs.resource.snapshot.destroy`` instead.
 
-        NOTE: To destroy snapshots, use `zfs.resource.snapshot.destroy`.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Args:
-            data (dict): Dictionary containing destruction parameters:
-                - path (str): Path of the ZFS resource to destroy. Must be in the form \
-                    'pool/name' or 'pool/zvol'. Snapshot paths (containing '@') are \
-                    not accepted - use `zfs.resource.snapshot.destroy` instead.
-                    Cannot be an absolute path or end with a forward slash.
-                - recursive (bool, optional): If True, recursively destroy all descendants \
-                    including their snapshots, clones, and holds. Default: False.
-
-        Returns:
-            None: On successful destruction.
-
-        Raises:
-            ValidationError: Raised in the following cases:
-                - Snapshot path provided (use zfs.resource.snapshot.destroy)
-                - Resource does not exist (ENOENT)
-                - Resource has children and recursive=False (EBUSY)
-                - Resource has snapshots and recursive=False
-                - Attempting to destroy root filesystem
-                - Path is absolute (starts with /)
-                - Path ends with forward slash
-                - Path references protected internal resources
+        - a snapshot path (containing ``@``) is supplied (use ``zfs.resource.snapshot.destroy``)
+        - the resource does not exist (``ENOENT``)
+        - the resource has children and ``recursive`` is ``false`` (``EBUSY``)
+        - the resource has snapshots and ``recursive`` is ``false``
+        - the target is the pool's root filesystem
+        - the path is absolute or ends with ``/``
+        - the path references a protected internal resource
 
         Examples:
-            # Destroy a simple filesystem
-            destroy({"path": "tank/temp"})
 
-            # Recursively destroy filesystem and all descendants
-            destroy({"path": "tank/parent", "recursive": True})
+        Destroy a single filesystem:
+
+        .. code:: json
+
+            {"path": "tank/temp"}
+
+        Recursively destroy a filesystem and all of its descendants:
+
+        .. code:: json
+
+            {"path": "tank/parent", "recursive": true}
 
         Notes:
-            - Root filesystem destruction is not allowed for safety
-            - Protected system paths cannot be destroyed via API
-            - Datasets with snapshots require recursive=True
-            - To destroy snapshots, use `zfs.resource.snapshot.destroy`
+
+        - Root filesystem destruction is not allowed for safety
+        - Protected system paths cannot be destroyed via API
+        - Datasets with snapshots require ``recursive=True``
+        - To destroy snapshots, use ``zfs.resource.snapshot.destroy``
         """
         schema = "zfs.resource.destroy"
         path = data.path
@@ -531,34 +525,45 @@ class ZFSResourceService(Service):
         """
         Query ZFS resources (datasets and volumes) with flexible filtering options.
 
-        This method provides a high-performance interface for retrieving information \
-        about ZFS resources, including their properties, hierarchical relationships, \
-        and metadata. The query can be customized to retrieve specific resources, \
-        properties, and control the output format.
+        This method provides a high-performance interface for retrieving information about ZFS
+        resources, including their properties, hierarchical relationships, and metadata. The query
+        can be customized to retrieve specific resources, properties, and control the output format.
 
-        NOTE: To query snapshots, use `zfs.resource.snapshot.query`.
+        To query snapshots, use ``zfs.resource.snapshot.query`` instead.
 
-        Raises:
-            ValidationError: If:
-                - Snapshot paths are provided (use zfs.resource.snapshot.query)
-                - Overlapping paths are provided with get_children=True
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
+
+        - a snapshot path is supplied (use ``zfs.resource.snapshot.query``)
+        - overlapping paths are supplied with ``get_children`` enabled
+        - a requested path does not exist (``ENOENT``)
 
         Examples:
-            # Query all resources with default properties
-            query()
 
-            # Query specific resources with all properties
-            query({"paths": ["tank/documents", "tank/media"]})
+        Query all resources with default properties:
 
-            # Query with specific properties and children
-            query({
-                "paths": ["tank"],
-                "properties": ["mounted", "compression", "used"],
-                "get_children": True
-            })
+        .. code:: json
 
-            # Get hierarchical view of resources
-            query({"paths": ["tank"], "nest_results": True, "get_children": True})
+            {}
+
+        Query specific resources:
+
+        .. code:: json
+
+            {"paths": ["tank/documents", "tank/media"]}
+
+        Query specific properties with children:
+
+        .. code:: json
+
+            {"paths": ["tank"], "properties": ["mounted", "compression", "used"], "get_children": true}
+
+        Get a hierarchical view of resources:
+
+        .. code:: json
+
+            {"paths": ["tank"], "nest_results": true, "get_children": true}
         """
         try:
             return [

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -455,14 +455,14 @@ class ZFSResourceService(Service):
         Destroy a ZFS resource (filesystem or volume), optionally recursing into its descendants.
 
         To destroy snapshots, use
-        :doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>` instead.
+        :method:`zfs.resource.snapshot.destroy` instead.
 
         Invalid input is returned to the client as a JSON-RPC ``error`` response (code
         ``-32602``, *Invalid params*); each failing condition appears in the error's
         ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
         - a snapshot path (containing ``@``) is supplied
-          (use :doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>`)
+          (use :method:`zfs.resource.snapshot.destroy`)
         - the resource does not exist (``ENOENT``)
         - the resource has children and ``recursive`` is ``false`` (``EBUSY``)
         - the resource has snapshots and ``recursive`` is ``false``
@@ -530,13 +530,13 @@ class ZFSResourceService(Service):
         resources, including their properties, hierarchical relationships, and metadata. The query
         can be customized to retrieve specific resources, properties, and control the output format.
 
-        To query snapshots, use :doc:`zfs.resource.snapshot.query <api_methods_zfs.resource.snapshot.query>` instead.
+        To query snapshots, use :method:`zfs.resource.snapshot.query` instead.
 
         Invalid input is returned to the client as a JSON-RPC ``error`` response (code
         ``-32602``, *Invalid params*); each failing condition appears in the error's
         ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        - a snapshot path is supplied (use :doc:`zfs.resource.snapshot.query <api_methods_zfs.resource.snapshot.query>`)
+        - a snapshot path is supplied (use :method:`zfs.resource.snapshot.query`)
         - overlapping paths are supplied with ``get_children`` enabled
         - a requested path does not exist (``ENOENT``)
 

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -488,7 +488,7 @@ class ZFSResourceService(Service):
 
         - Root filesystem destruction is not allowed for safety
         - Protected system paths cannot be destroyed via API
-        - Datasets with snapshots require ``recursive=True``
+        - Datasets with snapshots require ``recursive`` to be ``true``
         """
         schema = "zfs.resource.destroy"
         path = data.path

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -98,38 +98,33 @@ class ZFSResourceSnapshotService(Service):
     )
     def query(self, data: ZFSResourceSnapshotQuery) -> list[ZFSResourceSnapshotEntry]:
         """
-        This method provides an interface for retrieving information about ZFS snapshots,
-        including their properties and user properties.
-
-        Args:
-            data: Query parameters containing:
-                - paths: List of dataset or snapshot paths to query. If empty, queries all.
-                - properties: List of ZFS properties to retrieve. Empty list = defaults, None = none.
-                - get_user_properties: Whether to include user-defined properties.
-                - get_source: Whether to include property source information.
-                - recursive: Include snapshots from child datasets.
-                - min_txg: Minimum transaction group filter (0 = no minimum).
-                - max_txg: Maximum transaction group filter (0 = no maximum).
-
-        Returns:
-            List of snapshot entries with requested properties.
+        Retrieve information about ZFS snapshots, including their properties and user properties.
 
         Examples:
-            # Query all snapshots
-            query({})
 
-            # Query snapshots for a specific dataset
-            query({"paths": ["tank/data"]})
+        Query all snapshots:
 
-            # Query a specific snapshot
-            query({"paths": ["tank/data@backup"]})
+        .. code:: json
 
-            # Query with recursion and specific properties
-            query({
-                "paths": ["tank"],
-                "recursive": True,
-                "properties": ["used", "referenced", "creation"]
-            })
+            {}
+
+        Query snapshots for a specific dataset:
+
+        .. code:: json
+
+            {"paths": ["tank/data"]}
+
+        Query a specific snapshot:
+
+        .. code:: json
+
+            {"paths": ["tank/data@backup"]}
+
+        Query with recursion and specific properties:
+
+        .. code:: json
+
+            {"paths": ["tank"], "recursive": true, "properties": ["used", "referenced", "creation"]}
         """
         self.validate_recursive_paths("zfs.resource.snapshot.query", data)
         try:
@@ -177,30 +172,34 @@ class ZFSResourceSnapshotService(Service):
         """
         Count ZFS snapshots per dataset.
 
-        This method provides a fast way to count snapshots without retrieving
-        full snapshot information. Useful for UI displays and quota checks.
-
-        Args:
-            data: Count parameters containing:
-                - paths: List of dataset paths to count snapshots for. If empty,
-                         counts snapshots for root filesystems only.
-                - recursive: Include snapshots from child datasets in counts.
-
-        Returns:
-            Dict mapping dataset names to their snapshot counts.
+        This method provides a fast way to count snapshots without retrieving full snapshot
+        information. Useful for UI displays and quota checks.
 
         Examples:
-            # Count snapshots for root filesystems only
-            count({})
 
-            # Count all snapshots recursively
-            count({"recursive": True})
+        Count snapshots for root filesystems only:
 
-            # Count snapshots for a specific dataset
-            count({"paths": ["tank/data"]})
+        .. code:: json
 
-            # Count snapshots for a dataset and all children
-            count({"paths": ["tank"], "recursive": True})
+            {}
+
+        Count all snapshots recursively:
+
+        .. code:: json
+
+            {"recursive": true}
+
+        Count snapshots for a specific dataset:
+
+        .. code:: json
+
+            {"paths": ["tank/data"]}
+
+        Count snapshots for a dataset and all of its children:
+
+        .. code:: json
+
+            {"paths": ["tank"], "recursive": true}
         """
         self.validate_recursive_paths("zfs.resource.snapshot.count", data)
         try:
@@ -240,35 +239,46 @@ class ZFSResourceSnapshotService(Service):
         """
         Destroy ZFS snapshots.
 
-        Args:
-            data: Destroy parameters containing:
-                - path: Snapshot path (e.g., 'pool/dataset@snapshot') or dataset path
-                        when all_snapshots=True (e.g., 'pool/dataset').
-                - recursive: Recursively destroy matching snapshots in child datasets.
-                - all_snapshots: If True, path is a dataset and all its snapshots are destroyed.
-                - defer: Defer destruction if snapshot is in use (e.g., has clones).
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found, has clones (without defer), or has holds.
+        - the snapshot does not exist (``ENOENT``)
+        - it has dependent clones and ``defer`` is ``false`` (``ENOTEMPTY``)
+        - it has active holds (``ENOTEMPTY``)
+        - a protected path is targeted without ``bypass`` (``EACCES``)
 
         Examples:
-            # Destroy a single snapshot
-            destroy({"path": "tank/data@backup"})
 
-            # Destroy recursively (all matching child snapshots)
-            destroy({"path": "tank@backup", "recursive": True})
+        Destroy a single snapshot:
 
-            # Defer destruction if in use
-            destroy({"path": "tank/data@snap", "defer": True})
+        .. code:: json
 
-            # Destroy all snapshots for a dataset
-            destroy({"path": "tank/data", "all_snapshots": True})
+            {"path": "tank/data@backup"}
 
-            # Destroy all snapshots for a dataset and its children
-            destroy({"path": "tank", "all_snapshots": True, "recursive": True})
+        Destroy matching snapshots in child datasets:
+
+        .. code:: json
+
+            {"path": "tank@backup", "recursive": true}
+
+        Defer destruction if the snapshot is in use:
+
+        .. code:: json
+
+            {"path": "tank/data@snap", "defer": true}
+
+        Destroy all snapshots of a dataset:
+
+        .. code:: json
+
+            {"path": "tank/data", "all_snapshots": true}
+
+        Destroy all snapshots of a dataset and its children:
+
+        .. code:: json
+
+            {"path": "tank", "all_snapshots": true, "recursive": true}
         """
         # Validate path format based on all_snapshots flag
         if data.all_snapshots:
@@ -335,28 +345,27 @@ class ZFSResourceSnapshotService(Service):
         """
         Rename a ZFS snapshot.
 
-        Args:
-            data: Rename parameters containing:
-                - current_name: Current snapshot path (e.g., 'pool/dataset@old_name').
-                - new_name: New snapshot path (e.g., 'pool/dataset@new_name').
-                - recursive: Recursively rename matching snapshots in child datasets.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found, new name already exists, or invalid paths.
+        - the snapshot does not exist
+        - the new name already exists
+        - a supplied path is invalid
 
         Examples:
-            # Rename a single snapshot
-            rename({"current_name": "tank/data@old", "new_name": "tank/data@new"})
 
-            # Rename recursively (all matching child snapshots)
-            rename({
-                "current_name": "tank@old",
-                "new_name": "tank@new",
-                "recursive": True
-            })
+        Rename a single snapshot:
+
+        .. code:: json
+
+            {"current_name": "tank/data@old", "new_name": "tank/data@new"}
+
+        Rename matching snapshots in child datasets:
+
+        .. code:: json
+
+            {"current_name": "tank@old", "new_name": "tank@new", "recursive": true}
         """
         # Validate both paths are snapshot paths
         if "@" not in data.current_name:
@@ -430,28 +439,27 @@ class ZFSResourceSnapshotService(Service):
         """
         Clone a ZFS snapshot to create a new dataset.
 
-        Args:
-            data: Clone parameters containing:
-                - snapshot: Source snapshot path to clone (e.g., 'pool/dataset@snapshot').
-                - dataset: Destination dataset path for the clone (e.g., 'pool/clone').
-                - properties: Optional ZFS properties to set on the cloned dataset.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found, destination already exists, or source is not a snapshot.
+        - the source snapshot does not exist
+        - the destination dataset already exists
+        - the source is not a snapshot
 
         Examples:
-            # Clone a snapshot to a new dataset
-            clone({"snapshot": "tank/data@backup", "dataset": "tank/data_clone"})
 
-            # Clone with properties
-            clone({
-                "snapshot": "tank/data@backup",
-                "dataset": "tank/data_clone",
-                "properties": {"compression": "lz4", "quota": "10G"}
-            })
+        Clone a snapshot to a new dataset:
+
+        .. code:: json
+
+            {"snapshot": "tank/data@backup", "dataset": "tank/data_clone"}
+
+        Clone with properties:
+
+        .. code:: json
+
+            {"snapshot": "tank/data@backup", "dataset": "tank/data_clone", "properties": {"compression": "lz4", "quota": "10G"}}
         """
         # Validate snapshot path contains @
         if "@" not in data.snapshot:
@@ -511,37 +519,32 @@ class ZFSResourceSnapshotService(Service):
         """
         Create a ZFS snapshot.
 
-        Args:
-            data: Create parameters containing:
-                - dataset: Dataset path to snapshot (e.g., 'pool/dataset').
-                - name: Snapshot name (the part after @).
-                - recursive: Create snapshots recursively for child datasets.
-                - exclude: Datasets to exclude when creating recursive snapshots.
-                - user_properties: User properties to set on the snapshot.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            Snapshot entry for the created snapshot.
-
-        Raises:
-            ValidationError: If dataset not found or snapshot already exists.
+        - the dataset does not exist
+        - the snapshot already exists
 
         Examples:
-            # Create a single snapshot
-            create({"dataset": "tank/data", "name": "backup"})
 
-            # Create recursive snapshots
-            create({
-                "dataset": "tank",
-                "name": "backup",
-                "recursive": True
-            })
+        Create a single snapshot:
 
-            # Create with user properties
-            create({
-                "dataset": "tank/data",
-                "name": "backup",
-                "user_properties": {"com.company:backup_type": "daily"}
-            })
+        .. code:: json
+
+            {"dataset": "tank/data", "name": "backup"}
+
+        Create snapshots recursively:
+
+        .. code:: json
+
+            {"dataset": "tank", "name": "backup", "recursive": true}
+
+        Create with user properties:
+
+        .. code:: json
+
+            {"dataset": "tank/data", "name": "backup", "user_properties": {"com.company:backup_type": "daily"}}
         """
         # Validate dataset path does NOT contain @
         if "@" in data.dataset:
@@ -600,30 +603,35 @@ class ZFSResourceSnapshotService(Service):
         """
         Create a hold on a ZFS snapshot.
 
-        A hold prevents a snapshot from being destroyed. Multiple holds
-        can be placed on a snapshot with different tags.
+        A hold prevents a snapshot from being destroyed. Multiple holds can be placed on a
+        snapshot with different tags.
 
-        Args:
-            data: Hold parameters containing:
-                - path: Snapshot path to hold (e.g., 'pool/dataset@snapshot').
-                - tag: Hold tag name (default: 'truenas').
-                - recursive: Apply hold to matching snapshots in child datasets.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found or hold creation fails.
+        - the snapshot does not exist
+        - the hold cannot be created
 
         Examples:
-            # Hold a single snapshot
-            hold({"path": "tank/data@backup"})
 
-            # Hold with custom tag
-            hold({"path": "tank/data@backup", "tag": "replication"})
+        Hold a snapshot:
 
-            # Hold recursively
-            hold({"path": "tank@backup", "recursive": True})
+        .. code:: json
+
+            {"path": "tank/data@backup"}
+
+        Hold with a custom tag:
+
+        .. code:: json
+
+            {"path": "tank/data@backup", "tag": "replication"}
+
+        Hold matching snapshots in child datasets:
+
+        .. code:: json
+
+            {"path": "tank@backup", "recursive": true}
         """
         # Validate path is a snapshot
         if "@" not in data.path:
@@ -659,16 +667,13 @@ class ZFSResourceSnapshotService(Service):
         """
         Get holds on a ZFS snapshot.
 
-        Args:
-            data: Query parameters containing:
-                - path: Snapshot path to query (e.g., 'pool/dataset@snapshot').
-
-        Returns:
-            List of hold tag names on the snapshot.
-
         Examples:
-            holds({"path": "tank/data@backup"})
-            # Returns: ["truenas", "replication"]
+
+        Get the holds on a snapshot:
+
+        .. code:: json
+
+            {"path": "tank/data@backup"}
         """
         # Validate path is a snapshot
         if "@" not in data.path:
@@ -713,27 +718,32 @@ class ZFSResourceSnapshotService(Service):
         """
         Release hold(s) from a ZFS snapshot.
 
-        Args:
-            data: Release parameters containing:
-                - path: Snapshot path to release holds from (e.g., 'pool/dataset@snapshot').
-                - tag: Specific hold tag to release. If None, releases all holds.
-                - recursive: Release holds from matching snapshots in child datasets.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found or release fails.
+        - the snapshot does not exist
+        - the hold cannot be released
 
         Examples:
-            # Release a specific hold
-            release({"path": "tank/data@backup", "tag": "replication"})
 
-            # Release all holds from a snapshot
-            release({"path": "tank/data@backup"})
+        Release a specific hold:
 
-            # Release holds recursively
-            release({"path": "tank@backup", "tag": "backup", "recursive": True})
+        .. code:: json
+
+            {"path": "tank/data@backup", "tag": "replication"}
+
+        Release all holds from a snapshot:
+
+        .. code:: json
+
+            {"path": "tank/data@backup"}
+
+        Release a hold from matching snapshots in child datasets:
+
+        .. code:: json
+
+            {"path": "tank@backup", "tag": "backup", "recursive": true}
         """
         # Validate path is a snapshot
         if "@" not in data.path:
@@ -779,32 +789,35 @@ class ZFSResourceSnapshotService(Service):
         """
         Rollback a ZFS dataset to a snapshot.
 
-        WARNING: This is a destructive change. All data written since the
-        target snapshot was taken will be discarded.
+        WARNING: This is a destructive change. All data written since the target snapshot was
+        taken will be discarded.
 
-        Args:
-            data: Rollback parameters containing:
-                - path: Snapshot path to rollback to (e.g., 'pool/dataset@snapshot').
-                - recursive: Destroy any snapshots and bookmarks more recent than the one specified.
-                - recursive_clones: Like recursive, but also destroy any clones.
-                - force: Force unmount of any clones.
-                - recursive_rollback: Do a complete recursive rollback of each child snapshot.
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
 
-        Returns:
-            None on success.
-
-        Raises:
-            ValidationError: If snapshot not found or rollback fails.
+        - the snapshot does not exist
+        - the rollback cannot be completed
 
         Examples:
-            # Basic rollback
-            rollback({"path": "tank/data@backup"})
 
-            # Rollback destroying more recent snapshots
-            rollback({"path": "tank/data@backup", "recursive": True})
+        Roll back to a snapshot:
 
-            # Rollback all child datasets
-            rollback({"path": "tank@backup", "recursive_rollback": True})
+        .. code:: json
+
+            {"path": "tank/data@backup"}
+
+        Roll back, destroying more recent snapshots:
+
+        .. code:: json
+
+            {"path": "tank/data@backup", "recursive": true}
+
+        Roll back all child datasets:
+
+        .. code:: json
+
+            {"path": "tank@backup", "recursive_rollback": true}
         """
         # Validate path is a snapshot
         if "@" not in data.path:

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -789,8 +789,10 @@ class ZFSResourceSnapshotService(Service):
         """
         Rollback a ZFS dataset to a snapshot.
 
-        WARNING: This is a destructive change. All data written since the target snapshot was
-        taken will be discarded.
+        .. warning::
+
+            This is a destructive change. All data written since the target snapshot was
+            taken will be discarded.
 
         Invalid input is returned to the client as a JSON-RPC ``error`` response (code
         ``-32602``, *Invalid params*); each failing condition appears in the error's

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -459,7 +459,11 @@ class ZFSResourceSnapshotService(Service):
 
         .. code:: json
 
-            {"snapshot": "tank/data@backup", "dataset": "tank/data_clone", "properties": {"compression": "lz4", "quota": "10G"}}
+            {
+                "snapshot": "tank/data@backup",
+                "dataset": "tank/data_clone",
+                "properties": {"compression": "lz4", "quota": "10G"}
+            }
         """
         # Validate snapshot path contains @
         if "@" not in data.snapshot:

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_expand_method_refs.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_expand_method_refs.py
@@ -1,0 +1,47 @@
+import pytest
+
+from middlewared.api.base.server.doc import expand_method_refs, reflow_docstring
+
+
+@pytest.mark.parametrize(
+    "doc,expected",
+    [
+        # A bare reference expands to a :doc: link whose text is the method name and
+        # whose target is the api_methods_ page for that method.
+        (
+            ":method:`core.bulk`",
+            ":doc:`core.bulk <api_methods_core.bulk>`",
+        ),
+        # Dotted, multi-segment method names are preserved in both text and target.
+        (
+            ":method:`zfs.resource.snapshot.destroy`",
+            ":doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>`",
+        ),
+        # References are expanded inline, leaving surrounding prose untouched.
+        (
+            "To destroy snapshots, use :method:`zfs.resource.snapshot.destroy` instead.",
+            "To destroy snapshots, use "
+            ":doc:`zfs.resource.snapshot.destroy <api_methods_zfs.resource.snapshot.destroy>` instead.",
+        ),
+        # Multiple references on the same line are each expanded.
+        (
+            ":method:`interface.create` then :method:`interface.commit`",
+            ":doc:`interface.create <api_methods_interface.create>` then "
+            ":doc:`interface.commit <api_methods_interface.commit>`",
+        ),
+        # Text without a reference is returned unchanged.
+        (
+            "No references here.",
+            "No references here.",
+        ),
+    ],
+)
+def test_expand_method_refs(doc, expected):
+    assert expand_method_refs(doc) == expected
+
+
+def test_reflow_docstring_expands_method_refs():
+    # reflow_docstring runs the expansion as part of preprocessing, so :method:
+    # shorthand in a hard-wrapped paragraph is both expanded and unwrapped.
+    doc = "See :method:`core.bulk`\nfor details."
+    assert reflow_docstring(doc) == "See :doc:`core.bulk <api_methods_core.bulk>` for details."

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_reflow_docstring.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_reflow_docstring.py
@@ -1,0 +1,64 @@
+import pytest
+
+from middlewared.api.base.server.doc import reflow_docstring
+
+
+@pytest.mark.parametrize("doc,expected", [
+    # Plain prose hard-wrapped across lines is unwrapped into a single line so it
+    # reflows when rendered as HTML.
+    (
+        "Returns a list of things\nthat spans several lines.",
+        "Returns a list of things that spans several lines.",
+    ),
+    # Blank-line-separated paragraphs stay separate; each is unwrapped on its own.
+    (
+        "First paragraph\nwrapped.\n\nSecond paragraph.",
+        "First paragraph wrapped.\n\nSecond paragraph.",
+    ),
+    # A ``::`` paragraph opens a literal block: the following indented run is kept
+    # verbatim (indentation and line breaks preserved) instead of being unwrapped.
+    (
+        'Example output::\n\n    [\n        {"a": 1}\n    ]',
+        'Example output::\n\n    [\n        {"a": 1}\n    ]',
+    ),
+    # A literal block may span several blank-line-separated sub-blocks; each indented
+    # block is preserved.
+    (
+        "Fields::\n\n    a: first\n\n    b: second",
+        "Fields::\n\n    a: first\n\n    b: second",
+    ),
+    # The literal block ends when the text dedents; trailing prose is unwrapped.
+    (
+        "Example::\n\n    code()\n\nTrailing prose\nthat wraps.",
+        "Example::\n\n    code()\n\nTrailing prose that wraps.",
+    ),
+    # Indentation is preserved even without a ``::`` marker, so block quotes, tables,
+    # and similar constructs survive rather than being mangled into prose.
+    (
+        "See below:\n\n    quoted text\n    second line",
+        "See below:\n\n    quoted text\n    second line",
+    ),
+    # A list with wrapped (indented) continuation lines keeps its structure and is
+    # not flattened into a single run-on line.
+    (
+        "- item one\n  continued\n- item two",
+        "- item one\n  continued\n- item two",
+    ),
+    # Directive blocks and their indented bodies are preserved verbatim.
+    (
+        ".. note::\n\n    Body of the note\n    wraps here.",
+        ".. note::\n\n    Body of the note\n    wraps here.",
+    ),
+    # A top-level list with no continuation lines is preserved (not joined into prose).
+    (
+        "Options:\n\n- one\n- two",
+        "Options:\n\n- one\n- two",
+    ),
+    # Leading and trailing blank lines are stripped.
+    (
+        "\n\nHello there\nworld.\n\n",
+        "Hello there world.",
+    ),
+])
+def test_reflow_docstring(doc, expected):
+    assert reflow_docstring(doc) == expected

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_reflow_docstring.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_reflow_docstring.py
@@ -3,62 +3,65 @@ import pytest
 from middlewared.api.base.server.doc import reflow_docstring
 
 
-@pytest.mark.parametrize("doc,expected", [
-    # Plain prose hard-wrapped across lines is unwrapped into a single line so it
-    # reflows when rendered as HTML.
-    (
-        "Returns a list of things\nthat spans several lines.",
-        "Returns a list of things that spans several lines.",
-    ),
-    # Blank-line-separated paragraphs stay separate; each is unwrapped on its own.
-    (
-        "First paragraph\nwrapped.\n\nSecond paragraph.",
-        "First paragraph wrapped.\n\nSecond paragraph.",
-    ),
-    # A ``::`` paragraph opens a literal block: the following indented run is kept
-    # verbatim (indentation and line breaks preserved) instead of being unwrapped.
-    (
-        'Example output::\n\n    [\n        {"a": 1}\n    ]',
-        'Example output::\n\n    [\n        {"a": 1}\n    ]',
-    ),
-    # A literal block may span several blank-line-separated sub-blocks; each indented
-    # block is preserved.
-    (
-        "Fields::\n\n    a: first\n\n    b: second",
-        "Fields::\n\n    a: first\n\n    b: second",
-    ),
-    # The literal block ends when the text dedents; trailing prose is unwrapped.
-    (
-        "Example::\n\n    code()\n\nTrailing prose\nthat wraps.",
-        "Example::\n\n    code()\n\nTrailing prose that wraps.",
-    ),
-    # Indentation is preserved even without a ``::`` marker, so block quotes, tables,
-    # and similar constructs survive rather than being mangled into prose.
-    (
-        "See below:\n\n    quoted text\n    second line",
-        "See below:\n\n    quoted text\n    second line",
-    ),
-    # A list with wrapped (indented) continuation lines keeps its structure and is
-    # not flattened into a single run-on line.
-    (
-        "- item one\n  continued\n- item two",
-        "- item one\n  continued\n- item two",
-    ),
-    # Directive blocks and their indented bodies are preserved verbatim.
-    (
-        ".. note::\n\n    Body of the note\n    wraps here.",
-        ".. note::\n\n    Body of the note\n    wraps here.",
-    ),
-    # A top-level list with no continuation lines is preserved (not joined into prose).
-    (
-        "Options:\n\n- one\n- two",
-        "Options:\n\n- one\n- two",
-    ),
-    # Leading and trailing blank lines are stripped.
-    (
-        "\n\nHello there\nworld.\n\n",
-        "Hello there world.",
-    ),
-])
+@pytest.mark.parametrize(
+    "doc,expected",
+    [
+        # Plain prose hard-wrapped across lines is unwrapped into a single line so it
+        # reflows when rendered as HTML.
+        (
+            "Returns a list of things\nthat spans several lines.",
+            "Returns a list of things that spans several lines.",
+        ),
+        # Blank-line-separated paragraphs stay separate; each is unwrapped on its own.
+        (
+            "First paragraph\nwrapped.\n\nSecond paragraph.",
+            "First paragraph wrapped.\n\nSecond paragraph.",
+        ),
+        # A ``::`` paragraph opens a literal block: the following indented run is kept
+        # verbatim (indentation and line breaks preserved) instead of being unwrapped.
+        (
+            'Example output::\n\n    [\n        {"a": 1}\n    ]',
+            'Example output::\n\n    [\n        {"a": 1}\n    ]',
+        ),
+        # A literal block may span several blank-line-separated sub-blocks; each indented
+        # block is preserved.
+        (
+            "Fields::\n\n    a: first\n\n    b: second",
+            "Fields::\n\n    a: first\n\n    b: second",
+        ),
+        # The literal block ends when the text dedents; trailing prose is unwrapped.
+        (
+            "Example::\n\n    code()\n\nTrailing prose\nthat wraps.",
+            "Example::\n\n    code()\n\nTrailing prose that wraps.",
+        ),
+        # Indentation is preserved even without a ``::`` marker, so block quotes, tables,
+        # and similar constructs survive rather than being mangled into prose.
+        (
+            "See below:\n\n    quoted text\n    second line",
+            "See below:\n\n    quoted text\n    second line",
+        ),
+        # A list with wrapped (indented) continuation lines keeps its structure and is
+        # not flattened into a single run-on line.
+        (
+            "- item one\n  continued\n- item two",
+            "- item one\n  continued\n- item two",
+        ),
+        # Directive blocks and their indented bodies are preserved verbatim.
+        (
+            ".. note::\n\n    Body of the note\n    wraps here.",
+            ".. note::\n\n    Body of the note\n    wraps here.",
+        ),
+        # A top-level list with no continuation lines is preserved (not joined into prose).
+        (
+            "Options:\n\n- one\n- two",
+            "Options:\n\n- one\n- two",
+        ),
+        # Leading and trailing blank lines are stripped.
+        (
+            "\n\nHello there\nworld.\n\n",
+            "Hello there world.",
+        ),
+    ],
+)
 def test_reflow_docstring(doc, expected):
     assert reflow_docstring(doc) == expected

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -636,7 +636,7 @@ class CoreService(Service):
     async def bulk(self, app, job, method, params, description):
         """
         Will sequentially call `method` with the arguments from each entry of the `params` list. For
-        example, calling :doc:`core.bulk <api_methods_core.bulk>` with these parameters::
+        example, calling :method:`core.bulk` with these parameters::
 
             [
                 "zfs.resource.destroy",
@@ -646,9 +646,8 @@ class CoreService(Service):
                 ]
             ]
 
-        calls :doc:`zfs.resource.destroy <api_methods_zfs.resource.destroy>` twice: first with
-        ``{"path": "tank@snap-1", "recursive": true}``, then with
-        ``{"path": "tank@snap-2", "recursive": false}``.
+        calls :method:`zfs.resource.destroy` twice: first with ``{"path": "tank@snap-1", "recursive": true}``,
+        then with ``{"path": "tank@snap-2", "recursive": false}``.
 
         If the first call fails and the second succeeds (returning ``true``), the result of the overall
         call will be::
@@ -660,9 +659,9 @@ class CoreService(Service):
 
         .. important::
 
-            The execution status of :doc:`core.bulk <api_methods_core.bulk>` will always be a
-            ``SUCCESS`` (unless an unlikely internal error occurs). Caller must check for individual call
-            results to ensure the absence of any call errors.
+            The execution status of :method:`core.bulk` will always be a ``SUCCESS`` (unless
+            an unlikely internal error occurs). Caller must check for individual call results
+            to ensure the absence of any call errors.
         """
         serviceobj, methodobj = self.middleware.get_method(method)
 

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -638,7 +638,7 @@ class CoreService(Service):
     @job(lock=lambda args: f"bulk:{args[0]}")
     async def bulk(self, app, job, method, params, description):
         """
-        Will sequentially call `method` with arguments from the `params` list. For example, running
+        Will sequentially call `method` with arguments from the `params` list. For example, running::
 
             call(
                 "core.bulk",
@@ -649,12 +649,12 @@ class CoreService(Service):
                 ]
             )
 
-        will call
+        will call::
 
             call("zfs.resource.destroy", {"path": tank@snap-1", recursive=True})
             call("zfs.resource.destroy", {"path": "tank@snap-2", recursive=False)
 
-        If the first call fails and the seconds succeeds (returning `true`), the result of the overall call will be:
+        If the first call fails and the seconds succeeds (returning `true`), the result of the overall call will be::
 
             [
                 {"result": null, "error": "Error deleting snapshot"},

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -452,12 +452,9 @@ class CoreService(Service):
         """
         Respond to WebSocket ping frames with "pong".
 
-        This endpoint can be used to keep connections alive as outlined \
-        in the WebSocket specification. It does not require authentication \
+        This endpoint can be used to keep connections alive as outlined
+        in the WebSocket specification. It does not require authentication
         but is rate limited to prevent abuse.
-
-        Returns:
-            str: Always returns "pong"
         """
         # NOTE: The UI uses this endpoint to maintain the WebSocket
         # connection on the login page.

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -635,31 +635,32 @@ class CoreService(Service):
     @job(lock=lambda args: f"bulk:{args[0]}")
     async def bulk(self, app, job, method, params, description):
         """
-        Will sequentially call `method` with arguments from the `params` list. For example, running::
+        Will sequentially call `method` with the arguments from each entry of the `params` list. For
+        example, calling :doc:`core.bulk <api_methods_core.bulk>` with these parameters::
 
-            call(
-                "core.bulk",
+            [
                 "zfs.resource.destroy",
                 [
-                    {"path": "tank@snap-1", "recursive": True},
-                    {"path": "tank@snap-2", "recursive": False}
+                    [{"path": "tank@snap-1", "recursive": true}],
+                    [{"path": "tank@snap-2", "recursive": false}]
                 ]
-            )
+            ]
 
-        will call::
+        calls :doc:`zfs.resource.destroy <api_methods_zfs.resource.destroy>` twice: first with
+        ``{"path": "tank@snap-1", "recursive": true}``, then with
+        ``{"path": "tank@snap-2", "recursive": false}``.
 
-            call("zfs.resource.destroy", {"path": tank@snap-1", recursive=True})
-            call("zfs.resource.destroy", {"path": "tank@snap-2", recursive=False)
-
-        If the first call fails and the seconds succeeds (returning `true`), the result of the overall call will be::
+        If the first call fails and the second succeeds (returning ``true``), the result of the overall
+        call will be::
 
             [
                 {"result": null, "error": "Error deleting snapshot"},
                 {"result": true, "error": null}
             ]
 
-        Important note: the execution status of `core.bulk` will always be a `SUCCESS` (unless an unlikely internal
-        error occurs). Caller must check for individual call results to ensure the absence of any call errors.
+        Important note: the execution status of :doc:`core.bulk <api_methods_core.bulk>` will always be a
+        `SUCCESS` (unless an unlikely internal error occurs). Caller must check for individual call results
+        to ensure the absence of any call errors.
         """
         serviceobj, methodobj = self.middleware.get_method(method)
 

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -658,9 +658,11 @@ class CoreService(Service):
                 {"result": true, "error": null}
             ]
 
-        Important note: the execution status of :doc:`core.bulk <api_methods_core.bulk>` will always be a
-        `SUCCESS` (unless an unlikely internal error occurs). Caller must check for individual call results
-        to ensure the absence of any call errors.
+        .. important::
+
+            The execution status of :doc:`core.bulk <api_methods_core.bulk>` will always be a
+            ``SUCCESS`` (unless an unlikely internal error occurs). Caller must check for individual call
+            results to ensure the absence of any call errors.
         """
         serviceobj, methodobj = self.middleware.get_method(method)
 

--- a/src/middlewared_docs/docs/jobs.rst
+++ b/src/middlewared_docs/docs/jobs.rst
@@ -121,6 +121,8 @@ Uploading / Downloading Files
 There are some jobs which require input or output as files which can
 be uploaded or downloaded.
 
+.. _downloading-files:
+
 Downloading a File
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/middlewared_docs/generate_docs.py
+++ b/src/middlewared_docs/generate_docs.py
@@ -295,8 +295,8 @@ class DocumentationGenerator:
                     # Add note about file upload for jobs with input pipes
                     result += f"*This job {modal} be used with file upload.* See :ref:`uploading-files`.\n\n"
                 if item.output_pipes:
-                    # Add note about core.download for jobs with output pipes
-                    result += f"*This job {modal} be used with* :doc:`core.download <api_methods_core.download>`.\n\n"
+                    # Add note about file download for jobs with output pipes
+                    result += f"*This job {modal} produce a file for download.* See :ref:`downloading-files`.\n\n"
 
         result += ".. raw:: html\n\n"
         result += textwrap.indent('<div id="json-schema">' + schemas_html + "</div><br><br>", " " * 4) + "\n\n"


### PR DESCRIPTION
## Summary

Fix docutils errors and poor RST rendering on several API docs pages, and document conventions for public method docstrings in CLAUDE.md.

This PR does NOT represent a sweep of every public method docstring for formatting improvements. Its primary aim is to fix all docutils errors, format JSON embedded in descriptions, and fix other improper RST formatting. Other improvements like RST admonitions are limited in scope to these methods.

## Motivation

Public method docstrings are rendered into the API reference documentation. They need to be written with the generated docs and general API consumers in mind rather than developer comfort. We should move away from mixing styles: Google/NumPy-style `Args:`/`Returns:`/`Raises:` sections (which don't render well and duplicate the field descriptions already defined in the API models), Python-style example code (instead of the JSON-RPC the API client actually sends), bare `` `method.name` `` mentions that don't link, and plain-text `WARNING:`/`NOTE:` callouts.

Docstrings outside of public methods do not need to be subject to this strictness.

## Conventions followed

- **RST, not Google/NumPy.** Removed `Args:`, `Returns:`, `Parameters`, and `Raises:` sections from public method docstrings. Parameter and return descriptions live in the API models (`Field(description=...)`), not the method docstring, so they are no longer duplicated. Where a `Raises:` block conveyed real behavior, it was rewritten as RST prose describing the error response.
- **Doc references.** Convert mentions of other API methods (or the method itself) to `:doc:` references, e.g. `` :doc:`core.bulk <api_methods_core.bulk>` ``, so it links in the rendered docs. API versions that lack the linked method display only plaintext and generate a `ref.doc` warning (acceptable).
- **JSON-RPC examples.** Convert example code to JSON-RPC as passed by the API client (`true`/`false`, `.. code:: json` blocks), not Python (`True`/`False`, `call(...)`).
- **Admonitions.** Plain-text callouts were promoted to proper RST directives: `.. warning::` (destructive rollback), `.. important::` (`core.bulk` always reports `SUCCESS`), and `.. note::` (`zfs.resource.destroy` safety notes).

## CLAUDE.md updates

Added docstring conventions to a new "Method Docstrings" subsection. Made room by condensing long-winded logging guidance.

## Example

One of the worst offenders before this PR:

<img width="939" height="628" alt="image" src="https://github.com/user-attachments/assets/4ba489ca-2192-44d2-bf4e-b91a80a94a2c" />

and after this PR:

<img width="918" height="750" alt="image" src="https://github.com/user-attachments/assets/041edda9-6f1b-4925-b394-626803c2d203" />
