### PR TITLE
NAS-141629 / 27.0.0-BETA.1 / Fix SMB protocol test regressions

### DIFF
--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -176,9 +176,10 @@ def test_004_test_flags(request):
 def test_005_test_map_modify(request):
     """
     This test validates that we are generating an appropriate SD when user has
-    'stripped' an ACL from an SMB share. Appropriate in this case means one that
-    grants an access mask equaivalent to MODIFY or FULL depending on whether it's
-    the file owner or group / other.
+    'stripped' an ACL from an SMB share. The special identities (owner@ / group@
+    / everyone@) are presented with an access mask equivalent to MODIFY: ixnas
+    does not advertise WRITE_ACL / WRITE_OWNER on them because ZFS will not honor
+    those bits for the special identities.
     """
     depends(request, ["SMB_SERVICE_STARTED"], scope="session")
 
@@ -189,7 +190,7 @@ def test_005_test_map_modify(request):
             sleep(5)
             sd = get_windows_sd("MAP_MODIFY", "SMB")
             dacl = sd['dacl']
-            assert dacl[0]['access_mask']['standard'] == 'FULL', str(dacl[0])
+            assert dacl[0]['access_mask']['standard'] == 'CHANGE', str(dacl[0])
             assert dacl[1]['access_mask']['special']['WRITE_ATTRIBUTES'], str(dacl[1])
             assert dacl[1]['access_mask']['special']['WRITE_EA'], str(dacl[1])
             assert dacl[2]['access_mask']['special']['WRITE_ATTRIBUTES'], str(dacl[2])

--- a/tests/protocols/smb_proto.py
+++ b/tests/protocols/smb_proto.py
@@ -197,10 +197,15 @@ class SMB(object):
                 FileAttributes=dosmode,
             )
         elif mode == "w":
+            # A write open only needs the rights to create and write the file, not
+            # WRITE_OWNER. Request MAXIMUM_ALLOWED so the server grants whatever the
+            # caller is entitled to: the special identities (owner@/group@/everyone@)
+            # do not advertise WRITE_OWNER and the file owner is not implicitly
+            # granted it, so an explicit SEC_GENERIC_ALL open by the owner is denied.
             f = self._connection.create(
                 file,
                 CreateDisposition=3,
-                DesiredAccess=security.SEC_GENERIC_ALL,
+                DesiredAccess=security.SEC_FLAG_MAXIMUM_ALLOWED,
                 FileAttributes=dosmode,
             )
 

--- a/tests/sharing_protocols/smb/test_smb_client.py
+++ b/tests/sharing_protocols/smb/test_smb_client.py
@@ -71,11 +71,27 @@ def mount_share(setup_smb_tests):
         yield setup_smb_tests | {'mountpoint': mp}
 
 
+SPECIAL_TAGS = ('owner@', 'group@', 'everyone@')
+
+
+def present_special_as_smb(acl):
+    # ixnas (ixnas:zfs_acl_advertise_enforced, default on) does not advertise
+    # WRITE_ACL / WRITE_OWNER on the special identities owner@ / group@ / everyone@
+    # over SMB, since ZFS will not honor those bits there. Reading the ACL locally
+    # still reports them, so an ALLOW ace that is FULL_CONTROL locally is presented
+    # as MODIFY over SMB. Normalize the local copy to match before comparing.
+    for ace in acl:
+        if ace['tag'] in SPECIAL_TAGS and ace['type'] == 'ALLOW':
+            if ace['perms'].get('BASIC') == 'FULL_CONTROL':
+                ace['perms'] = {'BASIC': 'MODIFY'}
+
+
 def compare_acls(local_path, share_path):
     local_acl = call('filesystem.getacl', local_path)
     local_acl.pop('path')
     smb_acl = call('filesystem.getacl', share_path)
     smb_acl.pop('path')
+    present_special_as_smb(local_acl['acl'])
     assert local_acl == smb_acl
 
 


### PR DESCRIPTION
This commit fixes several regressions in SMB protocol tests that were caused by ACL presentation changes through vfs_ixnas.