### PR TITLE
NAS-141493 / 27.0.0-BETA.1 / Annotate supported_archs to fix mypy inference with VMGuestArch keys

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/capabilities.py
+++ b/src/middlewared/middlewared/plugins/vm/capabilities.py
@@ -10,7 +10,7 @@ RE_MACHINE_TYPE_CHOICES = re.compile(r'^\s*(?!none\s)(\S+)(?=\s{2,})', flags=re.
 
 
 def get_capabilities(context: ServiceContext) -> dict[str, list[str]]:
-    supported_archs = {}
+    supported_archs: dict[str, list[str]] = {}
 
     cp = subprocess.run(['/usr/bin/qemu-system-x86_64', '-machine', 'help'], capture_output=True, text=True)
     if cp.returncode:


### PR DESCRIPTION
This was introduced (during address review, of course) in PR #19167

There is another `mypy` error that should revolve when changes to `truenas_pylibvirt` propagate.