### PR TITLE
NAS-141586 / 27.0.0-BETA.1 / Use truenas_streams_xattr VFS module name for Samba 4.24

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -61,7 +61,7 @@ class TrueNASVfsObjects(enum.StrEnum):
     TRUENAS_AUDIT = 'truenas_audit'
     CATIA = 'catia'
     FRUIT = 'fruit'
-    STREAMS_XATTR = 'streams_xattr'
+    STREAMS_XATTR = 'truenas_streams_xattr'
     SHADOW_COPY_ZFS = 'shadow_copy_zfs'
     IXNAS = 'ixnas'
     WINMSA = 'winmsa'
@@ -349,6 +349,8 @@ def generate_smb_share_conf_dict(
             'fruit:encoding': 'native',
             'fruit:metadata': 'netatalk',
             'fruit:resource': 'file',
+            # The Samba module is named truenas_streams_xattr (renamed in 4.24), but its
+            # parametric options are still read under the streams_xattr: prefix. Do not rename.
             'streams_xattr:prefix': 'user.',
             'streams_xattr:store_stream_type': False,
             'streams_xattr:xattr_compat': True

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -369,6 +369,12 @@ def test__afp_share(nfsacl_dataset):
     assert conf['streams_xattr:xattr_compat'] is True
 
 
+def test__streams_xattr_module_name():
+    # Samba 4.24 renamed the module; middleware must emit the TrueNAS fork,
+    # otherwise shares silently fall back to upstream's streams_xattr.
+    assert TrueNASVfsObjects.STREAMS_XATTR == 'truenas_streams_xattr'
+
+
 def test__fruit_convert_adouble_default(nfsacl_dataset):
     """
     Stream-mode shares have no ._<base> companions to convert, so eager


### PR DESCRIPTION
Samba 4.24 forks the TrueNAS streams_xattr customizations into a separate module, truenas_streams_xattr. Emit that name in the generated vfs objects line so shares get the TrueNAS backend instead of silently falling back to upstream's streams_xattr. Parametric options keep the streams_xattr: prefix (the module still reads them there), so only the module name changes.