### PR TITLE
NAS-141564 / 27.0.0-BETA.1 / Fix failing directory services tests

### DIFF
--- a/tests/directory_services/test_activedirectory_basic.py
+++ b/tests/directory_services/test_activedirectory_basic.py
@@ -15,7 +15,6 @@ from middlewared.test.integration.utils.system import reset_systemd_svcs, get_gs
 
 from auto_config import ha
 from protocols import smb_connection, smb_share
-from truenas_api_client import ClientException
 
 SMB_NAME = "TestADShare"
 
@@ -352,7 +351,7 @@ def test_secrets_restore():
 
         ssh('rm /var/lib/truenas-samba/private/secrets.tdb')
 
-        with pytest.raises(ClientException):
+        with pytest.raises(Exception, match="Active Directory secrets file lacks an entry"):
             call('directoryservices.health.check')
 
         call('directoryservices.health.recover')

--- a/tests/directory_services/test_ipa_join.py
+++ b/tests/directory_services/test_ipa_join.py
@@ -4,7 +4,6 @@ from middlewared.test.integration.assets.directory_service import directoryservi
 from middlewared.test.integration.assets.product import product_type
 from middlewared.test.integration.utils import call, client, ssh
 from middlewared.test.integration.utils.client import truenas_server
-from truenas_api_client import ClientException
 
 
 @pytest.fixture(scope="module")
@@ -119,7 +118,7 @@ def test_dns_resolution(do_freeipa_connection):
 def test_ipa_config_recover(do_freeipa_connection):
     """ Remove the default config and verify our health check restores it """
     ssh('rm /etc/ipa/default.conf')
-    with pytest.raises(ClientException, match="IPA default.conf file is missing"):
+    with pytest.raises(Exception, match="IPA default.conf file is missing"):
         call('directoryservices.health.check')
 
     call('directoryservices.health.recover')


### PR DESCRIPTION
Change in backend presentation of errors in middleware responses basically broke the pytest expectations of exception types. This switches to simpler regex matching.