### PR TITLE
NAS-141612 / 26.0.0-RC.1 / pam_keyring: resolve UI cert via certificate.query on stable/26

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam_keyring.py
+++ b/src/middlewared/middlewared/etc_files/pam_keyring.py
@@ -49,13 +49,13 @@ def _resolve_ui_cert_pem(middleware) -> str | None:
 
     # Use query instead of get_instance so a missing/odd cert can't raise and break
     # pam rendering (mirrors the nginx template).
-    cert_list = middleware.call_sync2(
-        middleware.services.certificate.query, [['id', '=', general['ui_certificate']]]
+    cert_list = middleware.call_sync(
+        'certificate.query', [['id', '=', general['ui_certificate']]]
     )
     if not cert_list:
         return None
 
-    return cert_list[0].model_dump(context={'expose_secrets': True})['certificate']
+    return cert_list[0]['certificate']
 
 
 def _compute_server_binding(pem: str) -> bytes:


### PR DESCRIPTION
services.certificate exists only on master's typed ServiceContainer, so _resolve_ui_cert_pem raised AttributeError (swallowed by the best-effort except) and the SCRAM-PLUS server binding was never published to the keyring. Switch to call_sync('certificate.query') with dict access, mirroring nginx.conf.mako.

Fixes test__scram_plus_server_binding_published and test__login_with_api_key_over_tls_channel_binding.