### PR TITLE
NAS-141437 / 26.0.0-RC.1 / Ensure oath users file entries are always valid (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -149,13 +149,17 @@ class TwoFactorAuthService(ConfigService):
                 ad_user = True
 
             if username:
+                # The OATH users file only supports 30- or 60-second TOTP steps. Coerce any
+                # other interval to 30 so a misconfigured value can't render the entry
+                # unparseable and silently drop the second factor (fail closed, not open).
+                interval = config['interval'] if config['interval'] in (30, 60) else 30
                 users.append({
                     'username': username,
                     'secret_hex': base64.b16encode(base64.b32decode(config['secret'])).decode(),
                     'row_id': config['id'],
                     'ad_user': ad_user,
                     'otp_digits': config['otp_digits'],
-                    'interval': config['interval']
+                    'interval': interval
                 })
 
         return users


### PR DESCRIPTION
If we have an invalid TOTP entry (interval not supported by liboath) then lookups will fail with OATH_UNKNOWN_USER, which is an incorrect response when we'd expect rather to have an explicit failure mode. API model / more thorough changes are tracked in NAS-141431.

Original PR: https://github.com/truenas/middleware/pull/19159
