### PR TITLE
NAS-141553 / 26.0.0-RC.1 / Handle Basic auth Docker registries

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/client.py
+++ b/src/middlewared/middlewared/plugins/apps_images/client.py
@@ -69,13 +69,22 @@ class ContainerRegistryClientMixin:
         response = await self._api_call(manifest_url, headers=headers, mode=mode)
         if (error := response.get('error_obj')) and isinstance(error, aiohttp.ClientResponseError):
             if error.status == 401:
-                # 2) try to get token from manifest api call's response headers; the token
-                # request is sent with Basic auth when registry creds are configured, so
-                # the returned token has read scope on private repos.
+                # 2) Authenticate according to the scheme advertised in the challenge.
                 auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
-                headers['Authorization'] = f'Bearer {await self._get_token(**auth_data, auth=auth)}'
-                # 3) Redo the manifest call with updated token
-                response = await self._api_call(manifest_url, headers=headers, mode=mode)
+                if auth_data.pop('scheme', 'bearer') == 'basic':
+                    # Private registries using htpasswd/HTTP Basic auth answer with a
+                    # `Basic` challenge that has no token endpoint or scope - there is no
+                    # token to fetch. Replay the manifest request directly with the stored
+                    # registry credentials instead of attempting a token exchange.
+                    response = await self._api_call(manifest_url, headers=headers, mode=mode, auth=auth)
+                else:
+                    # Bearer/token auth: fetch a scoped token from the registry's auth
+                    # endpoint and retry with it. The token request is sent with Basic auth
+                    # when registry creds are configured so the returned token has read
+                    # scope on private repos.
+                    headers['Authorization'] = f'Bearer {await self._get_token(**auth_data, auth=auth)}'
+                    # 3) Redo the manifest call with updated token
+                    response = await self._api_call(manifest_url, headers=headers, mode=mode)
 
         if raise_error and response['error']:
             raise CallError(

--- a/src/middlewared/middlewared/plugins/apps_images/client.py
+++ b/src/middlewared/middlewared/plugins/apps_images/client.py
@@ -69,15 +69,20 @@ class ContainerRegistryClientMixin:
         response = await self._api_call(manifest_url, headers=headers, mode=mode)
         if (error := response.get('error_obj')) and isinstance(error, aiohttp.ClientResponseError):
             if error.status == 401:
-                # 2) Authenticate according to the scheme advertised in the challenge.
-                auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
-                if auth_data.pop('scheme', 'bearer') == 'basic':
+                # 2) Authenticate according to the scheme advertised in the challenge. An
+                # empty/unrecognized challenge - or a Bearer challenge that omits the scope
+                # needed to request a token - is left to surface as a CallError below rather
+                # than crashing.
+                auth_data = parse_auth_header((error.headers or {}).get(DOCKER_AUTH_HEADER) or '')
+                scheme = auth_data.pop('scheme', None)
+                if scheme == 'basic' and auth is not None:
                     # Private registries using htpasswd/HTTP Basic auth answer with a
                     # `Basic` challenge that has no token endpoint or scope - there is no
-                    # token to fetch. Replay the manifest request directly with the stored
-                    # registry credentials instead of attempting a token exchange.
+                    # token to fetch. Replay the manifest request with the stored
+                    # credentials. With no credentials the replay would just repeat the
+                    # anonymous request that already 401'd, so it is skipped.
                     response = await self._api_call(manifest_url, headers=headers, mode=mode, auth=auth)
-                else:
+                elif scheme == 'bearer' and 'scope' in auth_data:
                     # Bearer/token auth: fetch a scoped token from the registry's auth
                     # endpoint and retry with it. The token request is sent with Basic auth
                     # when registry creds are configured so the returned token has read

--- a/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
@@ -40,6 +40,10 @@ class ContainerImagesService(Service, ContainerRegistryClientMixin):
                     await self.check_update_for_image(tag, image, app_registries)
                 except CallError as e:
                     logger.error(str(e))
+                except Exception:
+                    # A single misbehaving image/registry must not abort the whole sweep
+                    # (and surface as an unretrieved task exception); log and move on.
+                    logger.error('Failed to check for image update for %r', tag, exc_info=True)
 
     async def retrieve_digest(self, reference: str):
         repo_digests = []

--- a/src/middlewared/middlewared/plugins/apps_images/utils.py
+++ b/src/middlewared/middlewared/plugins/apps_images/utils.py
@@ -42,15 +42,31 @@ def parse_digest_from_schema(response: dict) -> list[str]:
 
 def parse_auth_header(header: str) -> dict[str, str]:
     """
-    Parses header in format below:
+    Parses a ``WWW-Authenticate`` challenge header.
+
+    A Bearer/token-auth challenge, e.g.:
     'Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="redis:pull"'
 
-    Returns:
+    returns:
         {
+            'scheme': 'bearer',
             'auth_url': 'https://ghcr.io/token',
             'service': 'ghcr.io',
             'scope': 'redis:pull'
         }
+
+    An HTTP Basic challenge (e.g. a private registry using htpasswd auth):
+    'Basic realm="example.com"'
+
+    returns:
+        {
+            'scheme': 'basic',
+            'auth_url': 'example.com'
+        }
+
+    Basic challenges carry no token endpoint or ``scope`` (the parsed ``realm`` is
+    unused), so callers must branch on ``scheme`` rather than assuming a
+    token-exchange flow.
     """
     adapter = {
         'realm': 'auth_url',
@@ -59,6 +75,9 @@ def parse_auth_header(header: str) -> dict[str, str]:
     }
     results = {}
     parts = header.split()
+    if not parts:
+        return results
+    results['scheme'] = parts[0].lower()
     if len(parts) > 1:
         for part in parts[1].split(','):
             key_value = part.split('=')

--- a/src/middlewared/middlewared/plugins/apps_images/utils.py
+++ b/src/middlewared/middlewared/plugins/apps_images/utils.py
@@ -66,7 +66,8 @@ def parse_auth_header(header: str) -> dict[str, str]:
 
     Basic challenges carry no token endpoint or ``scope`` (the parsed ``realm`` is
     unused), so callers must branch on ``scheme`` rather than assuming a
-    token-exchange flow.
+    token-exchange flow. Optional whitespace around the comma-separated parameters
+    is tolerated (RFC 7235).
     """
     adapter = {
         'realm': 'auth_url',
@@ -74,15 +75,15 @@ def parse_auth_header(header: str) -> dict[str, str]:
         'scope': 'scope',
     }
     results = {}
-    parts = header.split()
-    if not parts:
+    scheme, _, params = header.strip().partition(' ')
+    if not scheme:
         return results
-    results['scheme'] = parts[0].lower()
-    if len(parts) > 1:
-        for part in parts[1].split(','):
-            key_value = part.split('=')
-            if len(key_value) == 2 and key_value[0] in adapter:
-                results[adapter[key_value[0]]] = key_value[1].strip('"')
+    results['scheme'] = scheme.lower()
+    for part in params.split(','):
+        # partition on the first '=' so values that themselves contain '=' survive.
+        key, sep, value = part.strip().partition('=')
+        if sep and key in adapter:
+            results[adapter[key]] = value.strip().strip('"')
     return results
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_manifest_auth_flow.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_manifest_auth_flow.py
@@ -1,0 +1,99 @@
+import asyncio
+
+import aiohttp
+import pytest
+
+from middlewared.plugins.apps_images.client import ContainerRegistryClientMixin
+from middlewared.plugins.apps_images.utils import DOCKER_AUTH_HEADER
+from middlewared.service import CallError
+
+
+CREDS = {"login": "user", "password": "pass"}
+BASIC = 'Basic realm="Registry Realm"'
+BEARER = 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:foo/bar:pull"'
+
+
+class _Client(ContainerRegistryClientMixin):
+    """Stubs the network layer so the 401 auth control flow can be asserted.
+
+    The first ``_api_call`` returns a 401 carrying ``challenge`` in its
+    WWW-Authenticate header; any retry returns a valid manifest.
+    """
+
+    def __init__(self, challenge):
+        self._challenge = challenge
+        self.api_call_auth = []  # the `auth` passed to each _api_call
+        self.token_calls = []
+
+    async def _api_call(self, url, options=None, headers=None, mode="get", auth=None):
+        self.api_call_auth.append(auth)
+        if len(self.api_call_auth) == 1:
+            err = aiohttp.ClientResponseError(None, (), status=401, headers={DOCKER_AUTH_HEADER: self._challenge})
+            return {"error": "401 Unauthorized", "response": {}, "response_obj": None, "error_obj": err}
+
+        class _Resp:
+            headers = {}
+
+        return {
+            "error": None,
+            "response": {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {"digest": "sha256:cafe"},
+            },
+            "response_obj": _Resp(),
+        }
+
+    async def _get_token(self, scope, auth_url=None, service=None, auth=None):
+        self.token_calls.append({"scope": scope, "auth": auth})
+        return "FAKE-TOKEN"
+
+
+async def _run(challenge, auth):
+    client = _Client(challenge)
+    err = None
+    try:
+        await client._get_manifest_response(
+            "registry.example.com", "foo/bar", "latest", {"Accept": "x"}, "get", True, auth=auth
+        )
+    except CallError as e:
+        err = e
+    return client, err
+
+
+def test__basic_auth_replays_manifest_with_credentials():
+    # htpasswd/Basic registry with stored creds: no token fetch, retry carries the creds.
+    client, err = asyncio.run(_run(BASIC, CREDS))
+    assert err is None
+    assert client.token_calls == []
+    assert client.api_call_auth == [None, CREDS]
+
+
+def test__basic_auth_without_credentials_does_not_replay():
+    # No creds: replaying would just repeat the same anonymous 401, so it is skipped and
+    # the 401 surfaces as a CallError (point 1 - no wasted round-trip, no crash).
+    client, err = asyncio.run(_run(BASIC, None))
+    assert isinstance(err, CallError)
+    assert client.token_calls == []
+    assert client.api_call_auth == [None]
+
+
+def test__bearer_auth_fetches_scoped_token():
+    client, err = asyncio.run(_run(BEARER, CREDS))
+    assert err is None
+    assert len(client.token_calls) == 1
+    assert client.token_calls[0]["scope"] == "repository:foo/bar:pull"
+
+
+@pytest.mark.parametrize(
+    "challenge",
+    [
+        "",  # present-but-empty WWW-Authenticate
+        'Bearer realm="x",service="y"',  # Bearer challenge missing scope
+    ],
+)
+def test__insufficient_challenge_raises_callerror_not_typeerror(challenge):
+    # An empty/unparseable challenge or a Bearer challenge without `scope` must degrade to
+    # a CallError instead of crashing with TypeError: _get_token() missing 'scope' (point 2).
+    client, err = asyncio.run(_run(challenge, CREDS))
+    assert isinstance(err, CallError)
+    assert client.token_calls == []

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_parse_auth_header.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_parse_auth_header.py
@@ -23,10 +23,25 @@ from middlewared.plugins.apps_images.utils import parse_auth_header
         ('Basic realm="example.com"', {"scheme": "basic", "auth_url": "example.com"}),
         # The auth scheme is case-insensitive per RFC 7235.
         ('BASIC realm="example.com"', {"scheme": "basic", "auth_url": "example.com"}),
+        # Optional whitespace after the parameter commas (RFC 7235) must not drop
+        # service/scope - otherwise a well-formed Bearer challenge would lose its scope
+        # and crash the caller with the same `missing scope` TypeError NAS-141553 targets.
+        (
+            'Bearer realm="https://ghcr.io/token", service="ghcr.io", scope="redis:pull"',
+            {
+                "scheme": "bearer",
+                "auth_url": "https://ghcr.io/token",
+                "service": "ghcr.io",
+                "scope": "redis:pull",
+            },
+        ),
+        # A realm value containing whitespace is preserved intact.
+        ('Basic realm="Registry Realm"', {"scheme": "basic", "auth_url": "Registry Realm"}),
         # A bare scheme with no parameters still reports the scheme.
         ("Basic", {"scheme": "basic"}),
-        # An empty header degrades gracefully.
+        # Empty / whitespace-only headers degrade gracefully.
         ("", {}),
+        ("   ", {}),
     ],
 )
 def test__parse_auth_header(header, expected):

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_parse_auth_header.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps_images/test_parse_auth_header.py
@@ -1,0 +1,33 @@
+import pytest
+
+from middlewared.plugins.apps_images.utils import parse_auth_header
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        # Bearer/token-auth challenge (Docker Hub, ghcr.io, ...) advertises a scope.
+        (
+            'Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="redis:pull"',
+            {
+                "scheme": "bearer",
+                "auth_url": "https://ghcr.io/token",
+                "service": "ghcr.io",
+                "scope": "redis:pull",
+            },
+        ),
+        # HTTP Basic challenge (private registry using htpasswd auth): no token endpoint
+        # and no scope. Regression for NAS-141553 - the scheme must be surfaced so the
+        # caller does not treat this as a Bearer flow (which crashed on the missing
+        # `scope` argument to `_get_token`).
+        ('Basic realm="example.com"', {"scheme": "basic", "auth_url": "example.com"}),
+        # The auth scheme is case-insensitive per RFC 7235.
+        ('BASIC realm="example.com"', {"scheme": "basic", "auth_url": "example.com"}),
+        # A bare scheme with no parameters still reports the scheme.
+        ("Basic", {"scheme": "basic"}),
+        # An empty header degrades gracefully.
+        ("", {}),
+    ],
+)
+def test__parse_auth_header(header, expected):
+    assert parse_auth_header(header) == expected


### PR DESCRIPTION
## Summary

Private Docker registries that authenticate with **htpasswd / HTTP Basic auth** crash the Apps image update checker. The 401 handler in `apps_images/client.py` assumes every `WWW-Authenticate` challenge is a Docker **Bearer/token** flow and unconditionally calls `_get_token(**auth_data)`. A `Basic` challenge carries no `scope` (and no token endpoint), so `parse_auth_header()` returns a dict without `scope` and the call raises `TypeError: ContainerRegistryClientMixin._get_token() missing 1 required positional argument: 'scope'`. Because that `TypeError` is not a `CallError`, it escapes the per-image guard in `check_update()`, aborts the entire image sweep, and recurs as "Task exception was never retrieved" (82 occurrences in the reporter's debug on 25.10.4).

Reported in NAS-141553. Distinct from NAS-141149: that fix threaded stored credentials into the existing Bearer path but did not add Basic-scheme handling, so this crash persists.

## Changes

- `apps_images/utils.py` — `parse_auth_header()` now surfaces the challenge `scheme` (`bearer`/`basic`). The parser was rewritten to tolerate RFC 7235 optional whitespace around the comma-separated parameters (previously a spec-legal `Bearer realm="…", service="…", scope="…"` dropped `scope` and re-triggered the same crash) and to `partition()` on the first `=` so values containing `=` survive.
- `apps_images/client.py` — `_get_manifest_response()` branches on the scheme: a `Basic` challenge replays the manifest request with the stored registry credentials (`_api_call(..., auth=auth)`) instead of attempting a token exchange; the `Bearer` path is unchanged. The no-credential `Basic` replay is skipped (it would only repeat the anonymous request that already 401'd), and an empty/unrecognized challenge — or a `Bearer` challenge missing `scope` — now falls through to the existing `CallError` instead of crashing with a `TypeError`. The `WWW-Authenticate` header is read defensively (`(error.headers or {}).get(...)`).
- `apps_images/update_alerts.py` — `check_update()` gains an `except Exception` arm so one misbehaving image/registry logs and continues instead of aborting the whole sweep and leaking an unretrieved-task exception.
- Added `pytest/unit/plugins/apps_images/test_parse_auth_header.py` (parser: Bearer/Basic, case-insensitivity, OWS, whitespace realm, bare scheme, empty/whitespace headers) and `test_manifest_auth_flow.py` (caller flow: Basic-with-creds replays with credentials, Basic-without-creds skips the replay and surfaces a `CallError`, Bearer fetches a scoped token, and empty / scope-less challenges degrade to `CallError` rather than `TypeError`).

## Testing

- Unit tests pass; control flow and parser additionally validated standalone against real Bearer and htpasswd `WWW-Authenticate` shapes.
- Reproduced and verified on a live TrueNAS 25.10.4 box (the ticket version): the installed code raises the exact `_get_token() missing 'scope'` TypeError on a Basic-auth 401; after applying the fix the Basic path authenticates (or degrades gracefully), the Bearer path is unaffected, and the no-credential / empty / scope-less challenges all resolve to a `CallError` with no crash.
- `ruff format` / `ruff check` clean on all changed files.

## Notes

Not unsupported configuration: signing in to an "Other Registry" with a URI + username/password is a documented Apps feature, and htpasswd is the default auth method of the CNCF reference registry. `master` carries the same defect in a refactored form (`scope=auth_data["scope"]` raises `KeyError`) and needs the equivalent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
