### PR TITLE
NAS-141603 / 27.0.0-BETA.1 / Remove xfail from compound cinfo monotonic test now that z_seq persists

### DIFF
--- a/tests/sharing_protocols/nfs/test_nfs_change_attr.py
+++ b/tests/sharing_protocols/nfs/test_nfs_change_attr.py
@@ -29,7 +29,6 @@ Two complementary angles, both targeting that failure:
 
 import nfs4lib
 import nfs_ops
-import pytest
 from xdrdef.nfs4_const import (
     FATTR4_MODE,
     FATTR4_TIME_ACCESS_SET,
@@ -65,12 +64,6 @@ def _zero_stateid():
     return stateid4(0, b"\0" * 12)
 
 
-@pytest.mark.xfail(
-    reason="knfsd on this build does not honor ZFS STATX_CHANGE_COOKIE, so it "
-    "synthesizes the change attribute from coarse ctime and the eight same-tick "
-    "CREATEs collide; this is a product (kernel and ZFS) gap, not a test issue",
-    strict=False,
-)
 def test_create_compound_cinfo_strictly_monotonic(start_nfs, nfs_dataset):
     """Eight ``CREATE(NF4DIR)`` ops in one COMPOUND must each return a
     strictly-advancing ``change_info4``.


### PR DESCRIPTION
`test_create_compound_cinfo_strictly_monotonic` now passes with `z_seq` persistence (truenas/zfs#407). Drop the `XFAIL` and the now-unused `pytest` import.

### Testing
`test_create_compound_cinfo_strictly_monotonic` (previously `XFAIL`) should pass once the test suite finishes: ~http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/2763/console (build didn't pull in latest ZFS changes)~ http://jenkins.eng.ixsystems.net:8080/job/tests/job/sharing_protocols_tests/2764/.