### PR TITLE
NAS-141527 / 27.0.0-BETA.1 / Add disabled on standby status reason (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v26_0_0/truecommand.py
@@ -6,11 +6,14 @@ from pydantic import Field, Secret
 from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, excluded_field, single_argument_args
 
 __all__ = [
-    'TRUECOMMAND_CONNECTING_STATUS_REASON', 'TruecommandStatus', 'TruecommandStatusReason',
+    'TRUECOMMAND_CONNECTING_STATUS_REASON',
+    'TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON',
+    'TruecommandStatus', 'TruecommandStatusReason',
     'TruecommandEntry', 'TruecommandUpdateArgs', 'TruecommandUpdateResult', 'TruecommandConfigChangedEvent',
 ]
 
 TRUECOMMAND_CONNECTING_STATUS_REASON = 'Waiting for connection from Truecommand.'
+TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON = 'Truecommand service is disabled on standby controller'
 
 
 class TruecommandStatus(enum.Enum):
@@ -48,7 +51,8 @@ class TruecommandEntry(BaseModel):
         description="Current connection status with TrueCommand service.",
     )
     status_reason: Literal[
-        tuple(s.value for s in TruecommandStatusReason) + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON])
+        tuple(s.value for s in TruecommandStatusReason)
+        + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON, TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON])
     ] = Field(description="Explanation of the current TrueCommand connection status.")
     remote_url: str | None = Field(description="URL of the connected TrueCommand instance. `null` if not connected.")
     remote_ip_address: str | None = Field(

--- a/src/middlewared/middlewared/api/v27_0_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v27_0_0/truecommand.py
@@ -6,12 +6,15 @@ from pydantic import Field, Secret
 from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, excluded_field
 
 __all__ = [
-    'TRUECOMMAND_CONNECTING_STATUS_REASON', 'TruecommandStatus', 'TruecommandStatusReason',
+    'TRUECOMMAND_CONNECTING_STATUS_REASON',
+    'TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON',
+    'TruecommandStatus', 'TruecommandStatusReason',
     'TruecommandEntry', 'TruecommandUpdate', 'TruecommandUpdateArgs', 'TruecommandUpdateResult',
     'TruecommandConfigChangedEvent',
 ]
 
 TRUECOMMAND_CONNECTING_STATUS_REASON = 'Waiting for connection from Truecommand.'
+TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON = 'Truecommand service is disabled on standby controller'
 
 
 class TruecommandStatus(enum.Enum):
@@ -49,7 +52,8 @@ class TruecommandEntry(BaseModel):
         description="Current connection status with TrueCommand service.",
     )
     status_reason: Literal[
-        tuple(s.value for s in TruecommandStatusReason) + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON])
+        tuple(s.value for s in TruecommandStatusReason)
+        + tuple([TRUECOMMAND_CONNECTING_STATUS_REASON, TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON])
     ] = Field(description="Explanation of the current TrueCommand connection status.")
     remote_url: str | None = Field(description="URL of the connected TrueCommand instance. `null` if not connected.")
     remote_ip_address: str | None = Field(

--- a/src/middlewared/middlewared/plugins/truecommand/config.py
+++ b/src/middlewared/middlewared/plugins/truecommand/config.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from middlewared.api.current import (
     TRUECOMMAND_CONNECTING_STATUS_REASON,
+    TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON,
     TruecommandEntry,
     TruecommandStatus,
     TruecommandStatusReason,
@@ -67,7 +68,7 @@ class TruecommandConfigServicePart(ConfigServicePart[TruecommandEntry]):
         else:
             if get_status() != TruecommandStatus.DISABLED:
                 await set_status(self, TruecommandStatus.DISABLED.value)
-            status_reason = 'Truecommand service is disabled on standby controller'
+            status_reason = TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON
 
         data['remote_ip_address'] = data['remote_url'] = data.pop('remote_address')
         if data['remote_ip_address']:


### PR DESCRIPTION
Add `TRUECOMMAND_DISABLED_ON_STANDBY_STATUS_REASON` to API.

This fixes an API literal error
```
Jun 23 06:28:48 truenas-b middlewared[3505]:   Input should be 'Truecommand serv
ice is connected.', 'Pending Confirmation From iX Portal for Truecommand API Key
.', 'Truecommand service is disabled.', 'Truecommand API Key Disabled by iX Port
al.' or 'Waiting for connection from Truecommand.' [type=literal_error, input_va
lue='Truecommand service is d...d on standby controller', input_type=str]
Jun 23 06:28:48 truenas-b middlewared[3505]:     For further information visit h
ttps://errors.pydantic.dev/2.10/v/literal_error
```

Original PR: https://github.com/truenas/middleware/pull/19185
