### PR TITLE
NAS-141531 / 25.10.5 / more zpool status checks in failover

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -51,6 +51,7 @@ from middlewared.plugins.failover_.enums import DisabledReasonsEnum
 from middlewared.plugins.failover_.event import BACKUP_STOP_SERVICES
 from middlewared.plugins.failover_.ha_hardware import is_licensed_for_ha
 from middlewared.plugins.failover_.remote import NETWORK_ERRORS
+from middlewared.plugins.failover_.stcnith import stcnith_reboot
 from middlewared.plugins.system.reboot import RebootReason
 from middlewared.plugins.update_.install import STARTING_INSTALLER
 from middlewared.plugins.update_.update import SYSTEM_UPGRADE_REBOOT_REASON
@@ -318,20 +319,7 @@ class FailoverService(ConfigService):
         if self.middleware.call_sync('failover.config')['disabled'] is True:
             raise ValidationError('failover.become_passive', 'Failover must be enabled.')
         else:
-            try:
-                # have to enable the "magic" sysrq triggers
-                with open('/proc/sys/kernel/sysrq', 'w') as f:
-                    f.write('1')
-
-                # now violently reboot
-                with open('/proc/sysrq-trigger', 'w') as f:
-                    f.write('b')
-            except Exception:
-                # yeah...this isn't good
-                self.logger.error('Unexpected failure in failover.become_passive', exc_info=True)
-            finally:
-                # this shouldn't be reached but better safe than sorry
-                os.system('shutdown -r now')
+            stcnith_reboot()
 
     @private
     async def force_master(self):

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -12,13 +12,14 @@ import logging
 import errno
 from collections import defaultdict
 
-from middlewared.utils import filter_list
+from middlewared.utils import BOOT_POOL_NAME_VALID, filter_list
 from middlewared.service import Service, job
 from middlewared.service_exception import CallError
 from middlewared.plugins.docker.state_utils import Status as DockerStatus
 # from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
+from middlewared.plugins.failover_.stcnith import stcnith_reboot
 from middlewared.plugins.service_.services.all import all_services
 from middlewared.plugins.virt.utils import VirtGlobalStatus as VirtStatus
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
@@ -226,23 +227,81 @@ class FailoverEventsService(Service):
             if refresh and job is not None:
                 self.middleware.create_task(self.refresh_failover_status(job.id, event))
 
-    def _export_zpools(self, volumes):
+    def force_reboot(self, reason):
+        """
+        Fail-closed guard reboot. Used when we cannot safely continue a failover
+        transition -- e.g. a pool is still imported and we must not release SCSI
+        fencing, or the pool import state is indeterminate.
 
-        # export the zpool(s)
+        We write the watchdog sentinel first so the post-reboot alert is correct
+        (ticket 39114), then hand off to the shared STCNITH reboot. Unlike
+        `failover.become_passive` this performs no failover-enabled check: a
+        still-attached pool must reboot us regardless.
+        """
+        with contextlib.suppress(Exception):
+            with open(WATCHDOG_ALERT_FILE, 'w') as f:
+                f.write(f'{time.time()}')
+                f.flush()  # be sure it goes straight to disk
+                os.fsync(f.fileno())  # be EXTRA sure it goes straight to disk
+
+        stcnith_reboot(reason)
+
+    def fence_if_pools_still_imported(self, volumes):
+        """
+        Fail-closed demotion guard. Before releasing SCSI fencing on a demoting
+        controller, authoritatively confirm every data pool has actually been
+        exported.
+
+        "Imported" is keyed on the pool's *presence* in the kstat namespace:
+        zfs.pool.query_imported_fast enumerates /proc/spl/kstat/zfs, whose per-pool
+        directory OpenZFS creates in spa_add() and removes in spa_remove() -- so it
+        exists for exactly as long as the pool is in the SPA namespace (import until
+        export, and spa_remove runs after the vdevs/disks are closed). The reads are
+        lockless (per OpenZFS spa_stats.c: "a lock-less read ... unlike 'zpool',
+        which can potentially block for seconds"), so this cannot hang on a wedged
+        or suspended pool.
+
+        We deliberately ignore the reported pool *state* -- spa_state_to_name() can
+        return OFFLINE or SUSPENDED while the pool is still imported, which is the
+        spurious-OFFLINE that made the old status-gated export skip a still-attached
+        pool. Any pool still present, or an indeterminate read, means we force-reboot
+        rather than release the disks.
+
+        The boot pool is excluded: each controller has its own boot pool that is
+        always imported, so it must never count as still-attached shared storage
+        (otherwise we would self-fence on every demotion).
+        """
         try:
-            for vol in volumes:
-                if vol['status'] != 'OFFLINE':
-                    self.middleware.call_sync('zfs.pool.export', vol['name'], {'force': True})
-                    logger.info('Exported "%s"', vol['name'])
+            imported_names = {
+                p['name'] for p in self.run_call('zfs.pool.query_imported_fast').values()
+                if p['name'] not in BOOT_POOL_NAME_VALID
+            }
         except Exception as e:
-            # catch any exception that could be raised
-            # We sleep for 5 seconds here because this is
-            # in its own thread. The calling thread waits
-            # for self.ZPOOL_EXPORT_TIMEOUT and if this
-            # thread is_alive(), then we violently reboot
-            # the node
-            logger.error('Error exporting "%s" with error %s', vol['name'], e)
-            time.sleep(self.ZPOOL_EXPORT_TIMEOUT + 1)
+            self.force_reboot(f'could not determine pool import state before releasing fencing: {e}')
+            return
+
+        still_imported = [v['name'] for v in volumes if v['name'] in imported_names]
+        if still_imported:
+            self.force_reboot(
+                f'pool(s) {still_imported} still imported after export; refusing to release fencing'
+            )
+
+    def _export_zpools(self, volumes):
+        # Best-effort export of each pool. NOTE: "finished" is not "succeeded" --
+        # a failed export leaves the pool imported. The caller (vrrp_backup)
+        # authoritatively re-checks every pool with zfs.pool.query_imported_fast
+        # before releasing fencing and force-reboots if any pool is still attached.
+        # A hung export keeps this thread alive past the join() timeout, which the
+        # caller also turns into a force-reboot. So to stay fail-closed and as safe
+        # as possible, we simply attempt every export here and let that caller's
+        # re-check be the single authoritative gate -- no need to gate on pool
+        # status or to sleep-to-force-reboot from in here.
+        for vol in volumes:
+            try:
+                self.middleware.call_sync('zfs.pool.export', vol['name'], {'force': True})
+                logger.info('Exported %r', vol['name'])
+            except Exception:
+                logger.error('Error exporting %r', vol['name'], exc_info=True)
 
     def generate_failover_data(self):
 
@@ -910,12 +969,9 @@ class FailoverEventsService(Service):
         # setup the zpool cachefile
         # self.run_call('failover.zpool.cachefile.setup', 'BACKUP')
 
-        # export zpools in a thread and set a timeout to
-        # to `self.ZPOOL_EXPORT_TIMEOUT`.
-        # if we can't export the zpool(s) in this timeframe,
-        # we send the 'b' character to the /proc/sysrq-trigger
-        # to trigger an immediate reboot of the system
-        # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
+        # export zpools in a thread with a timeout of `self.ZPOOL_EXPORT_TIMEOUT`.
+        # if the export can't finish in that timeframe (or leaves a pool still
+        # imported), we force-reboot this controller rather than release the disks.
         export_thread = threading.Thread(
             target=self._export_zpools,
             name='failover_export_zpools',
@@ -924,15 +980,15 @@ class FailoverEventsService(Service):
         export_thread.start()
         export_thread.join(timeout=self.ZPOOL_EXPORT_TIMEOUT)
         if export_thread.is_alive():
-            # have to enable the "magic" sysrq triggers
-            with open('/proc/sys/kernel/sysrq', 'w') as f:
-                f.write('1')
+            # export is wedged (e.g. a suspended pool whose I/O never completes);
+            # force-reboot rather than risk releasing the disks while still attached
+            self.force_reboot(f'zpool export did not complete within {self.ZPOOL_EXPORT_TIMEOUT}s')
 
-            # now violently reboot
-            with open('/proc/sysrq-trigger', 'w') as f:
-                f.write('b')
+        # A skipped/failed export leaves the pool imported. Confirm every pool is
+        # actually gone before releasing fencing, else force-reboot.
+        self.fence_if_pools_still_imported(fobj['volumes'])
 
-        # Pools are now exported and so we can make disks available to other controller
+        # Every pool is confirmed exported; safe to make disks available to peer.
         logger.warning('Stopping fenced')
         self.run_call('failover.fenced.stop')
 

--- a/src/middlewared/middlewared/plugins/failover_/stcnith.py
+++ b/src/middlewared/middlewared/plugins/failover_/stcnith.py
@@ -1,0 +1,43 @@
+# Copyright (c) - iXsystems Inc. dba TrueNAS
+#
+# Licensed under the terms of the TrueNAS Enterprise License Agreement
+# See the file LICENSE.IX for complete terms and conditions
+
+import logging
+import os
+
+logger = logging.getLogger('failover')
+
+
+def stcnith_reboot(reason=None):
+    """
+    STCNITH (Shoot The Current Node In The Head): immediately and violently
+    reboot THIS controller via the magic sysrq trigger, falling back to a
+    `shutdown -r now` if sysrq is somehow unavailable.
+    https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
+
+    This is the only "safe" way to get the current node completely out of the
+    way (e.g. on demotion) so that there is no chance of a zpool being imported
+    on both nodes at once, which can ultimately end in data corruption.
+
+    Idempotent: every step is best-effort and calling it more than once has the
+    same end result (this node reboots ASAP). It performs NO failover validation
+    so callers that require a guard (e.g. `failover.become_passive`) must do that
+    check *before* calling.
+    """
+    if reason:
+        logger.error('Force-rebooting this controller: %s', reason)
+    try:
+        # have to enable the "magic" sysrq triggers
+        with open('/proc/sys/kernel/sysrq', 'w') as f:
+            f.write('1')
+
+        # now violently reboot
+        with open('/proc/sysrq-trigger', 'w') as f:
+            f.write('b')
+    except Exception:
+        # yeah...this isn't good
+        logger.error('Unexpected failure triggering immediate reboot via sysrq', exc_info=True)
+    finally:
+        # this shouldn't be reached but better safe than sorry
+        os.system('shutdown -r now')

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_failover_event_failclosed.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_failover_event_failclosed.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock
+
+from middlewared.plugins.failover_.event import FailoverEventsService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+# fobj['volumes'] carries name/guid/status. NOTE the 'OFFLINE' status below: it is
+# what pool.query reports for a pool it could not read (the spurious-OFFLINE that
+# motivated this guard). The fail-closed check must IGNORE that and rely on the
+# authoritative /proc kstat (zfs.pool.query_imported_fast) instead.
+TANK_VOLUMES = [{'name': 'tank', 'guid': '123', 'status': 'OFFLINE'}]
+
+# zfs.pool.query_imported_fast() shape: {guid: {'name': ..., 'state': ...}}
+IMPORTED_WITH_TANK = {
+    '123': {'name': 'tank', 'state': 'ONLINE'},
+    '999': {'name': 'boot-pool', 'state': 'ONLINE'},
+}
+ONLY_BOOT_POOL = {'999': {'name': 'boot-pool', 'state': 'ONLINE'}}
+
+
+def make_service(**method_mocks):
+    m = Middleware()
+    for name, mock in method_mocks.items():
+        m[name.replace('__', '.')] = mock
+    svc = FailoverEventsService(m)
+    # never actually sysrq-reboot the test runner
+    svc.force_reboot = Mock()
+    return svc
+
+
+def test_demotion_reboots_when_pool_still_imported():
+    # pool.query said OFFLINE (see volumes), but the authoritative kstat shows tank
+    # is STILL imported -> must force-reboot instead of releasing fencing.
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=IMPORTED_WITH_TANK))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.force_reboot.assert_called_once()
+
+
+def test_demotion_reboots_when_present_but_state_offline():
+    # spa_state_to_name() can report OFFLINE/SUSPENDED while the pool is still
+    # imported. We key on PRESENCE in the kstat namespace, not the state value, so
+    # a still-present pool must force-reboot even when its state reads OFFLINE (the
+    # spurious-OFFLINE failure mode that fooled the old status-gated export).
+    imported = {'123': {'name': 'tank', 'state': 'OFFLINE'}}
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=imported))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.force_reboot.assert_called_once()
+
+
+def test_demotion_releases_when_pool_exported():
+    # kstat shows only the boot pool -> tank really is exported -> safe, no reboot
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=ONLY_BOOT_POOL))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.force_reboot.assert_not_called()
+
+
+def test_demotion_reboots_when_state_indeterminate():
+    # cannot determine import state -> fail closed (force-reboot), never release
+    svc = make_service(zfs__pool__query_imported_fast=Mock(side_effect=RuntimeError('boom')))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.force_reboot.assert_called_once()
+
+
+def test_demotion_ignores_boot_pools():
+    # Each controller has its own boot pool that is ALWAYS imported. Neither valid
+    # boot-pool name may count as still-attached data storage, otherwise we would
+    # force-reboot on every demotion. tank is gone -> no reboot despite boot pools.
+    imported = {
+        '111': {'name': 'boot-pool', 'state': 'ONLINE'},
+        '222': {'name': 'freenas-boot', 'state': 'ONLINE'},
+    }
+    svc = make_service(zfs__pool__query_imported_fast=Mock(return_value=imported))
+
+    svc.fence_if_pools_still_imported(TANK_VOLUMES)
+
+    svc.force_reboot.assert_not_called()

--- a/src/middlewared/middlewared/scripts/ha_panic.py
+++ b/src/middlewared/middlewared/scripts/ha_panic.py
@@ -8,6 +8,7 @@ import sys
 
 from middlewared.plugins.failover_.detect_utils import detect_platform
 from middlewared.plugins.failover_.ha_hardware import is_licensed_for_ha
+from middlewared.plugins.failover_.stcnith import stcnith_reboot
 from middlewared.utils.db import query_config_table
 
 
@@ -26,22 +27,12 @@ def is_failover_enabled() -> bool:
         return False
 
 
-def trigger_panic() -> None:
-    """Trigger immediate reboot via sysrq (same as failover.become_passive)."""
-    # Enable sysrq triggers
-    with open('/proc/sys/kernel/sysrq', 'w') as f:
-        f.write('1')
-    # Immediate reboot - no sync, no umount
-    with open('/proc/sysrq-trigger', 'w') as f:
-        f.write('b')
-
-
 def main() -> int:
     if is_ha_capable() is False or is_failover_enabled() is False or is_licensed_for_ha() is False:
         # If system is not HA or if failover is explicitly disabled or if system is not licensed for HA, let's not panic
         return 0
 
-    trigger_panic()
+    stcnith_reboot()
     return 0
 
 


### PR DESCRIPTION
These changes make the standby transition fail closed so a controller never releases its disks while a pool might still be imported.

When a controller demotes to standby it exports its pools and then stops fencing to make the disks available to the other controller. The old code exported each pool on a best effort basis and skipped any pool that reported a status of OFFLINE. In rare cases a pool can report OFFLINE while it is in fact still imported, so the old code could stop fencing and release the disks while a pool was still attached. That is a fail open scenario because the other controller could then import the same pool at the same time, which can lead to data corruption.

The new code attempts to export every pool and then confirms the outcome before releasing fencing. It checks each pool again using a lockless read of the kernel kstat namespace, which reflects whether a pool is actually present rather than what state it reports. If any pool is still imported, or the export is still running past its timeout, or the import state cannot be determined, the controller reboots itself instead of releasing the disks. A reboot is the only safe way to guarantee this node is fully out of the way. The boot pool is always excluded because each controller has its own boot pool that stays imported.

The logic that forcefully reboots the current controller was duplicated in several places and is now a single shared function reused by the failover become passive method, the failover event, and the HA panic script. The shared function also keeps the graceful shutdown fallback that was previously only present in become passive.

New unit tests cover the fail closed behavior, including a pool that is still imported, a pool that reports OFFLINE while present, an indeterminate read, and the boot pool exclusion.