### PR TITLE
NAS-141677 / 25.10.5 / Replication fixes

### DIFF
--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -116,10 +116,16 @@ class SFTPCloudSyncCredentialsSSHKeyPairUsedByDelegate(KeychainCredentialUsedByD
         return f"Cloud credentials {row['name']}"
 
     async def unbind(self, row):
-        row["attributes"].pop("private_key")
-        await self.middleware.call("datastore.update", "system.cloudcredentials", row["id"], {
-            "attributes": row["attributes"]
-        })
+        attributes = {k: v for k, v in row["provider"].items() if k != "type"}
+        attributes.pop("private_key", None)
+        await self.middleware.call(
+            "datastore.update",
+            "system.cloudcredentials",
+            row["id"],
+            {
+                "attributes": attributes,
+            },
+        )
 
 
 class SSHKeyPair(KeychainCredentialType):
@@ -150,7 +156,7 @@ class SSHKeyPair(KeychainCredentialType):
                 if proc.returncode == 0:
                     public_key = proc.stdout
                 else:
-                    if proc.stderr.startswith("Enter passphrase:"):
+                    if proc.stderr.startswith("Enter passphrase"):
                         error = "Encrypted private keys are not allowed"
                     else:
                         error = proc.stderr
@@ -559,6 +565,8 @@ class KeychainCredentialService(CRUDService):
         """
         replication_key = self.middleware.call_sync("keychaincredential.get_ssh_key_pair_with_private_key",
                                                     data["private_key"])
+        if replication_key is None:
+            raise CallError("Specified key pair not found")
 
         try:
             client = Client(os.path.join(re.sub("^http", "ws", data["url"]), "websocket"),

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -101,10 +101,14 @@ class ReplicationPeriodicSnapshotTaskModel(sa.Model):
     task_id = sa.Column(sa.ForeignKey('storage_task.id', ondelete='CASCADE'), index=True)
 
 
-class ReplicationPairArgs(BaseModel):
+class ReplicationPairData(BaseModel):
     hostname: str
     public_key: str = Field(alias="public-key")
-    user: str | None
+    user: str | None = None
+
+
+class ReplicationPairArgs(BaseModel):
+    data: ReplicationPairData
 
 
 class ReplicationPairResult(BaseModel):

--- a/tests/api2/test_keychain_key_pair.py
+++ b/tests/api2/test_keychain_key_pair.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.utils import call
+
+
+def _generate_private_key(passphrase=""):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key = os.path.join(tmpdir, "key")
+        subprocess.run(
+            ["ssh-keygen", "-t", "rsa", "-f", key, "-N", passphrase, "-q"], check=True
+        )
+        with open(key) as f:
+            return f.read()
+
+
+def _create_key_pair(attributes):
+    return call(
+        "keychaincredential.create",
+        {
+            "name": "keychain-key-pair-test",
+            "type": "SSH_KEY_PAIR",
+            "attributes": attributes,
+        },
+    )
+
+
+def _assert_error(ve, attribute, message):
+    assert any(
+        e.attribute == attribute and message in e.errmsg for e in ve.value.errors
+    ), ve.value.errors
+
+
+def test_create_key_pair_with_passphrase():
+    with pytest.raises(ValidationErrors) as ve:
+        _create_key_pair({"private_key": _generate_private_key("passphrase")})
+
+    _assert_error(
+        ve,
+        "keychain_credential_create.attributes.private_key",
+        "Encrypted private keys are not allowed",
+    )
+
+
+def test_create_key_pair_with_broken_private_key():
+    with pytest.raises(ValidationErrors) as ve:
+        _create_key_pair(
+            {
+                "private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nbroken\n-----END OPENSSH PRIVATE KEY-----\n",
+            }
+        )
+
+    assert any(
+        e.attribute == "keychain_credential_create.attributes.private_key"
+        for e in ve.value.errors
+    ), ve.value.errors
+
+
+def test_create_key_pair_without_keys():
+    with pytest.raises(ValidationErrors) as ve:
+        _create_key_pair({})
+
+    _assert_error(
+        ve, "keychain_credential_create.attributes.public_key", "You must specify a key"
+    )
+
+
+def test_create_key_pair_with_non_matching_keys():
+    pair1 = call("keychaincredential.generate_ssh_key_pair")
+    pair2 = call("keychaincredential.generate_ssh_key_pair")
+
+    with pytest.raises(ValidationErrors) as ve:
+        _create_key_pair(
+            {"private_key": pair1["private_key"], "public_key": pair2["public_key"]}
+        )
+
+    _assert_error(
+        ve,
+        "keychain_credential_create.attributes.public_key",
+        "Private key and public key do not match",
+    )
+
+
+def test_create_key_pair_with_invalid_public_key_only():
+    with pytest.raises(ValidationErrors) as ve:
+        _create_key_pair({"public_key": "this is not a valid public key"})
+
+    _assert_error(
+        ve, "keychain_credential_create.attributes.public_key", "Invalid public key"
+    )
+
+
+def test_create_key_pair_derives_public_key_from_private_key():
+    generated = call("keychaincredential.generate_ssh_key_pair")
+
+    keypair = _create_key_pair({"private_key": generated["private_key"]})
+    try:
+        # The public key is not supplied, so it must be derived from the private key. Compare the key material
+        # (second field) because the derived key carries no comment.
+        assert (
+            keypair["attributes"]["public_key"].split()[1]
+            == generated["public_key"].split()[1]
+        )
+    finally:
+        call("keychaincredential.delete", keypair["id"])

--- a/tests/api2/test_keychain_replication.py
+++ b/tests/api2/test_keychain_replication.py
@@ -1,0 +1,66 @@
+import pytest
+
+from middlewared.test.integration.assets.keychain import localhost_ssh_credentials
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+
+
+def test_keychain_credential_update_reloads_zettarepl():
+    # Updating a keychain credential must call `zettarepl.update_tasks` so that running replication tasks pick up the
+    # new credential. We verify this by breaking (and then restoring) the SSH key pair backing a replication task.
+    with localhost_ssh_credentials(username="root") as c:
+        keypair = c["keypair"]
+        original_attributes = keypair["attributes"]
+
+        with dataset("keychain_repl_src") as src, dataset("keychain_repl_dst") as dst:
+            task = call(
+                "replication.create",
+                {
+                    "name": "keychain-zettarepl",
+                    "direction": "PUSH",
+                    "transport": "SSH",
+                    "ssh_credentials": c["credentials"]["id"],
+                    "source_datasets": [src],
+                    "target_dataset": dst,
+                    "recursive": False,
+                    "auto": False,
+                    "retention_policy": "NONE",
+                    "also_include_naming_schema": ["auto-%Y-%m-%d-%H-%M"],
+                },
+            )
+            try:
+                # Valid key pair -> replication succeeds
+                ssh(f"touch /mnt/{src}/test1")
+                call(
+                    "pool.snapshot.create",
+                    {"dataset": src, "name": "auto-2024-01-01-00-00"},
+                )
+                call("replication.run", task["id"], job=True)
+                assert "test1" in ssh(f"ls /mnt/{dst}")
+
+                # Break the key pair; `do_update` must reload zettarepl so the task now uses the (wrong) key
+                call(
+                    "keychaincredential.update",
+                    keypair["id"],
+                    {
+                        "attributes": call("keychaincredential.generate_ssh_key_pair"),
+                    },
+                )
+                ssh(f"touch /mnt/{src}/test2")
+                call(
+                    "pool.snapshot.create",
+                    {"dataset": src, "name": "auto-2024-01-02-00-00"},
+                )
+                with pytest.raises(Exception):
+                    call("replication.run", task["id"], job=True)
+
+                # Restore the key pair -> zettarepl reloaded again, replication succeeds
+                call(
+                    "keychaincredential.update",
+                    keypair["id"],
+                    {"attributes": original_attributes},
+                )
+                call("replication.run", task["id"], job=True)
+                assert "test2" in ssh(f"ls /mnt/{dst}")
+            finally:
+                call("replication.delete", task["id"])

--- a/tests/api2/test_keychain_ssh.py
+++ b/tests/api2/test_keychain_ssh.py
@@ -3,7 +3,7 @@ import pytest
 from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, password
 
 
 @pytest.fixture(scope="module")
@@ -89,3 +89,59 @@ def test_ignore_ssl_certificate_error(credential):
         "private_key": credential["id"],
     })
     call("keychaincredential.delete", connection["id"])
+
+
+def test_remote_ssh_semiautomatic_setup_invalid_ip(credential):
+    with pytest.raises(CallError) as ve:
+        call("keychaincredential.remote_ssh_semiautomatic_setup", {
+            "name": "localhost",
+            # Nothing listens on port 1, so the connection is refused
+            "url": "http://localhost:1",
+            "token": call("auth.generate_token", 600, {}, False),
+            "private_key": credential["id"],
+        })
+
+    assert "Unable to connect to remote system" in ve.value.errmsg
+
+
+def test_remote_ssh_semiautomatic_setup_invalid_keypair():
+    with pytest.raises(CallError) as ve:
+        call("keychaincredential.remote_ssh_semiautomatic_setup", {
+            "name": "localhost",
+            "url": "http://localhost",
+            "token": call("auth.generate_token", 600, {}, False),
+            "private_key": 99999999,
+        })
+
+    assert "key pair not found" in ve.value.errmsg.lower()
+
+
+def test_remote_ssh_semiautomatic_setup_with_password(credential):
+    connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
+        "name": "localhost",
+        "url": "http://localhost",
+        "password": password(),
+        "private_key": credential["id"],
+    })
+    call("keychaincredential.delete", connection["id"])
+
+
+def test_remote_ssh_semiautomatic_setup_with_invalid_password(credential):
+    with pytest.raises(CallError):
+        call("keychaincredential.remote_ssh_semiautomatic_setup", {
+            "name": "localhost",
+            "url": "http://localhost",
+            "password": "invalid-password",
+            "private_key": credential["id"],
+        })
+
+
+def test_remote_ssh_semiautomatic_setup_without_password_or_token(credential):
+    with pytest.raises(CallError) as ve:
+        call("keychaincredential.remote_ssh_semiautomatic_setup", {
+            "name": "localhost",
+            "url": "http://localhost",
+            "private_key": credential["id"],
+        })
+
+    assert "specify either remote system password or temporary authentication token" in ve.value.errmsg

--- a/tests/api2/test_keychain_utils.py
+++ b/tests/api2/test_keychain_utils.py
@@ -1,0 +1,381 @@
+import contextlib
+import errno
+
+import pytest
+
+from middlewared.service_exception import CallError, ValidationError, ValidationErrors
+from middlewared.test.integration.assets.cloud_sync import (
+    credential as cloud_credential,
+)
+from middlewared.test.integration.assets.keychain import (
+    localhost_ssh_credentials,
+    ssh_keypair,
+)
+from middlewared.test.integration.assets.replication import replication_task
+from middlewared.test.integration.utils import call
+
+
+def _replication_data(ssh_credentials_id):
+    return {
+        "name": "keychain-used-by-test",
+        "direction": "PUSH",
+        "transport": "SSH",
+        "ssh_credentials": ssh_credentials_id,
+        "source_datasets": ["source"],
+        "target_dataset": "target",
+        "recursive": False,
+        "name_regex": ".+",
+        "auto": False,
+        "retention_policy": "NONE",
+    }
+
+
+@contextlib.contextmanager
+def sftp_cloud_credential(private_key_id):
+    with cloud_credential(
+        {
+            "name": "keychain-used-by-sftp",
+            "provider": {
+                "type": "SFTP",
+                "host": "localhost",
+                "user": "root",
+                "private_key": private_key_id,
+            },
+        }
+    ) as c:
+        yield c
+
+
+def test_used_by_empty_for_unused_key_pair():
+    with ssh_keypair() as keypair:
+        assert call("keychaincredential.used_by", keypair["id"]) == []
+
+
+def test_ssh_key_pair_used_by_ssh_credentials():
+    with localhost_ssh_credentials(username="root") as c:
+        used_by = call("keychaincredential.used_by", c["keypair"]["id"])
+        assert {
+            "title": f"SSH credentials {c['credentials']['name']}",
+            "unbind_method": "delete",
+        } in used_by
+
+
+def test_ssh_key_pair_used_by_sftp_cloud_credentials():
+    with ssh_keypair() as keypair:
+        with sftp_cloud_credential(keypair["id"]) as cred:
+            used_by = call("keychaincredential.used_by", keypair["id"])
+            assert {
+                "title": f"Cloud credentials {cred['name']}",
+                "unbind_method": "disable",
+            } in used_by
+
+
+def test_used_by_ignores_ssh_credentials_for_unrelated_key_pair():
+    # `c` provides an SSH credential referencing its own key pair; querying a different, unrelated key pair must
+    # exercise the delegate's `_is_related` check and return nothing.
+    with localhost_ssh_credentials(username="root"):
+        with ssh_keypair() as unrelated:
+            assert call("keychaincredential.used_by", unrelated["id"]) == []
+
+
+def test_used_by_ignores_sftp_cloud_credentials_for_unrelated_key_pair():
+    with ssh_keypair() as used_key:
+        with sftp_cloud_credential(used_key["id"]):
+            with ssh_keypair() as unrelated:
+                assert call("keychaincredential.used_by", unrelated["id"]) == []
+
+
+def test_ssh_credentials_used_by_replication_task():
+    with localhost_ssh_credentials(username="root") as c:
+        with replication_task(_replication_data(c["credentials"]["id"])) as task:
+            used_by = call("keychaincredential.used_by", c["credentials"]["id"])
+            assert {
+                "title": f"Replication task {task['name']}",
+                "unbind_method": "disable",
+            } in used_by
+
+
+def test_ssh_key_pair_used_by_is_recursive():
+    # Deleting the key pair cascades into the SSH credentials that reference it, which in turn are used by the
+    # replication task, so ``used_by`` for the key pair must report both objects.
+    with localhost_ssh_credentials(username="root") as c:
+        with replication_task(_replication_data(c["credentials"]["id"])) as task:
+            used_by = call("keychaincredential.used_by", c["keypair"]["id"])
+            assert {
+                "title": f"SSH credentials {c['credentials']['name']}",
+                "unbind_method": "delete",
+            } in used_by
+            assert {
+                "title": f"Replication task {task['name']}",
+                "unbind_method": "disable",
+            } in used_by
+
+
+def test_cascade_delete_disables_replication_task():
+    with localhost_ssh_credentials(username="root") as c:
+        with replication_task(_replication_data(c["credentials"]["id"])) as task:
+            call("keychaincredential.delete", c["credentials"]["id"], {"cascade": True})
+
+            task = call("replication.get_instance", task["id"])
+            assert not task["enabled"]
+            assert task["ssh_credentials"] is None
+
+
+def test_cascade_delete_ssh_key_pair_deletes_ssh_credentials():
+    # SSH credentials that reference a key pair are unbound with the DELETE method, so cascade-deleting the key pair
+    # deletes the SSH credentials that use it as well.
+    with localhost_ssh_credentials(username="root") as c:
+        call("keychaincredential.delete", c["keypair"]["id"], {"cascade": True})
+
+        assert (
+            call("keychaincredential.query", [["id", "=", c["credentials"]["id"]]])
+            == []
+        )
+
+
+def test_cascade_delete_unbinds_sftp_cloud_credentials():
+    with ssh_keypair() as keypair:
+        with sftp_cloud_credential(keypair["id"]) as cred:
+            call("keychaincredential.delete", keypair["id"], {"cascade": True})
+
+            cred = call("cloudsync.credentials.get_instance", cred["id"])
+            assert cred["provider"].get("private_key") is None
+
+
+def test_noncascade_delete_of_used_credential_raises():
+    with localhost_ssh_credentials(username="root") as c:
+        with pytest.raises(ValidationError) as ve:
+            call("keychaincredential.delete", c["keypair"]["id"])
+
+        assert ve.value.attribute == "options.cascade"
+
+
+def test_get_of_type_nonexistent():
+    with pytest.raises(CallError) as ve:
+        call("keychaincredential.get_of_type", 99999999, "SSH_KEY_PAIR")
+
+    assert ve.value.errno == errno.ENOENT
+
+
+def test_get_of_type_wrong_type():
+    with ssh_keypair() as keypair:
+        with pytest.raises(CallError) as ve:
+            call("keychaincredential.get_of_type", keypair["id"], "SSH_CREDENTIALS")
+
+        assert ve.value.errno == errno.EINVAL
+
+
+def test_get_of_type_decrypt_failure():
+    with ssh_keypair() as keypair:
+        # Blanking the stored attributes simulates a credential whose secret could not be decrypted.
+        call(
+            "datastore.update",
+            "system.keychaincredential",
+            keypair["id"],
+            {"attributes": {}},
+        )
+
+        with pytest.raises(CallError) as ve:
+            call("keychaincredential.get_of_type", keypair["id"], "SSH_KEY_PAIR")
+
+        assert ve.value.errno == errno.EFAULT
+
+
+def test_remote_ssh_host_key_scan():
+    result = call("keychaincredential.remote_ssh_host_key_scan", {"host": "localhost"})
+
+    assert result.strip()
+
+
+def test_remote_ssh_host_key_scan_failure():
+    with pytest.raises(CallError):
+        call(
+            "keychaincredential.remote_ssh_host_key_scan",
+            {"host": "localhost", "port": 1, "connect_timeout": 3},
+        )
+
+
+def test_remote_ssh_host_key_scan_invalid_host():
+    with pytest.raises(CallError):
+        call(
+            "keychaincredential.remote_ssh_host_key_scan",
+            {"host": "invalid.invalid.invalid", "connect_timeout": 3},
+        )
+
+
+@pytest.fixture(scope="module")
+def host_key():
+    return call("keychaincredential.remote_ssh_host_key_scan", {"host": "localhost"})
+
+
+def _delete_connection_and_key(connection):
+    key_id = connection["attributes"]["private_key"]
+    call("keychaincredential.delete", connection["id"])
+    with contextlib.suppress(Exception):
+        call("keychaincredential.delete", key_id)
+
+
+def test_setup_ssh_connection_manual_generate_key(host_key):
+    connection = call(
+        "keychaincredential.setup_ssh_connection",
+        {
+            "setup_type": "MANUAL",
+            "connection_name": "keychain-manual-generate",
+            "private_key": {
+                "generate_key": True,
+                "name": "keychain-manual-generate-key",
+            },
+            "manual_setup": {
+                "host": "localhost",
+                "username": "root",
+                "remote_host_key": host_key,
+            },
+        },
+    )
+    try:
+        assert connection["type"] == "SSH_CREDENTIALS"
+        assert connection["attributes"]["host"] == "localhost"
+        key_id = connection["attributes"]["private_key"]
+        assert (
+            call("keychaincredential.get_instance", key_id)["name"]
+            == "keychain-manual-generate-key"
+        )
+    finally:
+        _delete_connection_and_key(connection)
+
+
+def test_setup_ssh_connection_manual_existing_key(host_key):
+    with ssh_keypair() as keypair:
+        connection = call(
+            "keychaincredential.setup_ssh_connection",
+            {
+                "setup_type": "MANUAL",
+                "connection_name": "keychain-manual-existing",
+                "private_key": {
+                    "generate_key": False,
+                    "existing_key_id": keypair["id"],
+                },
+                "manual_setup": {"host": "localhost", "remote_host_key": host_key},
+            },
+        )
+        try:
+            assert connection["attributes"]["private_key"] == keypair["id"]
+        finally:
+            call("keychaincredential.delete", connection["id"])
+
+
+def test_setup_ssh_connection_semiautomatic():
+    token = call("auth.generate_token", 600, {}, False)
+    connection = call(
+        "keychaincredential.setup_ssh_connection",
+        {
+            "setup_type": "SEMI-AUTOMATIC",
+            "connection_name": "keychain-semi-automatic",
+            "private_key": {
+                "generate_key": True,
+                "name": "keychain-semi-automatic-key",
+            },
+            "semi_automatic_setup": {"url": "http://localhost", "token": token},
+        },
+    )
+    try:
+        assert connection["type"] == "SSH_CREDENTIALS"
+    finally:
+        _delete_connection_and_key(connection)
+
+
+def test_setup_ssh_connection_rollback_removes_generated_key():
+    key_name = "keychain-rollback-key"
+    with pytest.raises(CallError):
+        call(
+            "keychaincredential.setup_ssh_connection",
+            {
+                "setup_type": "SEMI-AUTOMATIC",
+                "connection_name": "keychain-rollback",
+                "private_key": {"generate_key": True, "name": key_name},
+                "semi_automatic_setup": {
+                    "url": "http://localhost",
+                    "token": "invalid-token",
+                },
+            },
+        )
+
+    assert call("keychaincredential.query", [["name", "=", key_name]]) == []
+
+
+def test_setup_ssh_connection_existing_key_not_found(host_key):
+    with pytest.raises(ValidationErrors) as ve:
+        call(
+            "keychaincredential.setup_ssh_connection",
+            {
+                "setup_type": "MANUAL",
+                "connection_name": "keychain-missing-key",
+                "private_key": {"generate_key": False, "existing_key_id": 99999999},
+                "manual_setup": {"host": "localhost", "remote_host_key": host_key},
+            },
+        )
+
+    assert any(
+        e.attribute == "setup_ssh_connection.private_key.existing_key_id"
+        for e in ve.value.errors
+    )
+
+
+def test_setup_ssh_connection_duplicate_key_name(host_key):
+    with ssh_keypair() as keypair:
+        existing_name = call("keychaincredential.get_instance", keypair["id"])["name"]
+        with pytest.raises(ValidationErrors) as ve:
+            call(
+                "keychaincredential.setup_ssh_connection",
+                {
+                    "setup_type": "MANUAL",
+                    "connection_name": "keychain-duplicate-key-name",
+                    "private_key": {"generate_key": True, "name": existing_name},
+                    "manual_setup": {"host": "localhost", "remote_host_key": host_key},
+                },
+            )
+
+        assert any(
+            e.attribute == "setup_ssh_connection.private_key.name"
+            for e in ve.value.errors
+        )
+
+
+def test_setup_ssh_connection_duplicate_connection_name(host_key):
+    with ssh_keypair() as keypair:
+        connection = call(
+            "keychaincredential.setup_ssh_connection",
+            {
+                "setup_type": "MANUAL",
+                "connection_name": "keychain-duplicate-connection",
+                "private_key": {
+                    "generate_key": False,
+                    "existing_key_id": keypair["id"],
+                },
+                "manual_setup": {"host": "localhost", "remote_host_key": host_key},
+            },
+        )
+        try:
+            with pytest.raises(ValidationErrors) as ve:
+                call(
+                    "keychaincredential.setup_ssh_connection",
+                    {
+                        "setup_type": "MANUAL",
+                        "connection_name": "keychain-duplicate-connection",
+                        "private_key": {
+                            "generate_key": True,
+                            "name": "keychain-duplicate-connection-key",
+                        },
+                        "manual_setup": {
+                            "host": "localhost",
+                            "remote_host_key": host_key,
+                        },
+                    },
+                )
+
+            assert any(
+                e.attribute == "setup_ssh_connection.connection_name"
+                for e in ve.value.errors
+            )
+        finally:
+            call("keychaincredential.delete", connection["id"])

--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -29,3 +29,16 @@ def localhost_ssh_connection():
 @pytest.mark.parametrize("transport", ["SSH", "SSH+NETCAT"])
 def test_list_datasets_ssh(localhost_ssh_connection, transport):
     assert pool in call("replication.list_datasets", transport, localhost_ssh_connection)
+
+
+def test_replication_pair():
+    public_key = call("keychaincredential.generate_ssh_key_pair")["public_key"]
+
+    result = call("replication.pair", {
+        "hostname": "127.0.0.1",
+        "public-key": public_key,
+        "user": "root",
+    })
+
+    assert result["ssh_port"] == call("ssh.config")["tcpport"]
+    assert "127.0.0.1 ssh-" in result["ssh_hostkey"]


### PR DESCRIPTION

	• Removing an SSH key pair now correctly updates SFTP cloud credentials that were using that key.
	• Encrypted SSH private keys are now rejected more consistently during validation.
	• Remote SSH semi-automatic setup now returns a clear error when the selected SSH key pair no longer exists or is invalid.
	• Fixed SSH pairing with TrueNAS 13 systems during remote replication setup.