### PR TITLE
NAS-141568 / 27.0.0-BETA.1 / Normalize Docker address pool base to its canonical network

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-07-01_12-00_docker_address_pool_canonical.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-07-01_12-00_docker_address_pool_canonical.py
@@ -1,0 +1,64 @@
+"""Normalize Docker address pool base networks to their canonical form
+
+Revision ID: 28e5285cfb2d
+Revises: c1d2e3f4a5b6
+Create Date: 2026-07-01 12:00:00.000000+00:00
+
+"""
+
+import ipaddress
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "28e5285cfb2d"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    row = conn.execute(text("SELECT id, address_pools FROM services_docker")).fetchone()
+    if not row:
+        return
+
+    try:
+        address_pools = json.loads(row[1])
+    except (TypeError, ValueError):
+        return
+
+    # Docker ignores host bits in an address pool base, e.g. a base of 172.17.0.0/12 is treated as
+    # 172.16.0.0/12 and networks are allocated from 172.16.0.0 upwards. Historically the default and
+    # user input were stored verbatim, so the value shown in the UI / written to daemon.json did not
+    # match the network Docker actually used. Normalize any stored base to its canonical network
+    # address so the configured pool matches the effective pool. This is a no-op for Docker.
+    changed = False
+    for pool in address_pools:
+        base = pool.get("base")
+        if not isinstance(base, str):
+            continue
+        try:
+            canonical = str(ipaddress.ip_network(base, strict=False))
+        except ValueError:
+            continue
+        if canonical != base:
+            logger.info("Normalizing Docker address pool base %r to %r", base, canonical)
+            pool["base"] = canonical
+            changed = True
+
+    if changed:
+        conn.execute(
+            text("UPDATE services_docker SET address_pools = :address_pools WHERE id = :id"),
+            {"address_pools": json.dumps(address_pools), "id": row[0]},
+        )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v27_0_0/docker.py
+++ b/src/middlewared/middlewared/api/v27_0_0/docker.py
@@ -26,7 +26,11 @@ __all__ = [
 
 
 class DockerAddressPool(BaseModel):
-    base: IPvAnyInterface = Field(description="Base network address with prefix for the pool.")
+    base: IPvAnyInterface = Field(
+        description="Base network for the pool. Host bits are ignored, and the value is stored as its "
+        "canonical network address (e.g. `172.17.0.0/12` is stored as `172.16.0.0/12`) which is the "
+        "range subnets are actually allocated from."
+    )
     size: Annotated[int, Field(ge=1)] = Field(description="Subnet size for networks allocated from this pool.")
 
     @field_serializer('base')

--- a/src/middlewared/middlewared/api/v27_0_0/docker.py
+++ b/src/middlewared/middlewared/api/v27_0_0/docker.py
@@ -1,3 +1,4 @@
+import ipaddress
 from typing import Annotated, Literal
 from urllib.parse import urlparse
 
@@ -34,10 +35,15 @@ class DockerAddressPool(BaseModel):
 
     @field_validator('base')
     @classmethod
-    def check_prefixlen(cls, v):
+    def normalize_base(cls, v):
         if v.network.prefixlen in (32, 128):
             raise ValueError('Prefix length of base network cannot be 32 or 128.')
-        return v
+        # Normalize to the canonical network address (host bits masked off) so the value we store,
+        # display and hand to Docker matches the network Docker actually allocates from. Docker ignores
+        # host bits in a pool base, e.g. 172.17.0.0/12 is treated as 172.16.0.0/12. Normalizing at the
+        # model boundary (before docker.update validation and change detection) also prevents a spurious
+        # address_pools change when the same pool is re-submitted in a non-canonical form.
+        return ipaddress.ip_interface(v.network)
 
     @model_validator(mode='after')
     def validate_attrs(self):

--- a/src/middlewared/middlewared/plugins/container/lxc_config.py
+++ b/src/middlewared/middlewared/plugins/container/lxc_config.py
@@ -12,7 +12,7 @@ from .info import pool_choices
 
 # Network defaults for the auto-managed container bridge (truenasbr0).
 # Chosen to avoid overlap with:
-#   - Docker address pools: 172.17.0.0/12 (v4), fdd0::/48 (v6)
+#   - Docker address pools: 172.16.0.0/12 (v4), fdd0::/48 (v6)
 #   - Incus auto-generated ranges: 10.x.x.0/24 (v4), fd42:random::/64 (v6)
 DEFAULT_V4_NETWORK = '172.200.0.0/24'
 DEFAULT_V6_NETWORK = 'fd42:4c58:43ae::/64'

--- a/src/middlewared/middlewared/plugins/docker/config.py
+++ b/src/middlewared/middlewared/plugins/docker/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import typing
 from typing import Any
 
@@ -36,7 +37,7 @@ class DockerModel(sa.Model):
     enable_image_updates = sa.Column(sa.Boolean(), default=True)
     cidr_v6 = sa.Column(sa.String(), default='fdd0::/64', nullable=False)
     address_pools = sa.Column(sa.JSON(list), default=[
-        {'base': '172.17.0.0/12', 'size': 24},
+        {'base': '172.16.0.0/12', 'size': 24},
         {'base': 'fdd0::/48', 'size': 64},
     ])
     registry_mirrors = sa.Column(sa.JSON(list), default=[])
@@ -123,7 +124,11 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
             # are not directly storable in SQLite. Convert them to plain strings for DB storage.
             if 'address_pools' in db_update:
                 for pool in db_update['address_pools']:
-                    pool['base'] = str(pool['base'])
+                    # Store the canonical network address (host bits masked off) so the stored/displayed
+                    # value matches the network Docker actually allocates from. Docker ignores host bits
+                    # in a pool base, e.g. 172.17.0.0/12 is treated as 172.16.0.0/12 and networks are
+                    # handed out from 172.16.0.0 upwards.
+                    pool['base'] = str(ipaddress.ip_network(str(pool['base']), strict=False))
             if 'cidr_v6' in db_update:
                 db_update['cidr_v6'] = str(db_update['cidr_v6'])
             if 'registry_mirrors' in db_update:

--- a/src/middlewared/middlewared/plugins/docker/config.py
+++ b/src/middlewared/middlewared/plugins/docker/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ipaddress
 import typing
 from typing import Any
 
@@ -124,11 +123,7 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
             # are not directly storable in SQLite. Convert them to plain strings for DB storage.
             if 'address_pools' in db_update:
                 for pool in db_update['address_pools']:
-                    # Store the canonical network address (host bits masked off) so the stored/displayed
-                    # value matches the network Docker actually allocates from. Docker ignores host bits
-                    # in a pool base, e.g. 172.17.0.0/12 is treated as 172.16.0.0/12 and networks are
-                    # handed out from 172.16.0.0 upwards.
-                    pool['base'] = str(ipaddress.ip_network(str(pool['base']), strict=False))
+                    pool['base'] = str(pool['base'])
             if 'cidr_v6' in db_update:
                 db_update['cidr_v6'] = str(db_update['cidr_v6'])
             if 'registry_mirrors' in db_update:

--- a/src/middlewared/middlewared/pytest/unit/plugins/docker/test_docker_config_change_detection.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/docker/test_docker_config_change_detection.py
@@ -85,6 +85,47 @@ async def test_address_pools_not_equal_after_updated_with_different_values():
 
 
 @pytest.mark.asyncio
+async def test_address_pool_base_normalized_to_canonical():
+    """A base with host bits set is stored/returned in canonical network form (172.17.0.0/12 -> 172.16.0.0/12)."""
+    m = Middleware()
+    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    svc = make_svc_part(m)
+
+    # read path (extend / model_validate of stored value)
+    extended = await svc.extend(dict(DB_DEFAULTS))
+    assert [str(p.base) for p in extended['address_pools']] == ['172.16.0.0/12', 'fdd0::/48']
+
+    # input path (DockerUpdate)
+    update = DockerUpdate(address_pools=[{'base': '172.17.0.0/12', 'size': 24}])
+    assert str(update.address_pools[0].base) == '172.16.0.0/12'
+
+
+@pytest.mark.asyncio
+async def test_no_spurious_address_pools_change_on_noncanonical_resubmit():
+    """Re-submitting the configured pool in non-canonical form must not be seen as a change.
+
+    Regression for the unnecessary docker restart: a stored canonical 172.16.0.0/12 pool
+    re-submitted as its non-canonical equivalent 172.17.0.0/12 must compare equal.
+    """
+    m = Middleware()
+    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    svc = make_svc_part(m)
+
+    stored = dict(DB_DEFAULTS, address_pools=[
+        {'base': '172.16.0.0/12', 'size': 24},
+        {'base': 'fdd0::/48', 'size': 64},
+    ])
+    old_config = DockerEntry.model_construct(**await svc.extend(stored))
+
+    update = DockerUpdate(address_pools=[
+        {'base': '172.17.0.0/12', 'size': 24},
+        {'base': 'fdd0::/48', 'size': 64},
+    ])
+    new_config = old_config.updated(update)
+    assert new_config.address_pools == old_config.address_pools
+
+
+@pytest.mark.asyncio
 async def test_registry_mirrors_equal_after_updated_with_same_values():
     m = Middleware()
     m['system.advanced.config'] = lambda *a: {'nvidia': False}

--- a/src/middlewared/middlewared/test/integration/assets/docker.py
+++ b/src/middlewared/middlewared/test/integration/assets/docker.py
@@ -13,7 +13,7 @@ def docker(pool: dict):
         docker_config = call(
             'docker.update', {
                 'pool': None, 'address_pools': [
-                    {'base': '172.17.0.0/12', 'size': 24}, {'base': 'fdd0::/48', 'size': 64}
+                    {'base': '172.16.0.0/12', 'size': 24}, {'base': 'fdd0::/48', 'size': 64}
                 ]
             }, job=True
         )

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -101,8 +101,10 @@ def test_apps_dataset_after_address_pool_update(docker_pool):
     docker_config = call('docker.update', {'address_pools': [
         {'base': '172.17.0.0/12', 'size': 27}, {"base": '2024:db8::/48', 'size': 64}]
     }, job=True)
+    # The base is normalized to its canonical network address (172.17.0.0/12 -> 172.16.0.0/12),
+    # which is the range Docker actually allocates from.
     assert docker_config['address_pools'] == [
-        {'base': '172.17.0.0/12', 'size': 27}, {"base": '2024:db8::/48', 'size': 64}
+        {'base': '172.16.0.0/12', 'size': 27}, {"base": '2024:db8::/48', 'size': 64}
     ]
     assert call('filesystem.statfs', IX_APPS_MOUNT_PATH)['source'] == docker_config['dataset']
     assert call('docker.status')['status'] == 'RUNNING'


### PR DESCRIPTION
## Summary

The Docker address pool base was stored and written to `/etc/docker/daemon.json` verbatim, including host bits. Docker ignores host bits in a pool base, so the shipped default `172.17.0.0/12` is treated as `172.16.0.0/12` and networks are allocated from `172.16.0.0` upward. The result: the UI and `daemon.json` showed `172.17.0.0/12` while Docker actually used `172.16.0.0/12`, which the reporter read as "Docker ignores the configured address pool" (NAS-141568).

## Changes

- Normalize the address pool base to its canonical network address when it is saved in `docker.update`, so the stored/displayed value matches the network Docker allocates from.
- Correct the shipped default to `172.16.0.0/12` (behaviourally identical to `172.17.0.0/12`, just canonical).
- Update the `docker.update` integration test to assert the normalized value.

## Notes

- No functional change to container networking: Docker allocated from `172.16.x` both before and after. This only makes the configured pool match the effective one, resolving the reported mismatch.
- Verified on a `MASTER/INCREMENTAL` VM — before: `daemon.json` showed `172.17.0.0/12` while `docker0` and new networks were in `172.16.x`; after: both are `172.16.0.0/12`.

## Prior report

- NAS-140924 raised the same `172.17.0.0/12`-vs-`172.16.x` mismatch in May 2026 and was closed without changes; the suggestion there was to "align the displayed config with the actual routing", which is what this PR does. NAS-141568 is effectively a re-report of that issue.
- Related: NAS-139547 (#18335) added the `validate_network_overlaps`/`system_ips_to_cidrs` helpers and the `lxc_config.py` default/comment this change touches.