### PR TITLE
NAS-141593 / 27.0.0-BETA.1 / License-gate ZFS deduplication on datasets and zvols

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -2,6 +2,7 @@ import errno
 import os
 import pathlib
 
+from truenas_pydmi.models import TRUENAS_UNKNOWN
 from truenas_pylibzfs import ZFSError, ZFSException, ZFSType
 
 from middlewared.api import api_method
@@ -209,6 +210,23 @@ class PoolDatasetService(CRUDService):
 
         # We raise validation errors here as parent could be used down to validate other aspects of the dataset
         verrors.check()
+
+        if data.get('deduplication') in ('ON', 'VERIFY'):
+            if await self.middleware.call('system.license') is not None:
+                # Any licensed system must carry the explicit DEDUP feature flag.
+                if not await self.middleware.call('system.feature_enabled', 'DEDUP'):
+                    verrors.add(
+                        f'{schema}.deduplication',
+                        "This system's license does not include the ZFS deduplication feature."
+                    )
+            else:
+                # Unlicensed: Community Edition (incl. minis) may use dedup; TrueNAS hardware may not.
+                chassis = await self.middleware.call('truenas.get_chassis_hardware')
+                if chassis != TRUENAS_UNKNOWN and 'MINI' not in chassis:
+                    verrors.add(
+                        f'{schema}.deduplication',
+                        'This system is not licensed to use ZFS deduplication.'
+                    )
 
         dataset_pool_is_draid = await self.middleware.call('pool.is_draid_pool', parent['pool'])
         if data['type'] == 'FILESYSTEM':


### PR DESCRIPTION
This commit adds changes to reject enabling ZFS deduplication (ON/VERIFY) on a dataset or zvol unless the system is entitled to it: any licensed system must carry the DEDUP feature flag, unlicensed TrueNAS hardware is blocked, and Community Edition (including minis) may still use it freely. The check lives in the shared dataset validation path so it covers both create and update, and OFF/INHERIT are left untouched.

