### PR TITLE
NAS-141431 / 26.0.0-RC.1 / Restrict TOTP interval to supported values

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-06-19_00-00_restrict_totp_interval.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-06-19_00-00_restrict_totp_interval.py
@@ -1,0 +1,64 @@
+"""Restrict per-user TOTP interval to liboath-supported values (30/60)
+
+Revision ID: b3f0a9c41d7e
+Revises: 7d3a1f9c2e84
+Create Date: 2026-06-19 00:00:00.000000+00:00
+
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = "b3f0a9c41d7e"
+down_revision = "7d3a1f9c2e84"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # liboath's usersfile parser only accepts HOTP/T30 and HOTP/T60 time-steps. An interval
+    # other than 30 or 60 renders the user's /etc/users.oath entry unparseable, so the user
+    # looks unknown to pam_oath and 2FA breaks. The API historically allowed any interval >= 5,
+    # so stray rows may exist. Clear the secret and normalize the interval for those rows; the
+    # affected users must re-enroll 2FA via user.renew_2fa_secret.
+    for row in conn.execute(
+        text(
+            "SELECT t.id, b.bsdusr_username, t.interval FROM account_twofactor_user_auth t "
+            "JOIN account_bsdusers b ON b.id = t.user_id WHERE t.interval NOT IN (30, 60)"
+        )
+    ).fetchall():
+        logger.warning(
+            "Clearing unsupported TOTP interval %r for local user %r (row %r); user must re-enroll 2FA.",
+            row[2],
+            row[1],
+            row[0],
+        )
+
+    for row in conn.execute(
+        text(
+            "SELECT id, user_sid, interval FROM account_twofactor_user_auth "
+            "WHERE interval NOT IN (30, 60) AND user_id IS NULL AND user_sid IS NOT NULL"
+        )
+    ).fetchall():
+        logger.warning(
+            "Clearing unsupported TOTP interval %r for directory user SID %r (row %r); user must re-enroll 2FA.",
+            row[2],
+            row[1],
+            row[0],
+        )
+
+    conn.execute(
+        text("UPDATE account_twofactor_user_auth SET secret = NULL, interval = 30 WHERE interval NOT IN (30, 60)")
+    )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v26_0_0/user.py
+++ b/src/middlewared/middlewared/api/v26_0_0/user.py
@@ -473,9 +473,11 @@ class UserUnset2faSecretResult(BaseModel):
 
 class TwofactorOptions(BaseModel, metaclass=ForUpdateMetaclass):
     otp_digits: int = Field(ge=6, le=8, description="Represents number of allowed digits in the OTP.")
-    interval: int = Field(
-        ge=5,
-        description="Time duration in seconds specifying OTP expiration time from its creation time.",
+    interval: Literal[30, 60] = Field(
+        description=(
+            "Time duration in seconds specifying OTP expiration time from its creation time. "
+            "Only 30 or 60 are supported."
+        ),
     )
 
 

--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -149,17 +149,13 @@ class TwoFactorAuthService(ConfigService):
                 ad_user = True
 
             if username:
-                # The OATH users file only supports 30- or 60-second TOTP steps. Coerce any
-                # other interval to 30 so a misconfigured value can't render the entry
-                # unparseable and silently drop the second factor (fail closed, not open).
-                interval = config['interval'] if config['interval'] in (30, 60) else 30
                 users.append({
                     'username': username,
                     'secret_hex': base64.b16encode(base64.b32decode(config['secret'])).decode(),
                     'row_id': config['id'],
                     'ad_user': ad_user,
                     'otp_digits': config['otp_digits'],
-                    'interval': interval
+                    'interval': config['interval']
                 })
 
         return users

--- a/tests/api2/test_twofactor_auth.py
+++ b/tests/api2/test_twofactor_auth.py
@@ -4,7 +4,7 @@ import errno
 
 import pytest
 
-from middlewared.service_exception import CallError
+from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.test.integration.assets.account import user as user_create
 from middlewared.test.integration.assets.directory_service import directoryservice
 from middlewared.test.integration.assets.two_factor_auth import (
@@ -23,7 +23,7 @@ TEST_GID = 544
 TEST_TWOFACTOR_INTERVAL = {'interval': 60}
 USERS_2FA_CONF = {
     TEST_USERNAME: {'interval': 30, 'otp_digits': 6},
-    TEST_USERNAME_2: {'interval': 40, 'otp_digits': 7}
+    TEST_USERNAME_2: {'interval': 60, 'otp_digits': 7}
 }
 
 
@@ -97,7 +97,7 @@ def test_login_without_2fa(clear_ratelimit):
 @pytest.mark.parametrize("user_name,password,renew_options", [
     ('test_user1', 'test_password1', {'interval': 30, 'otp_digits': 6}),
     ('test_user2', 'test_password2', {'interval': 60, 'otp_digits': 7}),
-    ('test_user3', 'test_password3', {'interval': 50, 'otp_digits': 8}),
+    ('test_user3', 'test_password3', {'interval': 30, 'otp_digits': 8}),
 ])
 def test_secret_generation_for_user(user_name, password, renew_options, clear_ratelimit):
     with user({
@@ -114,6 +114,19 @@ def test_secret_generation_for_user(user_name, password, renew_options, clear_ra
         assert user_secret_obj['secret'] is not None
         for k in ('interval', 'otp_digits'):
             assert user_secret_obj[k] == renew_options[k]
+
+
+@pytest.mark.parametrize("bad_interval", [5, 15, 40, 45, 50, 90, 120])
+def test_renew_2fa_secret_rejects_unsupported_interval(bad_interval, clear_ratelimit):
+    with user({
+        'username': TEST_USERNAME,
+        'password': TEST_PASSWORD,
+        'full_name': TEST_USERNAME,
+    }) as user_obj:
+        with pytest.raises(ValidationErrors):
+            call('user.renew_2fa_secret', user_obj['username'], {'interval': bad_interval, 'otp_digits': 6})
+
+        assert get_user_secret(user_obj['id'])['secret'] is None
 
 
 def test_secret_generation_for_multiple_users(clear_ratelimit):


### PR DESCRIPTION
This commit adds changes to restrict the per-user two-factor TOTP interval to 30 or 60 seconds, since the OATH users file consumed by pam_oath only understands those time-steps and any other value silently breaks 2FA for the user. A migration clears the secret and resets the interval for existing rows holding an unsupported value so affected users re-enroll, and the render-time coercion is dropped now that the input is validated at the API.