### PR TITLE
NAS-141582 / 27.0.0-BETA.1 / mypy mako templates

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -71,12 +71,54 @@ jobs:
             middlewared/service/generic_sharing_service.py \
             middlewared/utils/ \
             middlewared/test/integration/runner/ \
+            middlewared/test/linter/ \
             middlewared/auth.py \
             middlewared/job.py \
             --exclude middlewared/etc_files \
             --exclude middlewared/utils/directoryservices \
             --exclude middlewared/utils/lio \
             --exclude middlewared/utils/nvmet \
+            --follow-imports silent \
+            --strict
+
+      - name: mypy mako templates
+        run: |
+          cd src/middlewared
+          python3 -m middlewared.test.linter.mypy_mako \
+            middlewared/etc_files/chrony \
+            middlewared/etc_files/cron.d \
+            middlewared/etc_files/ctdb \
+            middlewared/etc_files/default \
+            middlewared/etc_files/dhcpcd.conf.mako \
+            middlewared/etc_files/fstab.mako \
+            middlewared/etc_files/ftpusers.mako \
+            middlewared/etc_files/hosts.mako \
+            middlewared/etc_files/idmapd.conf.mako \
+            middlewared/etc_files/initiators.deny.mako \
+            middlewared/etc_files/local/nut \
+            middlewared/etc_files/local/openldap \
+            middlewared/etc_files/local/smb4.conf.mako \
+            middlewared/etc_files/local/snmpd.conf.mako \
+            middlewared/etc_files/local/ssh \
+            middlewared/etc_files/local/users.oath.mako \
+            middlewared/etc_files/login_banner.mako \
+            middlewared/etc_files/mail \
+            middlewared/etc_files/motd.mako \
+            middlewared/etc_files/netdata \
+            middlewared/etc_files/nfs.conf.mako \
+            middlewared/etc_files/nscd.conf.mako \
+            middlewared/etc_files/nsswitch.conf.mako \
+            middlewared/etc_files/pam.d \
+            middlewared/etc_files/proftpd \
+            middlewared/etc_files/pykmip \
+            middlewared/etc_files/scst.direct.mako \
+            middlewared/etc_files/scst.env.mako \
+            middlewared/etc_files/security \
+            middlewared/etc_files/subgid.mako \
+            middlewared/etc_files/subuid.mako \
+            middlewared/etc_files/sysctl.d \
+            middlewared/etc_files/syslog-ng/conf.d/tndestinations.conf.mako \
+            middlewared/etc_files/wireguard \
             --follow-imports silent \
             --strict
 

--- a/src/middlewared/middlewared/etc_files/default/kdump-tools.mako
+++ b/src/middlewared/middlewared/etc_files/default/kdump-tools.mako
@@ -1,17 +1,15 @@
 <%
-    import contextlib
     import glob
-    import os
 
     enabled = middleware.call_sync('system.advanced.config')['kdump_enabled']
 
     if enabled:
-        initrd_boot_path = glob.glob('/boot/initrd.img*')
-        if not initrd_boot_path:
+        initrd_list = glob.glob('/boot/initrd.img*')
+        if not initrd_list:
             middleware.logger.error('Initrd image not found under /boot.')
             enabled = False
         else:
-            initrd_boot_path = initrd_boot_path[0]
+            initrd_boot_path = initrd_list[0]
 %>\
 % if enabled:
 USE_KDUMP=1

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -50,7 +50,7 @@ class NFSServicePathInfo(enum.Enum):
     SMBAKDIR = (os.path.join(SYSDATASET_PATH, 'nfs', 'sm.bak'), 0o755, True, {'uid': 'statd', 'gid': 'nogroup'})
     V4RECOVERYDIR = (os.path.join(SYSDATASET_PATH, 'nfs', 'v4recovery'), 0o755, True, {'uid': 0, 'gid': 0})
 
-    def path(self):
+    def path(self) -> str:
         return self.value[0]
 
     def mode(self):

--- a/src/middlewared/middlewared/test/linter/mypy_mako/__init__.py
+++ b/src/middlewared/middlewared/test/linter/mypy_mako/__init__.py
@@ -1,0 +1,187 @@
+"""Type-check the Python embedded in Mako templates.
+
+Mako compiles each template into a Python module. Templates that use the
+typesafe pattern (``middleware.call_sync2(middleware.services.kmip.config)``
+etc.) are worth running mypy against, but the compiled module is not mypy-clean
+out of the box -- see :mod:`.patches` for the source rewrites that fix that
+(notably typing ``middleware`` as :class:`middlewared.main.Middleware`) before
+the module is handed to mypy.
+
+Usage::
+
+    python -m middlewared.test.linter.mypy_mako [TARGET ...] [MYPY_ARG ...]
+
+A ``TARGET`` is any argument that exists on disk: either a ``.mako`` file or a
+directory (searched recursively for ``*.mako``). Every other argument is
+forwarded to mypy verbatim, so the CI flags work unchanged::
+
+    python -m middlewared.test.linter.mypy_mako \\
+        middlewared/etc_files/pykmip --follow-imports silent --strict
+
+Use ``--`` to stop target detection and force the remaining arguments to mypy
+(useful when a mypy flag value happens to be an existing path)::
+
+    python -m middlewared.test.linter.mypy_mako middlewared/etc_files/pykmip \\
+        -- --config-file mypy.ini
+"""
+
+import dataclasses
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+from mako.template import ModuleInfo
+
+import middlewared
+from middlewared.utils.mako import get_template
+
+from . import patches
+
+# The Mako TemplateLookup is rooted at the middlewared package directory and
+# templates are addressed by a URI relative to it. mypy runs from its parent
+# (src/middlewared) so that ``import middlewared`` resolves, matching CI.
+LOOKUP_BASE = os.path.dirname(os.path.abspath(middlewared.__file__))
+SRC_MIDDLEWARED = os.path.dirname(LOOKUP_BASE)
+
+# Strips ANSI so we can parse mypy output regardless of its own colorization.
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# `<path>:<line>:<col>: <severity>: <message>` (we force --show-column-numbers).
+MYPY_LINE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+):\s(?P<rest>.*)$")
+
+# Compiled-context window shown around each error.
+CONTEXT = 5
+
+RESET, BOLD, DIM = "\x1b[0m", "\x1b[1m", "\x1b[2m"
+SEVERITY_COLOR = {"error": "\x1b[91m", "warning": "\x1b[93m", "note": "\x1b[96m"}
+CARET_COLOR = "\x1b[91m"
+
+
+@dataclasses.dataclass
+class Compiled:
+    """A compiled template and the data needed to map mypy errors back to it."""
+
+    mako_rel: str  # template path relative to LOOKUP_BASE (e.g. etc_files/...)
+    source: list[str]  # compiled module lines, for showing context
+    line_map: list[int]  # full_line_map: compiled line (1-based) -> .mako line
+
+
+def split_args(argv: list[str]) -> tuple[list[str], list[str]]:
+    """Partition argv into Mako targets (existing paths) and mypy arguments.
+
+    Everything after a literal ``--`` is forced into the mypy bucket.
+    """
+    targets: list[str] = []
+    mypy_args: list[str] = []
+    forward_rest = False
+    for arg in argv:
+        if forward_rest:
+            mypy_args.append(arg)
+        elif arg == "--":
+            forward_rest = True
+        elif os.path.exists(arg):
+            targets.append(arg)
+        else:
+            mypy_args.append(arg)
+    return targets, mypy_args
+
+
+def collect_mako_files(targets: list[str]) -> list[str]:
+    """Expand the targets into a sorted, de-duplicated list of .mako files."""
+    files: set[str] = set()
+    for target in targets:
+        if os.path.isdir(target):
+            for root, _, names in os.walk(target):
+                for name in names:
+                    if name.endswith(".mako"):
+                        files.add(os.path.abspath(os.path.join(root, name)))
+        elif target.endswith(".mako"):
+            files.add(os.path.abspath(target))
+        else:
+            raise SystemExit(f"error: not a .mako file or directory: {target}")
+    return sorted(files)
+
+
+def compile_mako(path: str) -> str:
+    """Compile a single .mako file to patched, type-checkable Python source."""
+    if os.path.commonpath([path, LOOKUP_BASE]) != LOOKUP_BASE:
+        raise SystemExit(
+            f"error: {path} is not under the middlewared package ({LOOKUP_BASE}); "
+            f"the Mako template lookup cannot address it."
+        )
+    uri = os.path.relpath(path, LOOKUP_BASE)
+    return patches.patch(get_template(uri).code)
+
+
+def _color(text: str, code: str, enabled: bool) -> str:
+    return f"{code}{text}{RESET}" if enabled and code else text
+
+
+def _render(stdout: str, compiled: dict[str, Compiled], color: bool) -> None:
+    """Rewrite mypy output to point at the .mako source and show compiled context."""
+    for raw in stdout.splitlines():
+        match = MYPY_LINE.match(ANSI.sub("", raw))
+        info = compiled.get(match["path"]) if match else None
+        if match is None or info is None:
+            print(raw)  # summaries and anything not tied to a compiled file
+            continue
+
+        compiled_ln, col = int(match["line"]), int(match["col"])
+        rest = match["rest"]
+        severity = rest.split(":", 1)[0]
+        mako_ln = info.line_map[compiled_ln - 1] if compiled_ln <= len(info.line_map) else 0
+
+        location = _color(f"{info.mako_rel}:{mako_ln or '?'}", BOLD, color)
+        sev = _color(severity, SEVERITY_COLOR.get(severity, ""), color)
+        print(f"{location}: {sev}:{rest[len(severity) + 1 :]}")
+
+        if severity == "error":
+            _print_context(info.source, compiled_ln, col, color)
+
+
+def _print_context(source: list[str], error_ln: int, col: int, color: bool) -> None:
+    """Show the compiled file around ``error_ln`` with a caret under the column."""
+    lo, hi = max(1, error_ln - CONTEXT), min(len(source), error_ln + CONTEXT)
+    width = len(str(hi))
+    for n in range(lo, hi + 1):
+        gutter = f"{n:>{width}} | "
+        is_error = n == error_ln
+        print(f"  {_color(gutter, BOLD if is_error else DIM, color)}{source[n - 1]}")
+        if is_error:
+            print(_color(" " * (2 + len(gutter) + col - 1) + "^", CARET_COLOR, color))
+
+
+def main(argv: list[str]) -> int:
+    targets, mypy_args = split_args(argv)
+    if not targets:
+        print(__doc__, file=sys.stderr)
+        raise SystemExit("error: no .mako files or directories specified")
+
+    mako_files = collect_mako_files(targets)
+    if not mako_files:
+        raise SystemExit("error: no .mako files found in the given targets")
+
+    with tempfile.TemporaryDirectory(prefix="mypy_mako_") as tmpdir:
+        compiled: dict[str, Compiled] = {}
+        for path in mako_files:
+            rel = os.path.relpath(path, LOOKUP_BASE)
+            source = compile_mako(path)
+            # Flatten the package-relative path into a readable temp filename.
+            out = os.path.join(tmpdir, rel.replace(os.sep, "__") + ".py")
+            with open(out, "w") as f:
+                f.write(source)
+            meta = ModuleInfo.get_module_source_metadata(source, full_line_map=True)
+            compiled[out] = Compiled(rel, source.splitlines(), meta["full_line_map"])
+
+        result = subprocess.run(
+            [sys.executable, "-m", "mypy", "--show-column-numbers", *compiled, *mypy_args],
+            cwd=SRC_MIDDLEWARED,
+            capture_output=True,
+            text=True,
+        )
+
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    _render(result.stdout, compiled, color=sys.stdout.isatty())
+    return result.returncode

--- a/src/middlewared/middlewared/test/linter/mypy_mako/__main__.py
+++ b/src/middlewared/middlewared/test/linter/mypy_mako/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/middlewared/middlewared/test/linter/mypy_mako/patches.py
+++ b/src/middlewared/middlewared/test/linter/mypy_mako/patches.py
@@ -1,0 +1,105 @@
+"""Source patches applied to a Mako-compiled module before it is type-checked.
+
+Mako compiles each template into a Python module, but the generated source is
+not mypy-clean under ``--strict``: the ``middleware`` context variable is typed
+as ``Any`` (so the typesafe service accesses are never checked) and Mako's own
+scaffolding lines are untyped. Each patcher here rewrites the exact lines
+responsible, so the module type-checks honestly -- no error code is suppressed
+and no ``# type: ignore`` is added. Genuine errors in the template's embedded
+Python are left untouched.
+"""
+
+from collections.abc import Callable
+import re
+
+# Mako emits `middleware = context.get('middleware', UNDEFINED)` (typed as Any)
+# for any template that references `middleware`. Annotate it as the real
+# Middleware so the typesafe service accesses are actually checked.
+MIDDLEWARE_LINE = "        middleware = context.get('middleware', UNDEFINED)"
+MIDDLEWARE_LINE_TYPED = "        middleware: Middleware = context.get('middleware', UNDEFINED)"
+MIDDLEWARE_IMPORT = "from middlewared.main import Middleware"
+
+# Mako always emits these scaffolding lines untyped, which trips ``--strict`` with
+# errors that have nothing to do with the template's embedded logic. Annotate the
+# exact lines so they type-check cleanly (``runtime`` is imported by Mako's own
+# generated header; ``Any`` is injected by ``annotate_scaffolding``).
+SCAFFOLDING_TYPED = {
+    "def render_body(context,**pageargs):": "def render_body(context: runtime.Context, **pageargs: Any) -> str:",
+    "_exports = []": "_exports: list[str] = []",
+}
+TYPING_IMPORT = "from typing import Any"
+
+# Mako's own generated header; we splice our imports onto it instead of inserting
+# new lines so that the compiled module keeps its original line numbering and
+# Mako's embedded line map still translates mypy errors back to the .mako source.
+MAKO_IMPORT_PREFIX = "from mako import runtime, filters, cache"
+
+
+def _add_import(code: str, statement: str) -> str:
+    """Append an import onto Mako's header line, preserving the line count."""
+    lines = code.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(MAKO_IMPORT_PREFIX):
+            lines[i] = f"{line}; {statement}"
+            break
+    else:
+        # Mako's header changed shape; fall back to a (line-shifting) insert.
+        lines.insert(1, statement)
+    return "\n".join(lines) + "\n"
+
+
+def annotate_middleware(code: str) -> str:
+    """Type the ``middleware`` context variable as ``Middleware``."""
+    if MIDDLEWARE_LINE not in code:
+        return code
+    code = code.replace(MIDDLEWARE_LINE, MIDDLEWARE_LINE_TYPED)
+    return _add_import(code, MIDDLEWARE_IMPORT)
+
+
+def annotate_scaffolding(code: str) -> str:
+    """Annotate Mako's untyped scaffolding lines (``render_body``, ``_exports``)."""
+    lines = code.splitlines()
+    changed = False
+    for i, line in enumerate(lines):
+        replacement = SCAFFOLDING_TYPED.get(line)
+        if replacement is not None:
+            lines[i] = replacement
+            changed = True
+    code = "\n".join(lines) + "\n"
+    if changed:
+        code = _add_import(code, TYPING_IMPORT)
+    return code
+
+
+def annotate_locals_key(code: str) -> str:
+    """Give Mako's ``__M_key`` bookkeeping comprehension a concrete element type.
+
+    Mako copies a block's locals with
+    ``... for __M_key in [<names>] if __M_key in __M_locals_builtin_stored``.
+    When the block exports no locals the literal is empty (``for __M_key in []``),
+    which leaves ``__M_key`` untyped under ``--strict``. The keys are always local
+    variable names, so type the iterable as ``list[str]``.
+
+    We spell it ``builtins.str`` rather than ``str``: a template may use a bare
+    ``str`` that Mako pulls from the context (``str = context.get('str', ...)``),
+    shadowing the builtin so a plain ``str`` would be read as that variable.
+    """
+    code, count = re.subn(r"for __M_key in (\[[^\]]*\])", r"for __M_key in list[builtins.str](\1)", code)
+    if count:
+        code = _add_import(code, "import builtins")
+    return code
+
+
+# Applied in order; each takes the generated source and returns a modified copy.
+PATCHERS: list[Callable[[str], str]] = [
+    annotate_middleware,
+    annotate_scaffolding,
+    annotate_locals_key,
+]
+
+
+def patch(code: str) -> str:
+    """Apply every compiled-code patcher to the Mako-generated source."""
+    for patcher in PATCHERS:
+        code = patcher(code)
+    return code

--- a/src/middlewared/middlewared/utils/pam.py
+++ b/src/middlewared/middlewared/utils/pam.py
@@ -103,6 +103,11 @@ class PAMConfLines:
     secondary: tuple[PAMLine, ...] | None = None
 
 
+@dataclass(slots=True, frozen=True)
+class PAMConfLinesWithSecondary(PAMConfLines):
+    secondary: tuple[PAMLine, ...]
+
+
 # Below this point are intialized PAM configuration objects for use in mako files
 
 STANDALONE_ACCOUNT = PAMConfLines(
@@ -145,7 +150,7 @@ AD_ACCOUNT = PAMConfLines(
     )
 )
 
-SSS_ACCOUNT = PAMConfLines(
+SSS_ACCOUNT = PAMConfLinesWithSecondary(
     service=PAMService.ACCOUNT,
     primary=(
         PAMLine(
@@ -232,7 +237,7 @@ SSS_AUTH = PAMConfLines(
     )
 )
 
-STANDALONE_SESSION = PAMConfLines(
+STANDALONE_SESSION = PAMConfLinesWithSecondary(
     service=PAMService.SESSION,
     primary=(),
     secondary=(
@@ -249,7 +254,7 @@ STANDALONE_SESSION = PAMConfLines(
     )
 )
 
-AD_SESSION = PAMConfLines(
+AD_SESSION = PAMConfLinesWithSecondary(
     service=PAMService.SESSION,
     primary=(),
     secondary=(
@@ -275,7 +280,7 @@ AD_SESSION = PAMConfLines(
     )
 )
 
-SSS_SESSION = PAMConfLines(
+SSS_SESSION = PAMConfLinesWithSecondary(
     service=PAMService.SESSION,
     primary=(),
     secondary=(


### PR DESCRIPTION
New CI step to type-check mako templates. Most of them are already good (the ones that are now specified explicitly). Step-by-step we can inspect the rest.

The output will map compiled python file line numbers to the original mako file line numbers. It will also show the surrounding lines in the compiled file so we can see what code is actually being inspected.
```
etc_files/pam.d/truenas-session.mako:21: error: Item "None" of "tuple[PAMLine, ...] | None" has no attribute "__iter__" (not iterable)  [union-attr]
  37 |         __M_writer('# PAM configuration for the middleware (Web UI / API login)\n\n')
  38 |         if ds_auth:
  39 |             __M_writer('@include common-session-noninteractive\n')
  40 |         else:
  41 |             __M_writer('session [default=1]\t\t\tpam_permit.so\nsession\trequisite\t\t\tpam_deny.so\nsession\trequired\t\t\tpam_permit.so\n')
  42 |             __M_writer(str('\n'.join(line.as_conf() for line in STANDALONE_SESSION.secondary if line.pam_module is not PAMModule.MKHOMEDIR)))
                                                                       ^
  43 |             __M_writer('\n')
  44 |         __M_writer(str(truenas_session_line.as_conf()))
  45 |         __M_writer('\n')
  46 |         return ''
  47 |     finally:
Found 1 error in 1 file (checked 59 source files)
```