### PR TITLE
NAS-141520 / 27.0.0-BETA.1 / Supply -preserve_cluster_mode when calling scstadmin

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -269,7 +269,7 @@ class ISCSIGlobalService(SystemServiceService):
         need to be able to perform an explicit action.
         """
         cp = await run([
-            'scstadmin', '-force', '-noprompt', '-set_drv_attr', 'iscsi',
+            'scstadmin', '-force', '-noprompt', '-preserve_cluster_mode', '-set_drv_attr', 'iscsi',
             '-attributes', 'iSNSServer=""'
         ], check=False)
         if cp.returncode:

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -216,6 +216,7 @@ class iSCSITargetService(Service):
             [
                 'scstadmin',
                 '-noprompt',
+                '-preserve_cluster_mode',
                 '-rem_lun',
                 str(lun_id),
                 '-driver',
@@ -387,6 +388,7 @@ class iSCSITargetService(Service):
                     'scstadmin',
                     '-force',
                     '-noprompt',
+                    '-preserve_cluster_mode',
                     '-rem_target',
                     iqn,
                     '-driver',

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -95,7 +95,7 @@ class ISCSITargetService(SwitchableSimpleService):
             return await self.middleware.call("iscsi.scst.apply_config_file")
         else:
             return (await run(
-                ["scstadmin", "-noprompt", "-force", "-config", "/etc/scst.conf"], check=False
+                ["scstadmin", "-noprompt", "-preserve_cluster_mode", "-force", "-config", "/etc/scst.conf"], check=False
             )).returncode == 0
 
     async def become_active(self):


### PR DESCRIPTION
A recent change (PR #19074) stopped writing `cluster_mode` in scst.conf

If `scstadmin` is being used to write the config, then we need to supply a new optional parameter to prevent breakage.  Note: by default `pyscstadmin` is used instead.

(A corresponding SCST PR [#99](https://github.com/truenas/scst/pull/99) is required first.)