### PR TITLE
NAS-141461 / 27.0.0-BETA.1 / Clear stale SMB locked-dataset alert after boot unlock (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -155,7 +155,12 @@ class SMBService(ConfigService):
             smb_shares = []
 
         # Skip locked shares (alerting on each). For unlocked shares, clear any
-        # stale locked-dataset alert (e.g. generated at boot before pools unlocked).
+        # stale locked-dataset alert left from when the dataset was still locked.
+        locked_alert_share_ids = {
+            alert['args'].get('id')
+            for alert in self.middleware.call_sync('alert.list')
+            if alert['klass'] == 'ShareLocked' and alert['args'].get('type') == 'SMB'
+        }
         active_shares = []
         for share in smb_shares:
             if share[share_field.LOCKED]:
@@ -165,7 +170,8 @@ class SMBService(ConfigService):
                 )
                 self.middleware.call_sync('sharing.smb.generate_locked_alert', share['id'])
                 continue
-            self.middleware.call_sync('sharing.smb.remove_locked_alert', share['id'])
+            if share['id'] in locked_alert_share_ids:
+                self.middleware.call_sync('sharing.smb.remove_locked_alert', share['id'])
             active_shares.append(share)
         smb_shares = active_shares
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -156,6 +156,11 @@ class SMBService(ConfigService):
 
         # Skip locked shares (alerting on each). For unlocked shares, clear any
         # stale locked-dataset alert left from when the dataset was still locked.
+        # Gate the removal on an alert actually existing so the common all-unlocked
+        # case does not spawn a process_alerts job per share on every regeneration.
+        # alert.list hides alerts whose ShareLocked class policy is NEVER, so such an
+        # alert is not auto-cleared here; acceptable because it is hidden from the
+        # user and self-heals on a later regeneration if the policy becomes visible.
         locked_alert_share_ids = {
             alert['args'].get('id')
             for alert in self.middleware.call_sync('alert.list')

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -154,7 +154,8 @@ class SMBService(ConfigService):
             # Do not include SMB shares in configuration on standby controller
             smb_shares = []
 
-        # Skip locked shares and generate alerts for them
+        # Skip locked shares (alerting on each). For unlocked shares, clear any
+        # stale locked-dataset alert (e.g. generated at boot before pools unlocked).
         active_shares = []
         for share in smb_shares:
             if share[share_field.LOCKED]:
@@ -164,6 +165,7 @@ class SMBService(ConfigService):
                 )
                 self.middleware.call_sync('sharing.smb.generate_locked_alert', share['id'])
                 continue
+            self.middleware.call_sync('sharing.smb.remove_locked_alert', share['id'])
             active_shares.append(share)
         smb_shares = active_shares
 

--- a/src/middlewared/middlewared/test/integration/utils/alert.py
+++ b/src/middlewared/middlewared/test/integration/utils/alert.py
@@ -11,9 +11,13 @@ def process_alerts():
 def find_share_locked_alert(share_type, share_id):
     """Return the ShareLocked alert for the given share, or None.
 
-    `share_type` is the share task type used in the alert key (e.g. 'SMB', 'NFS')."""
+    `share_type` is the share task type (e.g. 'SMB', 'NFS')."""
     for alert in call('alert.list'):
-        if alert['klass'] == 'ShareLocked' and f'{share_type}_{share_id}' in alert['key']:
+        if (
+            alert['klass'] == 'ShareLocked'
+            and alert['args'].get('type') == share_type
+            and alert['args'].get('id') == share_id
+        ):
             return alert
     return None
 

--- a/src/middlewared/middlewared/test/integration/utils/alert.py
+++ b/src/middlewared/middlewared/test/integration/utils/alert.py
@@ -1,6 +1,34 @@
+from time import sleep
+
 from .call import call
 
 
 def process_alerts():
     call("alert.initialize")
     call("core.bulk", "alert.process_alerts", [[]], job=True)
+
+
+def find_share_locked_alert(share_type, share_id):
+    """Return the ShareLocked alert for the given share, or None.
+
+    `share_type` is the share task type used in the alert key (e.g. 'SMB', 'NFS')."""
+    for alert in call('alert.list'):
+        if alert['klass'] == 'ShareLocked' and f'{share_type}_{share_id}' in alert['key']:
+            return alert
+    return None
+
+
+def wait_for_share_locked_alert(share_type, share_id, timeout=30):
+    for _ in range(timeout):
+        if alert := find_share_locked_alert(share_type, share_id):
+            return alert
+        sleep(1)
+    return None
+
+
+def wait_for_share_locked_alert_cleared(share_type, share_id, timeout=30):
+    for _ in range(timeout):
+        if find_share_locked_alert(share_type, share_id) is None:
+            return True
+        sleep(1)
+    return False

--- a/tests/api2/test_nfs_share_locked_alert.py
+++ b/tests/api2/test_nfs_share_locked_alert.py
@@ -1,9 +1,12 @@
 import contextlib
-import time
 
 from middlewared.service_exception import InstanceNotFound
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.alert import (
+    wait_for_share_locked_alert,
+    wait_for_share_locked_alert_cleared,
+)
 
 
 PASSPHRASE = '12345678'
@@ -36,29 +39,6 @@ def nfs_service():
         call('service.control', 'STOP', 'nfs', job=True)
 
 
-def find_share_locked_alert(share_id):
-    for alert in call('alert.list'):
-        if alert['klass'] == 'ShareLocked' and f'NFS_{share_id}' in alert['key']:
-            return alert
-    return None
-
-
-def wait_for_alert(share_id, timeout=30):
-    for _ in range(timeout):
-        if alert := find_share_locked_alert(share_id):
-            return alert
-        time.sleep(1)
-    return None
-
-
-def wait_for_alert_cleared(share_id, timeout=30):
-    for _ in range(timeout):
-        if find_share_locked_alert(share_id) is None:
-            return True
-        time.sleep(1)
-    return False
-
-
 def test_share_locked_alert_on_dataset_lock_unlock():
     """Creating an NFS share on a locked dataset generates a ShareLocked alert.
     Unlocking the dataset clears the alert."""
@@ -77,7 +57,7 @@ def test_share_locked_alert_on_dataset_lock_unlock():
                 assert share['locked'] is True
 
                 # Locking the dataset should generate a ShareLocked alert
-                alert = wait_for_alert(share_id)
+                alert = wait_for_share_locked_alert('NFS', share_id)
                 assert alert is not None, 'ShareLocked alert was not created after locking dataset'
                 assert alert['level'] == 'WARNING'
 
@@ -91,5 +71,5 @@ def test_share_locked_alert_on_dataset_lock_unlock():
                 share = call('sharing.nfs.get_instance', share_id)
                 assert share['locked'] is False
 
-                assert wait_for_alert_cleared(share_id), \
+                assert wait_for_share_locked_alert_cleared('NFS', share_id), \
                     'ShareLocked alert was not cleared after unlocking dataset'

--- a/tests/api2/test_smb_share_locked_alert.py
+++ b/tests/api2/test_smb_share_locked_alert.py
@@ -7,49 +7,57 @@ from middlewared.test.integration.utils.alert import (
 )
 
 
-PASSPHRASE = '12345678'
+PASSPHRASE = "12345678"
 
 
 def encryption_props():
     return {
-        'encryption_options': {'generate_key': False, 'passphrase': PASSPHRASE},
-        'encryption': True,
-        'inherit_encryption': False,
+        "encryption_options": {"generate_key": False, "passphrase": PASSPHRASE},
+        "encryption": True,
+        "inherit_encryption": False,
     }
 
 
 def test_share_locked_alert_on_dataset_lock_unlock():
     """Locking the dataset behind an SMB share generates a ShareLocked alert.
     Unlocking the dataset clears the alert."""
-    with dataset('encrypted_smb', encryption_props()) as ds:
-        with smb_share(f'/mnt/{ds}', 'enc_smb_share') as share:
-            share_id = share['id']
+    with dataset("encrypted_smb", encryption_props()) as ds:
+        with smb_share(f"/mnt/{ds}", "enc_smb_share") as share:
+            share_id = share["id"]
 
             # Verify share is not locked initially
-            share = call('sharing.smb.get_instance', share_id)
-            assert share['locked'] is False
+            share = call("sharing.smb.get_instance", share_id)
+            assert share["locked"] is False
 
             # Lock the dataset
-            call('pool.dataset.lock', ds, job=True)
+            call("pool.dataset.lock", ds, job=True)
 
             # Share should now report as locked
-            share = call('sharing.smb.get_instance', share_id)
-            assert share['locked'] is True
+            share = call("sharing.smb.get_instance", share_id)
+            assert share["locked"] is True
 
             # Locking the dataset should generate a ShareLocked alert
-            alert = wait_for_share_locked_alert('SMB', share_id)
-            assert alert is not None, 'ShareLocked alert was not created after locking dataset'
-            assert alert['level'] == 'WARNING'
+            alert = wait_for_share_locked_alert("SMB", share_id)
+            assert alert is not None, (
+                "ShareLocked alert was not created after locking dataset"
+            )
+            assert alert["level"] == "WARNING"
 
             # Unlock the dataset — the stale locked-dataset alert must be cleared
-            call('pool.dataset.unlock', ds, {
-                'datasets': [{'name': ds, 'passphrase': PASSPHRASE}],
-                'recursive': True,
-            }, job=True)
+            call(
+                "pool.dataset.unlock",
+                ds,
+                {
+                    "datasets": [{"name": ds, "passphrase": PASSPHRASE}],
+                    "recursive": True,
+                },
+                job=True,
+            )
 
             # Verify the share is unlocked
-            share = call('sharing.smb.get_instance', share_id)
-            assert share['locked'] is False
+            share = call("sharing.smb.get_instance", share_id)
+            assert share["locked"] is False
 
-            assert wait_for_share_locked_alert_cleared('SMB', share_id), \
-                'ShareLocked alert was not cleared after unlocking dataset'
+            assert wait_for_share_locked_alert_cleared("SMB", share_id), (
+                "ShareLocked alert was not cleared after unlocking dataset"
+            )

--- a/tests/api2/test_smb_share_locked_alert.py
+++ b/tests/api2/test_smb_share_locked_alert.py
@@ -18,32 +18,27 @@ def encryption_props():
     }
 
 
-def test_share_locked_alert_on_dataset_lock_unlock():
-    """Locking the dataset behind an SMB share generates a ShareLocked alert.
-    Unlocking the dataset clears the alert."""
+def test_share_locked_alert_lifecycle():
+    """Locking the dataset behind an SMB share raises a ShareLocked alert; the normal
+    interactive unlock (toggle_attachments=True) clears it via the attachment-delegate
+    start() -> remove_alert path."""
     with dataset("encrypted_smb", encryption_props()) as ds:
         with smb_share(f"/mnt/{ds}", "enc_smb_share") as share:
             share_id = share["id"]
 
-            # Verify share is not locked initially
-            share = call("sharing.smb.get_instance", share_id)
-            assert share["locked"] is False
+            assert call("sharing.smb.get_instance", share_id)["locked"] is False
 
-            # Lock the dataset
+            # Lock the dataset -> share becomes locked and the alert is raised.
             call("pool.dataset.lock", ds, job=True)
+            assert call("sharing.smb.get_instance", share_id)["locked"] is True
 
-            # Share should now report as locked
-            share = call("sharing.smb.get_instance", share_id)
-            assert share["locked"] is True
-
-            # Locking the dataset should generate a ShareLocked alert
             alert = wait_for_share_locked_alert("SMB", share_id)
             assert alert is not None, (
                 "ShareLocked alert was not created after locking dataset"
             )
             assert alert["level"] == "WARNING"
 
-            # Unlock the dataset — the stale locked-dataset alert must be cleared
+            # Interactive unlock clears the alert through the attachment-delegate path.
             call(
                 "pool.dataset.unlock",
                 ds,
@@ -53,11 +48,40 @@ def test_share_locked_alert_on_dataset_lock_unlock():
                 },
                 job=True,
             )
-
-            # Verify the share is unlocked
-            share = call("sharing.smb.get_instance", share_id)
-            assert share["locked"] is False
+            assert call("sharing.smb.get_instance", share_id)["locked"] is False
 
             assert wait_for_share_locked_alert_cleared("SMB", share_id), (
                 "ShareLocked alert was not cleared after unlocking dataset"
+            )
+
+
+def test_stale_locked_alert_cleared_on_smb_regen():
+    """Regression guard for the boot path (the generate_smb_configuration fix).
+
+    At boot the encrypted pool is unlocked with toggle_attachments=False, so the
+    attachment-delegate path that normally clears a ShareLocked alert never runs.
+    The stale alert must instead be cleared when smb.conf is regenerated (the
+    post-unlock pool.post_import -> etc.generate('smb')) now that the share is no
+    longer locked.
+
+    The leftover boot state is reproduced directly: raise a ShareLocked alert for a
+    share whose dataset is NOT locked, then regenerate smb.conf and assert the alert
+    is gone. Reverting the generate_smb_configuration change fails this test (the
+    lifecycle test above still passes because it clears via a different path)."""
+    with dataset("smb_locked_alert") as ds:
+        with smb_share(f"/mnt/{ds}", "smb_locked_alert_share") as share:
+            share_id = share["id"]
+
+            # Share sits on a normal, unlocked dataset.
+            assert call("sharing.smb.get_instance", share_id)["locked"] is False
+
+            # Simulate the leftover boot alert (attachment-toggle clear path bypassed).
+            call("sharing.smb.generate_locked_alert", share_id)
+            assert wait_for_share_locked_alert("SMB", share_id) is not None
+
+            # Regenerating smb.conf must clear the stale alert for the unlocked share.
+            call("etc.generate", "smb")
+
+            assert wait_for_share_locked_alert_cleared("SMB", share_id), (
+                "stale ShareLocked alert was not cleared on smb.conf regeneration"
             )

--- a/tests/api2/test_smb_share_locked_alert.py
+++ b/tests/api2/test_smb_share_locked_alert.py
@@ -1,0 +1,76 @@
+import time
+
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.utils import call
+
+
+PASSPHRASE = '12345678'
+
+
+def encryption_props():
+    return {
+        'encryption_options': {'generate_key': False, 'passphrase': PASSPHRASE},
+        'encryption': True,
+        'inherit_encryption': False,
+    }
+
+
+def find_share_locked_alert(share_id):
+    for alert in call('alert.list'):
+        if alert['klass'] == 'ShareLocked' and f'SMB_{share_id}' in alert['key']:
+            return alert
+    return None
+
+
+def wait_for_alert(share_id, timeout=30):
+    for _ in range(timeout):
+        if alert := find_share_locked_alert(share_id):
+            return alert
+        time.sleep(1)
+    return None
+
+
+def wait_for_alert_cleared(share_id, timeout=30):
+    for _ in range(timeout):
+        if find_share_locked_alert(share_id) is None:
+            return True
+        time.sleep(1)
+    return False
+
+
+def test_share_locked_alert_on_dataset_lock_unlock():
+    """Locking the dataset behind an SMB share generates a ShareLocked alert.
+    Unlocking the dataset clears the alert."""
+    with dataset('encrypted_smb', encryption_props()) as ds:
+        with smb_share(f'/mnt/{ds}', 'enc_smb_share') as share:
+            share_id = share['id']
+
+            # Verify share is not locked initially
+            share = call('sharing.smb.get_instance', share_id)
+            assert share['locked'] is False
+
+            # Lock the dataset
+            call('pool.dataset.lock', ds, job=True)
+
+            # Share should now report as locked
+            share = call('sharing.smb.get_instance', share_id)
+            assert share['locked'] is True
+
+            # Locking the dataset should generate a ShareLocked alert
+            alert = wait_for_alert(share_id)
+            assert alert is not None, 'ShareLocked alert was not created after locking dataset'
+            assert alert['level'] == 'WARNING'
+
+            # Unlock the dataset — the stale locked-dataset alert must be cleared
+            call('pool.dataset.unlock', ds, {
+                'datasets': [{'name': ds, 'passphrase': PASSPHRASE}],
+                'recursive': True,
+            }, job=True)
+
+            # Verify the share is unlocked
+            share = call('sharing.smb.get_instance', share_id)
+            assert share['locked'] is False
+
+            assert wait_for_alert_cleared(share_id), \
+                'ShareLocked alert was not cleared after unlocking dataset'

--- a/tests/api2/test_smb_share_locked_alert.py
+++ b/tests/api2/test_smb_share_locked_alert.py
@@ -1,8 +1,10 @@
-import time
-
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.alert import (
+    wait_for_share_locked_alert,
+    wait_for_share_locked_alert_cleared,
+)
 
 
 PASSPHRASE = '12345678'
@@ -14,29 +16,6 @@ def encryption_props():
         'encryption': True,
         'inherit_encryption': False,
     }
-
-
-def find_share_locked_alert(share_id):
-    for alert in call('alert.list'):
-        if alert['klass'] == 'ShareLocked' and f'SMB_{share_id}' in alert['key']:
-            return alert
-    return None
-
-
-def wait_for_alert(share_id, timeout=30):
-    for _ in range(timeout):
-        if alert := find_share_locked_alert(share_id):
-            return alert
-        time.sleep(1)
-    return None
-
-
-def wait_for_alert_cleared(share_id, timeout=30):
-    for _ in range(timeout):
-        if find_share_locked_alert(share_id) is None:
-            return True
-        time.sleep(1)
-    return False
 
 
 def test_share_locked_alert_on_dataset_lock_unlock():
@@ -58,7 +37,7 @@ def test_share_locked_alert_on_dataset_lock_unlock():
             assert share['locked'] is True
 
             # Locking the dataset should generate a ShareLocked alert
-            alert = wait_for_alert(share_id)
+            alert = wait_for_share_locked_alert('SMB', share_id)
             assert alert is not None, 'ShareLocked alert was not created after locking dataset'
             assert alert['level'] == 'WARNING'
 
@@ -72,5 +51,5 @@ def test_share_locked_alert_on_dataset_lock_unlock():
             share = call('sharing.smb.get_instance', share_id)
             assert share['locked'] is False
 
-            assert wait_for_alert_cleared(share_id), \
+            assert wait_for_share_locked_alert_cleared('SMB', share_id), \
                 'ShareLocked alert was not cleared after unlocking dataset'


### PR DESCRIPTION
## Problem

A false-positive `ShareLocked` alert ("SMB share ... is unavailable because it uses a locked dataset") persists after boot for SMB shares on an encrypted dataset, even though the dataset is unlocked and the share works. Seen on 26.0.0-BETA.2 after upgrading from 25.10.4.

## Root cause

`generate_smb_configuration` (added in #18701) creates a `ShareLocked` one-shot alert for locked shares but never clears it for unlocked ones. At boot, SMB config is generated before encrypted pools are unlocked, so the alert is created while the share looks locked. The only path that clears it on unlock (`unlock_handle_attachments -> start() -> remove_alert`) is skipped at boot because `unlock_on_boot_impl` unlocks with `toggle_attachments=False`. Since the alert is `deleted_automatically = False`, it sticks forever.

## Fix

Make the handling symmetric: clear the `ShareLocked` alert for shares that are not locked, mirroring the existing rsync/cloud-sync/cloud-backup pattern. This self-heals at boot — after pools unlock, `pool.post_import` regenerates the SMB config, which now clears the stale alert. `oneshot_delete` is a no-op when nothing matches.

## Testing

- New `tests/api2/test_smb_share_locked_alert.py` covering lock -> alert -> unlock -> cleared.
- Extracted the shared alert helpers into `utils/alert.py` and refactored `test_nfs_share_locked_alert.py` to use them.

Original PR: https://github.com/truenas/middleware/pull/19198
