### PR TITLE
NAS-139535 / 25.10.5 / Decode CHANGE-without-DELETE_CHILD share ACL mask as CHANGE

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_security_descriptor.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_security_descriptor.py
@@ -1,6 +1,8 @@
 import pytest
 
 from middlewared.utils import security_descriptor
+from samba.dcerpc import security
+from samba.ndr import ndr_pack
 
 
 SAMPLE_DOM_SID = 'S-1-5-21-3510196835-1033636670-2319939847-200108'
@@ -65,3 +67,16 @@ def test__legacy_convert_share_acl(legacy, theacl):
 
     for idx, entry in enumerate(share_acl):
         assert entry == theacl[idx]
+
+
+def test__change_without_delete_child_read_as_change():
+    """ NAS-139535: CHANGE mask missing SEC_DIR_DELETE_CHILD (0x1301BF) decodes as CHANGE """
+    sddl_str = f'D:(A;;{hex(0x1301bf)};;;{SAMPLE_BUILTIN_SID})'
+    sd_bytes = ndr_pack(security.descriptor().from_sddl(sddl_str, security.dom_sid()))
+
+    share_acl = security_descriptor.sd_bytes_to_share_acl(sd_bytes)
+
+    assert len(share_acl) == 1
+    assert share_acl[0] == {
+        'ae_who_sid': SAMPLE_BUILTIN_SID, 'ae_perm': 'CHANGE', 'ae_type': 'ALLOWED'
+    }

--- a/src/middlewared/middlewared/utils/security_descriptor.py
+++ b/src/middlewared/middlewared/utils/security_descriptor.py
@@ -26,6 +26,13 @@ class SDDLAccessMaskStandard(enum.IntEnum):
     READ = security.SEC_RIGHTS_DIR_READ | security.SEC_RIGHTS_DIR_EXECUTE
 
 
+# Some Windows versions / older Samba builds persist the CHANGE preset without the
+# SEC_DIR_DELETE_CHILD right (0x40), yielding 0x1301BF instead of 0x1301FF. Treat it
+# as CHANGE so reading such a share ACL returns a supported value rather than raising.
+# See NAS-139535.
+CHANGE_NO_DELETE_CHILD = SDDLAccessMaskStandard.CHANGE.value & ~security.SEC_DIR_DELETE_CHILD
+
+
 def security_descriptor_from_bytes(sd_buf: bytes) -> security.descriptor:
     """
     method to convert bytes to security descriptor. This is particularly
@@ -67,7 +74,12 @@ def sd_bytes_to_share_acl(sd_bytes: bytes) -> list[dict]:
 
     for ace in sd.dacl.aces:
         dom_sid = str(ace.trustee)
-        perm = SDDLAccessMaskStandard(ace.access_mask).name
+
+        if ace.access_mask == CHANGE_NO_DELETE_CHILD:
+            perm = SDDLAccessMaskStandard.CHANGE.name
+        else:
+            perm = SDDLAccessMaskStandard(ace.access_mask).name
+
         match ace.type:
             case security.SEC_ACE_TYPE_ACCESS_ALLOWED:
                 ace_type = 'ALLOWED'


### PR DESCRIPTION
A customer's `sharing.smb.getacl` crashed with `ValueError: 1245631 is not a valid SDDLAccessMaskStandard` because the stored share ACL contained an ACE with access mask 0x1301BF -- the CHANGE preset (0x1301FF) minus the SEC_DIR_DELETE_CHILD bit (0x40). Such masks are produced by some Windows versions / older Samba / sharesec shell edits. `sd_bytes_to_share_acl` looked the mask up directly in the SDDLAccessMaskStandard enum, which raised for the unrecognized value and returned a 500 from getacl, so the admin could neither view nor fix the share ACL.

Normalize this known equivalent mask to CHANGE at the single decode site. This keeps the returned `ae_perm` within the existing API schema (Literal['FULL','CHANGE','READ']) so there is no public API surface change -- appropriate for a hotfix release. 

Re-saving such an entry via setacl writes canonical CHANGE (0x1301FF), healing the malformed mask.