### PR TITLE
NAS-141208 / 26.0.0-RC.1 / don't process IPv6 RAs when autoconfigure is disabled (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/addresses.py
+++ b/src/middlewared/middlewared/plugins/interface/addresses.py
@@ -167,15 +167,25 @@ def configure_addresses_impl(
                 broadcast=addr.broadcast,
             )
 
-    # Configure IPv6 autoconf
+    # Configure IPv6 autoconf / Router Advertisement handling.
+    #
+    # autoconf alone only controls SLAAC *address* creation; accept_ra must be
+    # cleared too, otherwise the kernel keeps processing RAs and installs
+    # routes on interfaces with "Autoconfigure IPv6" disabled (NAS-141208).
+    # Use accept_ra=2 (not 1) so RAs are still honoured when IPv6 forwarding is
+    # enabled (e.g. by Docker / VMs).
     has_ipv6 = (
         data["int_version"] == 6
         or data["int_ipv6auto"]
         or any(alias["alias_version"] == 6 for alias in aliases)
     )
     autoconf = "1" if has_ipv6 else "0"
+    accept_ra = "2" if has_ipv6 else "0"
     ctx.middleware.call_sync(
         "tunable.set_sysctl", f"net.ipv6.conf.{name}.autoconf", autoconf
+    )
+    ctx.middleware.call_sync(
+        "tunable.set_sysctl", f"net.ipv6.conf.{name}.accept_ra", accept_ra
     )
 
     # Add addresses in database but not configured. Iterate the dict in

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -18,11 +18,9 @@ class DockerService(SimpleService):
     async def before_start(self):
         await self.middleware.call('docker.state.set_status', Status.INITIALIZING.value)
         await self.middleware.call('docker.state.before_start_check')
-        physical_ifaces = await self.middleware.call('interface.query', [['type', '=', 'PHYSICAL']])
         for key, value in (
             ('vm.panic_on_oom', 0),
             ('vm.overcommit_memory', 1),
-            *[(f'net.ipv6.conf.{i["name"]}.accept_ra', 2) for i in physical_ifaces],
         ):
             await self.middleware.call('sysctl.set_value', key, value)
 


### PR DESCRIPTION
Disabling "Autoconfigure IPv6" on an interface only set net.ipv6.conf.<if>.autoconf=0, which stops SLAAC address assignment but not the kernel's processing of Router Advertisements. As a result, RA-derived routes (including an IPv6 default route) were still installed on interfaces that had autoconf disabled. The accept_ra sysctl that actually controls this was never managed alongside autoconf, and docker made it worse by force-setting accept_ra=2 on every physical interface. This sets accept_ra in lockstep with autoconf during interface sync (2 when IPv6 autoconf is enabled, so RAs are still honored once docker enables ipv6 forwarding, and 0 when disabled) and removes docker's blanket override so the per-interface value sticks.

Original PR: https://github.com/truenas/middleware/pull/19150
