### PR TITLE
NAS-140907 / 26.0.0-RC.1 / Tolerate malformed JSON in audit databases (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/alert/source/audit.py
+++ b/src/middlewared/middlewared/alert/source/audit.py
@@ -14,6 +14,26 @@ class AuditBackendSetupAlertClass(AlertClass, SimpleOneShotAlertClass):
     text = "Audit service failed backend setup: %(service)s. See /var/log/middlewared.log"
 
 
+class AuditDatabaseCorruptedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.AUDIT
+    level = AlertLevel.ERROR
+    title = "Audit Database Contains Corrupted Records"
+    text = (
+        "The %(service)s audit database contains %(count)s record(s) with unreadable data "
+        "that are skipped by audit queries. See /var/log/middlewared.log for details."
+    )
+
+    async def create(self, args):
+        # Key on the service alone so a changing count updates the alert instead of duplicating it.
+        return Alert(AuditDatabaseCorruptedAlertClass, args, key=args['service'])
+
+    async def delete(self, alerts, query):
+        return list(filter(
+            lambda alert: alert.args['service'] != query,
+            alerts
+        ))
+
+
 # --------------- Monitored Alerts ----------------
 class AuditServiceHealthAlertClass(AlertClass):
     category = AlertCategory.AUDIT

--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -10,7 +10,7 @@ import yaml
 from itertools import batched
 from pydantic import Field
 from sqlalchemy import create_engine, inspect, text
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, case, func, select
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import nullsfirst, nullslast
@@ -19,7 +19,7 @@ from middlewared.api import api_method
 from middlewared.api.base import BaseModel
 from middlewared.api.base.types import NonEmptyString
 from middlewared.api.current import GenericQueryResult, QueryFilters, QueryOptions
-from middlewared.service import job, periodic, Service
+from middlewared.service import job, periodic, private, Service
 from middlewared.service_exception import CallError, MatchNotFound
 
 from middlewared.plugins.audit.utils import AUDITED_SERVICES, audit_file_path, AUDIT_CHUNK_SZ
@@ -38,6 +38,20 @@ class AuditBackendQueryArgs(BaseModel):
 
 class AuditBackendQueryResult(GenericQueryResult):
     pass
+
+
+def decode_audit_json(data):
+    """
+    Decode a JSON string read from an audit database. A row can hold non-JSON or
+    otherwise undecodable text (e.g. on-disk corruption, or a syntactically valid
+    document carrying a malformed ``$date``/``$time``/``$type`` payload that ``ejson``
+    cannot reconstruct). In those cases fall back to the raw string rather than
+    propagating the decode error and failing the whole query.
+    """
+    try:
+        return ejson.loads(data)
+    except (json.decoder.JSONDecodeError, ejson.EJSONDecodeError):
+        return data
 
 
 class SQLConn:
@@ -104,10 +118,7 @@ class SQLConn:
                             elif isinstance(data, str):
                                 # Majority of time these will probably be JSON objects extracted
                                 # via json_extract()
-                                try:
-                                    entry[column_name] = ejson.loads(data)
-                                except json.decoder.JSONDecodeError:
-                                    entry[column_name] = data
+                                entry[column_name] = decode_audit_json(data)
                             else:
                                 entry[column_name] = data
                         else:
@@ -170,6 +181,23 @@ class SQLConn:
                 s.commit()
 
             self.connection.connection.execute('VACUUM')
+
+    def count_malformed(self):
+        """
+        Count rows whose JSON columns hold data that cannot be parsed by SQLite's
+        json1 extension. json_valid() never raises, so this is safe to run over a
+        table that contains corrupted entries.
+        """
+        with self.lock:
+            if not self.audit_table_exists():
+                return 0
+
+            cursor = self.connection.execute(text(
+                f'SELECT count(*) AS cnt FROM "{self.table_name}" '
+                f'WHERE (event_data IS NOT NULL AND NOT json_valid(event_data)) '
+                f'OR (service_data IS NOT NULL AND NOT json_valid(service_data))'
+            ), {})
+            return list(cursor.mappings())[0]['cnt']
 
 
 class AuditBackendService(Service, FilterMixin, SchemaMixin):
@@ -237,10 +265,14 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
         if name.startswith(JSON_PATH_PREFIX):
             name, path = json_path_parse(name)
             raw_column = self._get_col(table, name)
+            # Guard against rows whose JSON column holds non-JSON text: json_extract() in the
+            # SELECT list would otherwise abort the whole statement with "malformed JSON". CASE
+            # ensures json_valid() is checked first, projecting NULL for an unparseable row.
+            extracted = case((func.json_valid(raw_column), func.json_extract(raw_column, path)), else_=None)
             if label:
-                column = func.json_extract(raw_column, path).label(label)
+                column = extracted.label(label)
             else:
-                column = func.json_extract(raw_column, path)
+                column = extracted
         else:
             if label:
                 column = self._get_col(table, name).label(label)
@@ -286,7 +318,9 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
             qs = select(*columns).select_from(from_)
 
         if filters:
-            qs = qs.where(and_(*self._filters_to_queryset(filters, conn.table, None, {})))
+            qs = qs.where(and_(*self._filters_to_queryset(
+                filters, conn.table, None, {}, guard_malformed_json=True
+            )))
 
         if order_by:
             for i, order in enumerate(order_by):
@@ -430,3 +464,34 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
                 'Cleanup of auditing report directory failed',
                 exc_info=True
             )
+
+        self.scan_corruption()
+
+    @private
+    def scan_corruption(self):
+        """
+        Scan each audit database for records whose JSON columns cannot be parsed and
+        raise (or clear) a per-service alert accordingly. Audit queries skip these
+        records, so the data they hold is effectively lost; the alert exists so the
+        condition is surfaced rather than silently ignored.
+        """
+        for svc, conn in self.connections.items():
+            try:
+                count = conn.count_malformed()
+            except Exception:
+                self.logger.error(
+                    "%s: failed to scan audit DB for corrupted records.",
+                    svc, exc_info=True
+                )
+                continue
+
+            if count:
+                self.logger.warning(
+                    "%s: audit DB contains %d record(s) with unreadable data.",
+                    svc, count
+                )
+                self.middleware.call_sync(
+                    'alert.oneshot_create', 'AuditDatabaseCorrupted', {"service": svc, "count": count}
+                )
+            else:
+                self.middleware.call_sync('alert.oneshot_delete', 'AuditDatabaseCorrupted', svc)

--- a/src/middlewared/middlewared/plugins/datastore/filter.py
+++ b/src/middlewared/middlewared/plugins/datastore/filter.py
@@ -1,7 +1,7 @@
 import operator
 from typing import Any, Iterable, Literal
 
-from sqlalchemy import Column, ForeignKey, Table, func
+from sqlalchemy import Column, ForeignKey, Table, case, func
 
 from truenas_api_client import ejson as json
 from middlewared.utils.jsonpath import JSON_PATH_PREFIX, json_path_parse
@@ -45,7 +45,8 @@ class FilterMixin(SchemaMixin):
         filters: FiltersList,
         table: Table,
         prefix: str | None,
-        aliases: dict[ForeignKey, Table]
+        aliases: dict[ForeignKey, Table],
+        guard_malformed_json: bool = False
     ) -> list:
         opmap = {
             '=': operator.eq,
@@ -76,9 +77,9 @@ class FilterMixin(SchemaMixin):
                 # WARNING: this capability doesn't exist for encrypted JSON fields.
                 if name.startswith(JSON_PATH_PREFIX):
                     name, json_target = json_path_parse(name)
-                    col = self._get_col(table, name, prefix)
+                    raw_col = self._get_col(table, name, prefix)
                     # Set up JSON1 operation to extract JSON data for filtering
-                    col = func.json_extract(col, json_target)
+                    col = func.json_extract(raw_col, json_target)
                     is_json_extract = True
                 elif matched := next((x for x in ['__', '.'] if x in name), False):
                     fk, name = name.split(matched, 1)
@@ -96,12 +97,17 @@ class FilterMixin(SchemaMixin):
                     value = json.dumps(value, separators=(',', ':'), sort_keys=True)
 
                 q = opmap[op](col, value)
+                if is_json_extract and guard_malformed_json:
+                    # json_extract() raises "malformed JSON" if the column holds non-JSON text,
+                    # which aborts the entire statement. CASE guarantees json_valid() is evaluated
+                    # before json_extract(), so a row with non-JSON data is skipped instead.
+                    q = case((func.json_valid(raw_col), q), else_=False)
                 rv.append(q)
             elif len(f) == 2:
                 op, value = f
                 if op == 'OR':
                     or_value = None
-                    for value in self._filters_to_queryset(value, table, prefix, aliases):
+                    for value in self._filters_to_queryset(value, table, prefix, aliases, guard_malformed_json):
                         if or_value is None:
                             or_value = value
                         else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_audit_backend.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_audit_backend.py
@@ -1,0 +1,120 @@
+import sqlite3
+
+import pytest
+from sqlalchemy.dialects import sqlite
+
+from middlewared.alert.source.audit import AuditDatabaseCorruptedAlertClass
+from middlewared.plugins.audit.backend import AuditBackendService, SQLConn, decode_audit_json
+from middlewared.plugins.audit.table import AUDIT_TABLES
+from middlewared.plugins.datastore.schema import SchemaMixin
+from middlewared.pytest.unit.middleware import Middleware
+
+# AuditDatabaseCorrupted key handling -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_corruption_alert_cleared_by_service_key():
+    # The alert is keyed on the service alone, so oneshot_delete passes the scalar service
+    # name. This pins the create/clear key contract in unit CI.
+    klass = AuditDatabaseCorruptedAlertClass(Middleware())
+    alert = await klass.create({"service": "MIDDLEWARE", "count": 1})
+    assert await klass.delete([alert], "MIDDLEWARE") == []
+
+
+@pytest.mark.asyncio
+async def test_corruption_alert_other_service_not_cleared():
+    # Clearing one service must not drop another service's alert.
+    klass = AuditDatabaseCorruptedAlertClass(Middleware())
+    alert = await klass.create({"service": "MIDDLEWARE", "count": 1})
+    assert await klass.delete([alert], "SMB") == [alert]
+
+
+# decode_audit_json --------------------------------------------------------
+
+
+def test_decode_audit_json_valid_object():
+    assert decode_audit_json('{"a": 1}') == {"a": 1}
+
+
+def test_decode_audit_json_malformed_text_falls_back_to_raw():
+    assert decode_audit_json("{not valid json") == "{not valid json"
+
+
+def test_decode_audit_json_bad_ejson_payload_falls_back_to_raw():
+    # Syntactically valid JSON, but ejson cannot reconstruct the $date payload and raises
+    # EJSONDecodeError (a ValueError, not a JSONDecodeError). It must fall back to the raw
+    # string rather than propagating and failing the whole audit query.
+    raw = '{"$date": "not-a-number"}'
+    assert decode_audit_json(raw) == raw
+
+
+# SELECT-side json_extract guard ------------------------------------------
+
+
+class _Cols(SchemaMixin):
+    pass
+
+
+# __get_audit_column only depends on self._get_col, so we can drive it with a bare SchemaMixin.
+_get_audit_column = AuditBackendService.__dict__["_AuditBackendService__get_audit_column"]
+
+
+def test_select_json_path_is_guarded_with_json_valid():
+    column = _get_audit_column(_Cols(), AUDIT_TABLES["MIDDLEWARE"], "$.service_data.origin", "origin")
+    compiled = str(column.compile(dialect=sqlite.dialect()))
+    assert "json_valid" in compiled
+    assert "CASE WHEN" in compiled
+
+
+def test_select_plain_column_is_not_wrapped():
+    column = _get_audit_column(_Cols(), AUDIT_TABLES["MIDDLEWARE"], "username", "username")
+    compiled = str(column.compile(dialect=sqlite.dialect()))
+    assert "json_valid" not in compiled
+
+
+# SQLConn.count_malformed --------------------------------------------------
+
+
+def _seed_audit_db(path):
+    con = sqlite3.connect(path)
+    con.executescript(
+        "CREATE TABLE audit_MIDDLEWARE_0_1 ("
+        "audit_id TEXT, message_timestamp INTEGER, timestamp TEXT, address TEXT, "
+        "username TEXT, session TEXT, service TEXT, service_data TEXT, event TEXT, "
+        "event_data TEXT, success BOOLEAN);"
+    )
+    con.executemany(
+        "INSERT INTO audit_MIDDLEWARE_0_1 (event_data, service_data) VALUES (?, ?)",
+        [
+            ('{"a": 1}', '{"b": 2}'),  # both valid
+            ("{malformed", '{"b": 2}'),  # malformed event_data
+            ('{"a": 1}', "{malformed"),  # malformed service_data
+            (None, None),  # NULLs are ignored
+            ('{"a": 1}', None),  # valid + NULL
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def audit_conn(tmp_path):
+    db_path = tmp_path / "MIDDLEWARE.db"
+    _seed_audit_db(str(db_path))
+    conn = SQLConn("MIDDLEWARE", 0.1)
+    conn.path = str(db_path)
+    conn.setup()
+    yield conn
+
+
+def test_count_malformed_counts_only_unparseable_rows(audit_conn):
+    assert audit_conn.count_malformed() == 2
+
+
+def test_count_malformed_never_raises_on_corrupted_table(audit_conn):
+    # Adding a row malformed in both JSON columns is still counted once and does not raise.
+    con = sqlite3.connect(audit_conn.path)
+    con.execute("INSERT INTO audit_MIDDLEWARE_0_1 (event_data, service_data) VALUES ('{x', '{y')")
+    con.commit()
+    con.close()
+    assert audit_conn.count_malformed() == 3

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_datastore_json_valid.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_datastore_json_valid.py
@@ -1,0 +1,101 @@
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import and_, select
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.exc import OperationalError
+
+from middlewared.plugins.datastore.filter import FilterMixin
+
+
+class _Filters(FilterMixin):
+    pass
+
+
+METADATA = sa.MetaData()
+TABLE = sa.Table(
+    "audit_smb_0_1",
+    METADATA,
+    sa.Column("ROW_ID", sa.Integer(), primary_key=True),
+    sa.Column("event_data", sa.String()),
+)
+
+ROWS = [
+    {"ROW_ID": 1, "event_data": '{"serviceDescription": "SMB", "passwordType": "NTLMv1"}'},
+    {"ROW_ID": 2, "event_data": '{"serviceDescription": "SMB2", "passwordType": "NTLMv2"}'},
+    {"ROW_ID": 3, "event_data": '{"serviceDescription": broken'},  # malformed JSON
+    {"ROW_ID": 4, "event_data": None},  # NULL column
+    {"ROW_ID": 5, "event_data": "123"},  # valid JSON, not an object
+    {"ROW_ID": 6, "event_data": ""},  # empty string
+]
+
+
+def _seeded_engine():
+    engine = sa.create_engine("sqlite://")
+    METADATA.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(TABLE.insert(), ROWS)
+    return engine
+
+
+def _run(engine, filters, guard):
+    where = _Filters()._filters_to_queryset(filters, TABLE, None, {}, guard_malformed_json=guard)
+    qs = select(TABLE.c.ROW_ID).where(and_(*where)).order_by(TABLE.c.ROW_ID)
+    with engine.connect() as conn:
+        return [row[0] for row in conn.execute(qs).fetchall()]
+
+
+def test_guard_skips_malformed_row_and_returns_valid_match():
+    engine = _seeded_engine()
+    result = _run(engine, [["$.event_data.serviceDescription", "=", "SMB"]], guard=True)
+    assert result == [1]
+
+
+def test_unguarded_query_raises_on_malformed_row():
+    # Datastore behaviour must be unchanged: without opting in, a malformed row still
+    # aborts the statement. This documents that the guard is strictly opt-in.
+    engine = _seeded_engine()
+    with pytest.raises(OperationalError, match="malformed JSON"):
+        _run(engine, [["$.event_data.serviceDescription", "=", "SMB"]], guard=False)
+
+
+def test_guard_handles_or_nested_json_filters():
+    engine = _seeded_engine()
+    result = _run(
+        engine,
+        [
+            [
+                "OR",
+                [
+                    ["$.event_data.passwordType", "=", "NTLMv1"],
+                    ["$.event_data.passwordType", "=", "NTLMv2"],
+                ],
+            ]
+        ],
+        guard=True,
+    )
+    assert result == [1, 2]
+
+
+@pytest.mark.parametrize("value", ["SMB", "NTLMv1"])
+def test_guard_never_raises_across_edge_values(value):
+    # valid-but-non-object (123), NULL, empty string, and malformed rows must all be
+    # tolerated by the guard rather than aborting the query.
+    engine = _seeded_engine()
+    result = _run(engine, [["$.event_data.serviceDescription", "=", value]], guard=True)
+    assert all(row_id in {1, 2} for row_id in result)
+
+
+def test_guarded_sql_wraps_extract_in_json_valid_case():
+    where = _Filters()._filters_to_queryset(
+        [["$.event_data.serviceDescription", "=", "SMB"]], TABLE, None, {}, guard_malformed_json=True
+    )
+    compiled = str(and_(*where).compile(dialect=sqlite.dialect()))
+    assert "json_valid" in compiled
+    assert "CASE WHEN" in compiled
+
+
+def test_unguarded_sql_is_plain_json_extract():
+    where = _Filters()._filters_to_queryset([["$.event_data.serviceDescription", "=", "SMB"]], TABLE, None, {})
+    compiled = str(and_(*where).compile(dialect=sqlite.dialect()))
+    assert "json_valid" not in compiled
+    assert "json_extract" in compiled

--- a/tests/api2/test_audit_malformed_json.py
+++ b/tests/api2/test_audit_malformed_json.py
@@ -1,0 +1,100 @@
+import shlex
+
+import pytest
+
+from middlewared.test.integration.utils import call, ssh
+
+AUDIT_DB = "/audit/MIDDLEWARE.db"
+TABLE = "audit_MIDDLEWARE_0_1"
+TAG = "nas140907-test"
+ALERT_KLASS = "AuditDatabaseCorrupted"
+
+
+def _run_sql(sql):
+    full = f"PRAGMA busy_timeout=5000; {sql}"
+    return ssh(f"sqlite3 {AUDIT_DB} {shlex.quote(full)}")
+
+
+def _insert_corrupt_rows():
+    now = int(ssh("date +%s").strip())
+    # Row A: non-JSON text -> json_valid() is false.
+    # Row B: valid JSON whose $date payload ejson cannot reconstruct -> EJSONDecodeError on decode.
+    _run_sql(
+        f"INSERT INTO {TABLE} (audit_id, message_timestamp, service, event, event_data) "
+        f"VALUES ('{TAG}-a', {now}, 'MIDDLEWARE', 'METHOD_CALL', '{{malformed json');"
+        f"INSERT INTO {TABLE} (audit_id, message_timestamp, service, event, event_data) "
+        f"VALUES ('{TAG}-b', {now}, 'MIDDLEWARE', 'METHOD_CALL', '{{\"$date\": \"not-a-number\"}}');"
+    )
+
+
+def _delete_corrupt_rows():
+    _run_sql(f"DELETE FROM {TABLE} WHERE audit_id LIKE '{TAG}%';")
+
+
+def _scan():
+    ssh("midclt call auditbackend.scan_corruption")
+
+
+def _corruption_alerts():
+    return [
+        a
+        for a in call("alert.list")
+        if a["klass"] == ALERT_KLASS and a["args"].get("service") == "MIDDLEWARE"
+    ]
+
+
+@pytest.fixture(scope="module")
+def corrupt_audit_db():
+    _insert_corrupt_rows()
+    try:
+        yield
+    finally:
+        _delete_corrupt_rows()
+        _scan()
+
+
+def test_json_path_filter_does_not_abort_on_malformed_row(corrupt_audit_db):
+    # A JSONPath WHERE filter evaluates json_extract over every scanned row, including the
+    # corrupt ones. Without the guard this raises sqlite3.OperationalError: malformed JSON.
+    result = call(
+        "audit.query",
+        {
+            "services": ["MIDDLEWARE"],
+            "query-filters": [["event_data.method", "=", "user.create"]],
+            "query-options": {"limit": 10},
+        },
+    )
+    assert isinstance(result, list)
+
+
+def test_select_as_json_path_projects_null_for_corrupt_rows(corrupt_audit_db):
+    # SELECT AS on a JSON path evaluates json_extract in the projection; the guard must
+    # yield NULL for unparseable rows instead of aborting the query.
+    result = call(
+        "audit.query",
+        {
+            "services": ["MIDDLEWARE"],
+            "query-filters": [["audit_id", "^", TAG]],
+            "query-options": {
+                "select": ["audit_id", ["event_data.method", "method"]],
+                "limit": 10,
+            },
+        },
+    )
+    by_id = {row["audit_id"]: row for row in result}
+    assert set(by_id) == {f"{TAG}-a", f"{TAG}-b"}
+    assert by_id[f"{TAG}-a"]["method"] is None
+    assert by_id[f"{TAG}-b"]["method"] is None
+
+
+def test_scan_raises_corruption_alert(corrupt_audit_db):
+    _scan()
+    assert _corruption_alerts(), "expected AuditDatabaseCorrupted alert for MIDDLEWARE"
+
+
+def test_scan_clears_alert_once_rows_removed(corrupt_audit_db):
+    _delete_corrupt_rows()
+    _scan()
+    assert not _corruption_alerts(), (
+        "alert should be cleared after corrupt rows are removed"
+    )


### PR DESCRIPTION
## Problem
The audit databases store `event_data`/`service_data` as JSON in TEXT columns that SQLite does not validate on insert, so a corrupted or otherwise non-JSON value can persist in a row (e.g. after a storage/IO incident). Audit queries that filter or select on a JSON path compile to `json_extract()`, and SQLite aborts the entire statement with `OperationalError: malformed JSON` the moment it evaluates that over a bad row. This bubbles up uncaught from the SMB alert sources as recurring CRITICAL `AlertSourceRunFailed` alerts, and breaks `audit.query`/`audit.export` and the UI audit page.

## Solution
Guard every JSON-path `json_extract` so a non-JSON row is skipped instead of aborting the query, and surface the corruption rather than dropping it silently.

- **WHERE side** (`datastore/filter.py`): an opt-in `guard_malformed_json` flag wraps the comparison in `CASE WHEN json_valid(col) THEN ... ELSE false`. CASE guarantees `json_valid()` runs before `json_extract()`, so a malformed row is excluded. The flag is forwarded through the `OR` recursion and defaults off, leaving datastore queries byte-for-byte unchanged.
- **SELECT side** (`audit/backend.py`): the audit backend opts in for filters and applies the same guard to `SELECT AS` json-path projections (`ELSE NULL`).
- **Decode hardening**: `decode_audit_json()` also catches `EJSONDecodeError`, so a syntactically valid document with a bad `$date`/`$time`/`$type` payload falls back to the raw string instead of failing the query.
- **Observability**: a daily scan counts rows whose JSON columns are unparseable and raises a per-service `AuditDatabaseCorrupted` alert (cleared once the rows are gone), since the guards otherwise drop corrupt rows quietly.

Covered by unit tests for the WHERE/SELECT guards, the decode helper, the malformed-row count, and the alert clear-key contract, plus an api2 test that seeds a corrupt row end to end.

Original PR: https://github.com/truenas/middleware/pull/19181
