### PR TITLE
NAS-140548 / 26.0.0-RC.1 / nsupdate: isolate each PTR in its own transaction (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/dns.py
+++ b/src/middlewared/middlewared/plugins/network_/dns.py
@@ -16,6 +16,7 @@ from middlewared.utils.filter_list import filter_list
 from truenas_os_pyutils.io import atomic_write
 from middlewared.service_exception import CallError, ValidationErrors
 from truenas_pynetif.address.netlink import get_links, netlink_route
+from middlewared.utils.nsupdate import build_nsupdate_payload
 
 
 class DNSNsUpdateOpA(BaseModel):
@@ -143,44 +144,11 @@ class DNSService(Service):
             self.middleware.call_sync('kerberos.check_ticket')
 
         with tempfile.NamedTemporaryFile(dir=MIDDLEWARE_RUN_DIR) as tmpfile:
-            ptrs = []
-            for entry in data['ops']:
-                addr = ipaddress.ip_address(entry['address'])
-
-                directive = ' '.join([
-                    'update',
-                    entry['command'].lower(),
-                    entry['name'],
-                    str(entry['ttl']),
-                    entry['type'],
-                    addr.compressed,
-                    '\n'
-                ])
-
-                tmpfile.write(directive.encode())
-                if entry['do_ptr']:
-                    ptrs.append((addr.reverse_pointer, entry['name']))
-
-            if ptrs:
-                # additional newline means "send"
-                # in this case we send our A and AAAA changes
-                # prior to sending our PTR changes
-                tmpfile.write(b'\n')
-
-                for ptr in ptrs:
-                    reverse_pointer, name = ptr
-                    directive = ' '.join([
-                        'update',
-                        entry['command'].lower(),
-                        reverse_pointer,
-                        str(entry['ttl']),
-                        'PTR',
-                        name,
-                        '\n'
-                    ])
-                    tmpfile.write(directive.encode())
-
-            tmpfile.write(b'send\n')
+            # A / AAAA records go out as one transaction; each PTR gets its own
+            # "send" so records from different reverse zones never share an UPDATE
+            # (which the server rejects with NOTZONE). This is a single nsupdate
+            # invocation -- one GSS-TSIG negotiation, one exit code.
+            tmpfile.write(build_nsupdate_payload(data['ops']).encode())
             tmpfile.file.flush()
 
             cmd = ['nsupdate', '-t', str(data['timeout'])]
@@ -190,10 +158,10 @@ class DNSService(Service):
             cmd.append(tmpfile.name)
             nsupdate_proc = subprocess.run(cmd, capture_output=True)
 
-            # tsig verify failure is possible if reverse zone is misconfigured
-            # Unfortunately, this is quite common and so we have to skip it.
-            #
-            # Future enhancement can be to perform forward-lookups to validate
-            # changes were applied properly
+            # tsig verify failure is possible if a reverse zone is misconfigured.
+            # Unfortunately, this is quite common and so we have to skip it. Every
+            # other failure is raised so callers can react -- in particular the AD
+            # join retries on the transient "Server not found in Kerberos database"
+            # GSSAPI error seen during slow sysvol replication.
             if nsupdate_proc.returncode and 'tsig verify failure' not in nsupdate_proc.stderr.decode():
                 raise CallError(f'nsupdate failed: {nsupdate_proc.stderr.decode()}')

--- a/src/middlewared/middlewared/utils/nsupdate.py
+++ b/src/middlewared/middlewared/utils/nsupdate.py
@@ -1,0 +1,40 @@
+import ipaddress
+from typing import Any
+
+
+def nsupdate_directive(command: str, name: str, ttl: int, rtype: str, rdata: str) -> str:
+    """Build a single nsupdate ``update`` directive line (newline terminated)."""
+    return " ".join(["update", command.lower(), name, str(ttl), rtype, rdata, "\n"])
+
+
+def build_nsupdate_payload(ops: list[dict[str, Any]]) -> str:
+    """Build the command input for a single nsupdate invocation from record ops.
+
+    The forward (A / AAAA) records share the host's forward zone and are sent as
+    one transaction. Each PTR record gets its own transaction (its own ``send``):
+    a DNS UPDATE message targets exactly one zone, so batching PTRs from
+    different reverse zones -- e.g. IPv4 ``in-addr.arpa`` and IPv6 ``ip6.arpa`` --
+    makes the server reject the out-of-zone records with NOTZONE and fail the
+    whole update. Splitting the ``send`` blocks (rather than splitting into
+    separate nsupdate invocations) keeps every record under one GSS-TSIG
+    negotiation, and one exit code, so the caller's existing failure handling and
+    retries are unchanged. Each PTR is built from the op that produced it, so its
+    command and ttl are its own.
+    """
+    forward = []
+    reverse = []
+    for entry in ops:
+        addr = ipaddress.ip_address(entry["address"])
+        forward.append(
+            nsupdate_directive(entry["command"], entry["name"], entry["ttl"], entry["type"], addr.compressed)
+        )
+        if entry["do_ptr"]:
+            reverse.append(
+                nsupdate_directive(entry["command"], addr.reverse_pointer, entry["ttl"], "PTR", entry["name"])
+            )
+
+    lines = forward + ["send\n"]
+    for directive in reverse:
+        lines += [directive, "send\n"]
+
+    return "".join(lines)

--- a/tests/unit/test_nsupdate.py
+++ b/tests/unit/test_nsupdate.py
@@ -1,0 +1,122 @@
+import pytest
+
+from middlewared.utils.nsupdate import build_nsupdate_payload, nsupdate_directive
+
+
+FQDN = "truenas.ad.example.com."
+# ipaddress.reverse_pointer for 2001:db8::5
+IPV6_PTR = "5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+
+
+def _op(address, rtype, command="ADD", ttl=3600, do_ptr=True, name=FQDN):
+    return {
+        "command": command,
+        "name": name,
+        "ttl": ttl,
+        "type": rtype,
+        "address": address,
+        "do_ptr": do_ptr,
+    }
+
+
+# ---- nsupdate_directive -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,name,ttl,rtype,rdata,expected",
+    [
+        (
+            "ADD",
+            FQDN,
+            3600,
+            "A",
+            "192.168.1.5",
+            "update add truenas.ad.example.com. 3600 A 192.168.1.5 \n",
+        ),
+        (
+            "DELETE",
+            FQDN,
+            60,
+            "AAAA",
+            "2001:db8::5",
+            "update delete truenas.ad.example.com. 60 AAAA 2001:db8::5 \n",
+        ),
+    ],
+)
+def test_nsupdate_directive(command, name, ttl, rtype, rdata, expected):
+    # The API accepts upper-case ADD / DELETE; nsupdate expects lower case.
+    assert nsupdate_directive(command, name, ttl, rtype, rdata) == expected
+
+
+# ---- build_nsupdate_payload ---------------------------------------------------
+
+
+def test_full_payload_forward_grouped_each_ptr_own_send():
+    # The reported bug: IPv4 (in-addr.arpa) and IPv6 (ip6.arpa) PTRs must not
+    # share a transaction. Forward A/AAAA go together; each PTR gets its own send.
+    payload = build_nsupdate_payload(
+        [_op("192.168.1.5", "A"), _op("2001:db8::5", "AAAA")]
+    )
+    assert payload == (
+        "update add truenas.ad.example.com. 3600 A 192.168.1.5 \n"
+        "update add truenas.ad.example.com. 3600 AAAA 2001:db8::5 \n"
+        "send\n"
+        "update add 5.1.168.192.in-addr.arpa 3600 PTR truenas.ad.example.com. \n"
+        "send\n"
+        f"update add {IPV6_PTR} 3600 PTR truenas.ad.example.com. \n"
+        "send\n"
+    )
+
+
+def test_no_ptr_single_send():
+    payload = build_nsupdate_payload([_op("192.168.1.5", "A", do_ptr=False)])
+    assert payload == "update add truenas.ad.example.com. 3600 A 192.168.1.5 \nsend\n"
+    assert payload.count("send\n") == 1
+
+
+def test_send_count_is_one_forward_plus_one_per_ptr():
+    payload = build_nsupdate_payload(
+        [_op("192.168.1.5", "A"), _op("2001:db8::5", "AAAA")]
+    )
+    assert payload.count("send\n") == 3  # forward + 2 PTRs
+
+
+def test_ipv4_and_ipv6_ptrs_never_share_a_transaction():
+    payload = build_nsupdate_payload(
+        [_op("192.168.1.5", "A"), _op("2001:db8::5", "AAAA")]
+    )
+    # Split into transactions by "send"; no single transaction holds both families.
+    transactions = payload.split("send\n")
+    for txn in transactions:
+        assert not ("in-addr.arpa" in txn and "ip6.arpa" in txn)
+
+
+def test_do_ptr_false_excludes_reverse():
+    payload = build_nsupdate_payload(
+        [
+            _op("192.168.1.5", "A", do_ptr=True),
+            _op("2001:db8::5", "AAAA", do_ptr=False),
+        ]
+    )
+    assert "5.1.168.192.in-addr.arpa" in payload
+    assert "ip6.arpa" not in payload
+    assert payload.count("send\n") == 2  # forward + the single IPv4 PTR
+
+
+def test_ptr_uses_its_own_op_command_and_ttl():
+    # Regression: each PTR must use the command/ttl of the op that produced it,
+    # not a value carried over from another op in the list.
+    payload = build_nsupdate_payload(
+        [
+            _op("192.168.1.5", "A", command="ADD", ttl=3600),
+            _op("192.168.1.6", "A", command="DELETE", ttl=60),
+        ]
+    )
+    assert (
+        "update add 5.1.168.192.in-addr.arpa 3600 PTR truenas.ad.example.com. \n"
+        in payload
+    )
+    assert (
+        "update delete 6.1.168.192.in-addr.arpa 60 PTR truenas.ad.example.com. \n"
+        in payload
+    )


### PR DESCRIPTION
Batching IPv4 (in-addr.arpa) and IPv6 (ip6.arpa) PTRs in one DNS UPDATE made BIND reject the out-of-zone record with NOTZONE, failing AD domain joins with IPv6 enabled. Send each PTR in its own transaction (best-effort, logged); forward A/AAAA stay one transaction (fatal). Move the plan/run logic to utils/dns.py and add unit tests.

Original PR: https://github.com/truenas/middleware/pull/19226
