### PR TITLE
NAS-141565 / 27.0.0-BETA.1 / Match new TrueNAS license-gate wording in STIG test

### DIFF
--- a/tests/stig/test_01_stig.py
+++ b/tests/stig/test_01_stig.py
@@ -284,7 +284,7 @@ def setup_stig(full_admin_w_2fa_builtin_admin, module_stig_enabled, root_non_sti
 def test_nonenterprise_fail(community_product):
     # Clean up from prior runs of this module.
     user_and_config_cleanup()
-    with pytest.raises(ValidationErrors, match='Please contact iX sales for more information.'):
+    with pytest.raises(ValidationErrors, match='Please contact TrueNAS sales for more information.'):
         call('system.security.update', {'enable_gpos_stig': True}, job=True)
 
 


### PR DESCRIPTION
## Problem
The system.security typesafe conversion reworded the enterprise license-gate validation message from "iX enterprise/iX sales" to "TrueNAS Enterprise/TrueNAS sales", so test_nonenterprise_fail no longer matched and failed with "Regex pattern did not match."

## Solution
Updated the pytest.raises regex in test_nonenterprise_fail to expect the new "Please contact TrueNAS sales for more information." wording. The rebrand is intentional, so the test is brought in line rather than reverting the message.

Tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/stig_tests/2658/