### PR TITLE
NAS-141387 / 27.0.0-BETA.1 / Consolidate license feature checks into truenas.license.feature_available

### DIFF
--- a/src/middlewared/middlewared/plugins/container/info.py
+++ b/src/middlewared/middlewared/plugins/container/info.py
@@ -1,6 +1,5 @@
-from truenas_pydmi.models import TRUENAS_UNKNOWN
-
 from middlewared.api.current import ZFSResourceQuery
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.plugins.zfs.utils import get_encryption_info
 from middlewared.service import ServiceContext
 from middlewared.utils import BOOT_POOL_NAME_VALID
@@ -12,13 +11,10 @@ async def license_active(context: ServiceContext) -> bool:
     If this is iX enterprise hardware and has NOT been licensed to run containers
     then this will return False, otherwise this will return true.
     """
-    system_chassis = await context.call2(context.s.truenas.get_chassis_hardware)
-    if system_chassis == TRUENAS_UNKNOWN or 'MINI' in system_chassis:
-        # 1. if it's not iX branded hardware
-        # 2. OR if it's a MINI, then allow containers/vms
-        return True
-
-    return await context.middleware.call('system.feature_enabled', 'APPS')  # type: ignore[no-any-return]
+    available: bool = await context.middleware.call(
+        'truenas.license.feature_available', 'APPS', FeaturePolicy.IX_HARDWARE
+    )
+    return available
 
 
 async def pool_choices(context: ServiceContext) -> dict[str, str]:

--- a/src/middlewared/middlewared/plugins/docker/service_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/service_utils.py
@@ -1,12 +1,12 @@
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.service import ServiceContext
 
 
 async def license_active(context: ServiceContext) -> bool:
-    can_run_apps = True
-    if await context.middleware.call('system.is_ha_capable'):
-        can_run_apps = await context.middleware.call('system.feature_enabled', 'APPS')
-
-    return can_run_apps
+    available: bool = await context.middleware.call(
+        'truenas.license.feature_available', 'APPS', FeaturePolicy.HA_APPLIANCE
+    )
+    return available
 
 
 async def restart_docker_service(context: ServiceContext) -> None:

--- a/src/middlewared/middlewared/plugins/fc/fc.py
+++ b/src/middlewared/middlewared/plugins/fc/fc.py
@@ -6,6 +6,7 @@ import subprocess
 
 from middlewared.api import api_method
 from middlewared.api.current import FCCapableArgs, FCCapableResult
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.service import Service, filterable_api_method, private
 from middlewared.service_exception import CallError
 from middlewared.utils.filter_list import filter_list
@@ -34,10 +35,11 @@ class FCService(Service):
         Returns ``true`` if the system is licensed for FIBRECHANNEL and contains
         one or more Fibre Channel cards. ``false`` otherwise.
         """
-        if await self.middleware.call('system.is_enterprise'):
-            if await self.middleware.call('system.feature_enabled', 'FIBRECHANNEL'):
-                if await self.middleware.call('fc.hba_present'):
-                    return True
+        if await self.middleware.call(
+            'truenas.license.feature_available', 'FIBRECHANNEL', FeaturePolicy.ENTERPRISE
+        ):
+            if await self.middleware.call('fc.hba_present'):
+                return True
         return False
 
     @private

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -22,6 +22,7 @@ from middlewared.api.current import (
     iSCSITargetValidateNameArgs,
     iSCSITargetValidateNameResult,
 )
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import UnexpectedFailure, run
@@ -220,7 +221,7 @@ class iSCSITargetService(CRUDService):
 
         if (
             data['mode'] != 'ISCSI' and
-            not await self.middleware.call('system.feature_enabled', 'FIBRECHANNEL')
+            not await self.middleware.call('truenas.license.feature_available', 'FIBRECHANNEL', FeaturePolicy.ANY)
         ):
             verrors.add(f'{schema_name}.mode', 'Fibre Channel not enabled')
 

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -30,6 +30,7 @@ from middlewared.api.current import (
 )
 from middlewared.pipe import InputPipes, Pipes
 from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.service import CallError, ConfigService, ValidationErrors, job
 import middlewared.sqlalchemy as sa
 from middlewared.utils import sw_version
@@ -115,10 +116,9 @@ class SupportService(ConfigService):
         if await self.middleware.call('system.vendor.name'):
             return False
 
-        if not await self.middleware.call('system.is_enterprise'):
-            return False
-
-        return await self.middleware.call('system.feature_enabled', 'SUPPORT')
+        return await self.middleware.call(
+            'truenas.license.feature_available', 'SUPPORT', FeaturePolicy.ENTERPRISE
+        )
 
     @api_method(SupportIsAvailableAndEnabledArgs, SupportIsAvailableAndEnabledResult, roles=['SUPPORT_READ'])
     async def is_available_and_enabled(self):

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -6,8 +6,6 @@
 from datetime import date
 from types import MappingProxyType
 
-import truenas_pylicensed
-
 from middlewared.api import api_method
 from middlewared.api.current import (
     SystemFeatureEnabledArgs,
@@ -71,8 +69,8 @@ class SystemService(Service):
         )
 
     @private
-    def sed_enabled(self):
-        return truenas_pylicensed.is_feature_licensed("SED")
+    async def sed_enabled(self):
+        return await self.call2(self.s.truenas.license.feature_available, "SED")
 
     @api_method(
         SystemVersionShortArgs,
@@ -176,11 +174,7 @@ class SystemService(Service):
         """
         Returns whether the `feature` is enabled or not
         """
-        info = await self.call2(self.s.truenas.license.info_private)
-        if info is not None:
-            return any(f.name == name for f in info.features)
-
-        return False
+        return await self.call2(self.s.truenas.license.feature_available, name)
 
 
 async def hook_license_update(middleware, had_license, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -1,8 +1,10 @@
 import contextlib
 from dataclasses import asdict
+from datetime import date
 import os
 from typing import Any
 
+from truenas_pydmi.models import TRUENAS_UNKNOWN
 from truenas_pylicensed import LicenseError, LicenseType, verify
 
 from middlewared.api import api_method
@@ -21,6 +23,7 @@ from middlewared.service import Service, ValidationError, private
 
 from .license_legacy_utils import LEGACY_LICENSE_FILE, get_legacy_license_info
 from .license_utils import (
+    FeaturePolicy,
     LicenseInfo,
     configure_ha_license,
     get_fingerprint_b64,
@@ -117,3 +120,46 @@ class TrueNASLicenseService(Service):
             return get_legacy_license_info()
 
         return get_license_info(license_status)
+
+    @private
+    async def feature_available(self, name: str, policy: FeaturePolicy = FeaturePolicy.ANY) -> bool:
+        """Single source of truth for "is this system licensed to use ``name``".
+
+        The license is consulted only when the policy's gate is active; on hardware
+        where the feature is unrestricted the license is not consulted at all.
+        """
+        match policy:
+            case FeaturePolicy.ANY:
+                return await self.feature_licensed(name)
+            case FeaturePolicy.ENTERPRISE:
+                # enterprise add-on: not consulted on community systems
+                if not await self.middleware.call("system.is_enterprise"):
+                    return False
+                return await self.feature_licensed(name)
+            case FeaturePolicy.HA_APPLIANCE:
+                # enforced only on HA-capable appliances; everywhere else the feature
+                # runs unrestricted and the license is not consulted
+                if not await self.middleware.call("system.is_ha_capable"):
+                    return True
+                return await self.feature_licensed(name)
+            case FeaturePolicy.IX_HARDWARE:
+                # enforced only on iX-branded non-MINI hardware
+                chassis = await self.middleware.call("truenas.get_chassis_hardware")
+                if chassis == TRUENAS_UNKNOWN or "MINI" in chassis:
+                    return True
+                return await self.feature_licensed(name)
+            case _:
+                raise ValueError(f"Unknown feature policy: {policy!r}")
+
+    @private
+    async def feature_licensed(self, name: str) -> bool:
+        """Whether ``name`` is present in the (legacy-aware) license and not expired."""
+        info = await self.middleware.call("truenas.license.info_private")
+        if info is None:
+            return False
+
+        today = date.today()
+        return any(
+            f.name == name and (f.expires_at is None or today <= f.expires_at)
+            for f in info.features
+        )

--- a/src/middlewared/middlewared/plugins/truenas/license_legacy_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas/license_legacy_utils.py
@@ -67,7 +67,14 @@ def parse_legacy_license(text: str) -> LicenseInfo:
         model=lic.model or None,
         expires_at=lic.contract_end,
         features=[
-            FeatureInfo(name=name, start_date=lic.contract_start, expires_at=lic.contract_end)
+            # Legacy licenses grant their feature bits perpetually; contract_end is only the
+            # support-contract end (the system stays fully functional after it lapses). So bought
+            # features never expire, and only SUPPORT (proactive support) is tied to contract_end.
+            FeatureInfo(
+                name=name,
+                start_date=lic.contract_start,
+                expires_at=lic.contract_end if name == "SUPPORT" else None,
+            )
             for name in feature_names
         ],
         serials=serials,

--- a/src/middlewared/middlewared/plugins/truenas/license_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas/license_utils.py
@@ -4,6 +4,7 @@ import base64
 import contextlib
 from dataclasses import dataclass
 from datetime import date
+import enum
 import json
 import logging
 import os
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = (
     "LICENSE_FILE",
+    "FeaturePolicy",
     "FeatureInfo",
     "LicenseInfo",
     "upload_license",
@@ -30,6 +32,23 @@ __all__ = (
     "get_fingerprint_b64",
     "configure_ha_license",
 )
+
+
+class FeaturePolicy(enum.StrEnum):
+    """How a license feature's availability is gated.
+
+    The license is consulted only when the policy's gate is active; on hardware
+    where the feature is unrestricted the license is not consulted at all.
+    """
+
+    ANY = "any"
+    """Feature must be licensed."""
+    ENTERPRISE = "enterprise"
+    """System must be enterprise AND the feature licensed."""
+    HA_APPLIANCE = "ha_appliance"
+    """License enforced only on HA-capable appliances; freely available otherwise."""
+    IX_HARDWARE = "ix_hardware"
+    """License enforced only on iX-branded (non-MINI) hardware; freely available otherwise."""
 
 
 def get_fingerprint_b64() -> str:

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -19,6 +19,7 @@ from middlewared.api.current import (
     VMPortWizard,
     VMVirtualizationDetails,
 )
+from middlewared.plugins.truenas.license_utils import FeaturePolicy
 from middlewared.service import ServiceContext
 from middlewared.utils.cpu import cpu_info
 from middlewared.utils.libvirt.display import DisplayDelegate
@@ -90,11 +91,10 @@ def log_file_download(context: ServiceContext, job: Job, vm_id: int) -> None:
 
 
 async def license_active(context: ServiceContext) -> bool:
-    can_run_vms = True
-    if await context.middleware.call('system.is_ha_capable'):
-        can_run_vms = await context.middleware.call('system.feature_enabled', 'VMS')
-
-    return can_run_vms
+    available: bool = await context.middleware.call(
+        'truenas.license.feature_available', 'VMS', FeaturePolicy.HA_APPLIANCE
+    )
+    return available
 
 
 def virtualization_details() -> VMVirtualizationDetails:

--- a/src/middlewared/middlewared/pytest/unit/middleware.py
+++ b/src/middlewared/middlewared/pytest/unit/middleware.py
@@ -10,6 +10,7 @@ class Middleware(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self['failover.licensed'] = AsyncMock(return_value=False)
+        self['truenas.license.feature_available'] = AsyncMock(return_value=True)
 
         self.call_hook = AsyncMock()
         self.call_hook_inline = Mock()

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
@@ -1,13 +1,10 @@
-import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from middlewared.api.current import VMCreate, VMFlags
-from middlewared.plugins.vm.info import license_active
 from middlewared.pytest.unit.helpers import load_compound_service
 from middlewared.pytest.unit.middleware import Middleware
-from middlewared.service.context import ServiceContext
 from middlewared.service_exception import ValidationErrors
 
 VMService = load_compound_service('vm')
@@ -43,21 +40,6 @@ VM_PAYLOAD = {
 VM_FLAGS = VMFlags(intel_vmx=True, unrestricted_guest=True, amd_rvi=False, amd_asids=False)
 
 
-@pytest.mark.parametrize('ha_capable,feature_enabled,should_work', [
-    (True, False, False),
-    (True, True, True),
-    (False, False, True),
-])
-@pytest.mark.asyncio
-async def test_vm_license_active_response(ha_capable, feature_enabled, should_work):
-    m = Middleware()
-    m['system.is_ha_capable'] = lambda *args: ha_capable
-    m['system.feature_enabled'] = lambda *args: feature_enabled
-
-    context = ServiceContext(m, logging.getLogger('test'))
-    assert await license_active(context) is should_work
-
-
 @pytest.mark.parametrize('is_licensed', [True, False])
 @pytest.mark.asyncio
 async def test_vm_creation_for_licensed_and_unlicensed_systems(is_licensed):
@@ -65,7 +47,7 @@ async def test_vm_creation_for_licensed_and_unlicensed_systems(is_licensed):
     vm_svc = VMService(m)
 
     m['system.is_ha_capable'] = lambda *args: True
-    m['system.feature_enabled'] = lambda *args: is_licensed
+    m['truenas.license.feature_available'] = lambda *args: is_licensed
     m['datastore.query'] = lambda *args, **kwargs: []
 
     with patch('middlewared.plugins.vm.crud.vm_flags', new=MagicMock(return_value=VM_FLAGS)):

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_feature_available.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_feature_available.py
@@ -1,0 +1,310 @@
+from datetime import date
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from truenas_pydmi.models import TRUENAS_UNKNOWN
+from truenas_pylicensed import LicenseType
+
+from middlewared.plugins.container.info import license_active as container_license_active
+from middlewared.plugins.docker.service_utils import license_active as docker_license_active
+from middlewared.plugins.fc.fc import FCService
+from middlewared.plugins.iscsi_.targets import iSCSITargetService
+from middlewared.plugins.support import SupportService
+from middlewared.plugins.system.product import SystemService
+from middlewared.plugins.truenas.license import TrueNASLicenseService
+from middlewared.plugins.truenas.license_utils import FeatureInfo, FeaturePolicy, LicenseInfo
+from middlewared.plugins.vm.info import license_active as vm_license_active
+from middlewared.pytest.unit.helpers import create_service
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service.context import ServiceContext
+from middlewared.service_exception import ValidationErrors
+
+PAST = date(2000, 1, 1)
+FUTURE = date(2999, 1, 1)
+
+
+def make_license(features):
+    """Build a LicenseInfo. ``features`` is an iterable of ``(name, expires_at: date | None)``."""
+    return LicenseInfo(
+        id="x",
+        type=LicenseType.ENTERPRISE_SINGLE,
+        model=None,
+        expires_at=None,
+        features=[FeatureInfo(name=name, start_date=None, expires_at=expires_at) for name, expires_at in features],
+        serials=[],
+        enclosures={},
+        contract_type=None,
+    )
+
+
+def license_service(m, info=None):
+    """A real TrueNASLicenseService wired to mock middleware, with ``info_private`` stubbed.
+
+    Registers ``feature_available`` both as a string-routed method (for consumers that call
+    ``middleware.call``) and on the service container (for consumers that call via ``self.s``).
+    """
+    svc = create_service(m, TrueNASLicenseService)
+    m["truenas.license.info_private"] = MagicMock(return_value=info)
+    m["truenas.license.feature_available"] = svc.feature_available
+    m.services.truenas.license.feature_available = svc.feature_available
+    return svc
+
+
+def make_context(m):
+    return ServiceContext(m, logging.getLogger("test"))
+
+
+# ---- A. feature_available policy matrix -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "info, expected",
+    [
+        (make_license([("VMS", None)]), True),  # present, perpetual
+        (make_license([("DEDUP", None)]), False),  # absent
+        (make_license([("VMS", PAST)]), False),  # present but expired
+        (make_license([("VMS", FUTURE)]), True),  # present, future expiry
+        (None, False),  # no license
+    ],
+)
+@pytest.mark.asyncio
+async def test_policy_any(info, expected):
+    m = Middleware()
+    svc = license_service(m, info)
+    assert await svc.feature_available("VMS", FeaturePolicy.ANY) is expected
+
+
+@pytest.mark.parametrize(
+    "is_enterprise, licensed, expected",
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_policy_enterprise(is_enterprise, licensed, expected):
+    m = Middleware()
+    svc = license_service(m, make_license([("SUPPORT", None)] if licensed else []))
+    m["system.is_enterprise"] = AsyncMock(return_value=is_enterprise)
+    assert await svc.feature_available("SUPPORT", FeaturePolicy.ENTERPRISE) is expected
+
+
+@pytest.mark.parametrize(
+    "ha_capable, licensed, expected",
+    [
+        (False, False, True),
+        (False, True, True),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_policy_ha_appliance(ha_capable, licensed, expected):
+    m = Middleware()
+    svc = license_service(m, make_license([("VMS", None)] if licensed else []))
+    m["system.is_ha_capable"] = AsyncMock(return_value=ha_capable)
+    assert await svc.feature_available("VMS", FeaturePolicy.HA_APPLIANCE) is expected
+
+
+@pytest.mark.parametrize(
+    "chassis, licensed, expected",
+    [
+        (TRUENAS_UNKNOWN, False, True),  # not iX hardware
+        ("TRUENAS-MINI-3.0-X+", False, True),  # MINI is unrestricted
+        ("F100", True, True),  # iX hardware, licensed
+        ("F100", False, False),  # iX hardware, unlicensed
+    ],
+)
+@pytest.mark.asyncio
+async def test_policy_ix_hardware(chassis, licensed, expected):
+    m = Middleware()
+    svc = license_service(m, make_license([("APPS", None)] if licensed else []))
+    m["truenas.get_chassis_hardware"] = AsyncMock(return_value=chassis)
+    assert await svc.feature_available("APPS", FeaturePolicy.IX_HARDWARE) is expected
+
+
+@pytest.mark.asyncio
+async def test_policy_unknown_raises():
+    m = Middleware()
+    svc = license_service(m, make_license([("VMS", None)]))
+    with pytest.raises(ValueError):
+        await svc.feature_available("VMS", "bogus")
+
+
+# ---- B. license is not consulted unless the gate is active ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ha_appliance_skips_license_off_appliance():
+    m = Middleware()
+    svc = license_service(m, make_license([]))
+    m["system.is_ha_capable"] = AsyncMock(return_value=False)
+    assert await svc.feature_available("VMS", FeaturePolicy.HA_APPLIANCE) is True
+    m["truenas.license.info_private"].assert_not_called()
+
+
+@pytest.mark.parametrize("chassis", [TRUENAS_UNKNOWN, "TRUENAS-MINI-R"])
+@pytest.mark.asyncio
+async def test_ix_hardware_skips_license_off_ix(chassis):
+    m = Middleware()
+    svc = license_service(m, make_license([]))
+    m["truenas.get_chassis_hardware"] = AsyncMock(return_value=chassis)
+    assert await svc.feature_available("APPS", FeaturePolicy.IX_HARDWARE) is True
+    m["truenas.license.info_private"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enterprise_skips_license_on_community():
+    m = Middleware()
+    svc = license_service(m, make_license([("SUPPORT", None)]))
+    m["system.is_enterprise"] = AsyncMock(return_value=False)
+    assert await svc.feature_available("SUPPORT", FeaturePolicy.ENTERPRISE) is False
+    m["truenas.license.info_private"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_gate_consults_license():
+    m = Middleware()
+    svc = license_service(m, make_license([("VMS", None)]))
+    m["system.is_ha_capable"] = AsyncMock(return_value=True)
+    assert await svc.feature_available("VMS", FeaturePolicy.HA_APPLIANCE) is True
+    m["truenas.license.info_private"].assert_called()
+
+
+# ---- C. consumers, end-to-end through the real method -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ha_capable, licensed, expected",
+    [
+        (False, False, True),
+        (False, True, True),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_vm_license_active(ha_capable, licensed, expected):
+    m = Middleware()
+    license_service(m, make_license([("VMS", None)] if licensed else []))
+    m["system.is_ha_capable"] = AsyncMock(return_value=ha_capable)
+    assert await vm_license_active(make_context(m)) is expected
+
+
+@pytest.mark.parametrize(
+    "ha_capable, licensed, expected",
+    [
+        (False, False, True),
+        (False, True, True),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_docker_license_active(ha_capable, licensed, expected):
+    m = Middleware()
+    license_service(m, make_license([("APPS", None)] if licensed else []))
+    m["system.is_ha_capable"] = AsyncMock(return_value=ha_capable)
+    assert await docker_license_active(make_context(m)) is expected
+
+
+@pytest.mark.parametrize(
+    "chassis, licensed, expected",
+    [
+        (TRUENAS_UNKNOWN, False, True),
+        ("TRUENAS-MINI-R", False, True),
+        ("F100", True, True),
+        ("F100", False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_container_license_active(chassis, licensed, expected):
+    m = Middleware()
+    license_service(m, make_license([("APPS", None)] if licensed else []))
+    m["truenas.get_chassis_hardware"] = AsyncMock(return_value=chassis)
+    assert await container_license_active(make_context(m)) is expected
+
+
+# ---- D. consumers, wiring (feature_available mocked to a boolean) -----------------------------
+
+
+@pytest.mark.parametrize(
+    "available, hba_present, expected",
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fc_capable(available, hba_present, expected):
+    m = Middleware()
+    feature_available = MagicMock(return_value=available)
+    m["truenas.license.feature_available"] = feature_available
+    m["fc.hba_present"] = MagicMock(return_value=hba_present)
+    svc = create_service(m, FCService)
+    assert await svc.capable() is expected
+    feature_available.assert_called_once_with("FIBRECHANNEL", FeaturePolicy.ENTERPRISE)
+
+
+@pytest.mark.parametrize(
+    "mode, available, has_error",
+    [
+        ("FC", False, True),
+        ("FC", True, False),
+        ("ISCSI", False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_iscsi_target_fc_gate(mode, available, has_error):
+    m = Middleware()
+    m["datastore.query"] = MagicMock(return_value=[])
+    m["truenas.license.feature_available"] = MagicMock(return_value=available)
+    svc = create_service(m, iSCSITargetService)
+    svc.validate_name = AsyncMock(return_value=None)
+    verrors = ValidationErrors()
+    data = {"name": "tgt0", "alias": None, "mode": mode, "groups": [], "auth_networks": []}
+    await svc._iSCSITargetService__validate(verrors, data, "iscsi_create")
+    messages = [e.errmsg for e in verrors.errors]
+    assert ("Fibre Channel not enabled" in messages) is has_error
+
+
+@pytest.mark.parametrize(
+    "vendor, available, expected",
+    [
+        ("Dell", True, False),  # OEM vendor short-circuits before the license is consulted
+        (None, True, True),
+        (None, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_support_is_available(vendor, available, expected):
+    m = Middleware()
+    m["system.vendor.name"] = AsyncMock(return_value=vendor)
+    m["truenas.license.feature_available"] = MagicMock(return_value=available)
+    svc = create_service(m, SupportService)
+    assert await svc.is_available() is expected
+
+
+# ---- E. SED delegate -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "info, expected",
+    [
+        (make_license([("SED", None)]), True),  # legacy/new license carrying SED
+        (make_license([("SED", PAST)]), False),  # expired
+        (make_license([("SED", FUTURE)]), True),
+        (None, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_system_sed_enabled_delegates(info, expected):
+    m = Middleware()
+    license_service(m, info)
+    svc = create_service(m, SystemService)
+    assert await svc.sed_enabled() is expected

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_legacy_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_legacy_utils.py
@@ -17,8 +17,8 @@ from middlewared.plugins.truenas.license_utils import FeatureInfo, LicenseInfo
             model="H10",
             expires_at=date(2026, 4, 30),
             features=[
-                FeatureInfo(name="FIBRECHANNEL", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
-                FeatureInfo(name="VMS", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
+                FeatureInfo(name="FIBRECHANNEL", start_date=date(2026, 4, 8), expires_at=None),
+                FeatureInfo(name="VMS", start_date=date(2026, 4, 8), expires_at=None),
                 FeatureInfo(name="SUPPORT", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30))],
             serials=["TEST-000001", "TEST-000002"],
             enclosures={"E24": 3, "E16": 2},
@@ -34,7 +34,7 @@ from middlewared.plugins.truenas.license_utils import FeatureInfo, LicenseInfo
             model="X10",
             expires_at=date(2026, 4, 30),
             features=[
-                FeatureInfo(name="APPS", start_date=date(2026, 4, 8), expires_at=date(2026, 4, 30)),
+                FeatureInfo(name="APPS", start_date=date(2026, 4, 8), expires_at=None),
             ],
             serials=["TEST-000001"],
             enclosures={},

--- a/tests/sharing_protocols/fibre_channel/test_fibre_channel.py
+++ b/tests/sharing_protocols/fibre_channel/test_fibre_channel.py
@@ -571,7 +571,7 @@ class AbstractFibreChannel:
         # Make sure iSCSI service is not running.  Would go boom
         assert call('service.query', [['service', '=', 'iscsitarget']], {'get': True})['state'] == 'STOPPED'
         with mock('fc.capable', return_value=True):
-            with mock('system.feature_enabled', args=['FIBRECHANNEL',], return_value=True):
+            with mock('truenas.license.feature_available', args=['FIBRECHANNEL', 'any'], return_value=True):
                 call('fc.fc_host.reset_wired', True)
                 with mock_ports(self.NODE_A_PORTS, self.NODE_B_PORTS):
                     yield


### PR DESCRIPTION
This commit adds changes to route every "is the system licensed to use feature X" check through a single truenas.license.feature_available method, with the surrounding hardware/product gating captured as a FeaturePolicy enum (ANY, ENTERPRISE, HA_APPLIANCE, IX_HARDWARE) instead of being re-implemented at each call site. system.feature_enabled and system.sed_enabled now just delegate to it.

As part of this the SED check becomes legacy-license aware (it previously consulted only the daemon) and feature expiry is now honored everywhere, while the license is still never consulted on hardware where a feature was never gated, so apps and VMs stay unrestricted off HA/iX appliances exactly as before.

Legacy on-disk licenses grant their feature bits perpetually -- contract_end there is only the support-contract end, after which the system stays fully functional -- so those features are no longer stamped with that date as their expiry; only SUPPORT tracks contract_end. Without this, enforcing expiry would have wrongly disabled SED, FC, VMs and apps on legacy-licensed systems past their support contract.