### PR TITLE
NAS-141498 / 27.0.0-BETA.1 / Convert cloud_backup plugin to the typesafe pattern

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -33,6 +33,7 @@ jobs:
             middlewared/plugins/apps/ \
             middlewared/plugins/apps_images/ \
             middlewared/plugins/catalog/ \
+            middlewared/plugins/cloud_backup/ \
             middlewared/plugins/container/ \
             middlewared/plugins/cron/ \
             middlewared/plugins/docker/ \

--- a/src/middlewared/middlewared/api/v27_0_0/cloud_backup.py
+++ b/src/middlewared/middlewared/api/v27_0_0/cloud_backup.py
@@ -9,7 +9,9 @@ from .cloud import BaseCloudEntry
 from .common import CronModel
 
 __all__ = [
-    "CloudBackupEntry", "CloudBackupTransferSettingChoicesArgs", "CloudBackupTransferSettingChoicesResult",
+    "CloudBackupEntry", "CloudBackupCreate", "CloudBackupUpdate", "CloudBackupRestoreOptions",
+    "CloudBackupSnapshot", "CloudBackupSnapshotItem", "CloudBackupSyncOptions",
+    "CloudBackupTransferSettingChoicesArgs", "CloudBackupTransferSettingChoicesResult",
     "CloudBackupCreateArgs", "CloudBackupCreateResult", "CloudBackupUpdateArgs", "CloudBackupUpdateResult",
     "CloudBackupDeleteArgs", "CloudBackupDeleteResult", "CloudBackupRestoreArgs", "CloudBackupRestoreResult",
     "CloudBackupListSnapshotsArgs", "CloudBackupListSnapshotsResult", "CloudBackupListSnapshotDirectoryArgs",

--- a/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
+++ b/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
@@ -43,15 +43,15 @@ ${' '.join(middleware.call_sync('cronjob.construct_cron_command', job.schedule.m
 ${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call cloudsync.sync {job['id']}"))}
     % endfor
 
-    % for job in middleware.call_sync("cloud_backup.query", [["enabled", "=", True]]):
+    % for job in middleware.call_sync2(middleware.services.cloud_backup.query, [["enabled", "=", True]]):
 <%
-    if job["locked"]:
-        middleware.call_sync('cloud_backup.generate_locked_alert', job['id'])
+    if job.locked:
+        middleware.call_sync2(middleware.services.cloud_backup.generate_locked_alert, job.id)
         continue
     else:
-        middleware.call_sync('cloud_backup.remove_locked_alert', job['id'])
+        middleware.call_sync2(middleware.services.cloud_backup.remove_locked_alert, job.id)
 %>\
-${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call cloud_backup.sync {job['id']}"))}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job.schedule.model_dump(), "root", f"midclt call cloud_backup.sync {job.id}"))}
     % endfor
 
     % for job in middleware.call_sync("pool.scrub.query", [["enabled", "=", True]]):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -107,6 +107,7 @@ from middlewared.plugins.api_key import ApiKeyService
 from middlewared.plugins.apps import AppService
 from middlewared.plugins.catalog import CatalogService
 from middlewared.plugins.certificate import CertificateService
+from middlewared.plugins.cloud_backup import CloudBackupService
 from middlewared.plugins.container import ContainerService
 from middlewared.plugins.container.lxc import LXCConfigService
 from middlewared.plugins.cron import CronJobService
@@ -256,6 +257,7 @@ class ServiceContainer(BaseServiceContainer):
         self.app = AppService(middleware)
         self.catalog = CatalogService(middleware)
         self.certificate = CertificateService(middleware)
+        self.cloud_backup = CloudBackupService(middleware)
         self.container = ContainerService(middleware)
         self.cronjob = CronJobService(middleware)
         self.docker = DockerService(middleware)

--- a/src/middlewared/middlewared/migration/0018_resolve_dataset_paths.py
+++ b/src/middlewared/middlewared/migration/0018_resolve_dataset_paths.py
@@ -10,7 +10,7 @@ run before mount). Paths that cannot be resolved (encrypted datasets, hardware
 issues) are left as NULL and will be resolved via hook subscriptions when the
 datasets become available.
 """
-from middlewared.plugins.cloud_backup.crud import CloudBackupService
+from middlewared.plugins.cloud_backup import CloudBackupService
 from middlewared.plugins.cloud_sync import CloudSyncService
 from middlewared.plugins.iscsi_.extents import iSCSITargetExtentService
 from middlewared.plugins.nfs import SharingNFSService

--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -84,7 +84,7 @@ class CloudTaskServiceMixin:
                 verrors.add(f'{name}.{self.path_field}', f'{zvol!r} is an invalid location')
             else:
                 try:
-                    self.middleware.call_sync(f'{self._config.namespace}.validate_zvol', path)
+                    self.validate_zvol(path)
                 except CallError as e:
                     verrors.add(f'{name}.{self.path_field}', e.errmsg)
         else:

--- a/src/middlewared/middlewared/plugins/cloud/path.py
+++ b/src/middlewared/middlewared/plugins/cloud/path.py
@@ -8,9 +8,10 @@ from middlewared.service import CallError
 
 if TYPE_CHECKING:
     from middlewared.main import Middleware
+    from middlewared.rclone.base import BaseRcloneRemote
 
 
-def get_remote_path(provider: Any, attributes: dict[str, Any]) -> str:
+def get_remote_path(provider: BaseRcloneRemote, attributes: dict[str, Any]) -> str:
     remote_path = attributes["folder"].rstrip("/")
     if not remote_path:
         remote_path = "/"

--- a/src/middlewared/middlewared/plugins/cloud/path.py
+++ b/src/middlewared/middlewared/plugins/cloud/path.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import os
 import stat
+from typing import TYPE_CHECKING, Any
 
 from middlewared.service import CallError
 
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
-def get_remote_path(provider, attributes):
+
+def get_remote_path(provider: Any, attributes: dict[str, Any]) -> str:
     remote_path = attributes["folder"].rstrip("/")
     if not remote_path:
         remote_path = "/"
@@ -13,7 +19,13 @@ def get_remote_path(provider, attributes):
     return remote_path
 
 
-def check_local_path(middleware, path, *, check_mountpoint=True, error_text_path=None):
+def check_local_path(
+    middleware: Middleware,
+    path: str,
+    *,
+    check_mountpoint: bool = True,
+    error_text_path: str | None = None,
+) -> None:
     error_text_path = error_text_path or path
 
     try:

--- a/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -149,7 +149,7 @@ class CloudBackupService(GenericTaskPathService[CloudBackupEntry], TaskStateMixi
         return delete_snapshot_impl(self.context, job, id_, snapshot_id)
 
     @private
-    def ensure_initialized(self, cloud_backup: dict[str, Any]) -> None:
+    def ensure_initialized(self, cloud_backup: CloudBackupEntry | CloudBackupCreate) -> None:
         ensure_initialized_impl(self.context, cloud_backup)
 
     @private

--- a/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from middlewared.api import api_method
+from middlewared.api.current import (
+    CloudBackupAbortArgs,
+    CloudBackupAbortResult,
+    CloudBackupCreate,
+    CloudBackupCreateArgs,
+    CloudBackupCreateResult,
+    CloudBackupDeleteArgs,
+    CloudBackupDeleteResult,
+    CloudBackupDeleteSnapshotArgs,
+    CloudBackupDeleteSnapshotResult,
+    CloudBackupEntry,
+    CloudBackupListSnapshotDirectoryArgs,
+    CloudBackupListSnapshotDirectoryResult,
+    CloudBackupListSnapshotsArgs,
+    CloudBackupListSnapshotsResult,
+    CloudBackupRestoreArgs,
+    CloudBackupRestoreOptions,
+    CloudBackupRestoreResult,
+    CloudBackupSnapshot,
+    CloudBackupSnapshotItem,
+    CloudBackupSyncArgs,
+    CloudBackupSyncOptions,
+    CloudBackupSyncResult,
+    CloudBackupTransferSettingChoicesArgs,
+    CloudBackupTransferSettingChoicesResult,
+    CloudBackupUpdate,
+    CloudBackupUpdateArgs,
+    CloudBackupUpdateResult,
+)
+from middlewared.common.attachment import LockableFSAttachmentDelegate
+from middlewared.service import GenericTaskPathService, job, private
+from middlewared.utils.service.task_state import TaskStateMixin
+
+from .crud import CloudBackupServicePart
+from .init import ensure_initialized as ensure_initialized_impl
+from .restore import do_restore
+from .snapshot import delete_snapshot as delete_snapshot_impl
+from .snapshot import list_snapshot_directory as list_snapshot_directory_impl
+from .snapshot import list_snapshots as list_snapshots_impl
+from .sync import TRANSFER_SETTING_ARGS, do_abort, do_sync
+
+if TYPE_CHECKING:
+    from middlewared.api.base.server.app import App
+    from middlewared.job import Job
+    from middlewared.main import Middleware
+
+
+__all__ = ("CloudBackupService",)
+
+
+class CloudBackupService(GenericTaskPathService[CloudBackupEntry], TaskStateMixin):
+    _svc_part: CloudBackupServicePart
+
+    share_task_type = "CloudBackup"
+    task_state_methods = ["cloud_backup.sync", "cloud_backup.restore"]
+
+    class Config:
+        namespace = "cloud_backup"
+        cli_namespace = "task.cloud_backup"
+        entry = CloudBackupEntry
+        generic = True
+        role_prefix = "CLOUD_BACKUP"
+
+    def __init__(self, middleware: Middleware) -> None:
+        super().__init__(middleware)
+        self._svc_part = CloudBackupServicePart(self.context)
+
+    @api_method(CloudBackupCreateArgs, CloudBackupCreateResult, pass_app=True, check_annotations=True)
+    async def do_create(self, app: App, data: CloudBackupCreate) -> CloudBackupEntry:
+        """Create a new cloud backup task."""
+        return await self._svc_part.do_create(app, data)
+
+    @api_method(CloudBackupUpdateArgs, CloudBackupUpdateResult, pass_app=True, check_annotations=True)
+    async def do_update(self, app: App, id_: int, data: CloudBackupUpdate) -> CloudBackupEntry:
+        """Update the cloud backup entry `id` with `data`."""
+        return await self._svc_part.do_update(app, id_, data)
+
+    @api_method(CloudBackupDeleteArgs, CloudBackupDeleteResult, check_annotations=True)
+    async def do_delete(self, id_: int) -> Literal[True]:
+        """Delete cloud backup entry `id`."""
+        await self._svc_part.do_delete(id_)
+        return True
+
+    @api_method(
+        CloudBackupTransferSettingChoicesArgs, CloudBackupTransferSettingChoicesResult, check_annotations=True,
+    )
+    async def transfer_setting_choices(self) -> list[Literal["DEFAULT", "PERFORMANCE", "FAST_STORAGE"]]:
+        """Return all possible choices for `cloud_backup.create.transfer_setting`."""
+        return list(TRANSFER_SETTING_ARGS)
+
+    @api_method(CloudBackupSyncArgs, CloudBackupSyncResult, roles=["CLOUD_BACKUP_WRITE"], check_annotations=True)
+    @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True)
+    def sync(self, job: Job, id_: int, options: CloudBackupSyncOptions) -> None:
+        """Run the cloud backup job `id`."""
+        return do_sync(self.context, job, id_, options)
+
+    @api_method(CloudBackupAbortArgs, CloudBackupAbortResult, roles=["CLOUD_BACKUP_WRITE"], check_annotations=True)
+    def abort(self, id_: int) -> bool:
+        """Abort a running cloud backup task."""
+        return do_abort(self.context, id_)
+
+    @api_method(
+        CloudBackupRestoreArgs, CloudBackupRestoreResult, roles=["FILESYSTEM_DATA_WRITE"], check_annotations=True,
+    )
+    @job(logs=True)
+    def restore(
+        self,
+        job: Job,
+        id_: int,
+        snapshot_id: str,
+        subfolder: str,
+        destination_path: str,
+        options: CloudBackupRestoreOptions,
+    ) -> None:
+        """
+        Restore files to the directory `destination_path` from the `snapshot_id` subfolder `subfolder`
+        created by the cloud backup job `id`.
+        """
+        return do_restore(self.context, job, id_, snapshot_id, subfolder, destination_path, options)
+
+    @api_method(
+        CloudBackupListSnapshotsArgs, CloudBackupListSnapshotsResult, roles=["CLOUD_BACKUP_READ"],
+        check_annotations=True,
+    )
+    def list_snapshots(self, id_: int) -> list[CloudBackupSnapshot]:
+        """List existing snapshots for the cloud backup job `id`."""
+        return list_snapshots_impl(self.context, id_)
+
+    @api_method(
+        CloudBackupListSnapshotDirectoryArgs, CloudBackupListSnapshotDirectoryResult, roles=["CLOUD_BACKUP_READ"],
+        check_annotations=True,
+    )
+    def list_snapshot_directory(self, id_: int, snapshot_id: str, path: str) -> list[CloudBackupSnapshotItem]:
+        """List files in the directory `path` of the `snapshot_id` created by the cloud backup job `id`."""
+        return list_snapshot_directory_impl(self.context, id_, snapshot_id, path)
+
+    @api_method(
+        CloudBackupDeleteSnapshotArgs, CloudBackupDeleteSnapshotResult, roles=["CLOUD_BACKUP_WRITE"],
+        check_annotations=True,
+    )
+    @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1)
+    def delete_snapshot(self, job: Job, id_: int, snapshot_id: str) -> None:
+        """Delete snapshot `snapshot_id` created by the cloud backup job `id`."""
+        return delete_snapshot_impl(self.context, job, id_, snapshot_id)
+
+    @private
+    def ensure_initialized(self, cloud_backup: dict[str, Any]) -> None:
+        ensure_initialized_impl(self.context, cloud_backup)
+
+    @private
+    def validate_zvol(self, path: str) -> None:
+        self._svc_part.validate_zvol(path)
+
+    def _task_state_datastore(self) -> str:
+        return self._svc_part._datastore
+
+    def _task_state_datastore_prefix(self) -> str:
+        return self._svc_part._datastore_prefix
+
+
+class CloudBackupFSAttachmentDelegate(LockableFSAttachmentDelegate[CloudBackupEntry]):
+    name = "cloud_backup"
+    title = "Cloud Backup Task"
+    service_class = CloudBackupService
+    resource_name = "path"
+
+    async def restart_reload_services(self, attachments: list[CloudBackupEntry]) -> None:
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
+
+
+async def setup(middleware: Middleware) -> None:
+    await middleware.call("pool.dataset.register_attachment_delegate", CloudBackupFSAttachmentDelegate(middleware))
+    await middleware.call("network.general.register_activity", "cloud_backup", "Cloud backup")
+    await middleware.call2(middleware.services.cloud_backup.persist_task_state_on_job_complete)

--- a/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -149,8 +149,8 @@ class CloudBackupService(GenericTaskPathService[CloudBackupEntry], TaskStateMixi
         return delete_snapshot_impl(self.context, job, id_, snapshot_id)
 
     @private
-    def ensure_initialized(self, cloud_backup: CloudBackupEntry | CloudBackupCreate) -> None:
-        ensure_initialized_impl(self.context, cloud_backup)
+    def ensure_initialized(self, cloud_backup: CloudBackupEntry, credentials: dict[str, Any]) -> None:
+        ensure_initialized_impl(self.context, cloud_backup, credentials)
 
     @private
     def validate_zvol(self, path: str) -> None:

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -15,6 +15,7 @@ from middlewared.utils.cron import convert_db_format_to_schedule, convert_schedu
 from middlewared.utils.path import FSLocation
 
 from .init import IncorrectPassword
+from .utils import resolve_credentials
 
 if TYPE_CHECKING:
     from middlewared.api.base.server.app import App
@@ -79,9 +80,7 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
         return data
 
     async def do_create(self, app: App | None, data: CloudBackupCreate) -> CloudBackupEntry:
-        cloud_backup = data.model_dump(context={"expose_secrets": True})
-        await self.to_thread(self._run_validation, app, "cloud_backup_create", cloud_backup, data)
-
+        cloud_backup = await self.to_thread(self._run_validation, app, "cloud_backup_create", data)
         entry = await self._create(cloud_backup)
         await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
         return entry
@@ -89,17 +88,7 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
     async def do_update(self, app: App | None, id_: int, data: CloudBackupUpdate) -> CloudBackupEntry:
         old = await self.get_instance(id_)
         new = old.updated(data)
-
-        cloud_backup = new.model_dump(context={"expose_secrets": True})
-        cloud_backup.pop(self.locked_field, None)
-        cloud_backup.pop("job", None)
-        # credentials is a foreign key; collapse the extended entry back to its id for the
-        # datastore and the shared validation mixin (a changed credential is already an int).
-        if isinstance(cloud_backup["credentials"], dict):
-            cloud_backup["credentials"] = cloud_backup["credentials"]["id"]
-
-        await self.to_thread(self._run_validation, app, "cloud_backup_update", cloud_backup, new)
-
+        cloud_backup = await self.to_thread(self._run_validation, app, "cloud_backup_update", new)
         entry = await self._update(id_, cloud_backup)
         await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
         return entry
@@ -123,18 +112,28 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
         ):
             raise CallError("Backed up zvol must be used by a local or VMware VM")
 
-    def _run_validation(
-        self, app: App | None, schema: str, data: dict[str, Any], entry: CloudBackupEntry | CloudBackupCreate,
-    ) -> None:
+    def _run_validation(self, app: App | None, schema: str, entry: CloudBackupEntry) -> dict[str, Any]:
+        # FIXME: Drop this model->dict marshalling and validate the entry directly once CloudTaskServiceMixin
+        # is converted; it is shared with the unconverted cloud_sync and only operates on dicts for now.
+        data = entry.model_dump(context={"expose_secrets": True})
+        data.pop(self.locked_field, None)
+        data.pop("job", None)
+        # credentials is a foreign key; collapse the extended entry back to its id for the
+        # datastore and the shared validation mixin (a changed credential is already an int).
+        if isinstance(data["credentials"], dict):
+            data["credentials"] = data["credentials"]["id"]
+
         verrors = ValidationErrors()
         self._validate(app, verrors, schema, data)
         if not verrors:
+            credentials = resolve_credentials(self, entry.credentials)
             try:
                 # Route through the registry method so the suite can mock cloud_backup.ensure_initialized.
-                self.call_sync2(self.s.cloud_backup.ensure_initialized, entry)
+                self.call_sync2(self.s.cloud_backup.ensure_initialized, entry, credentials)
             except IncorrectPassword as e:
                 verrors.add(f"{schema}.password", e.errmsg)
         verrors.check()
+        return data
 
     def _validate(self, app: App | None, verrors: ValidationErrors, name: str, data: dict[str, Any]) -> None:
         # CloudTaskServiceMixin is shared with the unconverted cloud_sync and operates on the dict

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -80,24 +80,27 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
 
     async def do_create(self, app: App | None, data: CloudBackupCreate) -> CloudBackupEntry:
         cloud_backup = data.model_dump(context={"expose_secrets": True})
-        await self.to_thread(self._run_validation, app, "cloud_backup_create", cloud_backup)
+        await self.to_thread(self._run_validation, app, "cloud_backup_create", cloud_backup, data)
 
         entry = await self._create(cloud_backup)
         await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
         return entry
 
     async def do_update(self, app: App | None, id_: int, data: CloudBackupUpdate) -> CloudBackupEntry:
-        old = (await self.get_instance(id_)).model_dump(context={"expose_secrets": True})
-        old.pop(self.locked_field, None)
-        old.pop("job", None)
-        # credentials is a foreign key, collapse the extended entry back to its id before merging.
-        if old["credentials"]:
-            old["credentials"] = old["credentials"]["id"]
+        old = await self.get_instance(id_)
+        new = old.updated(data)
 
-        new = {**old, **data.model_dump(context={"expose_secrets": True})}
-        await self.to_thread(self._run_validation, app, "cloud_backup_update", new)
+        cloud_backup = new.model_dump(context={"expose_secrets": True})
+        cloud_backup.pop(self.locked_field, None)
+        cloud_backup.pop("job", None)
+        # credentials is a foreign key; collapse the extended entry back to its id for the
+        # datastore and the shared validation mixin (a changed credential is already an int).
+        if isinstance(cloud_backup["credentials"], dict):
+            cloud_backup["credentials"] = cloud_backup["credentials"]["id"]
 
-        entry = await self._update(id_, new)
+        await self.to_thread(self._run_validation, app, "cloud_backup_update", cloud_backup, new)
+
+        entry = await self._update(id_, cloud_backup)
         await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
         return entry
 
@@ -120,13 +123,22 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
         ):
             raise CallError("Backed up zvol must be used by a local or VMware VM")
 
-    def _run_validation(self, app: App | None, schema: str, data: dict[str, Any]) -> None:
+    def _run_validation(
+        self, app: App | None, schema: str, data: dict[str, Any], entry: CloudBackupEntry | CloudBackupCreate,
+    ) -> None:
         verrors = ValidationErrors()
         self._validate(app, verrors, schema, data)
+        if not verrors:
+            try:
+                # Route through the registry method so the suite can mock cloud_backup.ensure_initialized.
+                self.call_sync2(self.s.cloud_backup.ensure_initialized, entry)
+            except IncorrectPassword as e:
+                verrors.add(f"{schema}.password", e.errmsg)
         verrors.check()
 
     def _validate(self, app: App | None, verrors: ValidationErrors, name: str, data: dict[str, Any]) -> None:
-        # CloudTaskServiceMixin is shared with the unconverted cloud_sync and is left untyped.
+        # CloudTaskServiceMixin is shared with the unconverted cloud_sync and operates on the dict
+        # (it normalizes data["attributes"] in place, which must reach the datastore).
         super()._validate(app, verrors, name, data)  # type: ignore[no-untyped-call]
 
         if data["snapshot"] and data["absolute_paths"]:
@@ -142,10 +154,3 @@ class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTask
                 statfs = self.middleware.call_sync("filesystem.statfs", data["cache_path"])
                 if "RO" in statfs.flags:
                     verrors.add(f"{name}.cache_path", "The cache directory must be writeable")
-
-        if not verrors:
-            try:
-                # Route through the registry method so the suite can mock cloud_backup.ensure_initialized.
-                self.call_sync2(self.s.cloud_backup.ensure_initialized, data)
-            except IncorrectPassword as e:
-                verrors.add(f"{name}.password", e.errmsg)

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -1,29 +1,23 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 from middlewared.alert.base import AlertCategory, AlertClassConfig, AlertLevel, OneShotAlertClass
-from middlewared.api import api_method
-from middlewared.api.current import (
-    CloudBackupCreateArgs,
-    CloudBackupCreateResult,
-    CloudBackupDeleteArgs,
-    CloudBackupDeleteResult,
-    CloudBackupEntry,
-    CloudBackupTransferSettingChoicesArgs,
-    CloudBackupTransferSettingChoicesResult,
-    CloudBackupUpdateArgs,
-    CloudBackupUpdateResult,
-)
+from middlewared.api.current import CloudBackupCreate, CloudBackupEntry, CloudBackupUpdate
 from middlewared.async_validators import check_path_resides_within_volume
-from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.plugins.cloud.crud import CloudTaskServiceMixin
 from middlewared.plugins.cloud.model import CloudTaskModelMixin
-from middlewared.service import TaskPathService, ValidationErrors, private
+from middlewared.plugins.zfs.zvol_utils import zvol_path_to_name
+from middlewared.service import CallError, SharingTaskServicePart, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.cron import convert_db_format_to_schedule, convert_schedule_to_db_format
 from middlewared.utils.path import FSLocation
-from middlewared.utils.service.task_state import TaskStateMixin
 
 from .init import IncorrectPassword
+
+if TYPE_CHECKING:
+    from middlewared.api.base.server.app import App
 
 
 class CloudBackupModel(CloudTaskModelMixin, sa.Model):
@@ -37,125 +31,103 @@ class CloudBackupModel(CloudTaskModelMixin, sa.Model):
     rate_limit = sa.Column(sa.Integer(), nullable=True)
 
 
-class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin):
+@dataclass(kw_only=True)
+class CloudBackupTaskFailedAlert(OneShotAlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.TASKS,
+        level=AlertLevel.ERROR,
+        title="Cloud Backup Task Failed",
+        text="Cloud backup task \"%(name)s\" failed.",
+    )
+
+    id: int
+    name: str
+
+    @classmethod
+    def key_from_args(cls, args: Any) -> Any:
+        return args["id"]
+
+
+class CloudBackupServicePart(SharingTaskServicePart[CloudBackupEntry], CloudTaskServiceMixin):
+    _datastore = "tasks.cloud_backup"
+    _entry = CloudBackupEntry
+
     allow_zvol = True
-
-    share_task_type = "CloudBackup"
     allowed_path_types = [FSLocation.LOCAL]
-    task_state_methods = ["cloud_backup.sync", "cloud_backup.restore"]
+    path_field = "path"
 
-    class Config:
-        datastore = "tasks.cloud_backup"
-        datastore_extend = "cloud_backup.extend"
-        datastore_extend_context = "cloud_backup.extend_context"
-        cli_namespace = "task.cloud_backup"
-        namespace = "cloud_backup"
-        role_prefix = "CLOUD_BACKUP"
-        entry = CloudBackupEntry
-
-    @private
-    def transfer_setting_args(self):
+    async def sharing_task_extend_context(self, rows: list[dict[str, Any]], extra: dict[str, Any]) -> Any:
         return {
-            "DEFAULT": [],
-            "PERFORMANCE": ["--pack-size", "29"],
-            "FAST_STORAGE": ["--pack-size", "58", "--read-concurrency", "100"]
+            "task_state": await self.call2(self.s.cloud_backup.get_task_state_context),
         }
 
-    @private
-    def extend_context(self, rows, extra):
-        return {
-            "task_state": self.middleware.run_coroutine(self.get_task_state_context()),
-        }
+    async def sharing_task_extend(self, data: dict[str, Any], service_context: Any) -> dict[str, Any]:
+        data["credentials"] = await self.middleware.call("cloudsync.credentials.extend", data.pop("credential"))
 
-    @private
-    def extend(self, cloud_backup, context):
-        cloud_backup["credentials"] = self.middleware.call_sync(
-            "cloudsync.credentials.extend", cloud_backup.pop("credential"),
-        )
+        if job := await self.call2(self.s.cloud_backup.get_task_state_job, service_context["task_state"], data["id"]):
+            data["job"] = job
 
-        if job := self.middleware.run_coroutine(self.get_task_state_job(context["task_state"], cloud_backup["id"])):
-            cloud_backup["job"] = job
+        convert_db_format_to_schedule(data)
+        return data
 
-        convert_db_format_to_schedule(cloud_backup)
+    async def compress(self, data: dict[str, Any]) -> dict[str, Any]:
+        data["credential"] = data.pop("credentials")
+        convert_schedule_to_db_format(data)
+        # tasks_cloud_backup.job is NOT NULL; the runtime job state lives in task_state, so persist null here.
+        data["job"] = None
+        data.pop(self.locked_field, None)
+        return data
 
-        return cloud_backup
+    async def do_create(self, app: App | None, data: CloudBackupCreate) -> CloudBackupEntry:
+        cloud_backup = data.model_dump(context={"expose_secrets": True})
+        await self.to_thread(self._run_validation, app, "cloud_backup_create", cloud_backup)
 
-    @private
-    def _compress(self, cloud_backup):
-        cloud_backup["credential"] = cloud_backup.pop("credentials")
+        entry = await self._create(cloud_backup)
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
+        return entry
 
-        convert_schedule_to_db_format(cloud_backup)
+    async def do_update(self, app: App | None, id_: int, data: CloudBackupUpdate) -> CloudBackupEntry:
+        old = (await self.get_instance(id_)).model_dump(context={"expose_secrets": True})
+        old.pop(self.locked_field, None)
+        old.pop("job", None)
+        # credentials is a foreign key, collapse the extended entry back to its id before merging.
+        if old["credentials"]:
+            old["credentials"] = old["credentials"]["id"]
 
-        cloud_backup.pop("job", None)
-        cloud_backup.pop(self.locked_field, None)
+        new = {**old, **data.model_dump(context={"expose_secrets": True})}
+        await self.to_thread(self._run_validation, app, "cloud_backup_update", new)
 
-        return cloud_backup
+        entry = await self._update(id_, new)
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
+        return entry
 
-    @api_method(CloudBackupTransferSettingChoicesArgs, CloudBackupTransferSettingChoicesResult)
-    def transfer_setting_choices(self):
-        """
-        Return all possible choices for `cloud_backup.create.transfer_setting`.
-        """
-        args = self.transfer_setting_args()
-        return list(args.keys())
+    async def do_delete(self, id_: int) -> None:
+        await self.call2(self.s.cloud_backup.abort, id_)
+        await self.call2(self.s.alert.oneshot_delete, "CloudBackupTaskFailed", id_)
+        await self._delete(id_)
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
 
-    @api_method(CloudBackupCreateArgs, CloudBackupCreateResult, pass_app=True)
-    def do_create(self, app, cloud_backup):
-        """
-        Create a new cloud backup task
-        """
+    async def get_path_field(self, data: Any) -> Any:
+        if isinstance(data, dict):
+            return data[self.path_field]
+        return getattr(data, self.path_field)
+
+    def validate_zvol(self, path: str) -> None:
+        dataset = zvol_path_to_name(path)
+        if not (
+            self.call_sync2(self.s.vm.query_snapshot_begin, dataset, False) or
+            self.middleware.call_sync("vmware.dataset_has_vms", dataset, False)
+        ):
+            raise CallError("Backed up zvol must be used by a local or VMware VM")
+
+    def _run_validation(self, app: App | None, schema: str, data: dict[str, Any]) -> None:
         verrors = ValidationErrors()
-        self._validate(app, verrors, "cloud_backup_create", cloud_backup)
+        self._validate(app, verrors, schema, data)
         verrors.check()
 
-        cloud_backup = self._compress(cloud_backup)
-        cloud_backup["id"] = self.middleware.call_sync(
-            "datastore.insert", "tasks.cloud_backup", {**cloud_backup, "job": None},
-        )
-        self.middleware.call_sync("service.control", "RESTART", "cron").wait_sync(raise_error=True)
-
-        return self.get_instance__sync(cloud_backup["id"])
-
-    @api_method(CloudBackupUpdateArgs, CloudBackupUpdateResult, pass_app=True)
-    def do_update(self, app, id_, data):
-        """
-        Update the cloud backup entry `id` with `data`.
-        """
-        cloud_backup = self.get_instance__sync(id_)
-
-        # credentials is a foreign key for now
-        if cloud_backup["credentials"]:
-            cloud_backup["credentials"] = cloud_backup["credentials"]["id"]
-
-        cloud_backup.update(data)
-
-        verrors = ValidationErrors()
-
-        self._validate(app, verrors, "cloud_backup_update", cloud_backup)
-
-        verrors.check()
-
-        cloud_backup = self._compress(cloud_backup)
-
-        self.middleware.call_sync("datastore.update", "tasks.cloud_backup", id_, cloud_backup)
-        self.middleware.call_sync("service.control", "RESTART", "cron").wait_sync(raise_error=True)
-
-        return self.get_instance__sync(id_)
-
-    @api_method(CloudBackupDeleteArgs, CloudBackupDeleteResult)
-    def do_delete(self, id_):
-        """
-        Delete cloud backup entry `id`.
-        """
-        self.middleware.call_sync("cloud_backup.abort", id_)
-        self.call_sync2(self.s.alert.oneshot_delete, "CloudBackupTaskFailed", id_)
-        rv = self.middleware.call_sync("datastore.delete", "tasks.cloud_backup", id_)
-        self.middleware.call_sync("service.control", "RESTART", "cron").wait_sync(raise_error=True)
-        return rv
-
-    @private
-    def _validate(self, app, verrors, name, data):
-        super()._validate(app, verrors, name, data)
+    def _validate(self, app: App | None, verrors: ValidationErrors, name: str, data: dict[str, Any]) -> None:
+        # CloudTaskServiceMixin is shared with the unconverted cloud_sync and is left untyped.
+        super()._validate(app, verrors, name, data)  # type: ignore[no-untyped-call]
 
         if data["snapshot"] and data["absolute_paths"]:
             verrors.add(f"{name}.snapshot", "This option can't be used when absolute paths are enabled")
@@ -173,39 +145,7 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
 
         if not verrors:
             try:
-                self.middleware.call_sync("cloud_backup.ensure_initialized", data)
+                # Route through the registry method so the suite can mock cloud_backup.ensure_initialized.
+                self.call_sync2(self.s.cloud_backup.ensure_initialized, data)
             except IncorrectPassword as e:
                 verrors.add(f"{name}.password", e.errmsg)
-
-
-@dataclass(kw_only=True)
-class CloudBackupTaskFailedAlert(OneShotAlertClass):
-    config = AlertClassConfig(
-        category=AlertCategory.TASKS,
-        level=AlertLevel.ERROR,
-        title="Cloud Backup Task Failed",
-        text="Cloud backup task \"%(name)s\" failed.",
-    )
-
-    id: int
-    name: str
-
-    @classmethod
-    def key_from_args(cls, args):
-        return args["id"]
-
-
-class CloudBackupFSAttachmentDelegate(LockableFSAttachmentDelegate):
-    name = "cloud_backup"
-    title = "Cloud Backup Task"
-    service_class = CloudBackupService
-    resource_name = "path"
-
-    async def restart_reload_services(self, attachments):
-        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
-
-
-async def setup(middleware):
-    await middleware.call("pool.dataset.register_attachment_delegate", CloudBackupFSAttachmentDelegate(middleware))
-    await middleware.call("network.general.register_activity", "cloud_backup", "Cloud backup")
-    await middleware.call("cloud_backup.persist_task_state_on_job_complete")

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -1,88 +1,85 @@
-import subprocess
+from __future__ import annotations
 
-from middlewared.plugins.cloud_backup.restic import get_restic_config
-from middlewared.service import CallError, Service, private
+import subprocess
+from typing import Any
+
+from middlewared.plugins.cloud_backup.restic import ResticConfig, get_restic_config
+from middlewared.service import CallError, ServiceContext
 
 
 class IncorrectPassword(CallError):
     pass
 
 
-class CloudBackupService(Service):
+def ensure_initialized(context: ServiceContext, cloud_backup: dict[str, Any]) -> None:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    class Config:
-        cli_namespace = "task.cloud_backup"
-        namespace = "cloud_backup"
+    if isinstance(cloud_backup["credentials"], int):
+        cloud_backup = {
+            **cloud_backup,
+            "credentials": context.middleware.call_sync(
+                "cloudsync.credentials.get_instance", cloud_backup["credentials"],
+            ),
+        }
 
-    @private
-    def ensure_initialized(self, cloud_backup):
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+    attrs = cloud_backup["attributes"]
+    cred = cloud_backup["credentials"]["id"]
+    if "bucket" in attrs:
+        existing_buckets = [b["Name"] for b in context.middleware.call_sync("cloudsync.list_buckets", cred)]
+        if attrs["bucket"] not in existing_buckets:
+            context.middleware.call_sync("cloudsync.create_bucket", cred, attrs["bucket"])
 
-        if isinstance(cloud_backup["credentials"], int):
-            cloud_backup = {
-                **cloud_backup,
-                "credentials": self.middleware.call_sync("cloudsync.credentials.get_instance",
-                                                         cloud_backup["credentials"]),
-            }
+    restic_config = get_restic_config(cloud_backup)
 
-        attrs = cloud_backup["attributes"]
-        cred = cloud_backup["credentials"]["id"]
-        if "bucket" in attrs:
-            existing_buckets = [b["Name"] for b in self.middleware.call_sync("cloudsync.list_buckets", cred)]
-            if attrs["bucket"] not in existing_buckets:
-                self.middleware.call_sync("cloudsync.create_bucket", cred, attrs["bucket"])
+    subprocess.run(
+        restic_config.cmd + ["unlock"],
+        env=restic_config.env,
+        capture_output=True,
+        text=True,
+    )
 
-        restic_config = get_restic_config(cloud_backup)
+    if is_initialized(context, restic_config):
+        return
 
+    init(context, cloud_backup)
+
+
+def is_initialized(context: ServiceContext, restic_config: ResticConfig) -> bool:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+
+    try:
         subprocess.run(
-            restic_config.cmd + ["unlock"],
+            restic_config.cmd + ["cat", "config"],
             env=restic_config.env,
             capture_output=True,
             text=True,
+            check=True,
         )
+        return True
+    except subprocess.CalledProcessError as e:
+        text = e.stderr.strip()
 
-        if self.is_initialized(restic_config):
-            return
+        if "Is there a repository at the following location?" in text:
+            return False
 
-        self.init(cloud_backup)
+        if "wrong password or no key found" in text:
+            raise IncorrectPassword(text)
 
-    @private
-    def is_initialized(self, restic_config):
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+        raise CallError(text)
 
-        try:
-            subprocess.run(
-                restic_config.cmd + ["cat", "config"],
-                env=restic_config.env,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            return True
-        except subprocess.CalledProcessError as e:
-            text = e.stderr.strip()
 
-            if "Is there a repository at the following location?" in text:
-                return False
+def init(context: ServiceContext, cloud_backup: dict[str, Any]) -> None:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-            if "wrong password or no key found" in text:
-                raise IncorrectPassword(text)
+    restic_config = get_restic_config(cloud_backup)
 
-            raise CallError(text)
-
-    @private
-    def init(self, cloud_backup):
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
-
-        restic_config = get_restic_config(cloud_backup)
-
-        try:
-            subprocess.run(
-                restic_config.cmd + ["init"],
-                env=restic_config.env,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            raise CallError(e.stderr)
+    try:
+        subprocess.run(
+            restic_config.cmd + ["init"],
+            env=restic_config.env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise CallError(e.stderr)

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import subprocess
+from typing import Any
 
-from middlewared.api.current import CloudBackupCreate, CloudBackupEntry
+from middlewared.api.current import CloudBackupEntry
 from middlewared.plugins.cloud_backup.restic import ResticConfig, get_restic_config
-from middlewared.plugins.cloud_backup.utils import resolve_credentials
 from middlewared.service import CallError, ServiceContext
 
 
@@ -12,10 +12,11 @@ class IncorrectPassword(CallError):
     pass
 
 
-def ensure_initialized(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> None:
+# `entry` is typed as a persisted `CloudBackupEntry`, but the create/update validation path passes an
+# un-persisted `CloudBackupCreate` (which excludes `id`, `job`, `locked`, ...). Only read fields common to
+# both here (`attributes`, `cache_path`, `password`); the credential is supplied separately as `credentials`.
+def ensure_initialized(context: ServiceContext, entry: CloudBackupEntry, credentials: dict[str, Any]) -> None:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
-
-    credentials = resolve_credentials(context, entry.credentials)
 
     attrs = entry.attributes.model_dump()
     cred = credentials["id"]
@@ -24,7 +25,7 @@ def ensure_initialized(context: ServiceContext, entry: CloudBackupEntry | CloudB
         if attrs["bucket"] not in existing_buckets:
             context.middleware.call_sync("cloudsync.create_bucket", cred, attrs["bucket"])
 
-    restic_config = get_restic_config(context, entry)
+    restic_config = get_restic_config(entry, credentials)
 
     subprocess.run(
         restic_config.cmd + ["unlock"],
@@ -36,7 +37,7 @@ def ensure_initialized(context: ServiceContext, entry: CloudBackupEntry | CloudB
     if is_initialized(context, restic_config):
         return
 
-    init(context, entry)
+    init(context, entry, credentials)
 
 
 def is_initialized(context: ServiceContext, restic_config: ResticConfig) -> bool:
@@ -63,10 +64,10 @@ def is_initialized(context: ServiceContext, restic_config: ResticConfig) -> bool
         raise CallError(text)
 
 
-def init(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> None:
+def init(context: ServiceContext, entry: CloudBackupEntry, credentials: dict[str, Any]) -> None:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    restic_config = get_restic_config(context, entry)
+    restic_config = get_restic_config(entry, credentials)
 
     try:
         subprocess.run(

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import subprocess
-from typing import Any
 
+from middlewared.api.current import CloudBackupCreate, CloudBackupEntry
 from middlewared.plugins.cloud_backup.restic import ResticConfig, get_restic_config
+from middlewared.plugins.cloud_backup.utils import resolve_credentials
 from middlewared.service import CallError, ServiceContext
 
 
@@ -11,25 +12,19 @@ class IncorrectPassword(CallError):
     pass
 
 
-def ensure_initialized(context: ServiceContext, cloud_backup: dict[str, Any]) -> None:
+def ensure_initialized(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> None:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    if isinstance(cloud_backup["credentials"], int):
-        cloud_backup = {
-            **cloud_backup,
-            "credentials": context.middleware.call_sync(
-                "cloudsync.credentials.get_instance", cloud_backup["credentials"],
-            ),
-        }
+    credentials = resolve_credentials(context, entry.credentials)
 
-    attrs = cloud_backup["attributes"]
-    cred = cloud_backup["credentials"]["id"]
+    attrs = entry.attributes.model_dump()
+    cred = credentials["id"]
     if "bucket" in attrs:
         existing_buckets = [b["Name"] for b in context.middleware.call_sync("cloudsync.list_buckets", cred)]
         if attrs["bucket"] not in existing_buckets:
             context.middleware.call_sync("cloudsync.create_bucket", cred, attrs["bucket"])
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     subprocess.run(
         restic_config.cmd + ["unlock"],
@@ -41,7 +36,7 @@ def ensure_initialized(context: ServiceContext, cloud_backup: dict[str, Any]) ->
     if is_initialized(context, restic_config):
         return
 
-    init(context, cloud_backup)
+    init(context, entry)
 
 
 def is_initialized(context: ServiceContext, restic_config: ResticConfig) -> bool:
@@ -68,10 +63,10 @@ def is_initialized(context: ServiceContext, restic_config: ResticConfig) -> bool
         raise CallError(text)
 
 
-def init(context: ServiceContext, cloud_backup: dict[str, Any]) -> None:
+def init(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> None:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     try:
         subprocess.run(

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -5,14 +5,13 @@ from datetime import timedelta
 import json
 import subprocess
 import threading
-from typing import IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any
 
-from middlewared.api.current import CloudBackupCreate, CloudBackupEntry
+from middlewared.api.current import CloudBackupEntry
 from middlewared.job import JobCancelledException, JobProgressBuffer
 from middlewared.plugins.cloud.path import get_remote_path
 from middlewared.plugins.cloud.remotes import REMOTES
-from middlewared.plugins.cloud_backup.utils import resolve_credentials
-from middlewared.service import CallError, ServiceContext
+from middlewared.service import CallError
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -24,8 +23,7 @@ class ResticConfig:
     env: dict[str, str]
 
 
-def get_restic_config(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> ResticConfig:
-    credentials = resolve_credentials(context, entry.credentials)
+def get_restic_config(entry: CloudBackupEntry, credentials: dict[str, Any]) -> ResticConfig:
     attributes = entry.attributes.model_dump()
 
     remote = REMOTES[credentials["provider"]["type"]]

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 import json
 import subprocess
 import threading
+from typing import IO, TYPE_CHECKING, Any
 
 from middlewared.job import JobCancelledException, JobProgressBuffer
 from middlewared.plugins.cloud.path import get_remote_path
 from middlewared.plugins.cloud.remotes import REMOTES
 from middlewared.service import CallError
+
+if TYPE_CHECKING:
+    from middlewared.job import Job
 
 
 @dataclass
@@ -16,7 +22,7 @@ class ResticConfig:
     env: dict[str, str]
 
 
-def get_restic_config(cloud_backup):
+def get_restic_config(cloud_backup: dict[str, Any]) -> ResticConfig:
     remote = REMOTES[cloud_backup["credentials"]["provider"]["type"]]
 
     remote_path = get_remote_path(remote, cloud_backup["attributes"])
@@ -35,7 +41,16 @@ def get_restic_config(cloud_backup):
     return ResticConfig(cmd, env)
 
 
-def run_restic(job, cmd, env, *, cwd=None, stdin=None, track_progress=False):
+def run_restic(
+    job: Job,
+    cmd: list[str],
+    env: dict[str, str],
+    *,
+    cwd: str | None = None,
+    stdin: IO[bytes] | None = None,
+    track_progress: bool = False,
+) -> None:
+    assert job.logs_fd is not None
     job.logs_fd.write((json.dumps(cmd) + "\n").encode("utf-8", "ignore"))
     proc = subprocess.Popen(
         cmd,
@@ -77,7 +92,7 @@ def run_restic(job, cmd, env, *, cwd=None, stdin=None, track_progress=False):
         raise CallError(message)
 
 
-def restic_check_progress(job, proc, track_progress=False):
+def restic_check_progress(job: Job, proc: subprocess.Popen[bytes], track_progress: bool = False) -> None:
     """Record progress of restic backup, restore, and forget commands.
 
     `track_progress` cannot be set when running "restic forget".
@@ -85,9 +100,11 @@ def restic_check_progress(job, proc, track_progress=False):
     Relevant documentation: https://restic.readthedocs.io/en/stable/075_scripting.html#json-output
 
     """
+    assert proc.stdout is not None
+    assert job.logs_fd is not None
+
     if not track_progress:
-        read = proc.stdout.read()
-        job.logs_fd.write(read)
+        job.logs_fd.write(proc.stdout.read())
         return
 
     # backup or restore

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -5,12 +5,14 @@ from datetime import timedelta
 import json
 import subprocess
 import threading
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING
 
+from middlewared.api.current import CloudBackupCreate, CloudBackupEntry
 from middlewared.job import JobCancelledException, JobProgressBuffer
 from middlewared.plugins.cloud.path import get_remote_path
 from middlewared.plugins.cloud.remotes import REMOTES
-from middlewared.service import CallError
+from middlewared.plugins.cloud_backup.utils import resolve_credentials
+from middlewared.service import CallError, ServiceContext
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -22,21 +24,24 @@ class ResticConfig:
     env: dict[str, str]
 
 
-def get_restic_config(cloud_backup: dict[str, Any]) -> ResticConfig:
-    remote = REMOTES[cloud_backup["credentials"]["provider"]["type"]]
+def get_restic_config(context: ServiceContext, entry: CloudBackupEntry | CloudBackupCreate) -> ResticConfig:
+    credentials = resolve_credentials(context, entry.credentials)
+    attributes = entry.attributes.model_dump()
 
-    remote_path = get_remote_path(remote, cloud_backup["attributes"])
+    remote = REMOTES[credentials["provider"]["type"]]
 
-    url, env = remote.get_restic_config(cloud_backup)
+    remote_path = get_remote_path(remote, attributes)
 
-    if cloud_backup["cache_path"]:
-        cache = ["--cache-dir", cloud_backup["cache_path"]]
+    url, env = remote.get_restic_config({"credentials": credentials, "attributes": attributes})
+
+    if entry.cache_path:
+        cache = ["--cache-dir", entry.cache_path]
     else:
         cache = ["--no-cache"]
 
     cmd = ["restic"] + cache + ["--json", "-r", f"{remote.rclone_type}:{url}/{remote_path}"]
 
-    env["RESTIC_PASSWORD"] = cloud_backup["password"]
+    env["RESTIC_PASSWORD"] = entry.password.get_secret_value()
 
     return ResticConfig(cmd, env)
 

--- a/src/middlewared/middlewared/plugins/cloud_backup/restore.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restore.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from middlewared.api.current import CloudBackupRestoreOptions
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
+from middlewared.plugins.cloud_backup.utils import resolve_credentials
 from middlewared.service import ServiceContext, ValidationErrors
 
 if TYPE_CHECKING:
@@ -30,7 +31,8 @@ def do_restore(
 
     entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(context, entry)
+    credentials = resolve_credentials(context, entry.credentials)
+    restic_config = get_restic_config(entry, credentials)
 
     cmd = ["restore", f"{snapshot_id}:{subfolder}", "--target", destination_path]
     cmd += sum([["--exclude", exclude] for exclude in options.exclude], [])

--- a/src/middlewared/middlewared/plugins/cloud_backup/restore.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restore.py
@@ -1,46 +1,47 @@
-from middlewared.api import api_method
-from middlewared.api.current import CloudBackupRestoreArgs, CloudBackupRestoreResult
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from middlewared.api.current import CloudBackupRestoreOptions
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
-from middlewared.service import Service, ValidationErrors, job
+from middlewared.plugins.cloud_backup.utils import revealed_dict
+from middlewared.service import ServiceContext, ValidationErrors
+
+if TYPE_CHECKING:
+    from middlewared.job import Job
 
 
-class CloudBackupService(Service):
+def do_restore(
+    context: ServiceContext,
+    job: Job,
+    id_: int,
+    snapshot_id: str,
+    subfolder: str,
+    destination_path: str,
+    options: CloudBackupRestoreOptions,
+) -> None:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    class Config:
-        cli_namespace = "task.cloud_backup"
-        namespace = "cloud_backup"
+    verrors = ValidationErrors()
+    context.middleware.run_coroutine(
+        check_path_resides_within_volume(verrors, context.middleware, "destination_path", destination_path)
+    )
+    verrors.check()
 
-    @api_method(CloudBackupRestoreArgs, CloudBackupRestoreResult, roles=["FILESYSTEM_DATA_WRITE"])
-    @job(logs=True)
-    def restore(self, job, id_, snapshot_id, subfolder, destination_path, options):
-        """
-        Restore files to the directory `destination_path` from the `snapshot_id` subfolder `subfolder`
-        created by the cloud backup job `id`.
-        """
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
 
-        verrors = ValidationErrors()
+    restic_config = get_restic_config(cloud_backup)
 
-        self.middleware.run_coroutine(
-            check_path_resides_within_volume(verrors, self.middleware, "destination_path", destination_path)
-        )
+    cmd = ["restore", f"{snapshot_id}:{subfolder}", "--target", destination_path]
+    cmd += sum([["--exclude", exclude] for exclude in options.exclude], [])
+    cmd += sum([["--include", include] for include in options.include], [])
+    if limit := (options.rate_limit or cloud_backup["rate_limit"]):
+        cmd.append(f"--limit-download={limit}")
 
-        verrors.check()
-
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
-
-        restic_config = get_restic_config(cloud_backup)
-
-        cmd = ["restore", f"{snapshot_id}:{subfolder}", "--target", destination_path]
-        cmd += sum([["--exclude", exclude] for exclude in options["exclude"]], [])
-        cmd += sum([["--include", include] for include in options["include"]], [])
-        if limit := (options["rate_limit"] or cloud_backup["rate_limit"]):
-            cmd.append(f"--limit-download={limit}")
-
-        run_restic(
-            job,
-            restic_config.cmd + cmd,
-            restic_config.env,
-            track_progress=True,
-        )
+    run_restic(
+        job,
+        restic_config.cmd + cmd,
+        restic_config.env,
+        track_progress=True,
+    )

--- a/src/middlewared/middlewared/plugins/cloud_backup/restore.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restore.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from middlewared.api.current import CloudBackupRestoreOptions
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
-from middlewared.plugins.cloud_backup.utils import revealed_dict
 from middlewared.service import ServiceContext, ValidationErrors
 
 if TYPE_CHECKING:
@@ -29,14 +28,14 @@ def do_restore(
     )
     verrors.check()
 
-    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     cmd = ["restore", f"{snapshot_id}:{subfolder}", "--target", destination_path]
     cmd += sum([["--exclude", exclude] for exclude in options.exclude], [])
     cmd += sum([["--include", include] for include in options.include], [])
-    if limit := (options.rate_limit or cloud_backup["rate_limit"]):
+    if limit := (options.rate_limit or entry.rate_limit):
         cmd.append(f"--limit-download={limit}")
 
     run_restic(

--- a/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
@@ -1,110 +1,92 @@
+from __future__ import annotations
+
 from datetime import datetime
 import json
 import subprocess
+from typing import TYPE_CHECKING
 
-from middlewared.api import api_method
-from middlewared.api.current import (
-    CloudBackupDeleteSnapshotArgs,
-    CloudBackupDeleteSnapshotResult,
-    CloudBackupListSnapshotDirectoryArgs,
-    CloudBackupListSnapshotDirectoryResult,
-    CloudBackupListSnapshotsArgs,
-    CloudBackupListSnapshotsResult,
-)
+from middlewared.api.current import CloudBackupSnapshot, CloudBackupSnapshotItem
 from middlewared.plugins.cloud_backup.restic import get_restic_config
-from middlewared.service import CallError, Service, job
+from middlewared.plugins.cloud_backup.utils import revealed_dict
+from middlewared.service import CallError, ServiceContext
+
+if TYPE_CHECKING:
+    from middlewared.job import Job
 
 
-class CloudBackupService(Service):
+def list_snapshots(context: ServiceContext, id_: int) -> list[CloudBackupSnapshot]:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    class Config:
-        cli_namespace = "task.cloud_backup"
-        namespace = "cloud_backup"
+    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
 
-    @api_method(CloudBackupListSnapshotsArgs, CloudBackupListSnapshotsResult, roles=['CLOUD_BACKUP_READ'])
-    def list_snapshots(self, id_):
-        """
-        List existing snapshots for the cloud backup job `id`.
-        """
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+    restic_config = get_restic_config(cloud_backup)
 
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
+    try:
+        snapshots = json.loads(subprocess.run(
+            restic_config.cmd + ["--json", "snapshots"],
+            env=restic_config.env,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout)
+    except subprocess.CalledProcessError as e:
+        raise CallError(e.stderr)
 
-        restic_config = get_restic_config(cloud_backup)
+    for snapshot in snapshots:
+        snapshot["time"] = datetime.fromisoformat(snapshot["time"])
 
-        try:
-            snapshots = json.loads(subprocess.run(
-                restic_config.cmd + ["--json", "snapshots"],
-                env=restic_config.env,
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout)
-        except subprocess.CalledProcessError as e:
-            raise CallError(e.stderr)
+    return [CloudBackupSnapshot(**snapshot) for snapshot in snapshots]
 
-        for snapshot in snapshots:
-            snapshot["time"] = datetime.fromisoformat(snapshot["time"])
 
-        return snapshots
+def list_snapshot_directory(
+    context: ServiceContext, id_: int, snapshot_id: str, path: str,
+) -> list[CloudBackupSnapshotItem]:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    @api_method(CloudBackupListSnapshotDirectoryArgs, CloudBackupListSnapshotDirectoryResult,
-                roles=['CLOUD_BACKUP_READ'])
-    def list_snapshot_directory(self, id_, snapshot_id, path):
-        """
-        List files in the directory `path` of the `snapshot_id` created by the cloud backup job `id`.
-        """
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
 
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
+    restic_config = get_restic_config(cloud_backup)
 
-        restic_config = get_restic_config(cloud_backup)
+    try:
+        items = list(map(json.loads, subprocess.run(
+            restic_config.cmd + ["--json", "ls", snapshot_id, path],
+            env=restic_config.env,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.splitlines()))
+    except subprocess.CalledProcessError as e:
+        raise CallError(e.stderr)
 
-        try:
-            items = list(map(json.loads, subprocess.run(
-                restic_config.cmd + ["--json", "ls", snapshot_id, path],
-                env=restic_config.env,
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout.splitlines()))
-        except subprocess.CalledProcessError as e:
-            raise CallError(e.stderr)
+    contents = []
+    for item in items[1:]:
+        if item["struct_type"] != "node":
+            continue
 
-        contents = []
-        for item in items[1:]:
-            if item["struct_type"] != "node":
-                continue
+        item.setdefault("size", None)
 
-            item.setdefault("size", None)
+        for k in ["atime", "ctime", "mtime"]:
+            item[k] = datetime.fromisoformat(item[k])
 
-            for k in ["atime", "ctime", "mtime"]:
-                item[k] = datetime.fromisoformat(item[k])
+        contents.append(item)
 
-            contents.append(item)
+    return [CloudBackupSnapshotItem(**item) for item in contents]
 
-        return contents
 
-    @api_method(CloudBackupDeleteSnapshotArgs, CloudBackupDeleteSnapshotResult,
-                roles=['CLOUD_BACKUP_WRITE'])
-    @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1)
-    def delete_snapshot(self, job, id_, snapshot_id):
-        """
-        Delete snapshot `snapshot_id` created by the cloud backup job `id`.
-        """
-        self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
+def delete_snapshot(context: ServiceContext, job: Job, id_: int, snapshot_id: str) -> None:
+    context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
+    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
 
-        restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(cloud_backup)
 
-        try:
-            subprocess.run(
-                restic_config.cmd + ["forget", snapshot_id, "--prune"],
-                env=restic_config.env,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            raise CallError(e.stderr)
+    try:
+        subprocess.run(
+            restic_config.cmd + ["forget", snapshot_id, "--prune"],
+            env=restic_config.env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise CallError(e.stderr)

--- a/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from middlewared.api.current import CloudBackupSnapshot, CloudBackupSnapshotItem
 from middlewared.plugins.cloud_backup.restic import get_restic_config
-from middlewared.plugins.cloud_backup.utils import revealed_dict
 from middlewared.service import CallError, ServiceContext
 
 if TYPE_CHECKING:
@@ -17,9 +16,9 @@ if TYPE_CHECKING:
 def list_snapshots(context: ServiceContext, id_: int) -> list[CloudBackupSnapshot]:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     try:
         snapshots = json.loads(subprocess.run(
@@ -43,9 +42,9 @@ def list_snapshot_directory(
 ) -> list[CloudBackupSnapshotItem]:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     try:
         items = list(map(json.loads, subprocess.run(
@@ -76,9 +75,9 @@ def list_snapshot_directory(
 def delete_snapshot(context: ServiceContext, job: Job, id_: int, snapshot_id: str) -> None:
     context.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-    cloud_backup = revealed_dict(context, context.call_sync2(context.s.cloud_backup.get_instance, id_))
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(cloud_backup)
+    restic_config = get_restic_config(context, entry)
 
     try:
         subprocess.run(

--- a/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from middlewared.api.current import CloudBackupSnapshot, CloudBackupSnapshotItem
 from middlewared.plugins.cloud_backup.restic import get_restic_config
+from middlewared.plugins.cloud_backup.utils import resolve_credentials
 from middlewared.service import CallError, ServiceContext
 
 if TYPE_CHECKING:
@@ -18,7 +19,8 @@ def list_snapshots(context: ServiceContext, id_: int) -> list[CloudBackupSnapsho
 
     entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(context, entry)
+    credentials = resolve_credentials(context, entry.credentials)
+    restic_config = get_restic_config(entry, credentials)
 
     try:
         snapshots = json.loads(subprocess.run(
@@ -44,7 +46,8 @@ def list_snapshot_directory(
 
     entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(context, entry)
+    credentials = resolve_credentials(context, entry.credentials)
+    restic_config = get_restic_config(entry, credentials)
 
     try:
         items = list(map(json.loads, subprocess.run(
@@ -77,7 +80,8 @@ def delete_snapshot(context: ServiceContext, job: Job, id_: int, snapshot_id: st
 
     entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-    restic_config = get_restic_config(context, entry)
+    credentials = resolve_credentials(context, entry.credentials)
+    restic_config = get_restic_config(entry, credentials)
 
     try:
         subprocess.run(

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import subprocess
 import time
-from typing import IO, TYPE_CHECKING, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 from middlewared.api.current import (
     CloudBackupEntry,
@@ -37,6 +37,7 @@ def restic_backup(
     context: ServiceContext,
     job: Job,
     entry: CloudBackupEntry,
+    credentials: dict[str, Any],
     dry_run: bool = False,
     rate_limit: int | None = None,
 ) -> None:
@@ -105,10 +106,9 @@ def restic_backup(
 
         cmd.extend(["--exclude=" + excl for excl in entry.exclude])
 
-        restic_config = get_restic_config(context, entry)
+        restic_config = get_restic_config(entry, credentials)
         cmd = restic_config.cmd + ["--verbose", "backup"] + cmd
 
-        credentials = resolve_credentials(context, entry.credentials)
         env = env_mapping("CLOUD_BACKUP_", {
             "id": entry.id,
             "description": entry.description,
@@ -164,12 +164,13 @@ def do_sync(context: ServiceContext, job: Job, id_: int, options: CloudBackupSyn
 def _sync(context: ServiceContext, entry: CloudBackupEntry, options: CloudBackupSyncOptions, job: Job) -> None:
     job.set_progress(0, "Starting")
     try:
-        ensure_initialized(context, entry)
+        credentials = resolve_credentials(context, entry.credentials)
+        ensure_initialized(context, entry, credentials)
 
-        restic_backup(context, job, entry, dry_run=options.dry_run, rate_limit=options.rate_limit)
+        restic_backup(context, job, entry, credentials, dry_run=options.dry_run, rate_limit=options.rate_limit)
 
         job.set_progress(100, "Cleaning up")
-        restic_config = get_restic_config(context, entry)
+        restic_config = get_restic_config(entry, credentials)
         run_restic(
             job,
             restic_config.cmd + ["forget", "--keep-last", str(entry.keep_last), "--group-by", "", "--prune"],

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import itertools
 import subprocess
 import time
-from typing import IO, TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Literal
 
 from middlewared.api.current import (
+    CloudBackupEntry,
     CloudBackupSyncOptions,
     ZFSResourceSnapshotCloneQuery,
     ZFSResourceSnapshotDestroyQuery,
@@ -16,7 +17,7 @@ from middlewared.plugins.cloud.snapshot import create_snapshot
 from middlewared.plugins.cloud_backup.crud import CloudBackupTaskFailedAlert
 from middlewared.plugins.cloud_backup.init import ensure_initialized
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
-from middlewared.plugins.cloud_backup.utils import revealed_dict
+from middlewared.plugins.cloud_backup.utils import resolve_credentials
 from middlewared.plugins.zfs.zvol_utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.time_utils import utc_now
@@ -35,7 +36,7 @@ TRANSFER_SETTING_ARGS: dict[Literal["DEFAULT", "PERFORMANCE", "FAST_STORAGE"], l
 def restic_backup(
     context: ServiceContext,
     job: Job,
-    cloud_backup: dict[str, Any],
+    entry: CloudBackupEntry,
     dry_run: bool = False,
     rate_limit: int | None = None,
 ) -> None:
@@ -46,11 +47,11 @@ def restic_backup(
     clone = None
     stdin: IO[bytes] | None = None
     try:
-        local_path = cloud_backup["path"]
+        local_path = entry.path
         if local_path.startswith("/dev/zvol"):
             context.call_sync2(context.s.cloud_backup.validate_zvol, local_path)
 
-            name = f"cloud_backup-{cloud_backup.get('id', 'onetime')}-{utc_now().strftime('%Y%m%d%H%M%S')}"
+            name = f"cloud_backup-{entry.id}-{utc_now().strftime('%Y%m%d%H%M%S')}"
             snapshot = (middleware.call_sync("pool.snapshot.create", {
                 "dataset": zvol_path_to_name(local_path),
                 "name": name,
@@ -84,46 +85,50 @@ def restic_backup(
             cmd = ["--stdin", "--stdin-filename", "volume"]
         else:
             check_local_path(middleware, local_path)
-            if cloud_backup["snapshot"]:
-                snapshot_name = f"cloud_backup-{cloud_backup.get('id', 'onetime')}"
+            if entry.snapshot:
+                snapshot_name = f"cloud_backup-{entry.id}"
                 snapshot, local_path = create_snapshot(middleware, local_path, snapshot_name)
 
-            if cloud_backup["absolute_paths"]:
+            if entry.absolute_paths:
                 cwd = None
                 cmd = [local_path]
             else:
                 cwd = local_path
                 cmd = ["."]
 
-        cmd.extend(TRANSFER_SETTING_ARGS[cloud_backup["transfer_setting"]])
+        cmd.extend(TRANSFER_SETTING_ARGS[entry.transfer_setting])
 
         if dry_run:
             cmd.append("-n")
-        if limit := (rate_limit or cloud_backup["rate_limit"]):
+        if limit := (rate_limit or entry.rate_limit):
             cmd.append(f"--limit-upload={limit}")
 
-        cmd.extend(["--exclude=" + excl for excl in cloud_backup["exclude"]])
+        cmd.extend(["--exclude=" + excl for excl in entry.exclude])
 
-        restic_config = get_restic_config(cloud_backup)
+        restic_config = get_restic_config(context, entry)
         cmd = restic_config.cmd + ["--verbose", "backup"] + cmd
 
+        credentials = resolve_credentials(context, entry.credentials)
         env = env_mapping("CLOUD_BACKUP_", {
-            **{k: v for k, v in cloud_backup.items() if k in [
-                "id", "description", "snapshot", "password", "keep_last", "transfer_setting"
-            ]},
-            **cloud_backup["credentials"]["provider"],
-            **cloud_backup["attributes"],
+            "id": entry.id,
+            "description": entry.description,
+            "snapshot": entry.snapshot,
+            "password": entry.password.get_secret_value(),
+            "keep_last": entry.keep_last,
+            "transfer_setting": entry.transfer_setting,
+            **credentials["provider"],
+            **entry.attributes.model_dump(),
             "path": local_path
         })
-        run_script(job, "Pre-script", cloud_backup["pre_script"], env)
+        run_script(job, "Pre-script", entry.pre_script, env)
 
         run_restic(job, cmd, restic_config.env, cwd=cwd, stdin=stdin, track_progress=True)
 
-        if cloud_backup["cache_path"]:
-            subprocess.run(["restic", "--cache-dir", cloud_backup["cache_path"], "cache", "--cleanup"], check=False,
+        if entry.cache_path:
+            subprocess.run(["restic", "--cache-dir", entry.cache_path, "cache", "--cleanup"], check=False,
                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-        run_script(job, "Post-script", cloud_backup["post_script"], env)
+        run_script(job, "Post-script", entry.post_script, env)
     finally:
         if stdin:
             try:
@@ -153,33 +158,31 @@ def do_sync(context: ServiceContext, job: Job, id_: int, options: CloudBackupSyn
         context.call_sync2(context.s.cloud_backup.generate_locked_alert, id_)
         raise CallError("Dataset is locked")
 
-    _sync(context, revealed_dict(context, entry), options, job)
+    _sync(context, entry, options, job)
 
 
-def _sync(context: ServiceContext, cloud_backup: dict[str, Any], options: CloudBackupSyncOptions, job: Job) -> None:
+def _sync(context: ServiceContext, entry: CloudBackupEntry, options: CloudBackupSyncOptions, job: Job) -> None:
     job.set_progress(0, "Starting")
     try:
-        ensure_initialized(context, cloud_backup)
+        ensure_initialized(context, entry)
 
-        restic_backup(context, job, cloud_backup, dry_run=options.dry_run, rate_limit=options.rate_limit)
+        restic_backup(context, job, entry, dry_run=options.dry_run, rate_limit=options.rate_limit)
 
         job.set_progress(100, "Cleaning up")
-        restic_config = get_restic_config(cloud_backup)
+        restic_config = get_restic_config(context, entry)
         run_restic(
             job,
-            restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--group-by", "", "--prune"],
+            restic_config.cmd + ["forget", "--keep-last", str(entry.keep_last), "--group-by", "", "--prune"],
             restic_config.env,
         )
 
-        if "id" in cloud_backup:
-            context.call_sync2(context.s.alert.oneshot_delete, "CloudBackupTaskFailed", cloud_backup["id"])
+        context.call_sync2(context.s.alert.oneshot_delete, "CloudBackupTaskFailed", entry.id)
         job.set_progress(description="Done")
     except Exception:
-        if "id" in cloud_backup:
-            context.call_sync2(context.s.alert.oneshot_create, CloudBackupTaskFailedAlert(
-                id=cloud_backup["id"],
-                name=cloud_backup["description"],
-            ))
+        context.call_sync2(context.s.alert.oneshot_create, CloudBackupTaskFailedAlert(
+            id=entry.id,
+            name=entry.description,
+        ))
         raise
 
 

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
 import itertools
 import subprocess
 import time
+from typing import IO, TYPE_CHECKING, Any, Literal
 
-from middlewared.api import api_method
 from middlewared.api.current import (
-    CloudBackupAbortArgs,
-    CloudBackupAbortResult,
-    CloudBackupSyncArgs,
-    CloudBackupSyncResult,
+    CloudBackupSyncOptions,
     ZFSResourceSnapshotCloneQuery,
     ZFSResourceSnapshotDestroyQuery,
 )
@@ -15,22 +14,41 @@ from middlewared.plugins.cloud.path import check_local_path
 from middlewared.plugins.cloud.script import env_mapping, run_script
 from middlewared.plugins.cloud.snapshot import create_snapshot
 from middlewared.plugins.cloud_backup.crud import CloudBackupTaskFailedAlert
+from middlewared.plugins.cloud_backup.init import ensure_initialized
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
-from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
-from middlewared.service import CallError, Service, job, private
+from middlewared.plugins.cloud_backup.utils import revealed_dict
+from middlewared.plugins.zfs.zvol_utils import zvol_name_to_path, zvol_path_to_name
+from middlewared.service import CallError, ServiceContext
 from middlewared.utils.time_utils import utc_now
 
+if TYPE_CHECKING:
+    from middlewared.job import Job
 
-def restic_backup(middleware, job, cloud_backup: dict, dry_run: bool = False, rate_limit: int | None = None):
+
+TRANSFER_SETTING_ARGS: dict[Literal["DEFAULT", "PERFORMANCE", "FAST_STORAGE"], list[str]] = {
+    "DEFAULT": [],
+    "PERFORMANCE": ["--pack-size", "29"],
+    "FAST_STORAGE": ["--pack-size", "58", "--read-concurrency", "100"],
+}
+
+
+def restic_backup(
+    context: ServiceContext,
+    job: Job,
+    cloud_backup: dict[str, Any],
+    dry_run: bool = False,
+    rate_limit: int | None = None,
+) -> None:
+    middleware = context.middleware
     middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
     snapshot = None
     clone = None
-    stdin = None
+    stdin: IO[bytes] | None = None
     try:
         local_path = cloud_backup["path"]
         if local_path.startswith("/dev/zvol"):
-            middleware.call_sync("cloud_backup.validate_zvol", local_path)
+            context.call_sync2(context.s.cloud_backup.validate_zvol, local_path)
 
             name = f"cloud_backup-{cloud_backup.get('id', 'onetime')}-{utc_now().strftime('%Y%m%d%H%M%S')}"
             snapshot = (middleware.call_sync("pool.snapshot.create", {
@@ -42,8 +60,8 @@ def restic_backup(middleware, job, cloud_backup: dict, dry_run: bool = False, ra
 
             clone = zvol_path_to_name(local_path) + f"-{name}"
             try:
-                middleware.call_sync2(
-                    middleware.services.zfs.resource.snapshot.clone,
+                context.call_sync2(
+                    context.s.zfs.resource.snapshot.clone,
                     ZFSResourceSnapshotCloneQuery(snapshot=snapshot, dataset=clone),
                 )
             except Exception:
@@ -77,8 +95,7 @@ def restic_backup(middleware, job, cloud_backup: dict, dry_run: bool = False, ra
                 cwd = local_path
                 cmd = ["."]
 
-        args = middleware.call_sync("cloud_backup.transfer_setting_args")
-        cmd.extend(args[cloud_backup["transfer_setting"]])
+        cmd.extend(TRANSFER_SETTING_ARGS[cloud_backup["transfer_setting"]])
 
         if dry_run:
             cmd.append("-n")
@@ -112,94 +129,68 @@ def restic_backup(middleware, job, cloud_backup: dict, dry_run: bool = False, ra
             try:
                 stdin.close()
             except Exception as e:
-                middleware.logger.warning(f"Error closing snapshot device: {e!r}")
+                context.logger.warning(f"Error closing snapshot device: {e!r}")
 
         if clone is not None:
             try:
-                middleware.call_sync2(
-                    middleware.services.zfs.resource.destroy_impl,
-                    clone,
-                )
+                context.call_sync2(context.s.zfs.resource.destroy_impl, clone)
             except Exception as e:
-                middleware.logger.warning(f"Error deleting cloned dataset {clone}: {e!r}")
+                context.logger.warning(f"Error deleting cloned dataset {clone}: {e!r}")
 
         if snapshot is not None:
             try:
-                middleware.call_sync2(
-                    middleware.services.zfs.resource.snapshot.destroy_impl,
+                context.call_sync2(
+                    context.s.zfs.resource.snapshot.destroy_impl,
                     ZFSResourceSnapshotDestroyQuery(path=snapshot),
                 )
             except Exception as e:
-                middleware.logger.warning(f"Error deleting snapshot {snapshot}: {e!r}")
+                context.logger.warning(f"Error deleting snapshot {snapshot}: {e!r}")
 
 
-class CloudBackupService(Service):
+def do_sync(context: ServiceContext, job: Job, id_: int, options: CloudBackupSyncOptions) -> None:
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
+    if entry.locked:
+        context.call_sync2(context.s.cloud_backup.generate_locked_alert, id_)
+        raise CallError("Dataset is locked")
 
-    class Config:
-        cli_namespace = "task.cloud_backup"
-        namespace = "cloud_backup"
+    _sync(context, revealed_dict(context, entry), options, job)
 
-    @api_method(CloudBackupSyncArgs, CloudBackupSyncResult, roles=['CLOUD_BACKUP_WRITE'])
-    @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True)
-    def sync(self, job, id_, options):
-        """
-        Run the cloud backup job `id`.
-        """
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
-        if cloud_backup["locked"]:
-            self.middleware.call_sync("cloud_backup.generate_locked_alert", id_)
-            raise CallError("Dataset is locked")
 
-        self._sync(cloud_backup, options, job)
+def _sync(context: ServiceContext, cloud_backup: dict[str, Any], options: CloudBackupSyncOptions, job: Job) -> None:
+    job.set_progress(0, "Starting")
+    try:
+        ensure_initialized(context, cloud_backup)
 
-    def _sync(self, cloud_backup: dict, options: dict, job):
-        job.set_progress(0, "Starting")
-        try:
-            self.middleware.call_sync("cloud_backup.ensure_initialized", cloud_backup)
+        restic_backup(context, job, cloud_backup, dry_run=options.dry_run, rate_limit=options.rate_limit)
 
-            restic_backup(self.middleware, job, cloud_backup, **options)
+        job.set_progress(100, "Cleaning up")
+        restic_config = get_restic_config(cloud_backup)
+        run_restic(
+            job,
+            restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--group-by", "", "--prune"],
+            restic_config.env,
+        )
 
-            job.set_progress(100, "Cleaning up")
-            restic_config = get_restic_config(cloud_backup)
-            run_restic(
-                job,
-                restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--group-by", "",
-                                     "--prune"],
-                restic_config.env,
-            )
+        if "id" in cloud_backup:
+            context.call_sync2(context.s.alert.oneshot_delete, "CloudBackupTaskFailed", cloud_backup["id"])
+        job.set_progress(description="Done")
+    except Exception:
+        if "id" in cloud_backup:
+            context.call_sync2(context.s.alert.oneshot_create, CloudBackupTaskFailedAlert(
+                id=cloud_backup["id"],
+                name=cloud_backup["description"],
+            ))
+        raise
 
-            if "id" in cloud_backup:
-                self.call_sync2(self.s.alert.oneshot_delete, "CloudBackupTaskFailed", cloud_backup["id"])
-            job.set_progress(description="Done")
-        except Exception:
-            if "id" in cloud_backup:
-                self.call_sync2(self.s.alert.oneshot_create, CloudBackupTaskFailedAlert(
-                    id=cloud_backup["id"],
-                    name=cloud_backup["description"],
-                ))
-            raise
 
-    @api_method(CloudBackupAbortArgs, CloudBackupAbortResult, roles=['CLOUD_BACKUP_WRITE'])
-    def abort(self, id_):
-        """
-        Abort a running cloud backup task.
-        """
-        cloud_backup = self.middleware.call_sync("cloud_backup.get_instance", id_)
+def do_abort(context: ServiceContext, id_: int) -> bool:
+    entry = context.call_sync2(context.s.cloud_backup.get_instance, id_)
 
-        if cloud_backup["job"] is None:
-            return False
+    if entry.job is None:
+        return False
 
-        if cloud_backup["job"]["state"] not in ["WAITING", "RUNNING"]:
-            return False
+    if entry.job["state"] not in ["WAITING", "RUNNING"]:
+        return False
 
-        self.middleware.call_sync("core.job_abort", cloud_backup["job"]["id"])
-        return True
-
-    @private
-    def validate_zvol(self, path):
-        dataset = zvol_path_to_name(path)
-        if not (
-            self.call_sync2(self.s.vm.query_snapshot_begin, dataset, False) or
-            self.middleware.call_sync("vmware.dataset_has_vms", dataset, False)
-        ):
-            raise CallError("Backed up zvol must be used by a local or VMware VM")
+    context.middleware.call_sync("core.job_abort", entry.job["id"])
+    return True

--- a/src/middlewared/middlewared/plugins/cloud_backup/utils.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from middlewared.api.current import CloudBackupEntry
+from middlewared.service import ServiceContext
+
+
+def revealed_dict(context: ServiceContext, entry: CloudBackupEntry) -> dict[str, Any]:
+    """Return a cloud backup entry as a plain dict with the secrets restic needs revealed.
+
+    ``model_dump`` redacts the ``Secret`` password, and the credential's provider secrets are
+    only available as a plain dict from the (unconverted) ``cloudsync`` service. The restic
+    helpers consume this dict shape directly.
+    """
+    data = entry.model_dump(context={"expose_secrets": True})
+    data["credentials"] = context.middleware.call_sync(
+        "cloudsync.credentials.get_instance",
+        entry.credentials.id,
+    )
+    return data

--- a/src/middlewared/middlewared/plugins/cloud_backup/utils.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/utils.py
@@ -6,13 +6,16 @@ from middlewared.api.current import CredentialsEntry
 from middlewared.service import ServiceContext
 
 
+# FIXME: Remove once the cloud_sync plugin is converted; its dict-based rclone layer is why we marshal here.
 def resolve_credentials(context: ServiceContext, credentials: int | CredentialsEntry) -> dict[str, Any]:
-    """Return the cloud credential record (with the flat, revealed provider dict restic needs).
+    """Return the cloud credential as the flat, plaintext provider dict the restic/rclone helpers consume.
 
-    The credential id may come straight from a create/update payload (``int``) or from a persisted
-    entry (``CredentialsEntry``). Either way the provider secrets are owned by the unconverted
-    ``cloudsync.credentials`` service, which is the only source of the flat ``provider`` dict shape
-    the restic helpers consume.
+    This is the single place that turns a credential reference into that dict, and each operation calls
+    it once and threads the result down. The reference is an ``int`` id on a create/update payload or a
+    ``CredentialsEntry`` on a persisted task; either way it points at an existing ``system.cloudcredentials``
+    row, so we fetch it from the unconverted ``cloudsync.credentials`` service. We deliberately do not dump
+    the entry's ``CredentialsEntry`` instead: its secrets are masked, and ``model_dump`` drifts from the
+    stored shape (URL normalization, default-filled keys) that flows into the ``CLOUD_BACKUP_*`` script env.
     """
     cred_id = credentials if isinstance(credentials, int) else credentials.id
     record: dict[str, Any] = context.middleware.call_sync("cloudsync.credentials.get_instance", cred_id)

--- a/src/middlewared/middlewared/plugins/cloud_backup/utils.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/utils.py
@@ -2,20 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from middlewared.api.current import CloudBackupEntry
+from middlewared.api.current import CredentialsEntry
 from middlewared.service import ServiceContext
 
 
-def revealed_dict(context: ServiceContext, entry: CloudBackupEntry) -> dict[str, Any]:
-    """Return a cloud backup entry as a plain dict with the secrets restic needs revealed.
+def resolve_credentials(context: ServiceContext, credentials: int | CredentialsEntry) -> dict[str, Any]:
+    """Return the cloud credential record (with the flat, revealed provider dict restic needs).
 
-    ``model_dump`` redacts the ``Secret`` password, and the credential's provider secrets are
-    only available as a plain dict from the (unconverted) ``cloudsync`` service. The restic
-    helpers consume this dict shape directly.
+    The credential id may come straight from a create/update payload (``int``) or from a persisted
+    entry (``CredentialsEntry``). Either way the provider secrets are owned by the unconverted
+    ``cloudsync.credentials`` service, which is the only source of the flat ``provider`` dict shape
+    the restic helpers consume.
     """
-    data = entry.model_dump(context={"expose_secrets": True})
-    data["credentials"] = context.middleware.call_sync(
-        "cloudsync.credentials.get_instance",
-        entry.credentials.id,
-    )
-    return data
+    cred_id = credentials if isinstance(credentials, int) else credentials.id
+    record: dict[str, Any] = context.middleware.call_sync("cloudsync.credentials.get_instance", cred_id)
+    return record

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -56,6 +56,7 @@ from middlewared.api.current import (
     CredentialsUpdateResult,
     CredentialsVerifyArgs,
     CredentialsVerifyResult,
+    QueryOptions,
     ZFSResourceSnapshotDestroyQuery,
 )
 from middlewared.common.attachment import LockableFSAttachmentDelegate
@@ -703,11 +704,12 @@ class CredentialsService(CRUDService):
         if tasks:
             raise CallError(f"This credential is used by cloud sync task {tasks[0]['description'] or tasks[0]['id']}")
 
-        tasks = self.middleware.call_sync(
-            "cloud_backup.query", [["credentials.id", "=", id_]], {"select": ["id", "credentials", "description"]}
+        tasks = self.middleware.call_sync2(
+            self.middleware.services.cloud_backup.query,
+            [["credentials.id", "=", id_]], QueryOptions(select=["id", "credentials", "description"]),
         )
         if tasks:
-            raise CallError(f"This credential is used by cloud backup task {tasks[0]['description'] or tasks[0]['id']}")
+            raise CallError(f"This credential is used by cloud backup task {tasks[0].description or tasks[0].id}")
 
         return self.middleware.call_sync(
             "datastore.delete",


### PR DESCRIPTION
This commit adds changes to convert the cloud_backup plugin to the typesafe service/part pattern, so query and get_instance return Pydantic models, public methods use @api_method(check_annotations=True), and same-process calls go through call2/call_sync2.

The shared CloudTaskServiceMixin is left untyped since cloud_sync still depends on it, with a single sibling-safe edit to its zvol validation path. All in-process consumers were updated for model access: the cloud_sync credential delete check, the cron.d mako, and the path-resolution migration. Since the password is a Secret field, the create/update and restic paths dump with expose_secrets so an unchanged password isn't written back as the redaction string.

API tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/9432/