### PR TITLE
NAS-141571 / 26.0.0-RC.1 / Fix potential access of unassigned variable

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -118,7 +118,9 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
                 self.last_used_at = now
 
     def is_valid(self):
-        if self.assurance and (now := monotonic()) > self.expiry:
+        now = monotonic()
+
+        if self.assurance and now > self.expiry:
             return False
 
         if self.inactivity_timeout:


### PR DESCRIPTION
`self.inactivity_timeout` evals to true only when `self.assurance` evals to true, so there's no real bug here. However, if this changes, this code will crash.