### PR TITLE
NAS-141545 / 27.0.0-BETA.1 / proxy nginx-middleware over a private unix socket

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -174,6 +174,11 @@ http {
     access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
     error_log /var/log/nginx/error.log;
 
+    # All middleware API/UI traffic is proxied over a private unix socket
+    upstream middlewared {
+        server unix:/run/middleware/middlewared-nginx.sock;
+    }
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
@@ -286,7 +291,7 @@ ${spaces}gzip off;
         location /api {
             allow all;  # This is handled by `Middleware.ws_can_access` because if we return HTTP 403, browser security
                         # won't allow us to understand that connection error was due to client IP not being allowlisted.
-            proxy_pass http://127.0.0.1:6000/api;
+            proxy_pass http://middlewared/api;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -324,7 +329,7 @@ ${spaces}gzip off;
             add_header Access-Control-Allow-Origin $allow_origin always;
             add_header Access-Control-Allow-Headers "*" always;
 % endif
-            proxy_pass http://127.0.0.1:6000/api/versions;
+            proxy_pass http://middlewared/api/versions;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -405,7 +410,7 @@ ${spaces}gzip off;
         location /websocket {
             allow all;  # This is handled by `Middleware.ws_can_access` because if we return HTTP 403, browser security
                         # won't allow us to understand that connection error was due to client IP not being allowlisted.
-            proxy_pass http://127.0.0.1:6000/websocket;
+            proxy_pass http://middlewared/websocket;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -422,7 +427,7 @@ ${spaces}gzip off;
         location /websocket/shell {
             allow all;  # This is handled by `Middleware.ws_can_access` because if we return HTTP 403, browser security
                         # won't allow us to understand that connection error was due to client IP not being allowlisted.
-            proxy_pass http://127.0.0.1:6000/_shell;
+            proxy_pass http://middlewared/_shell;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -440,7 +445,7 @@ ${spaces}gzip off;
 	    # do not add the path to proxy_pass because of automatic url decoding
 	    # e.g. /api/v2.0/pool/dataset/id/tank%2Ffoo/ would become
 	    #      /api/v2.0/pool/dataset/id/tank/foo/
-            proxy_pass http://127.0.0.1:6000;
+            proxy_pass http://middlewared;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -460,7 +465,7 @@ ${spaces}gzip off;
             add_header Access-Control-Allow-Origin $allow_origin always;
             add_header Access-Control-Allow-Headers "*" always;
 % endif
-            proxy_pass http://127.0.0.1:6000;
+            proxy_pass http://middlewared;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;
@@ -474,7 +479,7 @@ ${spaces}gzip off;
         location /_upload {
             # Allow uploads of any size. Its middlewared job to handle size.
             client_max_body_size 0;
-            proxy_pass http://127.0.0.1:6000;
+            proxy_pass http://middlewared;
             # make sure nginx does not buffer the upload and pass directly to middlewared
             proxy_request_buffering off;
             proxy_http_version 1.1;
@@ -487,7 +492,7 @@ ${spaces}gzip off;
         }
 
         location /_plugins {
-            proxy_pass http://127.0.0.1:6000/_plugins;
+            proxy_pass http://middlewared/_plugins;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -57,11 +57,12 @@ from .pylibvirt import create_pylibvirt_domains_manager
 from .role import ROLES, RoleManager
 from .service_container import BaseServiceContainer
 from .service_exception import CallError, ErrnoMixin
-from .utils import MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH, sw_version
+from .utils import MIDDLEWARE_NGINX_SOCK, MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH, sw_version
 from .utils.audit import audit_username_from_session
 from .utils.debug import get_threads_stacks
 from .utils.limits import MsgSizeError, MsgSizeLimit, parse_message
 from .utils.mock import coerce_mock_result, get_mock_return_model
+from .utils.nss.pwd import getpwnam
 from .utils.plugins import LoadPluginsMixin
 from .utils.prctl import set_cmdline, set_name
 from .utils.privilege import credential_has_full_admin
@@ -132,6 +133,7 @@ from middlewared.plugins.snapshot import PeriodicSnapshotTaskService
 from middlewared.plugins.ssh import SSHService
 from middlewared.plugins.support import SupportService
 from middlewared.plugins.system_vendor import VendorService
+from middlewared.plugins.system_vendor.vendor import is_vendored
 from middlewared.plugins.truecommand import TruecommandService
 from middlewared.plugins.truenas import TrueNASService
 from middlewared.plugins.truenas_connect import TrueNASConnectService
@@ -2040,11 +2042,33 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
         if await self.call('system.state') == 'READY':
             self._setup_periodic_tasks()
 
-        await self.add_tcp_site('127.0.0.1')
+        # Private socket that nginx reverse-proxies all external API/UI traffic
+        # over. It is owned by the nginx worker uid (www-data) with 0o600 perms.
+        # Connections arriving here are classified as TCP/IP origins from the X-Real-Remote-*
+        # headers (see middlewared.utils.origin.ConnectionOrigin.create).
+        await self.site_manager.add_site(web.UnixSite, MIDDLEWARE_NGINX_SOCK)
+
+        # Public local socket used by midclt and other local clients.
         unix_socket_path = os.path.join(MIDDLEWARE_RUN_DIR, 'middlewared.sock')
         await self.site_manager.add_site(web.UnixSite, unix_socket_path)
+
+        # The loopback TCP listener is only consumed by the vendor (HexOS)
+        # websocat tunnel (scripts/vendor_service.py). On non-vendored systems
+        # nothing connects to it (HA binds its own :6000 site on the heartbeat
+        # IP), so we avoid exposing loopback TCP at all.
+        if is_vendored():
+            await self.add_tcp_site('127.0.0.1')
+
         await self.site_manager.start_sites(self.runner)
+
         os.chmod(unix_socket_path, 0o666)
+
+        # Restrict the nginx socket to the nginx worker uid now that the site
+        # has been started and the socket file exists. root (middleware) can
+        # still connect regardless of these perms.
+        www_data = getpwnam('www-data')
+        os.chown(MIDDLEWARE_NGINX_SOCK, www_data.pw_uid, www_data.pw_gid)
+        os.chmod(MIDDLEWARE_NGINX_SOCK, 0o600)
 
         self.logger.debug('Accepting connections')
         self._console_write('loading completed\n')

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -28,6 +28,9 @@ ProductType = ProductTypes()
 ProductName = ProductNames()
 
 MIDDLEWARE_RUN_DIR = '/run/middleware'
+# Private unix socket that nginx reverse-proxies all external API/UI traffic over.
+# Locked down to the nginx worker uid so this traffic is not exposed on loopback TCP.
+MIDDLEWARE_NGINX_SOCK = f'{MIDDLEWARE_RUN_DIR}/middlewared-nginx.sock'
 MIDDLEWARE_BOOT_ENV_STATE_DIR = '/var/lib/truenas-middleware'
 MIDDLEWARE_STARTED_SENTINEL_PATH = f'{MIDDLEWARE_RUN_DIR}/middlewared-started'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'

--- a/src/middlewared/middlewared/utils/origin.py
+++ b/src/middlewared/middlewared/utils/origin.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from aiohttp.web import Request
 from truenas_pynetif.diag import get_inet_diag, netlink_diag
 
+from . import MIDDLEWARE_NGINX_SOCK
 from .auth import AUID_UNSET, get_login_uid
 
 if TYPE_CHECKING:
@@ -64,6 +65,16 @@ class ConnectionOrigin:
 
             sock = transport.get_extra_info("socket")
             if sock.family == AF_UNIX:
+                if sock.getsockname() == MIDDLEWARE_NGINX_SOCK:
+                    # nginx reverse-proxies external API/UI traffic over a
+                    # private unix socket, but these connections represent
+                    # remote TCP/IP clients. Classify them as TCP/IP origins
+                    # from the reverse-proxy X-Real-Remote-* headers so that
+                    # all downstream access control treats them exactly like
+                    # direct nginx TCP connections (UI allowlist enforced, no
+                    # local/root auto-authentication, secure-transport, etc.).
+                    return get_tcp_ip_info(sock, request)
+
                 pid, uid, gid = unpack("3i", sock.getsockopt(SOL_SOCKET, SO_PEERCRED, calcsize("3i")))
                 login_uid = get_login_uid(pid)
                 return cls(
@@ -211,6 +222,12 @@ def get_tcp_ip_info(
         ssl = request.headers.get("X-Https", "") == "on"
         check_uids = True
     except (KeyError, ValueError):
+        if sock.family not in (AF_INET, AF_INET6):
+            # No reverse-proxy headers on a non-TCP/IP socket (e.g. the nginx
+            # unix socket reached without the expected headers). We cannot
+            # determine a meaningful origin, so reject the connection rather
+            # than attempt to unpack a unix peer name.
+            return None
         ra, rp = sock.getpeername()
         family = sock.family
         ssl = False

--- a/tests/unit/test_origin.py
+++ b/tests/unit/test_origin.py
@@ -1,0 +1,71 @@
+import struct
+from socket import AF_INET, AF_UNIX
+from unittest.mock import MagicMock, patch
+
+from middlewared.utils import MIDDLEWARE_NGINX_SOCK
+from middlewared.utils.origin import ConnectionOrigin, get_tcp_ip_info
+
+
+def _request_for(sock):
+    request = MagicMock()
+    request.transport.get_extra_info.return_value = sock
+    return request
+
+
+def test_nginx_unix_socket_classified_as_tcp_origin():
+    """Connections arriving on the private nginx unix socket must be classified
+    as TCP/IP origins built from the reverse-proxy headers (not as unix-socket
+    peer-credential origins), so that the UI allowlist is enforced and they are
+    never auto-authenticated as the local/root peer."""
+    sock = MagicMock()
+    sock.family = AF_UNIX
+    sock.getsockname.return_value = MIDDLEWARE_NGINX_SOCK
+    request = _request_for(sock)
+
+    tcp_origin = ConnectionOrigin(family=AF_INET, rem_addr="1.2.3.4", rem_port=5678)
+    with patch(
+        "middlewared.utils.origin.get_tcp_ip_info", return_value=tcp_origin
+    ) as gti:
+        origin = ConnectionOrigin.create(request)
+
+    gti.assert_called_once_with(sock, request)
+    assert origin is tcp_origin
+    assert origin.is_tcp_ip_family is True
+    assert origin.is_unix_family is False
+    # Peer credentials must not be consulted for the nginx socket.
+    sock.getsockopt.assert_not_called()
+
+
+def test_local_unix_socket_uses_peer_credentials():
+    """A connection on any other unix socket (e.g. midclt's middlewared.sock)
+    keeps the existing unix-credential behavior."""
+    sock = MagicMock()
+    sock.family = AF_UNIX
+    sock.getsockname.return_value = "/run/middleware/middlewared.sock"
+    sock.getsockopt.return_value = struct.pack("3i", 4321, 1000, 1000)
+    request = _request_for(sock)
+
+    with (
+        patch("middlewared.utils.origin.get_login_uid", return_value=1000),
+        patch("middlewared.utils.origin.get_tcp_ip_info") as gti,
+    ):
+        origin = ConnectionOrigin.create(request)
+
+    gti.assert_not_called()
+    assert origin.is_unix_family is True
+    assert origin.pid == 4321
+    assert origin.uid == 1000
+    assert origin.gid == 1000
+
+
+def test_get_tcp_ip_info_rejects_headerless_non_ip_socket():
+    """Without the X-Real-Remote-* headers we cannot determine an origin for a
+    non-TCP/IP socket (such as the nginx unix socket reached unexpectedly); it
+    must return None rather than attempt to unpack a unix peer name."""
+    sock = MagicMock()
+    sock.family = AF_UNIX
+    request = MagicMock()
+    request.headers = {}
+
+    assert get_tcp_ip_info(sock, request) is None
+    sock.getpeername.assert_not_called()


### PR DESCRIPTION
This commit changes our proxy settings for nginx so that UI / API traffic goes to a www-data-owned unix socket instead of loopback 127.0.0.1:6000. 

Connections on the unix socket are classified as TCP origins from the X-Real-Remote-* headers, so auth behavior is unchanged. Loopback :6000 is now bound only on vendored systems. HA heartbeat is unaffected.