### PR TITLE
NAS-141651 / 27.0.0-BETA.1 / Gate ZFS deduplication on pool creation (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -2,7 +2,6 @@ import errno
 import os
 import pathlib
 
-from truenas_pydmi.models import TRUENAS_UNKNOWN
 from truenas_pylibzfs import ZFSError, ZFSException, ZFSType
 
 from middlewared.api import api_method
@@ -50,6 +49,7 @@ from .utils import (
     ZFSKeyFormat,
     dataset_mountpoint,
     get_dataset_parents,
+    validate_dedup_license,
 )
 
 
@@ -211,22 +211,7 @@ class PoolDatasetService(CRUDService):
         # We raise validation errors here as parent could be used down to validate other aspects of the dataset
         verrors.check()
 
-        if data.get('deduplication') in ('ON', 'VERIFY'):
-            if await self.middleware.call('system.license') is not None:
-                # Any licensed system must carry the explicit DEDUP feature flag.
-                if not await self.middleware.call('system.feature_enabled', 'DEDUP'):
-                    verrors.add(
-                        f'{schema}.deduplication',
-                        "This system's license does not include the ZFS deduplication feature."
-                    )
-            else:
-                # Unlicensed: Community Edition (incl. minis) may use dedup; TrueNAS hardware may not.
-                chassis = await self.middleware.call('truenas.get_chassis_hardware')
-                if chassis != TRUENAS_UNKNOWN and 'MINI' not in chassis:
-                    verrors.add(
-                        f'{schema}.deduplication',
-                        'This system is not licensed to use ZFS deduplication.'
-                    )
+        await validate_dedup_license(self.middleware, verrors, schema, data.get('deduplication'))
 
         dataset_pool_is_draid = await self.middleware.call('pool.is_draid_pool', parent['pool'])
         if data['type'] == 'FILESYSTEM':

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -23,7 +23,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.size import format_size
 
-from .utils import RE_DRAID_DATA_DISKS, RE_DRAID_SPARE_DISKS, ZPOOL_CACHE_FILE
+from .utils import RE_DRAID_DATA_DISKS, RE_DRAID_SPARE_DISKS, ZPOOL_CACHE_FILE, validate_dedup_license
 
 # Redundancy/parity level per vdev type. Used to enforce that a redundant data
 # class is not paired with a non-redundant (parity 0) special vdev.
@@ -492,6 +492,8 @@ class PoolService(CRUDService):
         dedup_table_quota_value = None
         if data['deduplication'] == 'ON':
             dedup_table_quota_value = await self.validate_dedup_table_quota(data, verrors)
+
+        await validate_dedup_license(self.middleware, verrors, 'pool_create', data['deduplication'])
 
         verrors.check()
 

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -8,6 +8,8 @@ import re
 import typing
 from typing import TypedDict
 
+from truenas_pydmi.models import TRUENAS_UNKNOWN
+
 from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.service_exception import CallError
 from middlewared.utils.filesystem.directory import directory_is_empty
@@ -94,6 +96,33 @@ class UpdateImplArgsDataclass:
     """ZFS user properties to be applied during creation."""
     iprops: set = dataclasses.field(default_factory=set)
     """ZFS properties to be inherited from parent."""
+
+
+async def validate_dedup_license(middleware, verrors, schema, deduplication):
+    """Reject enabling ZFS deduplication on systems that are not entitled to it.
+
+    Licensed systems must carry the DEDUP feature flag; unlicensed TrueNAS hardware
+    (iX-branded, excluding minis) is blocked; Community Edition and minis may use
+    dedup freely. Only ON/VERIFY are gated.
+    """
+    if deduplication not in ('ON', 'VERIFY'):
+        return
+
+    if await middleware.call('system.license') is not None:
+        # Any licensed system must carry the explicit DEDUP feature flag.
+        if not await middleware.call('system.feature_enabled', 'DEDUP'):
+            verrors.add(
+                f'{schema}.deduplication',
+                "This system's license does not include the ZFS deduplication feature."
+            )
+    else:
+        # Unlicensed: Community Edition (incl. minis) may use dedup; TrueNAS hardware may not.
+        chassis = await middleware.call('truenas.get_chassis_hardware')
+        if chassis != TRUENAS_UNKNOWN and 'MINI' not in chassis:
+            verrors.add(
+                f'{schema}.deduplication',
+                'This system is not licensed to use ZFS deduplication.'
+            )
 
 
 def none_normalize(x):


### PR DESCRIPTION
This commit adds changes to extend the ZFS deduplication license gate to pool creation, which previously let a pool's root dataset be created with dedup enabled on a system that is not entitled to it. The check is factored into a shared validate_dedup_license helper so pool.create and the dataset create/update path enforce it identically and stay in sync.

Original PR: https://github.com/truenas/middleware/pull/19251
