### PR TITLE
NAS-141441 / 26.0.0-RC.1 / Fix missing 2FA account flag and re-enable STIG tests (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
+++ b/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
@@ -1,5 +1,4 @@
 import contextlib
-from datetime import datetime
 import time
 import typing
 
@@ -24,15 +23,29 @@ def get_user_secret_sid(user_sid: str, get: typing.Optional[bool] = True) -> typ
     return call('datastore.query', 'account.twofactor_user_auth', [['user_sid', '=', user_sid]], {'get': get})
 
 
-def get_2fa_totp_token(users_config: dict) -> str:
-    second = datetime.now().second
-    if second >= 55 or second < 5:
-        # We allow 5 seconds time difference between NAS and test client, and OTP expiry interval is 60 seconds.
-        # So tokens generated within 5 seconds of :00 are not safe to use
-        time.sleep(10)
+# Tracks the last TOTP token handed out per secret so the same one is never returned
+# twice: pam_oath enforces RFC 6238 one-time use and rejects a replayed token.
+_last_totp_token: dict[str, str] = {}
 
-    return pyotp.TOTP(
-        users_config['secret'],
-        interval=users_config['interval'],
-        digits=users_config['otp_digits'],
-    ).now()
+
+def get_2fa_totp_token(users_config: dict) -> str:
+    """ Return a fresh, single-use TOTP token for the given 2FA config.
+
+    pam_oath rejects a token that has already authenticated within its time step
+    (RFC 6238 one-time use), so callers that authenticate repeatedly with the same
+    secret (e.g. STIG setup/teardown) must not be handed the same token twice. Wait
+    for the next time step when the current token was already used, or is within a few
+    seconds of rolling over before the server can validate it.
+    """
+    secret = users_config['secret']
+    interval = users_config['interval']
+    totp = pyotp.TOTP(secret, interval=interval, digits=users_config['otp_digits'])
+
+    token = totp.now()
+    seconds_left = interval - (time.time() % interval)
+    if _last_totp_token.get(secret) == token or seconds_left < 5:
+        time.sleep(seconds_left + 1)
+        token = totp.now()
+
+    _last_totp_token[secret] = token
+    return token

--- a/src/middlewared/middlewared/utils/account/authenticator.py
+++ b/src/middlewared/middlewared/utils/account/authenticator.py
@@ -44,7 +44,7 @@ class AccountFlag(enum.StrEnum):
     LDAP = 'LDAP'  # account is provided by ordinary LDAP server
 
     # Flags about how authenticated
-    TWOFACTOR = '2FA'  # Account requires 2FA (NOTE: PAM currently isn't evaluating second factor)
+    TWOFACTOR = '2FA'  # Session authenticated with a second factor (OATH token)
     API_KEY = 'API_KEY'  # Account authenticated by API key
     SCRAM = 'SCRAM'
     OTPW = 'OTPW'  # Account authenticated by a single-use password
@@ -151,10 +151,6 @@ class UserPamAuthenticator(TrueNASUserPamAuthenticator):
 
         if self.state.service == TruenasPamFile.API_KEY.service:
             passwd['account_attributes'].append(AccountFlag.API_KEY)
-
-        # Compare normalized username from NSS with usernames in the /etc/users.oath file
-        if self.twofactor_user:
-            passwd['account_attributes'].append(AccountFlag.TWOFACTOR)
 
         if passwd['pw_uid'] in (0, ADMIN_UID):
             passwd['account_attributes'].append(AccountFlag.SYS_ADMIN)
@@ -316,6 +312,12 @@ class UserPamAuthenticator(TrueNASUserPamAuthenticator):
 
         resp = self.auth_continue([twofactor_token])
         if resp.code == PAMCode.PAM_SUCCESS:
+            assert resp.user_info is not None
+            # The second factor has now been verified for this session. Record it in the account
+            # flags here (rather than in _get_user_obj) because whether a second factor applies is
+            # only known after the PAM conversation has prompted for and accepted the OATH token.
+            self.passwd['account_attributes'].append(AccountFlag.TWOFACTOR)
+
             # Grab fresh copy since account flags may have changed due to OTPW login
             pw = self.truenas_user_obj
             assert pw['pw_name'] == resp.user_info['pw_name']

--- a/src/middlewared/middlewared/utils/auth.py
+++ b/src/middlewared/middlewared/utils/auth.py
@@ -116,10 +116,14 @@ AA_LEVEL1 = AuthenticatorAssuranceLevel(
 # Per these guidelines, our TOKEN_PLAIN and API_KEY_PLAIN provide insufficient replay resistance,
 # which is in addition to the replay-resistant nature of encrypted transport, and are therefore
 # unsuitable for this authentication level.
+#
+# SCRAM is likewise unsuitable here: although it is replay resistant, it authenticates through the
+# API key PAM stack which has no OATH plumbing, so a SCRAM exchange cannot prompt for the second
+# factor that this level mandates (otp_mandatory) and would otherwise grant single-factor access.
 AA_LEVEL2 = AuthenticatorAssuranceLevel(
     max_session_age=12 * 60 * 60,
     max_inactivity=30 * 60,
-    mechanisms=(AuthMech.PASSWORD_PLAIN, AuthMech.SCRAM),
+    mechanisms=(AuthMech.PASSWORD_PLAIN,),
     otp_mandatory=True,
     min_fail_delay=4
 )

--- a/tests/api2/test_authenticator_assurance_level.py
+++ b/tests/api2/test_authenticator_assurance_level.py
@@ -33,7 +33,7 @@ def sharing_admin_user(unprivileged_user_fixture):
 
 @pytest.mark.parametrize('level,expected', [
     ('LEVEL_1', ['API_KEY_PLAIN', 'TOKEN_PLAIN', 'PASSWORD_PLAIN', 'SCRAM']),
-    ('LEVEL_2', ['PASSWORD_PLAIN', 'SCRAM']),
+    ('LEVEL_2', ['PASSWORD_PLAIN']),
 ])
 def test_mechanism_choices(level, expected):
     with authenticator_assurance_level(level):
@@ -55,6 +55,23 @@ def test_level2_api_key_plain():
                     })
 
                 assert ce.value.errno == errno.EOPNOTSUPP
+
+
+def test_level2_scram():
+    """ SCRAM authenticates through the OATH-less API key PAM stack and so cannot
+    satisfy the mandatory second factor required at this level. It must therefore be
+    rejected with EOPNOTSUPP before any SCRAM exchange takes place.
+    """
+    with authenticator_assurance_level('LEVEL_2'):
+        with client(auth=None) as c:
+            with pytest.raises(CallError) as ce:
+                c.call('auth.login_ex', {
+                    'mechanism': 'SCRAM',
+                    'scram_type': 'CLIENT_FIRST_MESSAGE',
+                    'rfc_str': 'n,,n=root,r=fyko+d2lbbFgONRv9qkxdawL',
+                })
+
+            assert ce.value.errno == errno.EOPNOTSUPP
 
 
 def test_level2_password_plain_no_twofactor():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,5 +71,6 @@ def module_stig_enabled():
 
 @pytest.fixture(autouse=True)
 def init_test_environment():
-    truenas_server.client.call("test.init")
+    if not STIG_ENABLED:
+        truenas_server.client.call("test.init")
     yield

--- a/tests/stig/conftest.py
+++ b/tests/stig/conftest.py
@@ -153,8 +153,5 @@ def setup_server_single():
 
 
 def pytest_sessionstart(session):
-    # The entire STIG test module is currently disabled (every test in this
-    # directory is marked skipped), so skip the server setup that would
-    # otherwise run before collection. The setup helpers above are kept intact
-    # so the suite can be re-enabled by removing the skip markers and this guard.
-    return
+    setup_fn = setup_server_ha if ha else setup_server_single
+    setup_fn()

--- a/tests/stig/test_01_stig.py
+++ b/tests/stig/test_01_stig.py
@@ -8,12 +8,9 @@ from middlewared.test.integration.assets.two_factor_auth import (
     enabled_twofactor_auth, get_user_secret, get_2fa_totp_token
 )
 from middlewared.test.integration.utils import busy_wait_on_job, call, client, mock, password
-from truenas_api_client import ValidationErrors
+from truenas_api_client import ClientException, ValidationErrors
 
 from auto_config import ha
-
-# The entire STIG test module is currently disabled.
-pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
 
 # Alias
 pp = pytest.param
@@ -70,7 +67,14 @@ def root_non_stig_client():
 def clear_ratelimit(root_non_stig_client):
     # We need to use non stig client here because we cannot make private endpoint
     # calls when STIG is active.
-    root_non_stig_client.call('rate.limit.cache_clear')
+    try:
+        root_non_stig_client.call('rate.limit.cache_clear')
+    except ClientException:
+        # On HA the FIPS/STIG reboot in setup_stig severs this pre-STIG root session, and it
+        # can't be re-established under STIG (root can't satisfy AAL2, and rate.limit is a
+        # private namespace). Clearing is best-effort: the 2FA logins are spaced far enough
+        # apart (a step per login) to stay under the 20-calls/60s limit without it.
+        pass
 
 
 @pytest.fixture(scope='function')
@@ -106,7 +110,7 @@ def non_admin_w_2fa(two_factor_enabled, unprivileged_user_fixture):
     call('privilege.update', privilege[0]['id'], {'roles': ['SHARING_ADMIN']})
 
     try:
-        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 60})
+        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 30})
         user_obj_id = call('user.query', [['username', '=', unprivileged_user_fixture.username]], {'get': True})['id']
         secret = get_user_secret(user_obj_id)
         yield (unprivileged_user_fixture, secret)
@@ -121,7 +125,7 @@ def full_admin_w_2fa(two_factor_enabled, unprivileged_user_fixture):
     call('privilege.update', privilege[0]['id'], {'roles': ['FULL_ADMIN']})
 
     try:
-        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 60})
+        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 30})
         user_obj_id = call('user.query', [['username', '=', unprivileged_user_fixture.username]], {'get': True})['id']
         secret = get_user_secret(user_obj_id)
         yield (unprivileged_user_fixture, secret)
@@ -138,7 +142,7 @@ def full_admin_w_2fa_builtin_admin(two_factor_enabled, unprivileged_user_fixture
     call('group.update', builtin_admin['id'], {'users': builtin_admin['users'] + [user_obj_id]})
 
     try:
-        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 60})
+        call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 30})
         secret = get_user_secret(user_obj_id)
         yield (unprivileged_user_fixture, secret)
     finally:
@@ -185,77 +189,93 @@ def setup_stig(full_admin_w_2fa_builtin_admin, module_stig_enabled, root_non_sti
     user_obj, secret = full_admin_w_2fa_builtin_admin
     global STIG_ACTIVE
 
+    # Immutable admin accounts whose password auth gets disabled below. Captured in the
+    # outer scope so teardown_stig() can re-enable them even when setup fails before the
+    # yield. Otherwise a partial setup strands the system with no password-enabled admin
+    # and every subsequent test (and module) fails to authenticate.
+    admin_id = []
+
+    def teardown_stig():
+        # Restore default security, user and network settings (FIPS is mocked). Runs from
+        # the finally below on success and on a failed/partial setup alike, so it opens its
+        # own 2FA-authenticated sessions and tolerates STIG never having been enabled. It
+        # must finish before the product_type / set_fips_available mocks unwind, because
+        # their teardown logs in with a plain password.
+        global STIG_ACTIVE
+        with client(auth=None) as c:
+            do_stig_auth(c, user_obj, secret)
+            wait_for_failover_disabled_reasons([], call_fn=c.call)
+            unconfig_jobid = c.call('system.security.update', {
+                'enable_gpos_stig': False,
+                'min_password_age': None, 'max_password_age': None,
+                'password_complexity_ruleset': None, 'min_password_length': None,
+                'password_history_length': None
+            })
+            busy_wait_on_job(unconfig_jobid, call_fn=c.call)
+            if ha:
+                wait_for_failover_disabled_reasons(["LOC_FIPS_REBOOT_REQ"], call_fn=c.call)
+                c.call('system.reboot', 'teardown_stig: unconfigure')
+                time.sleep(10)
+
+        with client(auth=None) as c2:
+            do_stig_auth(c2, user_obj, secret)
+            if ha:
+                wait_for_failover_disabled_reasons([], call_fn=c2.call)
+            STIG_ACTIVE = False
+            # Need to turn off two-factor auth before can reenable admin password
+            c2.call('auth.twofactor.update', {'enabled': False, 'window': 0, 'services': {'ssh': False}})
+            for id in admin_id:
+                c2.call('user.update', id, {"password_disabled": False})
+            c2.call('network.configuration.update', {"activity": {"type": "DENY", "activities": []}})
+
     with product_type('ENTERPRISE'):
         with set_fips_available(True):
-            with client(auth=None) as c:
-                # Do two-factor authentication before enabling STIG support
-                do_stig_auth(c, user_obj, secret)
+            try:
+                with client(auth=None) as c:
+                    # Do two-factor authentication before enabling STIG support
+                    do_stig_auth(c, user_obj, secret)
 
-                # Disable password authentication for immutable admin accounts
-                admin_id = get_excluded_admins()
-                for id in admin_id:
-                    c.call('user.update', id, {"password_disabled": True})
+                    # Disable password authentication for immutable admin accounts
+                    admin_id = get_excluded_admins()
+                    for id in admin_id:
+                        c.call('user.update', id, {"password_disabled": True})
 
-                config_jobid = c.call('system.security.update', {'enable_fips': True, 'enable_gpos_stig': True})
-                busy_wait_on_job(config_jobid, call_fn=c.call)
-                STIG_ACTIVE = True
-                if ha:
-                    wait_for_failover_disabled_reasons(["LOC_FIPS_REBOOT_REQ"], call_fn=c.call)
-                    c.call('system.reboot', 'setup_stig: configure')
-                    time.sleep(10)
+                    config_jobid = c.call('system.security.update', {'enable_fips': True, 'enable_gpos_stig': True})
+                    busy_wait_on_job(config_jobid, call_fn=c.call)
+                    STIG_ACTIVE = True
+                    if ha:
+                        wait_for_failover_disabled_reasons(["LOC_FIPS_REBOOT_REQ"], call_fn=c.call)
+                        c.call('system.reboot', 'setup_stig: configure')
+                        time.sleep(10)
 
-            # We may have rebooted both controllers at this point.
-            # Need to create a new client, so we can see the nodes
-            # stabilize.
-            with client(auth=None) as c:
-                do_stig_auth(c, user_obj, secret)
-                # We can no longer call private APIs
-                if ha:
-                    wait_for_failover_disabled_reasons([], call_fn=c.call)
+                # We may have rebooted both controllers at this point.
+                # Need to create a new client, so we can see the nodes
+                # stabilize.
+                with client(auth=None) as c:
+                    do_stig_auth(c, user_obj, secret)
+                    # We can no longer call private APIs
+                    if ha:
+                        wait_for_failover_disabled_reasons([], call_fn=c.call)
 
-                # Since auth.get_authenticator_assurance_level is private,
-                # we cannot call it now.
-                #   aal = c.call('auth.get_authenticator_assurance_level')
-                #   assert aal == 'LEVEL_2'
-                # Instead, we can call auth.mechanism_choices and check that only
-                # "PASSWORD_PLAIN" is there
-                choices = c.call('auth.mechanism_choices')
-                assert len(choices) == 1, choices
-                assert choices[0] == "PASSWORD_PLAIN", choices
-                aal = 'LEVEL_2'
+                    # Since auth.get_authenticator_assurance_level is private,
+                    # we cannot call it now.
+                    #   aal = c.call('auth.get_authenticator_assurance_level')
+                    #   assert aal == 'LEVEL_2'
+                    # Instead, we can call auth.mechanism_choices and check that only
+                    # "PASSWORD_PLAIN" is there
+                    choices = c.call('auth.mechanism_choices')
+                    assert len(choices) == 1, choices
+                    assert choices[0] == "PASSWORD_PLAIN", choices
+                    aal = 'LEVEL_2'
 
-                try:
                     yield {
                         'connection': c,
                         'user_obj': user_obj,
                         'secret': secret,
                         'aal': aal
                     }
-                finally:
-                    # Restore default security, user and network settings
-                    # FIPS is mocked
-                    wait_for_failover_disabled_reasons([], call_fn=c.call)
-                    unconfig_jobid = c.call('system.security.update', {
-                        'enable_gpos_stig': False,
-                        'min_password_age': None, 'max_password_age': None,
-                        'password_complexity_ruleset': None, 'min_password_length': None,
-                        'password_history_length': None
-                    })
-                    busy_wait_on_job(unconfig_jobid, call_fn=c.call)
-                    if ha:
-                        wait_for_failover_disabled_reasons(["LOC_FIPS_REBOOT_REQ"], call_fn=c.call)
-                        c.call('system.reboot', 'teardown_stig: unconfigure')
-                        time.sleep(10)
-                    with client(auth=None) as c2:
-                        do_stig_auth(c2, user_obj, secret)
-                        if ha:
-                            wait_for_failover_disabled_reasons([], call_fn=c2.call)
-                        STIG_ACTIVE = False
-                        # Need to turn off two-factor auth before can reenable admin password
-                        c2.call('auth.twofactor.update', {'enabled': False, 'window': 0, 'services': {'ssh': False}})
-                        for id in admin_id:
-                            c2.call('user.update', id, {"password_disabled": False})
-                        c2.call('network.configuration.update', {"activity": {"type": "DENY", "activities": []}})
+            finally:
+                teardown_stig()
 
 
 # The order of the following tests is significant. We gradually add fixtures that have module scope

--- a/tests/stig/test_02_openssl.py
+++ b/tests/stig/test_02_openssl.py
@@ -4,8 +4,6 @@ import time
 from middlewared.test.integration.utils import call, ssh
 from auto_config import ha
 
-# The entire STIG test module is currently disabled.
-pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
 
 retry = 5
 fips_version = "3.1.2"

--- a/tests/stig/test_03_stig_auditing.py
+++ b/tests/stig/test_03_stig_auditing.py
@@ -18,8 +18,14 @@ from middlewared.test.integration.utils import call, ssh
 from os.path import dirname, join as path_join
 from time import sleep
 
-# The entire STIG test module is currently disabled.
-pytestmark = pytest.mark.skip(reason='STIG test suite is disabled')
+# These end-to-end tests require the auditd daemon to be running and writing
+# /var/log/audit/audit.log (ausearch reads it). That daemon's lifecycle is managed
+# outside middleware (Debian auditd.service + tnaudit.service from the
+# truenas/audit_rules repo), so they are deferred until that dependency is confirmed
+# in the STIG CI environment rather than re-enabled with the rest of the suite.
+pytestmark = pytest.mark.skip(
+    reason='Requires a running auditd daemon (managed outside middleware); deferred'
+)
 
 # Alias
 pp = pytest.param


### PR DESCRIPTION
AccountFlag.TWOFACTOR was set in _get_user_obj() based on self.twofactor_user, which only becomes true after the PAM OATH conversation runs -- i.e. it was always false at that point. As a result 2FA web sessions never carried the '2FA' flag and validate_stig() rejected every credential, blocking STIG enablement. This is why the suite had been failing for months.

Set TWOFACTOR in authenticate_oath() on success instead, where the second factor has actually been verified, mirroring how OTPW is recorded. Drop the now-dead check from _get_user_obj().

Re-enable tests/stig test_01 and test_02 and restore the conftest server setup. test_03 stays skipped.

Original PR: https://github.com/truenas/middleware/pull/19151
