### PR TITLE
NAS-141527 / 26.0.0-RC.1 / Add disabled on standby status reason

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v26_0_0/truecommand.py
@@ -7,11 +7,14 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateM
 
 
 __all__ = [
-    'TRUECOMMAND_CONNECTING_STATUS_REASON', 'TruecommandStatus', 'TruecommandStatusReason',
+    'TRUECOMMAND_CONNECTING_STATUS_REASON',
+    'TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON',
+    'TruecommandStatus', 'TruecommandStatusReason',
     'TruecommandEntry', 'TruecommandUpdateArgs', 'TruecommandUpdateResult', 'TruecommandConfigChangedEvent',
 ]
 
 TRUECOMMAND_CONNECTING_STATUS_REASON = 'Waiting for connection from Truecommand.'
+TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON = 'Truecommand service is disabled on standby controller'
 
 
 class TruecommandStatus(enum.Enum):
@@ -49,7 +52,8 @@ class TruecommandEntry(BaseModel):
         description="Current connection status with TrueCommand service.",
     )
     status_reason: Literal[
-        tuple(s.value for s in TruecommandStatusReason) + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON])
+        tuple(s.value for s in TruecommandStatusReason)
+        + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON, TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON])
     ] = Field(description="Explanation of the current TrueCommand connection status.")
     remote_url: str | None = Field(description="URL of the connected TrueCommand instance. `null` if not connected.")
     remote_ip_address: str | None = Field(

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -4,7 +4,9 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.api import api_method, Event
 from middlewared.api.current import (
-    TRUECOMMAND_CONNECTING_STATUS_REASON, TruecommandStatus, TruecommandStatusReason, TruecommandEntry,
+    TRUECOMMAND_CONNECTING_STATUS_REASON,
+    TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON,
+    TruecommandStatus, TruecommandStatusReason, TruecommandEntry,
     TruecommandUpdateArgs, TruecommandUpdateResult, TruecommandConfigChangedEvent,
 )
 from middlewared.service import ConfigService, private, ValidationErrors
@@ -69,7 +71,7 @@ class TruecommandService(ConfigService):
         else:
             if self.STATUS != TruecommandStatus.DISABLED:
                 await self.set_status(TruecommandStatus.DISABLED.value)
-            status_reason = 'Truecommand service is disabled on standby controller'
+            status_reason = TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON
 
         config['remote_ip_address'] = config['remote_url'] = config.pop('remote_address')
         if config['remote_ip_address']:


### PR DESCRIPTION
Add `TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON` to API.

This fixes an API literal error
```
Jun 23 06:28:48 truenas-b middlewared[3505]:   Input should be 'Truecommand serv
ice is connected.', 'Pending Confirmation From iX Portal for Truecommand API Key
.', 'Truecommand service is disabled.', 'Truecommand API Key Disabled by iX Port
al.' or 'Waiting for connection from Truecommand.' [type=literal_error, input_va
lue='Truecommand service is d...d on standby controller', input_type=str]
Jun 23 06:28:48 truenas-b middlewared[3505]:     For further information visit h
ttps://errors.pydantic.dev/2.10/v/literal_error
```