### PR TITLE
NAS-141620 / 26.0.0-RC.1 / Fix dataset alert quota (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -91,7 +91,7 @@ class AuditService(ConfigService):
             )
         )[0]
 
-        for k, default in TNUserProp.quotas():
+        for k, default in TNUserProp.audit_quotas():
             no_prefix = k.removeprefix(f'{LEGACY_USERPROP_PREFIX}:')
             try:
                 ds[k] = int(ds['user_properties'][no_prefix])

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -27,15 +27,19 @@ class TNUserProp(enum.Enum):
     MANAGED_BY = f'{USERPROP_PREFIX}:managedby'
 
     def default(self):
+        # NOTE: DONT CHANGE THESE VALUES WITHOUT CHANGING
+        # THE UX! The UX has hard-coded these values on
+        # a form and so changing them here will cause
+        # confusion for end-user.
         match self:
             case TNUserProp.QUOTA_WARN:
-                return AUDIT_DEFAULT_FILL_WARNING
+                return 80
             case TNUserProp.QUOTA_CRIT:
-                return AUDIT_DEFAULT_FILL_CRITICAL
+                return 95
             case TNUserProp.REFQUOTA_WARN:
-                return AUDIT_DEFAULT_FILL_WARNING
+                return 80
             case TNUserProp.REFQUOTA_CRIT:
-                return AUDIT_DEFAULT_FILL_CRITICAL
+                return 95
             case _:
                 raise ValueError(f'{self.value}: no default value is set')
 
@@ -46,6 +50,18 @@ class TNUserProp(enum.Enum):
             TNUserProp.REFQUOTA_WARN,
             TNUserProp.REFQUOTA_CRIT
         ]]
+
+    def audit_quotas():
+        # Same shape as quotas(), but the audit dataset defaults to its own
+        # warning/critical thresholds rather than the general-purpose values
+        # from default(). Only a default: the on-disk user properties (which
+        # can be changed by the user) take precedence when present.
+        return [
+            (TNUserProp.QUOTA_WARN.value, AUDIT_DEFAULT_FILL_WARNING),
+            (TNUserProp.QUOTA_CRIT.value, AUDIT_DEFAULT_FILL_CRITICAL),
+            (TNUserProp.REFQUOTA_WARN.value, AUDIT_DEFAULT_FILL_WARNING),
+            (TNUserProp.REFQUOTA_CRIT.value, AUDIT_DEFAULT_FILL_CRITICAL),
+        ]
 
     def values():
         return [a.value for a in TNUserProp]


### PR DESCRIPTION
The UX hard-codes the default thresholds for dataset alerts to 80 and 95 and this matched what we did in our quota alert. However, this regressed in 7f2a017cc59709defd05501740d8dd4525aac839 which coupled the quota alert with our audit dataset. This reverts those changes and decouples them so they're handled correctly. Essentially the default values for the audit dataset do not match any non-audit dataset default values. The audit alert tests come back clean.

Original PR: https://github.com/truenas/middleware/pull/19238
