### PR TITLE
failover: confirm pools exported before releasing fencing

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -24,6 +24,7 @@ from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_
 from middlewared.plugins.service_.services.all import all_services
 from middlewared.service import Service, job
 from middlewared.service_exception import CallError
+from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.filter_list import compile_filters, compile_options
 
 _FAILOVER_CRITICAL_FILTER = compile_filters([['failover_critical', '=', True]])
@@ -244,23 +245,81 @@ class FailoverEventsService(Service):
             if refresh and job is not None:
                 self.middleware.create_task(self.refresh_failover_status(job.id, event))
 
-    def _export_zpools(self, volumes):
+    def self_fence(self, reason):
+        """
+        STONITH: violently reboot this controller via sysrq.
 
-        # export the zpool(s)
+        Used when we cannot safely continue a failover transition -- e.g. a pool
+        is still imported and we must not release SCSI fencing, or the pool import
+        state is indeterminate. We write the watchdog sentinel first so the
+        post-reboot alert is correct (ticket 39114).
+        """
+        logger.error('Self-fencing (STONITH): %s', reason)
+        with contextlib.suppress(Exception):
+            with atomic_write(WATCHDOG_ALERT_FILE, 'w') as f:
+                f.write(f'{time.time()}')
+
+        # enable the "magic" sysrq triggers then violently reboot
+        # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
+        with open('/proc/sys/kernel/sysrq', 'w') as f:
+            f.write('1')
+        with open('/proc/sysrq-trigger', 'w') as f:
+            f.write('b')
+
+    def fence_if_pools_still_imported(self, volumes):
+        """
+        Fail-closed demotion guard. Before releasing SCSI fencing on a demoting
+        controller, authoritatively confirm every data pool has actually been
+        exported.
+
+        "Imported" is keyed on the pool's *presence* in the kstat namespace:
+        zfs.pool.query_imported_fast enumerates /proc/spl/kstat/zfs, whose per-pool
+        directory OpenZFS creates in spa_add() and removes in spa_remove() -- so it
+        exists for exactly as long as the pool is in the SPA namespace (import until
+        export, and spa_remove runs after the vdevs/disks are closed). The reads are
+        lockless (per OpenZFS spa_stats.c: "a lock-less read ... unlike 'zpool',
+        which can potentially block for seconds"), so this cannot hang on a wedged
+        or suspended pool.
+
+        We deliberately ignore the reported pool *state* -- spa_state_to_name() can
+        return OFFLINE or SUSPENDED while the pool is still imported, which is the
+        spurious-OFFLINE that made the old status-gated export skip a still-attached
+        pool. Any pool still present, or an indeterminate read, means self-fence
+        rather than release the disks.
+
+        The boot pool is excluded: each controller has its own boot pool that is
+        always imported, so it must never count as still-attached shared storage
+        (otherwise we would self-fence on every demotion).
+        """
         try:
-            for vol in volumes:
-                if vol['status'] != 'OFFLINE':
-                    self.middleware.call_sync('zfs.pool.export', vol['name'], {'force': True})
-                    logger.info('Exported "%s"', vol['name'])
+            imported_names = {
+                p['name'] for p in self.run_call('zfs.pool.query_imported_fast').values()
+                if p['name'] not in BOOT_POOL_NAME_VALID
+            }
         except Exception as e:
-            # catch any exception that could be raised
-            # We sleep for 5 seconds here because this is
-            # in its own thread. The calling thread waits
-            # for self.ZPOOL_EXPORT_TIMEOUT and if this
-            # thread is_alive(), then we violently reboot
-            # the node
-            logger.error('Error exporting "%s" with error %s', vol['name'], e)
-            time.sleep(self.ZPOOL_EXPORT_TIMEOUT + 1)
+            self.self_fence(f'could not determine pool import state before releasing fencing: {e}')
+            return
+
+        still_imported = [v['name'] for v in volumes if v['name'] in imported_names]
+        if still_imported:
+            self.self_fence(
+                f'pool(s) {still_imported} still imported after export; refusing to release fencing'
+            )
+
+    def _export_zpools(self, volumes):
+        # Best-effort export of each pool. NOTE: "finished" is not "succeeded" --
+        # a failed export leaves the pool imported. The caller (vrrp_backup)
+        # authoritatively re-checks every pool with zfs.pool.query_imported_fast
+        # before releasing fencing and self-fences if any pool is still attached.
+        # A hung export keeps this thread alive past the join() timeout, which the
+        # caller also turns into a self-fence. Hence there is no need to gate on
+        # (unreliable) pool status or to sleep-to-force-reboot from in here.
+        for vol in volumes:
+            try:
+                self.middleware.call_sync('zfs.pool.export', vol['name'], {'force': True})
+                logger.info('Exported %r', vol['name'])
+            except Exception:
+                logger.error('Error exporting %r', vol['name'], exc_info=True)
 
     def generate_failover_data(self):
 
@@ -980,15 +1039,15 @@ class FailoverEventsService(Service):
         export_thread.start()
         export_thread.join(timeout=self.ZPOOL_EXPORT_TIMEOUT)
         if export_thread.is_alive():
-            # have to enable the "magic" sysrq triggers
-            with open('/proc/sys/kernel/sysrq', 'w') as f:
-                f.write('1')
+            # export is wedged (e.g. a suspended pool whose I/O never completes);
+            # self-fence rather than risk releasing the disks while still attached
+            self.self_fence(f'zpool export did not complete within {self.ZPOOL_EXPORT_TIMEOUT}s')
 
-            # now violently reboot
-            with open('/proc/sysrq-trigger', 'w') as f:
-                f.write('b')
+        # A skipped/failed export leaves the pool imported. Confirm every pool is
+        # actually gone before releasing fencing, else self-fence.
+        self.fence_if_pools_still_imported(fobj['volumes'])
 
-        # Pools are now exported and so we can make disks available to other controller
+        # Every pool is confirmed exported; safe to make disks available to peer.
         logger.warning('Stopping fenced')
         self.run_call('failover.fenced.stop')
 

--- a/tests/unit/test_failover_event_failclosed.py
+++ b/tests/unit/test_failover_event_failclosed.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock
+
+from middlewared.plugins.failover_.event import FailoverEventsService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+# fobj['volumes'] carries name/guid/status. NOTE the 'OFFLINE' status below: it is
+# what pool.query reports for a pool it could not read (the spurious-OFFLINE that
+# motivated this guard). The fail-closed check must IGNORE that and rely on the
+# authoritative /proc kstat (zfs.pool.query_imported_fast) instead.
+TANK_VOLUMES = [{'name': 'tank', 'guid': '123', 'status': 'OFFLINE'}]
+
+# zfs.pool.query_imported_fast() shape: {guid: {'name': ..., 'state': ...}}
+IMPORTED_WITH_TANK = {
+    '123': {'name': 'tank', 'state': 'ONLINE'},
+    '999': {'name': 'boot-pool', 'state': 'ONLINE'},
+}
+ONLY_BOOT_POOL = {'999': {'name': 'boot-pool', 'state': 'ONLINE'}}
+
+
+def make_service(**method_mocks):
+    m = Middleware()
+    for name, mock in method_mocks.items():
+        m[name.replace('__', '.')] = mock
+    svc = FailoverEventsService(m)
+    # never actually sysrq-reboot the test runner
+    svc.self_fence = Mock()
+    return svc
+
+
+def test_demotion_self_fences_when_pool_still_imported():
+    # pool.query said OFFLINE (see volumes), but the authoritative kstat shows tank
+    # is STILL imported -> must self-fence instead of releasing fencing.
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=IMPORTED_WITH_TANK))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.self_fence.assert_called_once()
+
+
+def test_demotion_self_fences_when_present_but_state_offline():
+    # spa_state_to_name() can report OFFLINE/SUSPENDED while the pool is still
+    # imported. We key on PRESENCE in the kstat namespace, not the state value, so
+    # a still-present pool must self-fence even when its state reads OFFLINE (the
+    # spurious-OFFLINE failure mode that fooled the old status-gated export).
+    imported = {'123': {'name': 'tank', 'state': 'OFFLINE'}}
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=imported))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.self_fence.assert_called_once()
+
+
+def test_demotion_releases_when_pool_exported():
+    # kstat shows only the boot pool -> tank really is exported -> safe, no fence
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=ONLY_BOOT_POOL))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.self_fence.assert_not_called()
+
+
+def test_demotion_self_fences_when_state_indeterminate():
+    # cannot determine import state -> fail closed (self-fence), never release
+    svc = make_service(zfs__pool__query_imported_fast=Mock(side_effect=RuntimeError('boom')))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.self_fence.assert_called_once()
+
+
+def test_demotion_ignores_boot_pools():
+    # Each controller has its own boot pool that is ALWAYS imported. Neither valid
+    # boot-pool name may count as still-attached data storage, otherwise we would
+    # self-fence on every demotion. tank is gone -> no fence despite boot pools.
+    imported = {
+        '111': {'name': 'boot-pool', 'state': 'ONLINE'},
+        '222': {'name': 'freenas-boot', 'state': 'ONLINE'},
+    }
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=imported))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.self_fence.assert_not_called()


### PR DESCRIPTION
On demotion the old code exported pools best-effort, skipped any pool reading OFFLINE, then stopped fenced. There are theoretically some extreme edge cases in which the API can report a pool as OFFLINE resulting in fencing being released when it maybe shouldn't be (potentially a fail-open scenarion).

Fail closed: after the export attempt, re-check via zfs.pool.query_imported_fast (a lockless read keyed on the pool's presence in /proc/spl/kstat/zfs, so it cannot hang on a wedged pool) and self-fence if any data pool is still imported, the export is still running, or the state is indeterminate.