### PR TITLE
NAS-140857 / 26.0.0-RC.1 / Handle TNC license delivery and token states in heartbeat (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -28,6 +28,63 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
         config = await self.middleware.call('tn_connect.config_internal')
         return await self._call(url, mode, payload=payload, headers=await self.auth_headers(config), **(kwargs or {}))
 
+    async def persist_new_token(self, tnc_config, new_token):
+        try:
+            decoded_token = decode_and_validate_token(new_token)
+        except ValueError as e:
+            logger.error('TNC Heartbeat: failed to validate rotated token: %s', e)
+            return
+
+        await self.middleware.call(
+            'datastore.update',
+            'truenas_connect',
+            tnc_config['id'],
+            {
+                'jwt_token': new_token,
+                'registration_details': decoded_token,
+            },
+        )
+        # Keep the in-memory config in sync so the very next request authenticates with the new token.
+        tnc_config.update({
+            'jwt_token': new_token,
+            'registration_details': decoded_token,
+        })
+        logger.info('TNC Heartbeat: rotated to new token')
+
+    async def maybe_install_license(self, pem):
+        # TNC re-sends the same PEM until our heartbeat reports its id, so skip when it is already
+        # installed; reinstalling would needlessly re-run etc.generate / license hooks / ctdb restart.
+        current = await self.middleware.call('system.license', True)
+        if current and (current.get('raw_license') or '').strip() == pem.strip():
+            logger.debug('TNC Heartbeat: delivered license already installed, skipping')
+            return
+
+        try:
+            await self.middleware.call('truenas.license.upload', pem)
+        except Exception:
+            logger.error('TNC Heartbeat: failed to install delivered license', exc_info=True)
+        else:
+            logger.info('TNC Heartbeat: installed license delivered by TNC')
+
+    async def handle_response(self, tnc_config, status_code, body):
+        # Act on what the body carries, not on the token_status/license_status strings: a new token
+        # can be issued while the presented one is still active, and an error response would not carry
+        # the heartbeat body at all. Field presence is the safer, decoupled trigger.
+        new_token = body.get('new_token')
+        pem = body.get('license')
+
+        if new_token:
+            await self.persist_new_token(tnc_config, new_token)
+        if pem:
+            await self.maybe_install_license(pem)
+
+        # A 205 means the body carries an artifact the NAS must install before its next heartbeat. If
+        # it carries neither a license nor a new token, TNC violated its own contract; surface it
+        # rather than silently skipping. A 202 with a pending license but no PEM is normal (signing in
+        # progress), so it is intentionally not flagged here.
+        if status_code == 205 and not new_token and not pem:
+            logger.warning('TNC Heartbeat: received 205 but the response carried no license or token to install')
+
     async def start(self):
         logger.debug('TNC Heartbeat: Starting heartbeat service')
         tnc_config = await self.middleware.call('tn_connect.config_internal')
@@ -42,48 +99,26 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
         disk_mapping = {i.name: i.identifier for i in iterate_disks()}
         while tnc_config['status'] in CONFIGURED_TNC_STATES:
             sleep_error = False
-            resp = await self.call(heartbeat_url, 'post', await self.payload(disk_mapping), get_response=False)
+            resp = await self.call(heartbeat_url, 'post', await self.payload(disk_mapping))
             if resp['error'] is not None and resp['status_code'] is None:
                 logger.debug('TNC Heartbeat: Failed to connect to heart beat service (%s)', resp['error'])
                 sleep_error = True
             else:
                 match resp['status_code']:
-                    case 200 | 202:
-                        # Just keeping this here for valid codes, we don't need to do anything
-                        pass
-                    case 205:
-                        if (new_token := resp['headers'].get('X-New-Token')) is not None:
-                            logger.debug('TNC Heartbeat: Received new token')
-
-                            try:
-                                decoded_token = decode_and_validate_token(new_token)
-                            except ValueError as e:
-                                logger.error('TNC Heartbeat: Failed to validate received token: %s', e)
-                            else:
-                                await self.middleware.call(
-                                    'datastore.update',
-                                    'truenas_connect',
-                                    tnc_config['id'],
-                                    {
-                                        'jwt_token': new_token,
-                                        'registration_details': decoded_token,
-                                    },
-                                )
-                                tnc_config.update({
-                                    'jwt_token': new_token,
-                                    'registration_details': decoded_token,
-                                })
-                        else:
-                            logger.warning('TNC Heartbeat: Received 205 status but no X-New-Token header')
-                    case 400:
-                        logger.debug('TNC Heartbeat: Received 400')
-                        sleep_error = True
+                    case 202 | 205:
+                        await self.handle_response(tnc_config, resp['status_code'], resp['response'] or {})
                     case 401:
-                        logger.debug('TNC Heartbeat: Received 401, unsetting TNC')
+                        # An error response is an ErrorResponse ({"error": ..., "data": {...}}), not the
+                        # heartbeat body, so the token_status reason lives under "data" when present.
+                        reason = (resp['response'] or {}).get('data') or {}
+                        logger.info(
+                            'TNC Heartbeat: Received 401 (token_status=%s), unsetting TNC',
+                            reason.get('token_status'),
+                        )
                         await self.middleware.call('tn_connect.handle_tnc_deregistration')
                         return
-                    case 500:
-                        logger.debug('TNC Heartbeat: Received 500')
+                    case 400 | 500:
+                        logger.debug('TNC Heartbeat: Received %r', resp['status_code'])
                         sleep_error = True
                     case _:
                         logger.debug('TNC Heartbeat: Received unknown status code %r', resp['status_code'])
@@ -140,7 +175,21 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
                 'running': len([vm for vm in vms if vm['status']['state'] == 'RUNNING']),
             },
         })
+
+        # A fingerprint hiccup must not take down the heartbeat, so degrade to null on failure.
+        try:
+            fingerprint = await self.middleware.call('truenas.license.fingerprint')
+        except Exception:
+            logger.error('TNC Heartbeat: failed to compute system fingerprint', exc_info=True)
+            fingerprint = None
+
+        # license_id is the delivery acknowledgement: once we report the id of an installed license,
+        # TNC marks it accepted and stops resending the PEM. Null when we hold no valid license.
+        license_info = await self.middleware.call('truenas.license.info')
+
         return {
             'alerts': await self.middleware.call('alert.list'),
             'stats': stats,
+            'fingerprint': fingerprint,
+            'license_id': license_info['id'] if license_info else None,
         }

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -582,3 +582,214 @@ async def test_heartbeat_guard_rejects_when_no_creds():
     """Missing creds is rejected even in a configured state."""
     with pytest.raises(CallError):
         await _run_heartbeat_start(Status.CONFIGURED.name, None)
+
+
+# --- Heartbeat request payload --------------------------------------------------------------------
+
+def _payload_service(license_info, fingerprint='FP', fingerprint_raises=False):
+    """A TNCHeartbeatService whose middleware.call serves what payload() needs."""
+    service = TNCHeartbeatService(MagicMock())
+
+    async def mock_call(method, *args, **kwargs):
+        if method == 'reporting.realtime.stats':
+            return {}
+        if method in ('app.query', 'vm.query', 'alert.list'):
+            return []
+        if method == 'truenas.license.fingerprint':
+            if fingerprint_raises:
+                raise CallError('daemon down')
+            return fingerprint
+        if method == 'truenas.license.info':
+            return license_info
+        raise ValueError(f'Unexpected: {method}')
+
+    service.middleware.call = AsyncMock(side_effect=mock_call)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_payload_reports_fingerprint_and_license_id():
+    service = _payload_service(license_info={'id': 'LIC-1'}, fingerprint='FP-XYZ')
+    payload = await service.payload({})
+    assert payload['fingerprint'] == 'FP-XYZ'
+    assert payload['license_id'] == 'LIC-1'
+
+
+@pytest.mark.asyncio
+async def test_payload_license_id_null_when_unlicensed():
+    service = _payload_service(license_info=None)
+    payload = await service.payload({})
+    assert payload['license_id'] is None
+
+
+@pytest.mark.asyncio
+async def test_payload_fingerprint_failure_degrades_to_null():
+    service = _payload_service(license_info={'id': 'LIC-1'}, fingerprint_raises=True)
+    payload = await service.payload({})
+    assert payload['fingerprint'] is None
+    assert payload['license_id'] == 'LIC-1'  # other fields still populated
+
+
+# --- License install (dedup + always-install + never crash) ---------------------------------------
+
+def _install_service(installed_raw, upload_raises=False):
+    service = TNCHeartbeatService(MagicMock())
+
+    async def mock_call(method, *args, **kwargs):
+        if method == 'system.license':
+            return {'raw_license': installed_raw} if installed_raw is not None else None
+        if method == 'truenas.license.upload':
+            if upload_raises:
+                raise CallError('bad license')
+            return None
+        raise ValueError(f'Unexpected: {method}')
+
+    service.middleware.call = AsyncMock(side_effect=mock_call)
+    return service
+
+
+def _upload_calls(service):
+    return [c for c in service.middleware.call.call_args_list if c.args[0] == 'truenas.license.upload']
+
+
+@pytest.mark.asyncio
+async def test_maybe_install_license_installs_when_different():
+    service = _install_service(installed_raw='OLD-PEM')
+    await service.maybe_install_license('NEW-PEM')
+    calls = _upload_calls(service)
+    assert len(calls) == 1
+    assert calls[0].args[1] == 'NEW-PEM'
+
+
+@pytest.mark.asyncio
+async def test_maybe_install_license_installs_when_no_current():
+    service = _install_service(installed_raw=None)
+    await service.maybe_install_license('NEW-PEM')
+    assert len(_upload_calls(service)) == 1
+
+
+@pytest.mark.asyncio
+async def test_maybe_install_license_skips_when_identical():
+    # Trailing whitespace differs but content matches -> dedup must skip.
+    service = _install_service(installed_raw='SAME-PEM')
+    await service.maybe_install_license('  SAME-PEM\n')
+    assert _upload_calls(service) == []
+
+
+@pytest.mark.asyncio
+async def test_maybe_install_license_swallows_upload_error():
+    service = _install_service(installed_raw='OLD-PEM', upload_raises=True)
+    # Must not raise -- a failed install cannot kill the heartbeat loop.
+    await service.maybe_install_license('NEW-PEM')
+    assert len(_upload_calls(service)) == 1
+
+
+# --- Token rotation persistence -------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_persist_new_token_writes_and_updates_in_memory():
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    service = TNCHeartbeatService(MagicMock())
+    service.middleware.call = AsyncMock()
+    tnc_config = {'id': 1, 'jwt_token': 'OLD'}
+    decoded = {'account_id': 'a', 'system_id': 's'}
+
+    with patch.object(hb, 'decode_and_validate_token', return_value=decoded):
+        await service.persist_new_token(tnc_config, 'NEW-TOKEN')
+
+    update_call = next(
+        c for c in service.middleware.call.call_args_list if c.args[0] == 'datastore.update'
+    )
+    assert update_call.args[1] == 'truenas_connect'
+    assert update_call.args[3] == {'jwt_token': 'NEW-TOKEN', 'registration_details': decoded}
+    # In-memory config updated so the next request authenticates with the new token.
+    assert tnc_config['jwt_token'] == 'NEW-TOKEN'
+    assert tnc_config['registration_details'] == decoded
+
+
+@pytest.mark.asyncio
+async def test_persist_new_token_skips_invalid_token():
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    service = TNCHeartbeatService(MagicMock())
+    service.middleware.call = AsyncMock()
+    tnc_config = {'id': 1, 'jwt_token': 'OLD'}
+
+    with patch.object(hb, 'decode_and_validate_token', side_effect=ValueError('bad')):
+        await service.persist_new_token(tnc_config, 'BROKEN')
+
+    service.middleware.call.assert_not_called()
+    assert tnc_config['jwt_token'] == 'OLD'  # unchanged
+
+
+# --- 2xx response dispatch ------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('body, expect_token, expect_license', [
+    # A token is persisted whenever new_token is present -- even with token_status='active', which is
+    # the decoupling the reviewer asked for (rotation can be issued while the old token is active).
+    ({'token_status': 'active', 'new_token': 'T'}, 'T', None),
+    # A token under 'rotating' is likewise persisted.
+    ({'token_status': 'rotating', 'new_token': 'T'}, 'T', None),
+    # A PEM is installed whenever present, regardless of license_status.
+    ({'license_status': 'pending', 'license': 'PEM'}, None, 'PEM'),
+    ({'license_status': 'accepted', 'license': 'PEM'}, None, 'PEM'),
+    # Both artifacts present -> both handled.
+    ({'new_token': 'T', 'license': 'PEM'}, 'T', 'PEM'),
+    # Empty fields / empty body -> nothing.
+    ({'token_status': 'active', 'new_token': '', 'license_status': 'pending', 'license': ''}, None, None),
+    ({}, None, None),
+])
+async def test_handle_response_dispatch(body, expect_token, expect_license):
+    service = TNCHeartbeatService(MagicMock())
+    tnc_config = {'id': 1}
+
+    with patch.object(service, 'persist_new_token', new=AsyncMock()) as persist, \
+            patch.object(service, 'maybe_install_license', new=AsyncMock()) as install:
+        # 202 keeps the focus on field-driven routing without tripping the 205 fault check.
+        await service.handle_response(tnc_config, 202, body)
+
+    if expect_token is None:
+        persist.assert_not_called()
+    else:
+        persist.assert_awaited_once_with(tnc_config, expect_token)
+
+    if expect_license is None:
+        install.assert_not_called()
+    else:
+        install.assert_awaited_once_with(expect_license)
+
+
+@pytest.mark.asyncio
+async def test_handle_response_205_without_artifact_warns():
+    """A 205 promising an artifact but carrying none is a TNC fault we must surface, not skip."""
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    service = TNCHeartbeatService(MagicMock())
+    body = {'token_status': 'active', 'license_status': 'pending', 'license': '', 'new_token': ''}
+
+    with patch.object(service, 'persist_new_token', new=AsyncMock()) as persist, \
+            patch.object(service, 'maybe_install_license', new=AsyncMock()) as install, \
+            patch.object(hb.logger, 'warning') as warn:
+        await service.handle_response({'id': 1}, 205, body)
+
+    persist.assert_not_called()
+    install.assert_not_called()
+    assert any('no license or token' in str(c.args[0]) for c in warn.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_handle_response_202_pending_without_pem_is_quiet():
+    """A 202 with pending-but-no-PEM is normal (signing in progress) and must not warn."""
+    from middlewared.plugins.truenas_connect import heartbeat as hb
+
+    service = TNCHeartbeatService(MagicMock())
+    body = {'token_status': 'active', 'license_status': 'pending', 'license': '', 'new_token': ''}
+
+    with patch.object(service, 'maybe_install_license', new=AsyncMock()) as install, \
+            patch.object(hb.logger, 'warning') as warn:
+        await service.handle_response({'id': 1}, 202, body)
+
+    install.assert_not_called()
+    warn.assert_not_called()


### PR DESCRIPTION
This commit adds changes to read the TNC heartbeat response body so we can report the system fingerprint and installed license id, install a license PEM that TNC delivers, and drive token rotation and the terminal token states off the body fields instead of the old X-New-Token header. A delivered license is deduped against the one already installed so we don't reinstall it every beat, and a 205 that carries no license or token is logged as a TNC fault rather than silently skipped.

Original PR: https://github.com/truenas/middleware/pull/19153
