### PR TITLE
NAS-141504 / 27.0.0-BETA.1 / Convert system.vendor to the typesafe port pattern

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -46,6 +46,7 @@ jobs:
             middlewared/plugins/reporting/ \
             middlewared/plugins/rsync/ \
             middlewared/plugins/snapshot/ \
+            middlewared/plugins/system_vendor/ \
             middlewared/plugins/truenas/ \
             middlewared/plugins/truenas_connect/ \
             middlewared/plugins/truesearch.py \

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -128,6 +128,7 @@ from middlewared.plugins.pwenc import PWEncService
 from middlewared.plugins.reporting import ReportingService
 from middlewared.plugins.rsync import RsyncTaskService
 from middlewared.plugins.snapshot import PeriodicSnapshotTaskService
+from middlewared.plugins.system_vendor import VendorService
 from middlewared.plugins.truenas import TrueNASService
 from middlewared.plugins.truenas_connect import TrueNASConnectService
 from middlewared.plugins.truesearch import TrueSearchService
@@ -230,6 +231,7 @@ class SystemServicesContainer(BaseServiceContainer):
     def __init__(self, middleware: "Middleware"):
         super().__init__(middleware)
         self.ntpserver = NTPServerService(middleware)
+        self.vendor = VendorService(middleware)
 
 
 class ZfsServicesContainer(BaseServiceContainer):

--- a/src/middlewared/middlewared/plugins/device_/netlink_events.py
+++ b/src/middlewared/middlewared/plugins/device_/netlink_events.py
@@ -424,7 +424,7 @@ async def _systemctl_restart_ixvendor(middleware):
         return
 
     async with IX_VEND_LOCK:
-        if await middleware.call("system.vendor.is_vendored"):
+        if await middleware.call2(middleware.services.system.vendor.is_vendored):
             await system_dbus.call_unit_action_and_wait("ix-vendor.service", "Restart")
 
 

--- a/src/middlewared/middlewared/plugins/nvmet/subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/subsys.py
@@ -227,7 +227,7 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
     @private
     @cache
     def model(self):
-        vendor = self.middleware.call_sync('system.vendor.name')
+        vendor = self.call_sync2(self.s.system.vendor.name)
         dmiinfo = self.middleware.call_sync('system.dmidecode_info')
         if dmiinfo.get('system-manufacturer') == 'QEMU':
             system_product = 'KVM VM'

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -112,7 +112,7 @@ class SupportService(ConfigService):
         Returns whether Proactive Support is available for this product type and current license.
         """
 
-        if await self.middleware.call('system.vendor.name'):
+        if await self.call2(self.s.system.vendor.name):
             return False
 
         if not await self.middleware.call('system.is_enterprise'):
@@ -171,7 +171,7 @@ class SupportService(ConfigService):
         For Community Edition, `criticality`, `environment`, `phone`, `name`, and `email` attributes are not required.
         For Enterprise, `token` and `type` attributes are not required.
         """
-        vendor = await self.middleware.call('system.vendor.name')
+        vendor = await self.call2(self.s.system.vendor.name)
         if vendor:
             raise CallError(f'Support is not available for this product ({vendor})', errno.EINVAL)
 

--- a/src/middlewared/middlewared/plugins/system_vendor/__init__.py
+++ b/src/middlewared/middlewared/plugins/system_vendor/__init__.py
@@ -1,0 +1,40 @@
+import json
+
+from middlewared.service import Service
+
+from . import vendor as _vendor
+
+__all__ = ('VendorService',)
+
+
+class VendorService(Service):
+
+    class Config:
+        namespace = 'system.vendor'
+        private = True
+
+    def name(self) -> str | None:
+        try:
+            return _vendor.get_vendor()
+        except FileNotFoundError:
+            pass
+        except json.JSONDecodeError:
+            self.logger.exception(
+                "Can't retrieve vendor name: %r is not proper JSON format", _vendor.SENTINEL_FILE_PATH
+            )
+        except Exception:
+            self.logger.exception('Unexpected error while reading %r', _vendor.SENTINEL_FILE_PATH)
+        return None
+
+    def unvendor(self) -> None:
+        try:
+            _vendor.remove_vendor_file()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            self.logger.exception('Unexpected error attempting to remove %r', _vendor.SENTINEL_FILE_PATH)
+
+        self.middleware.call_sync('etc.generate', 'grub')
+
+    def is_vendored(self) -> bool:
+        return _vendor.is_vendored()

--- a/src/middlewared/middlewared/plugins/system_vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system_vendor/vendor.py
@@ -1,10 +1,6 @@
 import json
 import os
 
-from middlewared.api import api_method
-from middlewared.api.base import BaseModel
-from middlewared.service import Service
-
 SENTINEL_FILE_PATH = '/data/.vendor'
 
 
@@ -13,58 +9,9 @@ def get_vendor() -> str | None:
         return json.load(file).get('name') or None  # Don't return an empty string.
 
 
-class VendorNameArgs(BaseModel):
-    pass
+def remove_vendor_file() -> None:
+    os.remove(SENTINEL_FILE_PATH)
 
 
-class VendorNameResult(BaseModel):
-    result: str | None
-
-
-class UnvendorArgs(BaseModel):
-    pass
-
-
-class UnvendorResult(BaseModel):
-    result: None
-
-
-class IsVendoredArgs(BaseModel):
-    pass
-
-
-class IsVendoredResult(BaseModel):
-    result: bool
-
-
-class VendorService(Service):
-
-    class Config:
-        namespace = 'system.vendor'
-        cli_private = True
-
-    @api_method(VendorNameArgs, VendorNameResult, private=True)
-    def name(self) -> str | None:
-        try:
-            return get_vendor()
-        except FileNotFoundError:
-            pass
-        except json.JSONDecodeError:
-            self.logger.exception("Can't retrieve vendor name: %r is not proper JSON format", SENTINEL_FILE_PATH)
-        except Exception:
-            self.logger.exception('Unexpected error while reading %r', SENTINEL_FILE_PATH)
-
-    @api_method(UnvendorArgs, UnvendorResult, private=True)
-    def unvendor(self):
-        try:
-            os.remove(SENTINEL_FILE_PATH)
-        except FileNotFoundError:
-            pass
-        except Exception:
-            self.logger.exception('Unexpected error attempting to remove %r', SENTINEL_FILE_PATH)
-
-        self.middleware.call_sync('etc.generate', 'grub')
-
-    @api_method(IsVendoredArgs, IsVendoredResult, private=True)
-    def is_vendored(self):
-        return os.path.isfile(SENTINEL_FILE_PATH)
+def is_vendored() -> bool:
+    return os.path.isfile(SENTINEL_FILE_PATH)

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -272,8 +272,8 @@ class UsageService(Service):
         return {
             'platform': f'TrueNAS-{await self.middleware.call("system.product_type")}',
             'version': await self.middleware.call('system.version'),
-            'is_vendored': await self.middleware.call('system.vendor.is_vendored'),
-            'vendor_name': await self.middleware.call('system.vendor.name'),
+            'is_vendored': await self.call2(self.s.system.vendor.is_vendored),
+            'vendor_name': await self.call2(self.s.system.vendor.name),
             'is_virtualized': await self.call2(self.s.hardware.virtualization.is_virtualized),
             'hypervisor': await self.call2(self.s.hardware.virtualization.variant),
         }


### PR DESCRIPTION
## Context
system.vendor was an old-style service with inline BaseModel args/results and @api_method-wrapped methods. All three methods (name, unvendor, is_vendored) are private with no over-the-wire surface and there is no datastore, so it fits the fully-private port pattern — a lean private shim delegating to plain, fully type-annotated module functions — rather than a Generic*/Pydantic conversion. The wire shapes (str | None, bool, None) are unchanged.

## Solution
- vendor.py is now a plain typed logic module (get_vendor, remove_vendor_file, is_vendored); get_vendor stays importable there for scripts/vendor_service.py. The lean VendorService shim in __init__.py keeps the try/except + logging orchestration and delegates to it, with Config private. unvendor keeps the etc.generate string call since that's CtxMethod dynamic dispatch.
- Registered VendorService on SystemServicesContainer in main.py so it resolves as self.s.system.vendor.
- Switched the six in-process callers (support x2, usage x2, nvmet.subsys, device_ netlink events) from string middleware.call to call2/call_sync2 against the typed method handle.
- Added the plugin to the mypy workflow list.

API tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/9435/