### PR TITLE
NAS-141457 / 27.0.0-BETA.1 / V-series V2xx + rear-bay enclosure support (by darkfiberiru)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/constants.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/constants.py
@@ -1,3 +1,5 @@
+import re
+
 SYSFS_SLOT_KEY = "sysfs_slot"
 MAPPED_SLOT_KEY = "mapped_slot"
 SUPPORTS_IDENTIFY_KEY = "supports_identify_light"
@@ -18,3 +20,22 @@ DISK_INTERNAL_KEY = "is_internal"
 # detection is done properly.
 # NOTE: "-PC", "-SC", and "-C" are used on R60 platform
 DMI_SUFFIXES_TO_REMOVE = ("-HA", "-S", "-PC", "-SC", "-C")
+
+# SES Array Device Slot element type code (SES-4 7.1, Table 71 -- element type
+# codes). Numeric counterpart of enums.ElementType.ARRAY_DEVICE_SLOT.
+ARRAY_DEVICE_SLOT_ELEMENT_TYPE = 23
+
+# V-series enclosure products as reported by SES INQUIRY (bare product string,
+# no vendor prefix). V2xx (V260/V280) front bays are served by a PEX89088 PCIe
+# switch partitioned into two VirtualSES enclosures; all V-series rear bays are
+# served by the bifurcated PEX89032 NTB/NTG chip.
+VSERIES_FRONT_PRODUCTS = ("4IXGA-SWp", "4IXGA-SWs")
+VSERIES_REAR_PRODUCTS = ("4IXGA-NTBp", "4IXGA-NTBs", "4IXGA-NTGp", "4IXGA-NTGs")
+
+# Matches an SES Array Device Slot element descriptor like "slot01".."slot24".
+# V-series VirtualSES enclosures use these labels to advertise the slots a
+# partition owns; slots it does not own are reported with descriptor "<empty>".
+SLOT_DESCRIPTOR_RE = re.compile(r"^slot(\d+)$")
+
+# Matches an NVMe namespace block device name like "nvme7n1".
+NVME_NAMESPACE_RE = re.compile(r"nvme\d+n\d+")

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -11,12 +11,6 @@ from middlewared.utils.scsi_generic import inquiry
 
 from .constants import (
     ARRAY_DEVICE_SLOT_ELEMENT_TYPE,
-    MINI_MODEL_BASE,
-    MINIR_MODEL_BASE,
-    SYSFS_SLOT_KEY,
-    MAPPED_SLOT_KEY,
-    SUPPORTS_IDENTIFY_KEY,
-    SUPPORTS_IDENTIFY_STATUS_KEY,
     DISK_FRONT_KEY,
     DISK_INTERNAL_KEY,
     DISK_REAR_KEY,

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -10,6 +10,13 @@ from middlewared.utils.dmi import cached_dmi
 from middlewared.utils.scsi_generic import inquiry
 
 from .constants import (
+    ARRAY_DEVICE_SLOT_ELEMENT_TYPE,
+    MINI_MODEL_BASE,
+    MINIR_MODEL_BASE,
+    SYSFS_SLOT_KEY,
+    MAPPED_SLOT_KEY,
+    SUPPORTS_IDENTIFY_KEY,
+    SUPPORTS_IDENTIFY_STATUS_KEY,
     DISK_FRONT_KEY,
     DISK_INTERNAL_KEY,
     DISK_REAR_KEY,
@@ -116,8 +123,6 @@ class Enclosure:
             # the one whose enclosure id is "3000000000000001"). So we ignore the
             # other enclosure device otherwise.
             self.should_ignore = True
-        elif self.is_vseries and self.vendor == 'ECStream':
-            self.should_ignore = True
         else:
             self.should_ignore = False
 
@@ -177,8 +182,19 @@ class Enclosure:
                 | 'ECStream_4IXGA-NTGp'
                 | 'ECStream_4IXGA-NTGs'
             ):
-                # V series — NTB on the original board, NTG on the new
-                # 4IXGA_PEX89032 (X710) board. Same -p/-s convention.
+                # V-series rear-bay NTG chip (bifurcated PEX89032).
+                # Same -p/-s convention as the front-bay enclosures.
+                self.model = dmi_model.value
+                self.controller = True
+            case (
+                'ECStream_4IXGA-SWp'
+                | 'ECStream_4IXGA-SWs'
+            ):
+                # V2xx (V260/V280) — front-bay PEX89088 PCIe switch enclosure
+                # (replaces V1xx's dual 9600w-12i4e SAS HBAs). Same -p/-s
+                # convention as the NTG rear-bay enclosures: each controller
+                # sees one suffix (p or s) determined by its chassis slot
+                # position.
                 self.model = dmi_model.value
                 self.controller = True
             case 'CELESTIC_P3215-O' | 'CELESTIC_P3217-B':
@@ -255,7 +271,7 @@ class Enclosure:
             (
                 not self.is_hseries
                 # Array Device Slot elements' descriptors on V-series are "<empty>"
-                and not (self.is_vseries and element['type'] == 23)
+                and not (self.is_vseries and element['type'] == ARRAY_DEVICE_SLOT_ELEMENT_TYPE)
                 and desc in (
                     ElementDescriptorsToIgnore.EMPTY.value,
                     ElementDescriptorsToIgnore.AD.value,

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -231,100 +231,6 @@ def map_plx_r50bm(model, ctx):
     return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
 
 
-def map_vseries_nvme(model, ctx):
-    """Map NVMe devices for V-series using PCIe switch downstream port topology.
-
-    Unlike /sys/bus/pci/slots/ names -- which the kernel disambiguates with
-    "-N" suffixes when another PCI device shares the same firmware slot
-    number (e.g. an add-in NIC assigned the same firmware slot as a rear
-    NVMe bay) -- the PCIe switch downstream port addresses are a fixed
-    property of the topology and provide stable slot identity regardless
-    of system configuration.
-    """
-    num_of_nvme_slots = 4
-    mapped = {}
-    pci_bdf_re = re.compile(r'^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9]$')
-
-    # Walk from each NVMe controller up the PCIe tree:
-    # nvme ctrl -> nvme PCI dev -> downstream port -> switch upstream port.
-    # Group block devices by their switch; the rear-NVMe switch is the one
-    # with the most NVMes attached.
-    by_switch = {}
-    for ctrl in ctx.list_devices(subsystem='nvme'):
-        for child in ctrl.children:
-            if child.device_type != 'disk':
-                continue
-
-            try:
-                downstream_port = ctrl.parent.parent
-                switch = downstream_port.parent
-            except AttributeError:
-                continue
-
-            if switch is None or switch.subsystem != 'pci':
-                continue
-
-            by_switch.setdefault(switch.sys_path, []).append(
-                (downstream_port.sys_name, child.sys_name)
-            )
-
-    if not by_switch:
-        return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
-
-    rear_switch_path, nvme_info = max(
-        by_switch.items(), key=lambda kv: len(kv[1])
-    )
-
-    # Enumerate the switch's downstream ports. The rear-NVMe switch
-    # multiplexes an on-board SAS HBA onto one of its downstream ports
-    # (an LSI SAS controller, PCI class 0x0107xx); every other downstream
-    # port is a rear NVMe bay.
-    #
-    # A populated bay shows an NVMe endpoint (class 0x0108xx). An *empty*
-    # bay is not absent from the tree: the Broadcom switch substitutes a
-    # "Virtual PCIe Placeholder Endpoint" (class 0x0880xx) so the
-    # downstream port still has a child. We must therefore keep a port for
-    # every bay -- populated, placeholder, or truly empty -- and exclude
-    # only the SAS HBA. Dropping placeholder/empty bays would renumber the
-    # survivors and shift the empty slot to the end (e.g. pulling bay 2 of
-    # 4 would wrongly report bays 1-3 populated and bay 4 empty).
-    nvme_ports = []
-    for entry in pathlib.Path(rear_switch_path).iterdir():
-        if not pci_bdf_re.match(entry.name):
-            continue
-
-        has_sas_child = False
-        for child in entry.iterdir():
-            if not pci_bdf_re.match(child.name):
-                continue
-
-            try:
-                pci_class = (child / 'class').read_text().strip()
-            except (FileNotFoundError, OSError):
-                continue
-
-            if pci_class.startswith('0x0107'):
-                has_sas_child = True
-                break
-
-        if not has_sas_child:
-            nvme_ports.append(entry.name)
-
-    # Sorted PCI BDF gives stable bay order independent of firmware slot
-    # naming. Truncate to num_of_nvme_slots as a final safety bound.
-    nvme_ports.sort()
-    nvme_ports = nvme_ports[:num_of_nvme_slots]
-    port_to_slot = {port: idx for idx, port in enumerate(nvme_ports, start=1)}
-    for port_name, dev_name in nvme_info:
-        slot = port_to_slot.get(port_name)
-        if slot is None:
-            continue
-
-        mapped[slot] = dev_name
-
-    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
-
-
 def map_r50_or_r50b(model, ctx):
     num_of_nvme_slots = 3 if model == 'R50' else 2  # r50 has 3 rear nvme slots, r50b has 2
     if model == 'R50':
@@ -437,13 +343,6 @@ def map_nvme():
     ):
         # all nvme systems which we need to handle separately
         return map_r30_r60_or_fseries(model, ctx)
-    elif model in (
-        ControllerModels.V140.value,
-        ControllerModels.V160.value,
-        ControllerModels.V260.value,
-        ControllerModels.V280.value,
-    ):
-        return map_vseries_nvme(model, ctx)
     elif model == ControllerModels.R50BM.value:
         return map_plx_r50bm(model, ctx)
     elif model in (

--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Iterable
 
 from libsg3.ses import EnclosureDevice
+
 from .constants import (
     ARRAY_DEVICE_SLOT_ELEMENT_TYPE,
     SLOT_DESCRIPTOR_RE,

--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from typing import Iterable
 
 from libsg3.ses import EnclosureDevice
-
+from .constants import (
+    ARRAY_DEVICE_SLOT_ELEMENT_TYPE,
+    SLOT_DESCRIPTOR_RE,
+    VSERIES_FRONT_PRODUCTS,
+    VSERIES_REAR_PRODUCTS,
+)
 from .enclosure_class import ElementsDict, Enclosure, EnclosureStatusDict
 
 logger = getLogger(__name__)
@@ -25,18 +30,50 @@ def _extend_rv(rv: list, iterable: Iterable[Enclosure], asdict: bool = True) -> 
         rv.extend(iterable)
 
 
-def _initialize_v_series_enclosures(
-    rv: list, deferred_enclosures: list[tuple[Enclosure, ElementsDict]], asdict: bool = True
-) -> None:
-    """
-    Compare the encids (SAS addresses) of the two VirtualSES enclosures
-    to determine their slot designations for initialization.
-    """
-    if len(deferred_enclosures) != 2:
-        logger.error('Unable to map elements: Expected 2 VirtualSES enclosures, found %r', len(deferred_enclosures))
-        return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred_enclosures), asdict)
+def _vseries_slot_designation_from_descriptors(elements: ElementsDict) -> str | None:
+    """Derive a V-series slot_designation by inspecting Array Device Slot
+    element descriptors. V-series VirtualSES enclosures label the slots each
+    partition owns as 'slot01'..'slot12' (NVME0 partition) or
+    'slot13'..'slot24' (NVME8 partition); slots not owned by a partition are
+    reported with descriptor '<empty>'.
 
-    (enc1, elements1), (enc2, elements2) = deferred_enclosures
+    Returns 'NVME0', 'NVME8', or None if the descriptors don't clearly
+    identify a single partition.
+    """
+    has_low = False
+    has_high = False
+    for element in elements.values():
+        if element.get('type') != ARRAY_DEVICE_SLOT_ELEMENT_TYPE:
+            continue
+        match = SLOT_DESCRIPTOR_RE.match(element.get('descriptor', '').strip())
+        if not match:
+            continue
+        slot_num = int(match.group(1))
+        if 1 <= slot_num <= 12:
+            has_low = True
+        elif 13 <= slot_num <= 24:
+            has_high = True
+    if has_low and not has_high:
+        return 'NVME0'
+    if has_high and not has_low:
+        return 'NVME8'
+    return None
+
+
+def _initialize_v_series_front_enclosures(
+    rv: list, deferred: list[tuple[Enclosure, ElementsDict]], asdict: bool = True
+) -> None:
+    """Assign NVME0/NVME8 to the two V-series front-bay enclosures.
+
+    V1xx HBAs have distinct encids (compared). V2xx PEX89088 partitions
+    share an encid — fall back to Array Device Slot descriptor labels
+    ('slot01'..'slot12' = NVME0; 'slot13'..'slot24' = NVME8).
+    """
+    if len(deferred) != 2:
+        logger.error('Unable to map elements: Expected 2 V-series front-bay enclosures, found %r', len(deferred))
+        return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred), asdict)
+
+    (enc1, elements1), (enc2, elements2) = deferred
     hex_id1 = int(enc1.encid, 16)
     hex_id2 = int(enc2.encid, 16)
 
@@ -47,15 +84,66 @@ def _initialize_v_series_enclosures(
         enc1.initialize(elements1, slot_designation='NVME8')
         enc2.initialize(elements2, slot_designation='NVME0')
     else:
-        logger.error('Unable to map elements: Both VirtualSES enclosures have the same ID / SAS address')
-        return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred_enclosures), asdict)
+        # V2xx: both VirtualSES enclosures share an encid because they are
+        # two partitions of a single PEX89088 chip. Disambiguate by reading
+        # the Array Device Slot element descriptor labels each partition
+        # advertises.
+        d1 = _vseries_slot_designation_from_descriptors(elements1)
+        d2 = _vseries_slot_designation_from_descriptors(elements2)
+        if d1 and d2 and d1 != d2:
+            enc1.initialize(elements1, slot_designation=d1)
+            enc2.initialize(elements2, slot_designation=d2)
+        else:
+            logger.error(
+                'Unable to map elements: V-series front-bay enclosures share encid %r and could not be '
+                'disambiguated by element descriptor labels (got %r and %r)',
+                enc1.encid, d1, d2,
+            )
+            return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred), asdict)
 
     _extend_rv(rv, (enc1, enc2), asdict)
 
 
+def _vseries_rear_partition_owns_bays(elements: ElementsDict) -> bool:
+    """True if this NTG partition serves the 4 rear bays (descriptors
+    'slot01'..'slot04'); the no-drives partition reports all slots '<empty>'.
+    """
+    for element in elements.values():
+        if element.get('type') != ARRAY_DEVICE_SLOT_ELEMENT_TYPE:
+            continue
+        match = SLOT_DESCRIPTOR_RE.match(element.get('descriptor', '').strip())
+        if match and 1 <= int(match.group(1)) <= 4:
+            return True
+    return False
+
+
+def _initialize_v_series_rear_enclosures(
+    rv: list, deferred: list[tuple[Enclosure, ElementsDict]], asdict: bool = True
+) -> None:
+    """Keep the bay-serving half of the bifurcated NTG chip as 'REAR';
+    drop the no-drives half so it doesn't surface in enclosure2.query.
+    """
+    if len(deferred) != 2:
+        logger.error('Unable to map elements: Expected 2 V-series rear-bay enclosures, found %r', len(deferred))
+        return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred), asdict)
+
+    bay_partitions = [(enc, els) for enc, els in deferred if _vseries_rear_partition_owns_bays(els)]
+    if len(bay_partitions) != 1:
+        logger.error(
+            'Unable to map elements: expected exactly 1 rear-bay-serving partition among %r, found %r',
+            [enc.product for enc, _ in deferred], len(bay_partitions),
+        )
+        return _extend_rv(rv, (enc.initialize(status) for enc, status in deferred), asdict)
+
+    enc, elements = bay_partitions[0]
+    enc.initialize(elements, slot_designation='REAR')
+    _extend_rv(rv, (enc,), asdict)
+
+
 def get_ses_enclosures(asdict=True):
     rv = list()
-    deferred_enclosures = list()
+    deferred_front = list()
+    deferred_rear = list()
 
     with suppress(FileNotFoundError):
         for i in Path('/sys/class/enclosure').iterdir():
@@ -64,16 +152,22 @@ def get_ses_enclosures(asdict=True):
                 sg = next((i / 'device/scsi_generic').iterdir())
                 enc = Enclosure(bsg, f'/dev/{sg.name}', status)
 
-                if enc.is_vseries and status['name'] == 'BROADCOMVirtualSES0001':
-                    # Carve-out for V-series since their slot mappings depend on the
-                    # SAS address of the opposite VirtualSES enclosure
-                    deferred_enclosures.append((enc, status['elements']))
+                if enc.is_vseries and (
+                    status['name'] == 'BROADCOMVirtualSES0001'
+                    or enc.product in VSERIES_FRONT_PRODUCTS
+                ):
+                    # V-series front-bay: defer for NVME0/NVME8 disambiguation.
+                    deferred_front.append((enc, status['elements']))
+                elif enc.is_vseries and enc.product in VSERIES_REAR_PRODUCTS:
+                    # V-series rear-bay: defer to pick bay-serving partition.
+                    deferred_rear.append((enc, status['elements']))
                 else:
-                    # Every other system can initialize their enclosures independently
                     enc.initialize(status['elements'])
                     rv.append(enc.asdict() if asdict else enc)
 
-    if deferred_enclosures:
-        _initialize_v_series_enclosures(rv, deferred_enclosures, asdict)
+    if deferred_front:
+        _initialize_v_series_front_enclosures(rv, deferred_front, asdict)
+    if deferred_rear:
+        _initialize_v_series_rear_enclosures(rv, deferred_rear, asdict)
 
     return rv

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -12,6 +12,8 @@ from .constants import (
     SUPPORTS_IDENTIFY_KEY,
     SUPPORTS_IDENTIFY_STATUS_KEY,
     SYSFS_SLOT_KEY,
+    VSERIES_FRONT_PRODUCTS,
+    VSERIES_REAR_PRODUCTS,
 )
 from .enums import ControllerModels, JbodModels, JbofModels
 
@@ -68,10 +70,6 @@ def get_nvme_slot_info(model):
         ControllerModels.M40.value,
         ControllerModels.M50.value,
         ControllerModels.M60.value,
-        ControllerModels.V140.value,
-        ControllerModels.V160.value,
-        ControllerModels.V260.value,
-        ControllerModels.V280.value,
         ControllerModels.R30.value,
         ControllerModels.R50.value,
         ControllerModels.R50B.value,
@@ -171,54 +169,6 @@ def get_nvme_slot_info(model):
                                 DISK_REAR_KEY: True,
                                 DISK_INTERNAL_KEY: False
                             } for i, j in zip(range(1, 5), range(25, 29))
-                        },
-                        'v140_nvme_enclosure': {
-                            i: {
-                                SYSFS_SLOT_KEY: i,
-                                MAPPED_SLOT_KEY: j,
-                                SUPPORTS_IDENTIFY_KEY: False,
-                                DISK_FRONT_KEY: False,
-                                DISK_TOP_KEY: False,
-                                DISK_REAR_KEY: True,
-                                DISK_INTERNAL_KEY: False
-                            }
-                            for i, j in zip(range(1, 5), range(25, 29))
-                        },
-                        'v160_nvme_enclosure': {
-                            i: {
-                                SYSFS_SLOT_KEY: i,
-                                MAPPED_SLOT_KEY: j,
-                                SUPPORTS_IDENTIFY_KEY: False,
-                                DISK_FRONT_KEY: False,
-                                DISK_TOP_KEY: False,
-                                DISK_REAR_KEY: True,
-                                DISK_INTERNAL_KEY: False
-                            }
-                            for i, j in zip(range(1, 5), range(25, 29))
-                        },
-                        'v260_nvme_enclosure': {
-                            i: {
-                                SYSFS_SLOT_KEY: i,
-                                MAPPED_SLOT_KEY: j,
-                                SUPPORTS_IDENTIFY_KEY: False,
-                                DISK_FRONT_KEY: False,
-                                DISK_TOP_KEY: False,
-                                DISK_REAR_KEY: True,
-                                DISK_INTERNAL_KEY: False
-                            }
-                            for i, j in zip(range(1, 5), range(25, 29))
-                        },
-                        'v280_nvme_enclosure': {
-                            i: {
-                                SYSFS_SLOT_KEY: i,
-                                MAPPED_SLOT_KEY: j,
-                                SUPPORTS_IDENTIFY_KEY: False,
-                                DISK_FRONT_KEY: False,
-                                DISK_TOP_KEY: False,
-                                DISK_REAR_KEY: True,
-                                DISK_INTERNAL_KEY: False
-                            }
-                            for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'r30_nvme_enclosure': {
                             i: {
@@ -724,15 +674,116 @@ def get_slot_info(enc):
             }
         }
     elif enc.is_vseries:
-        # V-series has 2 VirtualSES enclosures (one per 9600-12i4e HBA)
-        # Front 24 slots are split between two HBAs with interleaved mapping
-        # Use slot designation to distinguish between enclosures
+        # V-series has 2 VirtualSES enclosures.
+        # V1xx (V100/V140/V160): one VirtualSES per 9600-12i4e SAS HBA. Each
+        # HBA's SES exposes its own 12 slots at libsg3 element indices 1-12
+        # with sysfs slot files starting at 0.
+        # V2xx (V260/V280): a single PEX89088 PCIe switch chip is partitioned
+        # into two VirtualSES enclosures. Each partition exposes ALL 24 chip
+        # elements through every sg device; the slots it actually owns are
+        # at libsg3 indices 1-12 (NVME0 partition) or 13-24 (NVME8 partition)
+        # with sysfs slot files matching the index 1:1 (not offset). Some
+        # physical chassis positions are also wired differently from V1xx —
+        # at minimum display slots 4 and 8 swap.
+        # Front 24 slots are split between the two SES enclosures with
+        # interleaved mapping; slot_designation (NVME0/NVME8) distinguishes
+        # them. We branch by enc.product so the right table is picked.
+        if enc.product in VSERIES_REAR_PRODUCTS:
+            # V-series rear-bay PEX89032 NTG chip. Bifurcated into 2 SES
+            # partitions per controller; ses_enclosures2 picks the
+            # bay-serving partition and tags it 'REAR'. Slots are libsg3
+            # keys 1-4 with sysfs slot files matching the key 1:1
+            # (slot01..slot04).
+            return {
+                'any_version': True,
+                'versions': {
+                    'DEFAULT': {
+                        'id': {
+                            'REAR': {
+                                key: {
+                                    SYSFS_SLOT_KEY: key,
+                                    MAPPED_SLOT_KEY: 24 + key,
+                                    SUPPORTS_IDENTIFY_KEY: True,
+                                    DISK_FRONT_KEY: False,
+                                    DISK_TOP_KEY: False,
+                                    DISK_REAR_KEY: True,
+                                    DISK_INTERNAL_KEY: False,
+                                }
+                                for key in range(1, 5)
+                            },
+                        }
+                    }
+                }
+            }
+        if enc.product in VSERIES_FRONT_PRODUCTS:
+            return {
+                'any_version': True,
+                'versions': {
+                    'DEFAULT': {
+                        'id': {
+                            # V2xx NVME0 — first PEX89088 partition.
+                            # Handles TrueNAS slots 1-10, 13-14.
+                            # libsg3 element key 1-12 → kernel sysfs slot
+                            # file 1-12 (same value, no offset). Display
+                            # slots 4/8 use SES keys 8/7 (swapped from V160).
+                            'NVME0': {
+                                key: {
+                                    SYSFS_SLOT_KEY: sysfs_key,
+                                    MAPPED_SLOT_KEY: mapped_key,
+                                    SUPPORTS_IDENTIFY_KEY: True,
+                                }
+                                for key, sysfs_key, mapped_key in (
+                                    (1, 1, 1),
+                                    (4, 4, 2),
+                                    (5, 5, 3),
+                                    (8, 8, 4),   # V2xx: SES key 8 → display 4 (V1xx had key 7)
+                                    (2, 2, 5),
+                                    (3, 3, 6),
+                                    (6, 6, 7),
+                                    (7, 7, 8),   # V2xx: SES key 7 → display 8 (V1xx had key 8)
+                                    (9, 9, 9),
+                                    (12, 12, 10),
+                                    (10, 10, 13),
+                                    (11, 11, 14),
+                                )
+                            },
+                            # V2xx NVME8 — second PEX89088 partition.
+                            # Handles TrueNAS slots 11-12, 15-24.
+                            # On V2xx the partition exposes its 12 slots at
+                            # libsg3 element indices 13-24 (offset +12 from
+                            # V1xx convention). Sysfs slot files match the
+                            # index 13-24 1:1.
+                            'NVME8': {
+                                key: {
+                                    SYSFS_SLOT_KEY: sysfs_key,
+                                    MAPPED_SLOT_KEY: mapped_key,
+                                    SUPPORTS_IDENTIFY_KEY: True,
+                                }
+                                for key, sysfs_key, mapped_key in (
+                                    (13, 13, 11),
+                                    (16, 16, 12),
+                                    (14, 14, 15),
+                                    (15, 15, 16),
+                                    (17, 17, 17),
+                                    (20, 20, 18),
+                                    (21, 21, 19),
+                                    (24, 24, 20),
+                                    (18, 18, 21),
+                                    (19, 19, 22),
+                                    (22, 22, 23),
+                                    (23, 23, 24),
+                                )
+                            },
+                        }
+                    }
+                }
+            }
         return {
             'any_version': True,
             'versions': {
                 'DEFAULT': {
                     'id': {
-                        # First VirtualSES enclosure
+                        # V1xx NVME0 — first 9600-12i4e SAS HBA VirtualSES.
                         # Handles TrueNAS slots 1-10, 13-14
                         'NVME0': {
                             key: {SYSFS_SLOT_KEY: sysfs_key, MAPPED_SLOT_KEY: mapped_key, SUPPORTS_IDENTIFY_KEY: True}
@@ -751,7 +802,7 @@ def get_slot_info(enc):
                                 (11, 10, 14),
                             )
                         },
-                        # Second VirtualSES enclosure
+                        # V1xx NVME8 — second 9600-12i4e SAS HBA VirtualSES.
                         # Handles TrueNAS slots 11-12, 15-24
                         'NVME8': {
                             key: {SYSFS_SLOT_KEY: sysfs_key, MAPPED_SLOT_KEY: mapped_key, SUPPORTS_IDENTIFY_KEY: True}

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from os import scandir
 from pathlib import Path
 
+from .constants import NVME_NAMESPACE_RE
 from .enums import ControllerModels
 
 
@@ -58,8 +59,22 @@ def map_disks_to_enclosure_slots(enc) -> dict[int, BaseDev]:
                 try:
                     name = next((path / "device/block").iterdir(), None).name
                 except (AttributeError, FileNotFoundError):
-                    # no disk in this slot
-                    name = None
+                    # No SCSI/SATA block device under this slot. Try the
+                    # NVMe layout: V-series PEX89088-fronted bays expose
+                    # the NVMe controller as the slot's `device/` and the
+                    # namespace as a sibling directory (e.g.
+                    # `device/nvme7n1`). Pick the first namespace dir.
+                    try:
+                        name = next(
+                            (
+                                d.name for d in (path / "device").iterdir()
+                                if d.is_dir() and NVME_NAMESPACE_RE.fullmatch(d.name)
+                            ),
+                            None,
+                        )
+                    except (AttributeError, FileNotFoundError):
+                        # no disk in this slot
+                        name = None
                 try:
                     locate = (
                         "ON" if (path / "locate").read_text().strip() == "1" else "OFF"

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test-cases/V260-NOJBODS/expected.json
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test-cases/V260-NOJBODS/expected.json
@@ -1,0 +1,606 @@
+[
+  {
+    "bsg": "/dev/bsg/0:0:0:0",
+    "controller": true,
+    "dmi": "TRUENAS-V260-HA",
+    "elements": {
+      "Array Device Slot": {
+        "1": {
+          "descriptor": "slot01",
+          "dev": "nvme7n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot1",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 1
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "2": {
+          "descriptor": "slot04",
+          "dev": "nvme4n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot4",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 4
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "3": {
+          "descriptor": "slot05",
+          "dev": "nvme3n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot5",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 5
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "4": {
+          "descriptor": "slot08",
+          "dev": "nvme0n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot8",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 8
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "5": {
+          "descriptor": "slot02",
+          "dev": "nvme6n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot2",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 2
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "6": {
+          "descriptor": "slot03",
+          "dev": "nvme5n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot3",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 3
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "7": {
+          "descriptor": "slot06",
+          "dev": "nvme2n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot6",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 6
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "8": {
+          "descriptor": "slot07",
+          "dev": "nvme1n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot7",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 7
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "9": {
+          "descriptor": "slot09",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot9",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 9
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "10": {
+          "descriptor": "slot12",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot12",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 12
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "11": {
+          "descriptor": "slot13",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot13",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 13
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "12": {
+          "descriptor": "slot16",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot16",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 16
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "13": {
+          "descriptor": "slot10",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot10",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 10
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "14": {
+          "descriptor": "slot11",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot11",
+            "enclosure_bsg": "/dev/bsg/0:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg0",
+            "slot": 11
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "15": {
+          "descriptor": "slot14",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot14",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 14
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "16": {
+          "descriptor": "slot15",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot15",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 15
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "17": {
+          "descriptor": "slot17",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot17",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 17
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "18": {
+          "descriptor": "slot20",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot20",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 20
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "19": {
+          "descriptor": "slot21",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot21",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 21
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "20": {
+          "descriptor": "slot24",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot24",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 24
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "21": {
+          "descriptor": "slot18",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot18",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 18
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "22": {
+          "descriptor": "slot19",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot19",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 19
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "23": {
+          "descriptor": "slot22",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot22",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 22
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "24": {
+          "descriptor": "slot23",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": true,
+          "is_internal": false,
+          "is_rear": false,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot23",
+            "enclosure_bsg": "/dev/bsg/3:0:0:0",
+            "enclosure_id": "5b0bd6d600000070",
+            "enclosure_sg": "/dev/sg3",
+            "slot": 23
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        },
+        "25": {
+          "descriptor": "slot01",
+          "dev": "nvme9n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": false,
+          "is_internal": false,
+          "is_rear": true,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot1",
+            "enclosure_bsg": "/dev/bsg/1:0:0:0",
+            "enclosure_id": "5b0bd6d6000000c0",
+            "enclosure_sg": "/dev/sg1",
+            "slot": 1
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "26": {
+          "descriptor": "slot02",
+          "dev": "nvme10n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": false,
+          "is_internal": false,
+          "is_rear": true,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot2",
+            "enclosure_bsg": "/dev/bsg/1:0:0:0",
+            "enclosure_id": "5b0bd6d6000000c0",
+            "enclosure_sg": "/dev/sg1",
+            "slot": 2
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "27": {
+          "descriptor": "slot03",
+          "dev": "nvme11n1",
+          "drive_bay_light_status": "OFF",
+          "is_front": false,
+          "is_internal": false,
+          "is_rear": true,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot3",
+            "enclosure_bsg": "/dev/bsg/1:0:0:0",
+            "enclosure_id": "5b0bd6d6000000c0",
+            "enclosure_sg": "/dev/sg1",
+            "slot": 3
+          },
+          "status": "OK, Swapped",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 285212672
+        },
+        "28": {
+          "descriptor": "slot04",
+          "dev": null,
+          "drive_bay_light_status": "OFF",
+          "is_front": false,
+          "is_internal": false,
+          "is_rear": true,
+          "is_top": false,
+          "original": {
+            "descriptor": "slot4",
+            "enclosure_bsg": "/dev/bsg/1:0:0:0",
+            "enclosure_id": "5b0bd6d6000000c0",
+            "enclosure_sg": "/dev/sg1",
+            "slot": 4
+          },
+          "status": "Not installed",
+          "supports_identify_light": true,
+          "value": null,
+          "value_raw": 83886080
+        }
+      },
+      "Enclosure": {
+        "28": {
+          "descriptor": "EnclosureElement01",
+          "status": "OK",
+          "value": null,
+          "value_raw": 16777216
+        }
+      },
+      "Temperature Sensors": {
+        "26": {
+          "descriptor": "Pcie Die",
+          "status": "OK",
+          "value": "47C",
+          "value_raw": 16794368
+        }
+      }
+    },
+    "front_loaded": true,
+    "front_slots": 24,
+    "id": "5b0bd6d600000070",
+    "internal_slots": 0,
+    "label": "ECStream 4IXGA-SWp 04f0",
+    "model": "V260",
+    "name": "ECStream 4IXGA-SWp 04f0",
+    "pci": "0:0:0:0",
+    "product": "4IXGA-SWp",
+    "rackmount": true,
+    "rear_slots": 4,
+    "revision": "04f0",
+    "sg": "/dev/sg0",
+    "status": [
+      "INFO"
+    ],
+    "top_loaded": false,
+    "top_slots": 0,
+    "vendor": "ECStream"
+  }
+]

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test-cases/V260-NOJBODS/mocked.json
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test-cases/V260-NOJBODS/mocked.json
@@ -1,0 +1,702 @@
+{
+  "chassis": "TRUENAS-V260-HA",
+  "dmi": {
+    "system-product-name": "TRUENAS-V260-HA"
+  },
+  "labels": {},
+  "nvme": [],
+  "ses": [
+    {
+      "bsg": "/dev/bsg/3:0:0:0",
+      "controller": true,
+      "dmi": "TRUENAS-V260-HA",
+      "elements": {
+        "Array Device Slot": {
+          "11": {
+            "descriptor": "slot13",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot13",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 13
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "12": {
+            "descriptor": "slot16",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot16",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 16
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "15": {
+            "descriptor": "slot14",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot14",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 14
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "16": {
+            "descriptor": "slot15",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot15",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 15
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "17": {
+            "descriptor": "slot17",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot17",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 17
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "18": {
+            "descriptor": "slot20",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot20",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 20
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "19": {
+            "descriptor": "slot21",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot21",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 21
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "20": {
+            "descriptor": "slot24",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot24",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 24
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "21": {
+            "descriptor": "slot18",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot18",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 18
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "22": {
+            "descriptor": "slot19",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot19",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 19
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "23": {
+            "descriptor": "slot22",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot22",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 22
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "24": {
+            "descriptor": "slot23",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot23",
+              "enclosure_bsg": "/dev/bsg/3:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg3",
+              "slot": 23
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          }
+        },
+        "Enclosure": {
+          "28": {
+            "descriptor": "EnclosureElement01",
+            "status": "OK",
+            "value": null,
+            "value_raw": 16777216
+          }
+        },
+        "Temperature Sensors": {
+          "26": {
+            "descriptor": "Pcie Die",
+            "status": "OK",
+            "value": "47C",
+            "value_raw": 16794368
+          }
+        }
+      },
+      "front_loaded": true,
+      "front_slots": 24,
+      "id": "5b0bd6d600000070",
+      "internal_slots": 0,
+      "model": "V260",
+      "name": "ECStream 4IXGA-SWp 04f0",
+      "pci": "3:0:0:0",
+      "product": "4IXGA-SWp",
+      "rackmount": true,
+      "rear_slots": 4,
+      "revision": "04f0",
+      "sg": "/dev/sg3",
+      "should_ignore": false,
+      "status": [
+        "INFO"
+      ],
+      "top_loaded": false,
+      "top_slots": 0,
+      "vendor": "ECStream"
+    },
+    {
+      "bsg": "/dev/bsg/0:0:0:0",
+      "controller": true,
+      "dmi": "TRUENAS-V260-HA",
+      "elements": {
+        "Array Device Slot": {
+          "1": {
+            "descriptor": "slot01",
+            "dev": "nvme7n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot1",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 1
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "2": {
+            "descriptor": "slot04",
+            "dev": "nvme4n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot4",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 4
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "3": {
+            "descriptor": "slot05",
+            "dev": "nvme3n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot5",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 5
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "4": {
+            "descriptor": "slot08",
+            "dev": "nvme0n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot8",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 8
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "5": {
+            "descriptor": "slot02",
+            "dev": "nvme6n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot2",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 2
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "6": {
+            "descriptor": "slot03",
+            "dev": "nvme5n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot3",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 3
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "7": {
+            "descriptor": "slot06",
+            "dev": "nvme2n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot6",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 6
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "8": {
+            "descriptor": "slot07",
+            "dev": "nvme1n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot7",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 7
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "9": {
+            "descriptor": "slot09",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot9",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 9
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "10": {
+            "descriptor": "slot12",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot12",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 12
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "13": {
+            "descriptor": "slot10",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot10",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 10
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          },
+          "14": {
+            "descriptor": "slot11",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": true,
+            "is_internal": false,
+            "is_rear": false,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot11",
+              "enclosure_bsg": "/dev/bsg/0:0:0:0",
+              "enclosure_id": "5b0bd6d600000070",
+              "enclosure_sg": "/dev/sg0",
+              "slot": 11
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          }
+        },
+        "Enclosure": {
+          "28": {
+            "descriptor": "EnclosureElement01",
+            "status": "OK",
+            "value": null,
+            "value_raw": 16777216
+          }
+        },
+        "Temperature Sensors": {
+          "26": {
+            "descriptor": "Pcie Die",
+            "status": "OK",
+            "value": "47C",
+            "value_raw": 16794368
+          }
+        }
+      },
+      "front_loaded": true,
+      "front_slots": 24,
+      "id": "5b0bd6d600000070",
+      "internal_slots": 0,
+      "model": "V260",
+      "name": "ECStream 4IXGA-SWp 04f0",
+      "pci": "0:0:0:0",
+      "product": "4IXGA-SWp",
+      "rackmount": true,
+      "rear_slots": 4,
+      "revision": "04f0",
+      "sg": "/dev/sg0",
+      "should_ignore": false,
+      "status": [
+        "INFO"
+      ],
+      "top_loaded": false,
+      "top_slots": 0,
+      "vendor": "ECStream"
+    },
+    {
+      "bsg": "/dev/bsg/1:0:0:0",
+      "controller": true,
+      "dmi": "TRUENAS-V260-HA",
+      "elements": {
+        "Array Device Slot": {
+          "25": {
+            "descriptor": "slot01",
+            "dev": "nvme9n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": false,
+            "is_internal": false,
+            "is_rear": true,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot1",
+              "enclosure_bsg": "/dev/bsg/1:0:0:0",
+              "enclosure_id": "5b0bd6d6000000c0",
+              "enclosure_sg": "/dev/sg1",
+              "slot": 1
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "26": {
+            "descriptor": "slot02",
+            "dev": "nvme10n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": false,
+            "is_internal": false,
+            "is_rear": true,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot2",
+              "enclosure_bsg": "/dev/bsg/1:0:0:0",
+              "enclosure_id": "5b0bd6d6000000c0",
+              "enclosure_sg": "/dev/sg1",
+              "slot": 2
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "27": {
+            "descriptor": "slot03",
+            "dev": "nvme11n1",
+            "drive_bay_light_status": "OFF",
+            "is_front": false,
+            "is_internal": false,
+            "is_rear": true,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot3",
+              "enclosure_bsg": "/dev/bsg/1:0:0:0",
+              "enclosure_id": "5b0bd6d6000000c0",
+              "enclosure_sg": "/dev/sg1",
+              "slot": 3
+            },
+            "status": "OK, Swapped",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 285212672
+          },
+          "28": {
+            "descriptor": "slot04",
+            "dev": null,
+            "drive_bay_light_status": "OFF",
+            "is_front": false,
+            "is_internal": false,
+            "is_rear": true,
+            "is_top": false,
+            "original": {
+              "descriptor": "slot4",
+              "enclosure_bsg": "/dev/bsg/1:0:0:0",
+              "enclosure_id": "5b0bd6d6000000c0",
+              "enclosure_sg": "/dev/sg1",
+              "slot": 4
+            },
+            "status": "Not installed",
+            "supports_identify_light": true,
+            "value": null,
+            "value_raw": 83886080
+          }
+        },
+        "Enclosure": {
+          "8": {
+            "descriptor": "EnclosureElement01",
+            "status": "OK",
+            "value": null,
+            "value_raw": 16777216
+          }
+        },
+        "Temperature Sensors": {
+          "6": {
+            "descriptor": "Pcie Die",
+            "status": "OK",
+            "value": "43C",
+            "value_raw": 16793344
+          }
+        }
+      },
+      "front_loaded": true,
+      "front_slots": 24,
+      "id": "5b0bd6d6000000c0",
+      "internal_slots": 0,
+      "model": "V260",
+      "name": "ECStream 4IXGA-NTBp 04ff",
+      "pci": "1:0:0:0",
+      "product": "4IXGA-NTBp",
+      "rackmount": true,
+      "rear_slots": 4,
+      "revision": "04ff",
+      "sg": "/dev/sg1",
+      "should_ignore": false,
+      "status": [
+        "INFO"
+      ],
+      "top_loaded": false,
+      "top_slots": 0,
+      "vendor": "ECStream"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds V2xx (V260/V280) enclosure management and reworks V-series rear-bay
support to use the bifurcated PEX89032 NTG chip's SES path. Two commits,
each independently functional / bisectable:

### Commit 1 — V2xx front-bay enclosure support

V2xx front bays are served by a single Broadcom PEX89088 PCIe switch
chip partitioned into two SES VirtualSES enclosures (replacing V1xx's
dual 9600-12i4e SAS HBAs). The two partitions advertise the SAME encid,
so the V1xx encid-comparison disambiguation fails — `ses_enclosures2`
falls back to inspecting Array Device Slot element descriptor labels
(`slot01..slot12` = NVME0; `slot13..slot24` = NVME8). `slot_mappings`
gets a V2xx branch keyed by `enc.product` (`4IXGA-SWp/s`).
`enclosure_class` recognizes the V2xx model and exempts `4IXGA-SW` from
the V-series ECStream filter. `sysfs_disks` gains an NVMe-namespace
fallback for slots whose `device/block/` is missing.

### Commit 2 — V-series rear-bay enclosure support via bifurcated NTG SES partition

Adds enclosure2.query support for V-series rear bays (V140, V160, V260,
V280) served by the bay-serving half of the bifurcated PEX89032 NTG
chip. The other half has no drives and is dropped from enclosure2.query
— discriminated by Array Device Slot descriptor labels (`slot01..slot04`
= bay-serving; `<empty>` = no-drives). `slot_mappings` gets a REAR
branch (libsg3 keys 1-4 → display slots 25-28). `nvme2` removes the
V140/V160/V260/V280 dispatch entirely and deletes `map_vseries_nvme` —
all V-series rear bays now surface via SES. **This explicitly
supersedes NAS-141181's PCIe-switch-topology approach.** The four
`v140/v160/v260/v280_nvme_enclosure` synthetic mappings in
`slot_mappings` are also removed (unreachable now).

Commit 2 is designed to backport cleanly to stable/goldeye to enable
rear-bay identify control on older V-series releases.

## Test plan

- [X] `enclosure2.query` returns the V260 head unit with 28 slots
      (24 front via `4IXGA-SWp/s`, 4 rear via `4IXGA-NTG`).
- [X] `enclosure2.query` returns the V160 head unit with 28 slots
      (24 front via dual `BROADCOMVirtualSES0001`, 4 rear via NTG).
- [X] `enclosure2.set_slot_status` lights the expected physical bay on
      V260 (front 1-24 + rear 25-28).
- [X] Same on V160 — no regression vs prior behavior.
- [X] Unit test passes: `pytest src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_enclosure2_query.py` against the new `V260-NOJBODS` fixture (added in commit 2 under `test-cases/`).

## Verification done

Deployed and tested against a V260-100 HA pair (chassis IXS260100470,
TrueNAS 26.0.0-MASTER+20260618 nightly) on both controllers; HA failover
across patched middleware works cleanly. Front + rear bay LEDs exercised
end-to-end via the `enclosure2.set_slot_status` middleware path and a
chase-pattern script. Also deployed and validated on a v160-102 HA pair
(26.0.0-BETA.2-INTERNAL.2) — same 28-slot head unit surfaces, no
regression on V1xx front-bay path.

## Refs

JIRA: NAS-141457
Supersedes (for V160/V260/V280 rear bays): NAS-141181
Predecessors: NAS-137930 (initial V-series enclosure support),
NAS-138747 (V140 sysfs slot fix)


Original PR: https://github.com/truenas/middleware/pull/19168
