### PR TITLE
NAS-141469 / 26.0.0-RC.1 / Fix AD keytab freshness check and recovery churn (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -510,7 +510,7 @@ class DirectoryServices(ConfigService):
         roles=['DIRECTORY_SERVICE_WRITE'],
         audit='Directory Services Update'
     )
-    @job(lock='directoryservices_change')
+    @job(lock='directoryservices_change', lock_queue_size=1)
     def update(self, job, data):
         old = self.middleware.call_sync('directoryservices.config')
         new = old | data
@@ -896,7 +896,7 @@ class DirectoryServices(ConfigService):
         roles=['DIRECTORY_SERVICE_WRITE'],
         audit='Leaving directory services domain'
     )
-    @job(lock='directoryservices_change')
+    @job(lock='directoryservices_change', lock_queue_size=1)
     def leave(self, job, cred):
         """ Leave an Active Directory or IPA domain. Calling this endpoint when the directory services status is
         `HEALTHY` will cause TrueNAS to remove its account from the domain and then reset the local directory
@@ -992,7 +992,7 @@ class DirectoryServices(ConfigService):
         DirectoryServicesSyncKeytabArgs, DirectoryServicesSyncKeytabResult,
         roles=['DIRECTORY_SERVICE_WRITE']
     )
-    @job(lock='directoryservices_change')
+    @job(lock='directoryservices_change', lock_queue_size=1)
     async def sync_keytab(self, job):
         """ Sync local keytab with remote domain controller. This is required if additional
         kerberos SPNs were added to the truenas account in the remote domain controller after

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -141,7 +141,7 @@ class DomainSecrets(Service):
         """
         cluster = self.middleware.call_sync("smb.config")["stateful_failover"]
         encoded_change_ts = fetch_secrets_entry(
-            f"{Secrets.MACHINE_LAST_CHANGE_TIME.value}/{domain.upper()}]", cluster
+            f"{Secrets.MACHINE_LAST_CHANGE_TIME.value}/{domain.upper()}", cluster
         )
         try:
             bytes_passwd_chng = b64decode(encoded_change_ts)
@@ -238,6 +238,7 @@ class DomainSecrets(Service):
         except json.decoder.JSONDecodeError:
             self.logger.warning("Stored secrets are not valid JSON "
                                 "a new backup of secrets should be generated.")
+            return {'id': db['id']}
         return {'id': db['id']} | secrets
 
     async def backup(self):

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -6,6 +6,7 @@ from middlewared.api import api_method
 from middlewared.api.current import IdmapDomainClearIdmapCacheArgs, IdmapDomainClearIdmapCacheResult
 from middlewared.service import CallError, Service, job, private, ValidationError, filterable_api_method
 from middlewared.service_exception import MatchNotFound
+from middlewared.utils.directoryservices.constants import DSStatus
 from middlewared.utils.directoryservices.constants import DSType as DirectoryServiceType
 from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID
 from middlewared.plugins.idmap_.idmap_constants import (
@@ -14,6 +15,7 @@ from middlewared.plugins.idmap_.idmap_constants import (
 from middlewared.plugins.idmap_.idmap_winbind import (WBClient, WBCErr)
 from middlewared.plugins.idmap_.idmap_sss import SSSClient
 from middlewared.plugins.smb_.constants import SMBBuiltin
+from middlewared.utils.directoryservices.health import DSHealthObj
 from middlewared.utils.filter_list import filter_list
 from middlewared.utils.sid import (
     get_domain_rid,
@@ -58,6 +60,13 @@ class IdmapDomainService(Service):
             return WBClient()
         except wbclient.WBCError as e:
             if not retry or e.error_code != wbclient.WBC_ERR_WINBIND_NOT_AVAILABLE:
+                raise e
+
+            # Directory services are FAULTED: do not (re)start winbind here. This is a
+            # hot path (idmap.convert_sids resolves SIDs per request), so attempting a
+            # start on every call during an outage produces a winbind restart storm.
+            # Surface the original error and let the health check own recovery.
+            if DSHealthObj.status is DSStatus.FAULTED:
                 raise e
 
         if not self.middleware.call_sync('systemdataset.sysdataset_path'):

--- a/tests/directory_services/test_activedirectory_basic.py
+++ b/tests/directory_services/test_activedirectory_basic.py
@@ -358,6 +358,28 @@ def test_secrets_restore():
 
         assert check_ad_started() is True
 
+        # After restore the on-disk secret must be readable again (regression: the
+        # last_password_change key typo made the on-disk timestamp unreadable) and agree
+        # with the DB backup, so check_updated_keytab does not churn.
+        passwd_change = call('directoryservices.get_last_password_change')
+        assert passwd_change['secrets'] is not None
+        assert passwd_change['dbconfig'] == passwd_change['secrets']
+
+
+def test_secrets_in_sync_after_join():
+    with directoryservice('ACTIVEDIRECTORY', retrieve_user=False):
+        reset_systemd_svcs('winbind')
+        assert check_ad_started() is True
+
+        # Regression: the stray ']' in the secrets.tdb key made last_password_change
+        # always return None, so kerberos.check_updated_keytab saw a permanent
+        # dbconfig/secrets mismatch and rewrote the backup + keytab every hour. A clean
+        # join must leave the on-disk and DB timestamps equal.
+        passwd_change = call('directoryservices.get_last_password_change')
+        assert passwd_change['dbconfig'] is not None
+        assert passwd_change['secrets'] is not None
+        assert passwd_change['dbconfig'] == passwd_change['secrets']
+
 
 def test_keytab_restore():
 

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -8,12 +8,18 @@ dump of the prior bind's secrets. The fix makes backup() retain only the current
 import asyncio
 import json
 import logging
+import os
+import struct
+from base64 import b64encode
 
 import pytest
+import tdb
 
 from unittest.mock import AsyncMock, MagicMock
 
+from middlewared.plugins.directoryservices_ import secrets as secrets_mod
 from middlewared.plugins.directoryservices_.secrets import DomainSecrets
+from middlewared.utils.tdb import get_tdb_handle
 
 
 @pytest.fixture
@@ -100,3 +106,60 @@ def test__backup_skips_when_failover_status_is_backup(secrets_service):
 
     # Should return without raising and without making any non-failover.status calls.
     asyncio.run(secrets_service.backup())
+
+
+def test__last_password_change_real_tdb_roundtrip(secrets_service, tmp_path, monkeypatch):
+    """
+    Regression for the stray ']' in the secrets.tdb key, exercised end-to-end against a real
+    secrets.tdb instead of a stubbed fetch. last_password_change must read
+    SECRETS/MACHINE_LAST_CHANGE_TIME/<DOMAIN> -- the exact key the writer and the DB-side
+    reader (directoryservices.get_last_password_change) use. With the ']' the lookup misses,
+    the disk read raises MatchNotFound, last_password_change returns None, and
+    kerberos.check_updated_keytab churns a backup + keytab rewrite every hour.
+
+    Writing a real entry and reading it back through samba's tdb library covers the full
+    key + struct + base64 path that the stray bracket broke -- a wrong key surfaces here as a
+    failure rather than passing because the fetch itself was mocked away.
+    """
+    tdb_path = str(tmp_path / 'secrets.tdb')
+    # The secrets.tdb path opens O_RDWR without O_CREAT, so the db must already exist.
+    tdb.Tdb(tdb_path, 0, tdb.DEFAULT, os.O_CREAT | os.O_RDWR, 0o600).close()
+    monkeypatch.setattr(
+        secrets_mod, 'SECRETS_TDB_CONFIG', (tdb_path, secrets_mod.SECRETS_TDB_OPTIONS)
+    )
+
+    key = f'{secrets_mod.Secrets.MACHINE_LAST_CHANGE_TIME.value}/MSC'
+    with get_tdb_handle(tdb_path, secrets_mod.SECRETS_TDB_OPTIONS) as hdl:
+        hdl.store(key, b64encode(struct.pack('<L', 1718800000)).decode())
+
+    secrets_service.middleware.call_sync = MagicMock(return_value={'stateful_failover': False})
+
+    assert secrets_service.last_password_change('msc') == 1718800000
+
+
+def test__get_db_secrets_invalid_json_returns_id_only(secrets_service):
+    """
+    Corrupt JSON in cifs.secrets must degrade to "no backup" ({'id': ...}) instead of
+    raising UnboundLocalError -- previously the except branch fell through to
+    `return {'id': ...} | secrets` with `secrets` never bound.
+    """
+    async def fake_call(method, *args, **kwargs):
+        assert method == "datastore.config"
+        return {"id": 5, "secrets": "{not valid json"}
+
+    secrets_service.middleware.call.side_effect = fake_call
+
+    assert asyncio.run(secrets_service.get_db_secrets()) == {"id": 5}
+
+
+def test__get_db_secrets_valid_json_merges_id(secrets_service):
+    """A well-formed backup blob is returned merged with the row id."""
+    blob = {"NEWHOST$": {"SECRETS/MACHINE_PASSWORD/NEWDOMAIN": "ZnJlc2g="}}
+
+    async def fake_call(method, *args, **kwargs):
+        assert method == "datastore.config"
+        return {"id": 7, "secrets": json.dumps(blob)}
+
+    secrets_service.middleware.call.side_effect = fake_call
+
+    assert asyncio.run(secrets_service.get_db_secrets()) == {"id": 7} | blob


### PR DESCRIPTION
last_password_change read the secrets.tdb timestamp with a stray ']' in the key, so it always returned None and check_updated_keytab re-ran the secrets backup + keytab store hourly. Drop the bracket.

Also cut directory-services recovery churn when AD is FAULTED: fast-fail the winbind start in idmap.__wbclient_ctx rather than restarting per SID lookup, cap the directoryservices_change job queue, and fix get_db_secrets UnboundLocalError on invalid JSON.

Expand CI tests to cover regression.

Original PR: https://github.com/truenas/middleware/pull/19184
