### PR TITLE
NAS-141646 / 27.0.0-BETA.1 / Restore middleware dispatch for create-time zvol validation

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -84,7 +84,7 @@ class CloudTaskServiceMixin:
                 verrors.add(f'{name}.{self.path_field}', f'{zvol!r} is an invalid location')
             else:
                 try:
-                    self.validate_zvol(path)
+                    self.call_sync2(self.s.cloud_backup.validate_zvol, path)
                 except CallError as e:
                     verrors.add(f'{name}.{self.path_field}', e.errmsg)
         else:


### PR DESCRIPTION
This commit fixes an issue where the cloud_backup typesafe conversion switched the create-time zvol check to a direct in-process call, which the integration tests can't mock (mock only intercepts middleware-dispatched calls). Routing it back through call_sync2 restores the mockable dispatch, matching what the runtime path in sync.py already does.

Cloud tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/cloud_tests/1994/