### PR TITLE
NAS-141549 / 27.0.0-BETA.1 / Add vm.get_guest_network_interfaces API method

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    IPvAnyAddress,
     NonEmptyString,
     UUIDv4String,
     excluded_field,
@@ -34,6 +35,8 @@ __all__ = [
     'VMRandomMacResult', 'VMCreate', 'VMUpdate', 'VMDeleteOptions', 'VMVirtualizationDetails', 'VMFlags',
     'VMGetVmemoryInUse', 'VMStatus', 'VMGetVmMemoryInfo', 'VMStartOptions', 'VMStopOptions', 'VMPortWizard',
     'VMBootloaderOptions',
+    'VMGuestNetworkInterfaceIPAddress', 'VMGuestNetworkInterface',
+    'VMGetGuestNetworkInterfacesArgs', 'VMGetGuestNetworkInterfacesResult',
 ]
 
 
@@ -572,3 +575,27 @@ class VMRandomMacArgs(BaseModel):
 
 class VMRandomMacResult(BaseModel):
     result: str = Field(description="Randomly generated MAC address suitable for virtual machine network interfaces.")
+
+
+class VMGuestNetworkInterfaceIPAddress(BaseModel):
+    ip_address: IPvAnyAddress = Field(description="IP address assigned to the interface.")
+    prefix: int = Field(description="Prefix length (subnet mask bits).")
+    ip_address_type: Literal["ipv4", "ipv6"] = Field(description="Address family: 'ipv4' or 'ipv6'.")
+
+
+class VMGuestNetworkInterface(BaseModel):
+    name: str = Field(description="Interface name as seen in the guest OS (e.g. 'eth0', 'ens3').")
+    hardware_address: str = Field(description="MAC address of the interface.")
+    ip_addresses: list[VMGuestNetworkInterfaceIPAddress] = Field(
+        description="IP addresses currently assigned to this interface."
+    )
+
+
+class VMGetGuestNetworkInterfacesArgs(BaseModel):
+    id: int = Field(description="ID of the virtual machine.")
+
+
+class VMGetGuestNetworkInterfacesResult(BaseModel):
+    result: list[VMGuestNetworkInterface] = Field(
+        description="Network interfaces reported by the QEMU guest agent."
+    )

--- a/src/middlewared/middlewared/api/v27_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm.py
@@ -580,7 +580,7 @@ class VMRandomMacResult(BaseModel):
 class VMGuestNetworkInterfaceIPAddress(BaseModel):
     ip_address: IPvAnyAddress = Field(description="IP address assigned to the interface.")
     prefix: int = Field(description="Prefix length (subnet mask bits).")
-    ip_address_type: Literal["ipv4", "ipv6"] = Field(description="Address family: 'ipv4' or 'ipv6'.")
+    ip_address_type: Literal["IPV4", "IPV6"] = Field(description="Address family: 'IPV4' or 'IPV6'.")
 
 
 class VMGuestNetworkInterface(BaseModel):

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -39,6 +39,8 @@ from middlewared.api.current import (
     VMGetDisplayWebUri,
     VMGetDisplayWebUriArgs,
     VMGetDisplayWebUriResult,
+    VMGetGuestNetworkInterfacesArgs,
+    VMGetGuestNetworkInterfacesResult,
     VMGetMemoryUsageArgs,
     VMGetMemoryUsageResult,
     VMGetVmemoryInUse,
@@ -49,6 +51,7 @@ from middlewared.api.current import (
     VMGetVmMemoryInfoResult,
     VMGuestArchitectureAndMachineChoicesArgs,
     VMGuestArchitectureAndMachineChoicesResult,
+    VMGuestNetworkInterface,
     VMLogFileDownloadArgs,
     VMLogFileDownloadResult,
     VMLogFilePathArgs,
@@ -104,6 +107,7 @@ from .info import (
     bootloader_ovmf_choices,
     cpu_model_choices,
     get_console,
+    get_guest_network_interfaces,
     log_file_download,
     log_file_path,
     port_wizard,
@@ -296,6 +300,20 @@ class VMService(GenericCRUDService[VMEntry]):
         Get the console device from a given guest.
         """
         return await get_console(self.context, id_)
+
+    @api_method(VMGetGuestNetworkInterfacesArgs, VMGetGuestNetworkInterfacesResult, roles=['VM_READ'],
+                check_annotations=True)
+    def get_guest_network_interfaces(self, id_: int) -> list[VMGuestNetworkInterface]:
+        """
+        Return the network interfaces visible inside a running VM as reported by the QEMU guest agent.
+
+        Requires the guest to have ``qemu-guest-agent`` installed and running.
+
+        .. note::
+            This method polls the guest agent with a 30-second timeout. If the agent is not yet ready
+            (e.g. the guest just booted), a :exc:`CallError` is raised and the caller should retry.
+        """
+        return get_guest_network_interfaces(self.context, id_)
 
     @api_method(VMGetDisplayDevicesArgs, VMGetDisplayDevicesResult, roles=['VM_READ'], check_annotations=True)
     async def get_display_devices(self, id_: int) -> list[VMDisplayDeviceInfo]:

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -8,7 +8,7 @@ import shutil
 from socket import AF_INET6
 import typing
 
-import libvirt  # type: ignore[import-untyped]
+from truenas_pylibvirt import GuestAgentError
 from truenas_pylibvirt.utils import kvm_supported
 from truenas_pylibvirt.utils.cpu import get_cpu_model_choices
 
@@ -169,8 +169,8 @@ def get_guest_network_interfaces(context: ServiceContext, id_: int) -> list[VMGu
         raw = context.middleware.libvirt_domains_manager.vms_connection.guest_agent_command(
             domain, '{"execute":"guest-network-get-interfaces"}'
         )
-    except libvirt.libvirtError as e:
-        raise CallError(f'Guest agent not available for VM {id_}: {e}')
+    except GuestAgentError as e:
+        raise CallError(f'VM {id_}: {e}')
     data = json.loads(raw)
     return [
         VMGuestNetworkInterface.model_validate({

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import functools
+import json
 import os
 import re
 import shutil
 from socket import AF_INET6
 import typing
 
+import libvirt  # type: ignore[import-untyped]
 from truenas_pylibvirt.utils import kvm_supported
 from truenas_pylibvirt.utils.cpu import get_cpu_model_choices
 
@@ -16,10 +18,11 @@ from middlewared.api.current import (
     VMDisplayWebURIOptions,
     VMFlags,
     VMGetDisplayWebUri,
+    VMGuestNetworkInterface,
     VMPortWizard,
     VMVirtualizationDetails,
 )
-from middlewared.service import ServiceContext
+from middlewared.service import CallError, ServiceContext
 from middlewared.utils.cpu import cpu_info
 from middlewared.utils.libvirt.display import DisplayDelegate
 from middlewared.utils.libvirt.nic import NICDelegate
@@ -149,6 +152,41 @@ async def get_display_devices(context: ServiceContext, id_: int) -> list[VMDispl
         device_dict['attributes']['password_configured'] = bool(device_dict['attributes'].get('password'))
         devices.append(VMDisplayDeviceInfo.model_validate(device_dict))
     return devices
+
+
+def get_guest_network_interfaces(context: ServiceContext, id_: int) -> list[VMGuestNetworkInterface]:
+    """Return network interfaces reported by the QEMU guest agent.
+
+    Raises CallError if the VM is not running or the guest agent is unavailable.
+    """
+    uuid = context.middleware.call_sync(
+        'datastore.query', 'vm.vm', [['id', '=', id_]], {'get': True}
+    )['uuid']
+    domain = context.middleware.libvirt_domains_manager.vms_connection.get_domain(uuid)
+    if domain is None:
+        raise CallError(f'VM {id_} is not running')
+    try:
+        raw = context.middleware.libvirt_domains_manager.vms_connection.guest_agent_command(
+            domain, '{"execute":"guest-network-get-interfaces"}'
+        )
+    except libvirt.libvirtError as e:
+        raise CallError(f'Guest agent not available for VM {id_}: {e}')
+    data = json.loads(raw)
+    return [
+        VMGuestNetworkInterface.model_validate({
+            'name': iface.get('name', ''),
+            'hardware_address': iface.get('hardware-address', ''),
+            'ip_addresses': [
+                {
+                    'ip_address': addr.get('ip-address', ''),
+                    'prefix': addr.get('prefix', 0),
+                    'ip_address_type': addr.get('ip-address-type', 'ipv4'),
+                }
+                for addr in iface.get('ip-addresses', [])
+            ],
+        })
+        for iface in data.get('return', [])
+    ]
 
 
 async def get_display_web_uri(

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -178,11 +178,12 @@ def get_guest_network_interfaces(context: ServiceContext, id_: int) -> list[VMGu
             'hardware_address': iface.get('hardware-address', ''),
             'ip_addresses': [
                 {
-                    'ip_address': addr.get('ip-address', ''),
+                    'ip_address': addr['ip-address'],
                     'prefix': addr.get('prefix', 0),
-                    'ip_address_type': addr.get('ip-address-type', 'ipv4'),
+                    'ip_address_type': addr.get('ip-address-type', 'ipv4').upper(),
                 }
                 for addr in iface.get('ip-addresses', [])
+                if addr.get('ip-address')
             ],
         })
         for iface in data.get('return', [])


### PR DESCRIPTION
Queries the QEMU guest agent virtio-serial channel via truenas_pylibvirt to return the guest's network interfaces without requiring IP-layer connectivity to the guest.
