### PR TITLE
NAS-141615 / 27.0.0-BETA.1 / Convert sysctl plugin to typesafe port pattern

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -53,6 +53,7 @@ jobs:
             middlewared/plugins/snmp/ \
             middlewared/plugins/ssh/ \
             middlewared/plugins/support/ \
+            middlewared/plugins/sysctl/ \
             middlewared/plugins/system_vendor/ \
             middlewared/plugins/truecommand/ \
             middlewared/plugins/truenas/ \

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -136,6 +136,7 @@ from middlewared.plugins.snapshot import PeriodicSnapshotTaskService
 from middlewared.plugins.snmp import SNMPService
 from middlewared.plugins.ssh import SSHService
 from middlewared.plugins.support import SupportService
+from middlewared.plugins.sysctl import SysctlService
 from middlewared.plugins.system_vendor import VendorService
 from middlewared.plugins.system_vendor.vendor import is_vendored
 from middlewared.plugins.truecommand import TruecommandService
@@ -288,6 +289,7 @@ class ServiceContainer(BaseServiceContainer):
         self.ssh = SSHService(middleware)
         self.staticroute = StaticRouteService(middleware)
         self.support = SupportService(middleware)
+        self.sysctl = SysctlService(middleware)
         self.system = SystemServicesContainer(middleware)
         self.tn_connect = TrueNASConnectService(middleware)
         self.truecommand = TruecommandService(middleware)

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -22,7 +22,7 @@ class DockerService(SimpleService):
             ('vm.panic_on_oom', 0),
             ('vm.overcommit_memory', 1),
         ):
-            await self.middleware.call('sysctl.set_value', key, value)
+            await self.middleware.call2(self.s.sysctl.set_value, key, value)
 
     async def start(self) -> None:
         try:

--- a/src/middlewared/middlewared/plugins/sysctl/__init__.py
+++ b/src/middlewared/middlewared/plugins/sysctl/__init__.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+from middlewared.service import Service
+
+from . import sysctl_info as _sysctl
+
+__all__ = ('SysctlService',)
+
+
+class SysctlService(Service):
+
+    class Config:
+        private = True
+
+    async def get_value(self, sysctl_name: str) -> str:
+        return await _sysctl.get_value(sysctl_name)
+
+    def store_default_arc_max(self) -> int:
+        return _sysctl.store_default_arc_max()
+
+    def get_default_arc_max(self) -> int:
+        return _sysctl.get_default_arc_max()
+
+    def get_arc_max(self) -> int:
+        return _sysctl.get_arc_max()
+
+    def get_arc_min(self) -> int:
+        return _sysctl.get_arc_min()
+
+    async def get_pagesize(self) -> int:
+        return await _sysctl.get_pagesize()
+
+    def get_arcstats(self) -> dict[str, Any]:
+        return _sysctl.get_arcstats()
+
+    def get_arcstats_size(self) -> int:
+        return _sysctl.get_arcstats_size()
+
+    async def set_value(self, key: str, value: str | int) -> None:
+        await _sysctl.set_value(key, value)
+
+    def write_to_file(self, path: str, value: int) -> None:
+        _sysctl.write_to_file(path, value)
+
+    def set_arc_max(self, value: int) -> None:
+        _sysctl.set_arc_max(value)
+
+    def set_zvol_volmode(self, value: int) -> None:
+        _sysctl.set_zvol_volmode(value)

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -1,74 +1,81 @@
 import os
+from typing import Any
 
 from truenas_pylibzfs import kstat
 
-from middlewared.service import CallError, Service
+from middlewared.service import CallError
 from middlewared.utils import MIDDLEWARE_RUN_DIR, run
 
 ZFS_MODULE_PARAMS_PATH = '/sys/module/zfs/parameters'
 DEFAULT_ARC_MAX_FILE = f'{MIDDLEWARE_RUN_DIR}/default_arc_max'
 
 
-class SysctlService(Service):
+async def get_value(sysctl_name: str) -> str:
+    cp = await run(['sysctl', sysctl_name], check=False)
+    if cp.returncode:
+        raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
+    return cp.stdout.decode().split('=')[-1].strip()
 
-    class Config:
-        private = True
 
-    async def get_value(self, sysctl_name):
-        cp = await run(['sysctl', sysctl_name], check=False)
-        if cp.returncode:
-            raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
-        return cp.stdout.decode().split('=')[-1].strip()
+def store_default_arc_max() -> int:
+    """This should be called _BEFORE_ we initialize any VMs so that we can capture what the
+    ARC max value was before we start changing the various ARC sysctls based on VM memory
+    configurations."""
+    val = kstat.get_arcstats().c_max
+    try:
+        with open(DEFAULT_ARC_MAX_FILE, 'x') as f:
+            f.write(str(val))
+            f.flush()
+    except FileExistsError:
+        return get_default_arc_max()
+    else:
+        return val
 
-    def store_default_arc_max(self):
-        """This method should be called _BEFORE_ we initialize any VMs
-        so that we can capture what the ARC max value was before we start
-        changing the various ARC sysctls based on VM memory configurations"""
-        val = kstat.get_arcstats().c_max
-        try:
-            with open(DEFAULT_ARC_MAX_FILE, 'x') as f:
-                f.write(str(val))
-                f.flush()
-        except FileExistsError:
-            return self.get_default_arc_max()
-        else:
-            return val
 
-    def get_default_arc_max(self):
-        try:
-            with open(DEFAULT_ARC_MAX_FILE) as f:
-                return int(f.read())
-        except FileNotFoundError:
-            return self.store_default_arc_max()
+def get_default_arc_max() -> int:
+    try:
+        with open(DEFAULT_ARC_MAX_FILE) as f:
+            return int(f.read())
+    except FileNotFoundError:
+        return store_default_arc_max()
 
-    def get_arc_max(self):
-        return kstat.get_arcstats().c_max
 
-    def get_arc_min(self):
-        return kstat.get_arcstats().c_min
+def get_arc_max() -> int:
+    return kstat.get_arcstats().c_max
 
-    async def get_pagesize(self):
-        cp = await run(['getconf', 'PAGESIZE'], check=False)
-        if cp.returncode:
-            raise CallError(f'Unable to retrieve pagesize value: {cp.stderr.decode()}')
-        return int(cp.stdout.decode().strip())
 
-    def get_arcstats(self):
-        arcstats = kstat.get_arcstats()
-        return {name: getattr(arcstats, name) for name in kstat.ArcStats.__match_args__}
+def get_arc_min() -> int:
+    return kstat.get_arcstats().c_min
 
-    def get_arcstats_size(self):
-        return kstat.get_arcstats().size
 
-    async def set_value(self, key, value):
-        await run(['sysctl', f'{key}={value}'])
+async def get_pagesize() -> int:
+    cp = await run(['getconf', 'PAGESIZE'], check=False)
+    if cp.returncode:
+        raise CallError(f'Unable to retrieve pagesize value: {cp.stderr.decode()}')
+    return int(cp.stdout.decode().strip())
 
-    def write_to_file(self, path, value):
-        with open(path, 'w') as f:
-            f.write(str(value))
 
-    def set_arc_max(self, value):
-        return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zfs_arc_max'), value)
+def get_arcstats() -> dict[str, Any]:
+    arcstats = kstat.get_arcstats()
+    return {name: getattr(arcstats, name) for name in kstat.ArcStats.__match_args__}
 
-    def set_zvol_volmode(self, value):
-        return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zvol_volmode'), value)
+
+def get_arcstats_size() -> int:
+    return kstat.get_arcstats().size
+
+
+async def set_value(key: str, value: str | int) -> None:
+    await run(['sysctl', f'{key}={value}'])
+
+
+def write_to_file(path: str, value: int) -> None:
+    with open(path, 'w') as f:
+        f.write(str(value))
+
+
+def set_arc_max(value: int) -> None:
+    write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zfs_arc_max'), value)
+
+
+def set_zvol_volmode(value: int) -> None:
+    write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zvol_volmode'), value)

--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -49,4 +49,4 @@ async def setup(middleware):
     tz = effective_timezone(settings['timezone'])
     middleware.logger.debug('Setting timezone to %r', tz)
     await middleware.call('core.environ_update', {'TZ': tz})
-    await middleware.call('sysctl.set_zvol_volmode', 2)
+    await middleware.call2(middleware.services.sysctl.set_zvol_volmode, 2)

--- a/src/middlewared/middlewared/plugins/vm/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/__init__.py
@@ -575,7 +575,7 @@ async def setup(middleware: Middleware) -> None:
     # any type of VM initialization. We have to capture the
     # zfs c_max value before we start manipulating these
     # sysctls during vm start/stop
-    await middleware.call('sysctl.store_default_arc_max')
+    await middleware.call2(middleware.services.sysctl.store_default_arc_max)
 
     middleware.event_subscribe('system.ready', __event_system_ready)
     middleware.event_subscribe('system.shutdown', __event_system_shutdown)

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -39,8 +39,8 @@ async def get_available_memory(context: ServiceContext, overcommit: bool) -> int
     free = int((await context.to_thread(get_memory_info))['available'] * 0.9)
 
     # Difference between current ARC total size and the minimum allowed
-    arc_total = await context.middleware.call('sysctl.get_arcstats_size')
-    arc_min = await context.middleware.call('sysctl.get_arc_min')
+    arc_total = await context.call2(context.s.sysctl.get_arcstats_size)
+    arc_min = await context.call2(context.s.sysctl.get_arc_min)
     arc_shrink = max(0, arc_total - arc_min)
     total_free = free + arc_shrink
 
@@ -76,8 +76,8 @@ async def get_vm_memory_info(context: ServiceContext, vm_id: int) -> VMGetVmMemo
         #  show separate info of each VM in the UI moving on
         raise CallError(f'Unable to retrieve {vm.name!r} VM information as it is already running.')
 
-    arc_max = await context.middleware.call('sysctl.get_arc_max')
-    arc_min = await context.middleware.call('sysctl.get_arc_min')
+    arc_max = await context.call2(context.s.sysctl.get_arc_max)
+    arc_min = await context.call2(context.s.sysctl.get_arc_min)
     shrinkable_arc_max = max(0, arc_max - arc_min)
 
     available_memory = await get_available_memory(context, False)
@@ -118,7 +118,7 @@ async def _set_guest_vmemory(context: ServiceContext, vm_id: int, overcommit: bo
         context.logger.debug(
             'Setting ARC from %s to %s', memory_details.current_arc_max, memory_details.arc_max_after_shrink
         )
-        await context.middleware.call('sysctl.set_arc_max', memory_details.arc_max_after_shrink)
+        await context.call2(context.s.sysctl.set_arc_max, memory_details.arc_max_after_shrink)
 
 
 async def init_guest_vmemory(context: ServiceContext, vm_id: int, overcommit: bool) -> None:
@@ -135,16 +135,16 @@ async def teardown_guest_vmemory(context: ServiceContext, vm_id: int) -> None:
         return
 
     guest_memory = vm.memory * 1024 * 1024
-    arc_max = await context.middleware.call('sysctl.get_arc_max')
-    arc_min = await context.middleware.call('sysctl.get_arc_min')
+    arc_max = await context.call2(context.s.sysctl.get_arc_max)
+    arc_min = await context.call2(context.s.sysctl.get_arc_min)
     new_arc_max = min(
-        await context.middleware.call('sysctl.get_default_arc_max'),
+        await context.call2(context.s.sysctl.get_default_arc_max),
         arc_max + guest_memory
     )
     if arc_max != new_arc_max:
         if new_arc_max > arc_min:
             context.logger.debug(f'Giving back guest memory to ARC: {new_arc_max}')
-            await context.middleware.call('sysctl.set_arc_max', new_arc_max)
+            await context.call2(context.s.sysctl.set_arc_max, new_arc_max)
         else:
             context.logger.warn(
                 f'Not giving back memory to ARC because new arc_max ({new_arc_max}) <= arc_min ({arc_min})'


### PR DESCRIPTION
## Context
`SysctlService` was a `private = True` dict-based service with no over-the-wire surface, only consumed by other plugins. The typesafe convention for fully-private services is the port pattern: a lean `Service` shim delegating to plain, fully type-annotated module functions, keeping the existing return shapes (no Pydantic models).

## Solution
- Split the plugin into a lean `sysctl/__init__.py` shim (`SysctlService`, every method typed) delegating to plain functions moved into `sysctl/sysctl_info.py`.
- Registered the service in `main.py`'s `ServiceContainer` so `self.s.sysctl` is typed for consumers.
- Converted every same-process string `call('sysctl.…')` in `vm`, `system`, and the docker `SimpleService` to typed `call2`/`call2(services.…)`. Return shapes are unchanged, so there are no dict-vs-model breaks.
- Added the plugin path to `mypy.yml`.

Custom build: http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/351/ (environmental failures)