### PR TITLE
NAS-141620 / 27.0.0-BETA.1 / Fix dataset alert quota

### DIFF
--- a/src/middlewared/middlewared/alert/source/quota.py
+++ b/src/middlewared/middlewared/alert/source/quota.py
@@ -23,7 +23,6 @@ class QuotaWarningAlert(AlertClass):
         title="Quota Exceeded on Dataset",
         text="%(name)s exceeded on dataset %(dataset)s. Used %(used_fraction).2f%% (%(used)s of %(quota_value)s).",
     )
-
     name: str
     dataset: str
     used_fraction: float
@@ -44,7 +43,6 @@ class QuotaCriticalAlert(AlertClass):
         title="Critical Quota Exceeded on Dataset",
         text="%(name)s exceeded on dataset %(dataset)s. Used %(used_fraction).2f%% (%(used)s of %(quota_value)s).",
     )
-
     name: str
     dataset: str
     used_fraction: float

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -100,7 +100,7 @@ class AuditService(ConfigService):
             )
         )[0]
 
-        for k, default in TNUserProp.quotas():
+        for k, default in TNUserProp.audit_quotas():
             no_prefix = k.removeprefix(f'{LEGACY_USERPROP_PREFIX}:')
             try:
                 ds[k] = int(ds['user_properties'][no_prefix])

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -3,7 +3,6 @@ import os
 
 from truenas_os_pyutils.mount import statmount
 
-from middlewared.plugins.audit.utils import AUDIT_DEFAULT_FILL_CRITICAL, AUDIT_DEFAULT_FILL_WARNING
 from middlewared.service_exception import CallError
 from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.path import is_child
@@ -28,15 +27,19 @@ class TNUserProp(enum.Enum):
     MANAGED_BY = f'{USERPROP_PREFIX}:managedby'
 
     def default(self):
+        # NOTE: DONT CHANGE THESE VALUES WITHOUT CHANGING
+        # THE UX! The UX has hard-coded these values on
+        # a form and so changing them here will cause
+        # confusion for end-user.
         match self:
             case TNUserProp.QUOTA_WARN:
-                return AUDIT_DEFAULT_FILL_WARNING
+                return 80
             case TNUserProp.QUOTA_CRIT:
-                return AUDIT_DEFAULT_FILL_CRITICAL
+                return 95
             case TNUserProp.REFQUOTA_WARN:
-                return AUDIT_DEFAULT_FILL_WARNING
+                return 80
             case TNUserProp.REFQUOTA_CRIT:
-                return AUDIT_DEFAULT_FILL_CRITICAL
+                return 95
             case _:
                 raise ValueError(f'{self.value}: no default value is set')
 

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -3,6 +3,7 @@ import os
 
 from truenas_os_pyutils.mount import statmount
 
+from middlewared.plugins.audit.utils import AUDIT_DEFAULT_FILL_CRITICAL, AUDIT_DEFAULT_FILL_WARNING
 from middlewared.service_exception import CallError
 from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.path import is_child
@@ -50,6 +51,18 @@ class TNUserProp(enum.Enum):
             TNUserProp.REFQUOTA_WARN,
             TNUserProp.REFQUOTA_CRIT
         ]]
+
+    def audit_quotas():
+        # Same shape as quotas(), but the audit dataset defaults to its own
+        # warning/critical thresholds rather than the general-purpose values
+        # from default(). Only a default: the on-disk user properties (which
+        # can be changed by the user) take precedence when present.
+        return [
+            (TNUserProp.QUOTA_WARN.value, AUDIT_DEFAULT_FILL_WARNING),
+            (TNUserProp.QUOTA_CRIT.value, AUDIT_DEFAULT_FILL_CRITICAL),
+            (TNUserProp.REFQUOTA_WARN.value, AUDIT_DEFAULT_FILL_WARNING),
+            (TNUserProp.REFQUOTA_CRIT.value, AUDIT_DEFAULT_FILL_CRITICAL),
+        ]
 
     def values():
         return [a.value for a in TNUserProp]


### PR DESCRIPTION
The UX hard-codes the default thresholds for dataset alerts to 80 and 95 and this matched what we did in our quota alert. However, this regressed in 7f2a017cc59709defd05501740d8dd4525aac839 which coupled the quota alert with our audit dataset. This reverts those changes and decouples them so they're handled correctly. Essentially the default values for the audit dataset do not match any non-audit dataset default values. The audit alert tests come back clean.