### PR TITLE
NAS-141667 / 27.0.0-BETA.1 / Convert system.advanced plugin to the typesafe pattern

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -55,6 +55,7 @@ jobs:
             middlewared/plugins/ssh/ \
             middlewared/plugins/support/ \
             middlewared/plugins/sysctl/ \
+            middlewared/plugins/system_advanced/ \
             middlewared/plugins/system_vendor/ \
             middlewared/plugins/truecommand/ \
             middlewared/plugins/truenas/ \

--- a/src/middlewared/middlewared/api/v27_0_0/system_advanced.py
+++ b/src/middlewared/middlewared/api/v27_0_0/system_advanced.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import Field, NonNegativeInt, PositiveInt, Secret
 
@@ -19,8 +19,8 @@ __all__ = [
     "SystemAdvancedSedGlobalPasswordIsSetResult", "SystemAdvancedSerialPortChoicesArgs",
     "SystemAdvancedSerialPortChoicesResult", "SystemAdvancedSyslogCertificateAuthorityChoicesArgs",
     "SystemAdvancedSyslogCertificateAuthorityChoicesResult", "SystemAdvancedSyslogCertificateChoicesArgs",
-    "SystemAdvancedSyslogCertificateChoicesResult", "SystemAdvancedUpdateArgs", "SystemAdvancedUpdateResult",
-    "SystemAdvancedUpdateGpuPciIdsArgs", "SystemAdvancedUpdateGpuPciIdsResult",
+    "SystemAdvancedSyslogCertificateChoicesResult", "SystemAdvancedUpdate", "SystemAdvancedUpdateArgs",
+    "SystemAdvancedUpdateResult", "SystemAdvancedUpdateGpuPciIdsArgs", "SystemAdvancedUpdateGpuPciIdsResult",
     "SystemAdvancedNvidiaPresentArgs", "SystemAdvancedNvidiaPresentResult",
 ]
 
@@ -126,7 +126,7 @@ class SystemAdvancedGetGpuPciChoicesArgs(BaseModel):
 
 
 class SystemAdvancedGetGpuPciChoicesResult(BaseModel):
-    result: dict = Field(description="Available GPU PCI devices that can be isolated for VM passthrough.")
+    result: dict[str, Any] = Field(description="Available GPU PCI devices that can be isolated for VM passthrough.")
 
 
 class SystemAdvancedLoginBannerArgs(BaseModel):

--- a/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
+++ b/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
@@ -2,7 +2,7 @@
     import random
     import shlex
 
-    system_advanced = middleware.call_sync("system.advanced.config")
+    system_advanced = middleware.call_sync2(middleware.services.system.advanced.config)
     resilver = middleware.call_sync("pool.resilver.config")
     boot_pool = middleware.call_sync("boot.pool_name")
 %>\
@@ -12,7 +12,7 @@ PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 30 3 * * * root midclt call directoryservices.cache_refresh > /dev/null 2>&1
 45 3 * * * root midclt call config.backup >/dev/null 2>&1
 
-45 3 * * * root midclt call pool.scrub.run ${boot_pool} ${system_advanced['boot_scrub']} > /dev/null 2>&1
+45 3 * * * root midclt call pool.scrub.run ${boot_pool} ${system_advanced.boot_scrub} > /dev/null 2>&1
 
 ## Don't run these on TrueNAS HA standby controllers
 ## Redmine 55908

--- a/src/middlewared/middlewared/etc_files/default/kdump-tools.mako
+++ b/src/middlewared/middlewared/etc_files/default/kdump-tools.mako
@@ -1,7 +1,7 @@
 <%
     import glob
 
-    enabled = middleware.call_sync('system.advanced.config')['kdump_enabled']
+    enabled = middleware.call_sync2(middleware.services.system.advanced.config).kdump_enabled
 
     if enabled:
         initrd_list = glob.glob('/boot/initrd.img*')

--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -43,7 +43,7 @@ def render(service, middleware):
         )
     }
 
-    isolated = middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']
+    isolated = middleware.call_sync2(middleware.services.system.advanced.config).isolated_gpu_pci_ids
     for gpu in filter(lambda x: x not in isolated, get_nvidia_gpus()):
         base.update({
             'runtimes': {

--- a/src/middlewared/middlewared/etc_files/motd.mako
+++ b/src/middlewared/middlewared/etc_files/motd.mako
@@ -1,6 +1,6 @@
 <%
 	buildtime = middleware.call_sync('system.build_time')
-	motd = middleware.call_sync('system.advanced.config')['motd']
+	motd = middleware.call_sync2(middleware.services.system.advanced.config).motd
 %>\
 
 	TrueNAS (c) 2009-${buildtime.year}, iXsystems, Inc. dba TrueNAS

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -32,9 +32,9 @@ filter f_tnremote_f_is_info { level(info); };
 filter f_tnremote_f_debug { level(debug..emerg); };
 
 filter f_tnremote {
-    filter(f_tnremote_${adv_conf["sysloglevel"].lower()})
+    filter(f_tnremote_${adv_conf.sysloglevel.lower()})
 ## syslog_audit is associated with remote logging only
-% if not adv_conf['syslog_audit']:
+% if not adv_conf.syslog_audit:
     and not filter(f_tnaudit_all)
 % endif
 };

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -9,8 +9,8 @@ syslog_template = 'template("${MESSAGE}\\n")'
 
 
 def generate_syslog_remote_destination(server, d_name):
-    address = server["host"]
-    transport = server["transport"].lower()
+    address = server.host
+    transport = server.transport.lower()
 
     if "]:" in address or (":" in address and not "]" in address): 
         host, port = address.rsplit(":", 1)
@@ -20,7 +20,7 @@ def generate_syslog_remote_destination(server, d_name):
         host, port = address, "514"
 
     host = host.replace("[", "").replace("]", "")
-    cert_id = server["tls_certificate"]
+    cert_id = server.tls_certificate
 
     remotelog_stanza = (
      f'destination {d_name} {{\n'
@@ -69,7 +69,7 @@ options {
   chain_hostnames(off);
   flush_lines(0);
   use_dns(no);
-  use_fqdn(${'yes' if render_ctx['system.advanced.config']['fqdn_syslog'] else 'no'});
+  use_fqdn(${'yes' if render_ctx['system.advanced.config'].fqdn_syslog else 'no'});
   dns_cache(no);
   owner("root");
   group("adm");
@@ -102,7 +102,7 @@ source s_tn_auditd {
 @include "/etc/syslog-ng/conf.d/tndestinations.conf"
 
 ## Remote syslog stanza needs to be here _before_ the audit-related configuration
-% if render_ctx['system.advanced.config']['syslogservers']:
+% if render_ctx['system.advanced.config'].syslogservers:
 ##################
 # remote logging
 ##################
@@ -117,7 +117,7 @@ source s_nginx_logs {
   );
 };
 
-% for i, server in enumerate(render_ctx['system.advanced.config']['syslogservers']):
+% for i, server in enumerate(render_ctx['system.advanced.config'].syslogservers):
 ${generate_syslog_remote_destination(server, 'loghost' + str(i))}
 % endfor
 % endif

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -139,6 +139,7 @@ from middlewared.plugins.snmp import SNMPService
 from middlewared.plugins.ssh import SSHService
 from middlewared.plugins.support import SupportService
 from middlewared.plugins.sysctl import SysctlService
+from middlewared.plugins.system_advanced import SystemAdvancedService
 from middlewared.plugins.system_vendor import VendorService
 from middlewared.plugins.system_vendor.vendor import is_vendored
 from middlewared.plugins.truecommand import TruecommandService
@@ -244,6 +245,7 @@ class SharingServicesContainer(BaseServiceContainer):
 class SystemServicesContainer(BaseServiceContainer):
     def __init__(self, middleware: "Middleware"):
         super().__init__(middleware)
+        self.advanced = SystemAdvancedService(middleware)
         self.ntpserver = NTPServerService(middleware)
         self.security = SystemSecurityService(middleware)
         self.vendor = VendorService(middleware)

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -111,8 +111,8 @@ class AuditService(ConfigService):
 
     @private
     def extend(self, data):
-        sys_adv = self.middleware.call_sync('system.advanced.config')
-        data['remote_logging_enabled'] = bool(sys_adv['syslogservers']) and sys_adv['syslog_audit']
+        sys_adv = self.call_sync2(self.s.system.advanced.config)
+        data['remote_logging_enabled'] = bool(sys_adv.syslogservers) and sys_adv.syslog_audit
         ds_info = self.get_audit_dataset()
         data['space'] = {'used': None, 'used_by_snapshots': None, 'available': None}
         data['space']['used'] = ds_info['properties']['used']['value']

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -216,7 +216,7 @@ class BootService(Service):
         await self.middleware.call(
             'datastore.update',
             'system.advanced',
-            (await self.middleware.call('system.advanced.config'))['id'],
+            (await self.call2(self.s.system.advanced.config)).id,
             {'adv_boot_scrub': interval},
         )
         return interval

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -225,7 +225,7 @@ class DeviceService(Service):
     @private
     def get_gpus(self):
         gpus = get_gpus()
-        to_isolate_gpus = self.middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']
+        to_isolate_gpus = self.call_sync2(self.s.system.advanced.config).isolated_gpu_pci_ids
         for gpu in gpus:
             gpu['available_to_host'] = gpu['addr']['pci_slot'] not in to_isolate_gpus
         return gpus

--- a/src/middlewared/middlewared/plugins/disk_/sed.py
+++ b/src/middlewared/middlewared/plugins/disk_/sed.py
@@ -88,7 +88,7 @@ class DiskService(Service):
         verrors.check()
 
         if to_setup_sed_disks:
-            global_sed_password = await self.middleware.call('system.advanced.sed_global_password')
+            global_sed_password = (await self.call2(self.s.system.advanced.sed_global_password)).get_secret_value()
             if not global_sed_password:
                 verrors.add(
                     schema_name,
@@ -167,9 +167,9 @@ class DiskService(Service):
         Setup specified ``options.name`` SED disk.
         """
         disk, verrors = await self.common_sed_validation('disk_sed_setup', options, 'UNINITIALIZED')
-        password = options.get('password') or disk['passwd'] or await self.middleware.call(
-            'system.advanced.sed_global_password'
-        )
+        password = options.get('password') or disk['passwd'] or (
+            await self.call2(self.s.system.advanced.sed_global_password)
+        ).get_secret_value()
         if not password:
             verrors.add('disk_sed_setup.password', 'Please specify a password to be used for setting up SED disk')
 
@@ -195,7 +195,7 @@ class DiskService(Service):
         Unlock specified ``options.name`` SED disk.
         """
         disk, verrors = await self.common_sed_validation('disk_sed_unlock', options, 'LOCKED')
-        global_sed_password = await self.middleware.call('system.advanced.sed_global_password')
+        global_sed_password = (await self.call2(self.s.system.advanced.sed_global_password)).get_secret_value()
         password = options.get('password') or disk['passwd'] or global_sed_password
         if not password:
             verrors.add(
@@ -248,7 +248,7 @@ class DiskService(Service):
 
     @private
     async def map_disks_to_passwd(self, disk_name=None):
-        global_passwd = await self.middleware.call('system.advanced.sed_global_password')
+        global_passwd = (await self.call2(self.s.system.advanced.sed_global_password)).get_secret_value()
         disks = []
         filters = [] if disk_name is None else [('real_name', '=', disk_name)]
         for disk in await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/docker/__init__.py
+++ b/src/middlewared/middlewared/plugins/docker/__init__.py
@@ -150,7 +150,7 @@ class DockerService(GenericConfigService[DockerEntry]):
     @api_method(DockerNvidiaPresentArgs, DockerNvidiaPresentResult, roles=['DOCKER_READ'], check_annotations=True)
     async def nvidia_present(self) -> bool:
         """Returns whether a non-isolated NVIDIA GPU is present in the system."""
-        return await self.middleware.call('system.advanced.nvidia_present')  # type: ignore[no-any-return]
+        return await self.call2(self.s.system.advanced.nvidia_present)
 
     @api_method(
         DockerRestoreBackupArgs, DockerRestoreBackupResult,

--- a/src/middlewared/middlewared/plugins/docker/config.py
+++ b/src/middlewared/middlewared/plugins/docker/config.py
@@ -48,7 +48,7 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
 
     async def extend(self, data: dict[str, Any]) -> dict[str, Any]:
         data['dataset'] = applications_ds_name(data['pool']) if data.get('pool') else None
-        data['nvidia'] = (await self.middleware.call('system.advanced.config'))['nvidia']
+        data['nvidia'] = (await self.call2(self.s.system.advanced.config)).nvidia
         data['address_pools'] = [DockerAddressPool.model_validate(p) for p in data.get('address_pools', [])]
         data['registry_mirrors'] = [DockerRegistryMirror.model_validate(m) for m in data.get('registry_mirrors', [])]
         return data
@@ -154,7 +154,7 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
 
         if nvidia_changed:
             job.set_progress(97, 'Applying requested nvidia configuration changes')
-            await self.middleware.call('system.advanced.update', {'nvidia': new_nvidia})
+            await self.call2(self.s.system.advanced.update, {'nvidia': new_nvidia})
 
         job.set_progress(100, 'Requested configuration applied')
         return await self.config()

--- a/src/middlewared/middlewared/plugins/grub_config.py
+++ b/src/middlewared/middlewared/plugins/grub_config.py
@@ -126,9 +126,9 @@ def _read_vendor() -> str:
 def render_grub_config(middleware: Middleware) -> str:
     """Compute the `truenas.cfg` content. Pure function of DB + hardware +
     memory; no side effects."""
-    advanced = middleware.call_sync("system.advanced.config")
+    advanced = middleware.call_sync2(middleware.services.system.advanced.config)
     vendor = _read_vendor()
-    kernel_extra_options = advanced.get("kernel_extra_options") or ""
+    kernel_extra_options = advanced.kernel_extra_options or ""
 
     cmdline_default = KERNEL_CMDLINE_DEFAULT
     if kernel_extra_options:
@@ -143,21 +143,21 @@ def render_grub_config(middleware: Middleware) -> str:
     terminal_output = ["console"]
     terminal_input = ["console"]
     cmdline: list[str] = []
-    if advanced["serialconsole"]:
+    if advanced.serialconsole:
         ports = {e["start"]: e["name"].replace("uart", "ttyS") for e in serial_port_choices()}
-        port = ports.get(advanced["serialport"], advanced["serialport"])
+        port = ports.get(advanced.serialport, advanced.serialport)
         port_nr = port.replace("ttyS", "")
         config.append(
             f'GRUB_SERIAL_COMMAND="serial --unit={port_nr}'
-            f' --speed={advanced["serialspeed"]} --word=8 --parity=no --stop=1"'
+            f' --speed={advanced.serialspeed} --word=8 --parity=no --stop=1"'
         )
         if os.path.exists("/sys/firmware/efi"):
             terminal_output = ["gfxterm"]
         terminal_output.append("serial")
         terminal_input.append("serial")
-        cmdline.append(f"console=tty1 console={port},{advanced['serialspeed']}")
+        cmdline.append(f"console=tty1 console={port},{advanced.serialspeed}")
 
-    if advanced.get("kdump_enabled"):
+    if advanced.kdump_enabled:
         # For every 4KB of physical memory allocate 2 bits to the crash
         # kernel (1 byte per 16KB). 400MB base was needed in testing for our
         # custom kernel; see RHEL kdump memory requirements and the

--- a/src/middlewared/middlewared/plugins/initramfs.py
+++ b/src/middlewared/middlewared/plugins/initramfs.py
@@ -91,10 +91,10 @@ def _read_from_sqlite(db_path: str) -> InitramfsConfig:
 
 
 def _read_from_middleware(middleware: Middleware) -> InitramfsConfig:
-    cfg = middleware.call_sync("system.advanced.config")
+    cfg = middleware.call_sync2(middleware.services.system.advanced.config)
     return InitramfsConfig(
-        debugkernel=cfg["debugkernel"],
-        isolated_gpu_pci_ids=cfg.get("isolated_gpu_pci_ids") or [],
+        debugkernel=cfg.debugkernel,
+        isolated_gpu_pci_ids=cfg.isolated_gpu_pci_ids or [],
         zfs_tunables=[
             (t.var, t.value)
             for t in middleware.call_sync2(
@@ -179,7 +179,7 @@ async def _reconcile(middleware):
         # GPU validation may mutate the DB (removes invalid PCI IDs and emits
         # alerts), so run it before materializing flags so the writes pick up
         # the cleaned state.
-        await middleware.call("system.advanced.validate_isolated_gpus_on_boot")
+        await middleware.call2(middleware.services.system.advanced.validate_isolated_gpus_on_boot)
         changed = await asyncio.to_thread(write_initramfs_flags, middleware)
         if changed:
             await middleware.call("boot.update_initramfs", {"force": True})

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -512,7 +512,7 @@ class PoolService(CRUDService):
 
         disks, vdevs = await self._process_topology('pool_create', data, None, data['all_sed'])
 
-        if osize := (await self.middleware.call('system.advanced.config'))['overprovision']:
+        if osize := (await self.call2(self.s.system.advanced.config)).overprovision:
             if log_disks := {disk: osize
                              for disk in sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])}:
                 # will log errors if there are any so it won't crash here (this matches CORE behavior)

--- a/src/middlewared/middlewared/plugins/system/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/system/cert_attachments.py
@@ -24,8 +24,8 @@ class SystemAdvancedCertificateAttachmentDelegate(CertificateServiceAttachmentDe
     SERVICE = 'syslogd'
 
     async def state(self, cert_id):
-        config = await self.middleware.call('system.advanced.config')
-        return any(server['tls_certificate'] == cert_id for server in config['syslogservers'])
+        config = await self.middleware.call2(self.middleware.services.system.advanced.config)
+        return any(server.tls_certificate == cert_id for server in config.syslogservers)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/system/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/system/lifecycle.py
@@ -159,7 +159,7 @@ class SystemService(Service):
 async def _event_system_ready(middleware, event_type, args):
     lifecycle_conf.SYSTEM_READY = True
 
-    if (await middleware.call("system.advanced.config"))["kdump_enabled"]:
+    if (await middleware.call2(middleware.services.system.advanced.config)).kdump_enabled:
         cp = await run(["kdump-config", "status"], check=False)
         if cp.returncode:
             middleware.logger.error(

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -10,6 +10,7 @@ import truenas_pylicensed
 
 from middlewared.api import api_method
 from middlewared.api.current import (
+    SystemAdvancedUpdate,
     SystemFeatureEnabledArgs,
     SystemFeatureEnabledResult,
     SystemLicenseUpdateArgs,
@@ -182,7 +183,7 @@ class SystemService(Service):
 
 async def hook_license_update(middleware, had_license, *args, **kwargs):
     if not had_license and await middleware.call("system.product_type") == "ENTERPRISE":
-        await middleware.call2(middleware.services.system.advanced.update, {"autotune": True})
+        await middleware.call2(middleware.services.system.advanced.update, SystemAdvancedUpdate(autotune=True))
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -182,7 +182,7 @@ class SystemService(Service):
 
 async def hook_license_update(middleware, had_license, *args, **kwargs):
     if not had_license and await middleware.call("system.product_type") == "ENTERPRISE":
-        await middleware.call("system.advanced.update", {"autotune": True})
+        await middleware.call2(middleware.services.system.advanced.update, {"autotune": True})
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/system_advanced/__init__.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/__init__.py
@@ -130,13 +130,11 @@ class SystemAdvancedService(GenericConfigService[SystemAdvancedEntry]):
         SystemAdvancedSyslogCertificateAuthorityChoicesResult,
         authorization_required=False,
         check_annotations=True,
+        removed_in='v27',
     )
     async def syslog_certificate_authority_choices(self) -> EmptyDict:
         """
         Return choices of certificate authorities which can be used for ``syslog_tls_certificate_authority``.
-
-        .. deprecated:: 25.10
-            This method is no longer used and will be removed after the UI is updated.
         """
         return _syslog.syslog_certificate_authority_choices()
 

--- a/src/middlewared/middlewared/plugins/system_advanced/__init__.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/__init__.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Secret
+
+from middlewared.api import api_method
+from middlewared.api.base import EmptyDict
+from middlewared.api.current import (
+    SystemAdvancedEntry,
+    SystemAdvancedGetGpuPciChoicesArgs,
+    SystemAdvancedGetGpuPciChoicesResult,
+    SystemAdvancedLoginBannerArgs,
+    SystemAdvancedLoginBannerResult,
+    SystemAdvancedNvidiaPresentArgs,
+    SystemAdvancedNvidiaPresentResult,
+    SystemAdvancedSedGlobalPasswordArgs,
+    SystemAdvancedSedGlobalPasswordIsSetArgs,
+    SystemAdvancedSedGlobalPasswordIsSetResult,
+    SystemAdvancedSedGlobalPasswordResult,
+    SystemAdvancedSerialPortChoicesArgs,
+    SystemAdvancedSerialPortChoicesResult,
+    SystemAdvancedSyslogCertificateAuthorityChoicesArgs,
+    SystemAdvancedSyslogCertificateAuthorityChoicesResult,
+    SystemAdvancedSyslogCertificateChoicesArgs,
+    SystemAdvancedSyslogCertificateChoicesResult,
+    SystemAdvancedUpdate,
+    SystemAdvancedUpdateArgs,
+    SystemAdvancedUpdateGpuPciIdsArgs,
+    SystemAdvancedUpdateGpuPciIdsResult,
+    SystemAdvancedUpdateResult,
+)
+from middlewared.service import GenericConfigService, private
+
+from . import gpu as _gpu
+from . import nvidia as _nvidia
+from . import serial as _serial
+from . import syslog as _syslog
+from .config import SystemAdvancedConfigServicePart
+
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
+
+__all__ = ('SystemAdvancedService',)
+
+
+class SystemAdvancedService(GenericConfigService[SystemAdvancedEntry]):
+
+    class Config:
+        namespace = 'system.advanced'
+        cli_namespace = 'system.advanced'
+        role_prefix = 'SYSTEM_ADVANCED'
+        entry = SystemAdvancedEntry
+        generic = True
+
+    def __init__(self, middleware: Middleware) -> None:
+        super().__init__(middleware)
+        self._svc_part = SystemAdvancedConfigServicePart(self.context)
+
+    @api_method(SystemAdvancedUpdateArgs, SystemAdvancedUpdateResult, audit='System advanced update',
+                check_annotations=True)
+    async def do_update(self, data: SystemAdvancedUpdate) -> SystemAdvancedEntry:
+        """
+        Update System Advanced Service Configuration.
+        """
+        return await self._svc_part.do_update(data)
+
+    @api_method(
+        SystemAdvancedSedGlobalPasswordIsSetArgs,
+        SystemAdvancedSedGlobalPasswordIsSetResult,
+        roles=['SYSTEM_ADVANCED_READ'],
+        check_annotations=True,
+    )
+    async def sed_global_password_is_set(self) -> bool:
+        """Returns a boolean identifying whether or not a global
+        SED password has been set."""
+        return bool(await self._svc_part.sed_global_password())
+
+    @api_method(
+        SystemAdvancedSedGlobalPasswordArgs,
+        SystemAdvancedSedGlobalPasswordResult,
+        roles=['SYSTEM_ADVANCED_READ'],
+        check_annotations=True,
+    )
+    async def sed_global_password(self) -> Secret[str]:
+        """Returns configured global SED password in clear-text if one
+        is configured, otherwise an empty string."""
+        return Secret[str](await self._svc_part.sed_global_password())
+
+    @api_method(SystemAdvancedLoginBannerArgs, SystemAdvancedLoginBannerResult, authentication_required=False,
+                check_annotations=True)
+    def login_banner(self) -> str:
+        """Returns user set login banner."""
+        # NOTE: This endpoint doesn't require authentication because
+        # it is used by UI on the login page
+        return self._svc_part.login_banner()
+
+    @api_method(
+        SystemAdvancedNvidiaPresentArgs,
+        SystemAdvancedNvidiaPresentResult,
+        roles=['SYSTEM_ADVANCED_READ'],
+        check_annotations=True,
+    )
+    def nvidia_present(self) -> bool:
+        """Returns whether a non-isolated NVIDIA GPU is present in the system."""
+        return _nvidia.nvidia_present(self.context)
+
+    @api_method(SystemAdvancedSerialPortChoicesArgs, SystemAdvancedSerialPortChoicesResult, roles=['READONLY_ADMIN'],
+                check_annotations=True)
+    async def serial_port_choices(self) -> dict[str, str]:
+        """
+        Get available choices for ``serialport``.
+        """
+        return await _serial.serial_port_choices(self.context)
+
+    @api_method(
+        SystemAdvancedSyslogCertificateChoicesArgs,
+        SystemAdvancedSyslogCertificateChoicesResult,
+        roles=['READONLY_ADMIN'],
+        check_annotations=True,
+    )
+    async def syslog_certificate_choices(self) -> dict[int, str]:
+        """
+        Return choices of certificates which can be used for ``syslogservers.N.tls_certificate``.
+        """
+        return await _syslog.syslog_certificate_choices(self.context)
+
+    @api_method(
+        SystemAdvancedSyslogCertificateAuthorityChoicesArgs,
+        SystemAdvancedSyslogCertificateAuthorityChoicesResult,
+        authorization_required=False,
+        check_annotations=True,
+    )
+    async def syslog_certificate_authority_choices(self) -> EmptyDict:
+        """
+        Return choices of certificate authorities which can be used for ``syslog_tls_certificate_authority``.
+
+        .. deprecated:: 25.10
+            This method is no longer used and will be removed after the UI is updated.
+        """
+        return _syslog.syslog_certificate_authority_choices()
+
+    @api_method(
+        SystemAdvancedGetGpuPciChoicesArgs,
+        SystemAdvancedGetGpuPciChoicesResult,
+        roles=['SYSTEM_ADVANCED_READ'],
+        check_annotations=True,
+    )
+    def get_gpu_pci_choices(self) -> dict[str, Any]:
+        """
+        This endpoint gives all the gpu pci ids/slots that can be isolated.
+        """
+        return _gpu.get_gpu_pci_choices(self.context)
+
+    @api_method(
+        SystemAdvancedUpdateGpuPciIdsArgs,
+        SystemAdvancedUpdateGpuPciIdsResult,
+        roles=['SYSTEM_ADVANCED_WRITE'],
+        check_annotations=True,
+    )
+    async def update_gpu_pci_ids(self, isolated_gpu_pci_ids: list[str]) -> None:
+        """
+        Update the list of GPU PCI IDs isolated from the host system.
+        """
+        await _gpu.update_gpu_pci_ids(self.context, isolated_gpu_pci_ids)
+
+    @private
+    async def validate_isolated_gpus_on_boot(self) -> None:
+        await _gpu.validate_isolated_gpus_on_boot(self.context)
+
+
+async def setup(middleware: Middleware) -> None:
+    try:
+        await middleware.run_in_thread(_nvidia.configure_nvidia, middleware.services.system.advanced.context)
+    except Exception:
+        middleware.logger.error('Unhandled exception configuring nvidia', exc_info=True)

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -96,7 +96,7 @@ class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
         return str(self.middleware.call_sync('datastore.config', self._datastore)['adv_login_banner'])
 
     @settings.fields_validator('serialport', 'serialconsole')
-    async def _validate_serial(self, verrors: ValidationErrors, serialport: str, serialconsole: bool) -> None:
+    async def _validate_serial(self, verrors: ValidationErrors, /, serialport: str, serialconsole: bool) -> None:
         if serialconsole:
             if not serialport:
                 verrors.add(
@@ -117,7 +117,7 @@ class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
                 )
 
     @settings.fields_validator('syslogservers')
-    async def _validate_syslogserver(self, verrors: ValidationErrors, syslogservers: list[dict[str, Any]]) -> None:
+    async def _validate_syslogserver(self, verrors: ValidationErrors, /, syslogservers: list[dict[str, Any]]) -> None:
         seen_hosts = set()
         for i, server in enumerate(syslogservers):
             host = server['host']
@@ -144,7 +144,7 @@ class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
                     verrors.extend(cert_verrors)
 
     @settings.fields_validator('kernel_extra_options')
-    async def _validate_kernel_extra_options(self, verrors: ValidationErrors, kernel_extra_options: str) -> None:
+    async def _validate_kernel_extra_options(self, verrors: ValidationErrors, /, kernel_extra_options: str) -> None:
         for invalid_char in ('\n', '"'):
             if invalid_char in kernel_extra_options:
                 verrors.add('kernel_extra_options', f'{invalid_char!r} is an invalid character and not allowed')
@@ -168,7 +168,7 @@ class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
             verrors.add('kernel_extra_options', f'Modifying {invalid_param!r} is not allowed')
 
     @settings.fields_validator('nvidia')
-    async def _validate_nvidia(self, verrors: ValidationErrors, nvidia: bool) -> None:
+    async def _validate_nvidia(self, verrors: ValidationErrors, /, nvidia: bool) -> None:
         # Only validate when nvidia is being disabled
         if nvidia is True:
             return
@@ -192,21 +192,26 @@ class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
         old_config = await self.config()
         old_sed = await self.sed_global_password()
 
+        # `sed_passwd` is not a field on the entry and `consolemsg` lives in `system.general`; read both
+        # side-channel values here since they are handled separately from the entry merge below.
         update = data.model_dump(context={"expose_secrets": True})
-        new_sed = update.pop('sed_passwd', old_sed)
+        new_sed = update.get('sed_passwd', old_sed)
 
         consolemsg = None
         if 'consolemsg' in update:
-            consolemsg = update.pop('consolemsg')
+            consolemsg = update['consolemsg']
             warnings.warn("`consolemsg` has been deprecated and moved to `system.general`", DeprecationWarning)
 
-        for server in update.get('syslogservers', []):
-            if server['transport'] != 'TLS':
-                server['tls_certificate'] = None
-
-        merged = old_config.model_dump()
-        merged.update(update)
-        new_config = SystemAdvancedEntry(**merged)
+        new_config = old_config.updated(data)
+        new_config = new_config.model_copy(update={
+            # consolemsg lives in system.general, so it must not count as an advanced change
+            'consolemsg': old_config.consolemsg,
+            # a non-TLS server can't carry a client certificate
+            'syslogservers': [
+                server if server.transport == 'TLS' else server.model_copy(update={'tls_certificate': None})
+                for server in new_config.syslogservers
+            ],
+        })
 
         await settings.validate(self, 'system_advanced_update', old_config.model_dump(), new_config.model_dump())
 

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -1,27 +1,21 @@
+from __future__ import annotations
+
 import asyncio
-from copy import deepcopy
 import re
 import tempfile
 import textwrap
+from typing import Any
 import warnings
 
-from middlewared.api import api_method
-from middlewared.api.current import (
-    SystemAdvancedEntry,
-    SystemAdvancedLoginBannerArgs,
-    SystemAdvancedLoginBannerResult,
-    SystemAdvancedSedGlobalPasswordArgs,
-    SystemAdvancedSedGlobalPasswordIsSetArgs,
-    SystemAdvancedSedGlobalPasswordIsSetResult,
-    SystemAdvancedSedGlobalPasswordResult,
-    SystemAdvancedUpdateArgs,
-    SystemAdvancedUpdateResult,
-)
+from middlewared.api.current import SystemAdvancedEntry, SystemAdvancedUpdate
 from middlewared.plugins.initramfs import write_initramfs_flags
-from middlewared.service import ConfigService, private
+from middlewared.service import ConfigServicePart, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run
 from middlewared.utils.service.settings import SettingsHelper
+
+from .nvidia import handle_nvidia_toggle
+from .serial import configure_tty, serial_port_choices
 
 settings = SettingsHelper()
 
@@ -59,38 +53,57 @@ class SystemAdvancedModel(sa.Model):
     adv_nvidia = sa.Column(sa.Boolean(), default=False)
 
 
-class SystemAdvancedService(ConfigService):
+def syslogd_changes(orig_config: dict[str, Any], new_config: dict[str, Any]) -> bool:
+    """Return `True` if syslogd should be restarted to apply the new configuration."""
+    if (
+        orig_config['fqdn_syslog'] != new_config['fqdn_syslog']
+        or orig_config['sysloglevel'].lower() != new_config['sysloglevel'].lower()
+        or orig_config['syslog_audit'] != new_config['syslog_audit']
+    ):
+        return True
+    # Convert syslogservers to sets to disregard ordering for the comparison
+    orig_items_set = {frozenset(d.items()) for d in orig_config['syslogservers']}
+    new_items_set = {frozenset(d.items()) for d in new_config['syslogservers']}
+    return orig_items_set != new_items_set
 
-    class Config:
-        datastore = 'system.advanced'
-        datastore_prefix = 'adv_'
-        datastore_extend = 'system.advanced.system_advanced_extend'
-        namespace = 'system.advanced'
-        cli_namespace = 'system.advanced'
-        role_prefix = 'SYSTEM_ADVANCED'
-        entry = SystemAdvancedEntry
 
-    @private
-    async def system_advanced_extend(self, data):
+class SystemAdvancedConfigServicePart(ConfigServicePart[SystemAdvancedEntry]):
+    _datastore = 'system.advanced'
+    _datastore_prefix = 'adv_'
+    _entry = SystemAdvancedEntry
+
+    async def extend(self, data: dict[str, Any]) -> dict[str, Any]:
         data['consolemsg'] = (await self.middleware.call('system.general.config'))['ui_consolemsg']
 
         if data.get('sed_user'):
-            data['sed_user'] = data.get('sed_user').upper()
+            data['sed_user'] = data['sed_user'].upper()
 
         data.pop('sed_passwd')
         data.pop('kmip_uid')
 
         return data
 
+    async def sed_global_password(self) -> str:
+        """Returns the configured global SED password in clear-text if one is set, otherwise an empty string."""
+        passwd = (await self.middleware.call(
+            'datastore.config', self._datastore, {'prefix': self._datastore_prefix}
+        ))['sed_passwd']
+        if passwd:
+            return str(passwd)
+        return str(await self.middleware.call('kmip.sed_global_password'))
+
+    def login_banner(self) -> str:
+        return str(self.middleware.call_sync('datastore.config', self._datastore)['adv_login_banner'])
+
     @settings.fields_validator('serialport', 'serialconsole')
-    async def _validate_serial(self, verrors, serialport, serialconsole):
+    async def _validate_serial(self, verrors: ValidationErrors, serialport: str, serialconsole: bool) -> None:
         if serialconsole:
             if not serialport:
                 verrors.add(
                     'serialport',
                     'Please specify a serial port when serial console option is checked'
                 )
-            elif serialport not in await self.middleware.call('system.advanced.serial_port_choices'):
+            elif serialport not in await serial_port_choices(self):
                 verrors.add(
                     'serialport',
                     'Serial port specified has not been identified by the system'
@@ -104,7 +117,7 @@ class SystemAdvancedService(ConfigService):
                 )
 
     @settings.fields_validator('syslogservers')
-    async def _validate_syslogserver(self, verrors, syslogservers):
+    async def _validate_syslogserver(self, verrors: ValidationErrors, syslogservers: list[dict[str, Any]]) -> None:
         seen_hosts = set()
         for i, server in enumerate(syslogservers):
             host = server['host']
@@ -121,17 +134,17 @@ class SystemAdvancedService(ConfigService):
 
             seen_hosts.add(host)
 
-            cert_id = server['tls_certificate']
+            cert_id: int = server['tls_certificate']
             if server['transport'] == 'TLS' and cert_id:
-                verrors.extend(
-                    await self.middleware.call2(
-                        self.s.certificate.cert_services_validation,
-                        cert_id, f'syslogservers.{i}.tls_certificate', False,
-                    )
+                cert_verrors = await self.call2(
+                    self.s.certificate.cert_services_validation,
+                    cert_id, f'syslogservers.{i}.tls_certificate', False,
                 )
+                if cert_verrors:
+                    verrors.extend(cert_verrors)
 
     @settings.fields_validator('kernel_extra_options')
-    async def _validate_kernel_extra_options(self, verrors, kernel_extra_options):
+    async def _validate_kernel_extra_options(self, verrors: ValidationErrors, kernel_extra_options: str) -> None:
         for invalid_char in ('\n', '"'):
             if invalid_char in kernel_extra_options:
                 verrors.add('kernel_extra_options', f'{invalid_char!r} is an invalid character and not allowed')
@@ -155,18 +168,19 @@ class SystemAdvancedService(ConfigService):
             verrors.add('kernel_extra_options', f'Modifying {invalid_param!r} is not allowed')
 
     @settings.fields_validator('nvidia')
-    async def _validate_nvidia(self, verrors, nvidia):
+    async def _validate_nvidia(self, verrors: ValidationErrors, nvidia: bool) -> None:
         # Only validate when nvidia is being disabled
         if nvidia is True:
             return
 
         container_ids = {
-            device.container for device in await self.middleware.call(
-                'container.device.query', [['attributes.dtype', '=', 'GPU'], ['attributes.gpu_type', '=', 'NVIDIA']]
+            device.container for device in await self.call2(
+                self.s.container.device.query,
+                [['attributes.dtype', '=', 'GPU'], ['attributes.gpu_type', '=', 'NVIDIA']],
             )
         }
-        if containers := await self.middleware.call(
-            'container.query', [['id', 'in', container_ids], ['status.state', '=', 'RUNNING']]
+        if containers := await self.call2(
+            self.s.container.query, [['id', 'in', container_ids], ['status.state', '=', 'RUNNING']]
         ):
             verrors.add(
                 'nvidia',
@@ -174,132 +188,87 @@ class SystemAdvancedService(ConfigService):
                 f'NVIDIA GPUs: {", ".join(c.name for c in containers)}. Please stop these containers first.'
             )
 
-    def _syslogd_changes(self, orig_config: dict, new_config: dict) -> bool:
-        """Return `True` if syslogd should be restarted to apply the new configuration."""
-        if (
-            orig_config['fqdn_syslog'] != new_config['fqdn_syslog']
-            or orig_config['sysloglevel'].lower() != new_config['sysloglevel'].lower()
-            or orig_config['syslog_audit'] != new_config['syslog_audit']
-        ):
-            return True
-        # Convert syslogservers to sets to disregard ordering for the comparison
-        orig_items_set = {frozenset(d.items()) for d in orig_config['syslogservers']}
-        new_items_set = {frozenset(d.items()) for d in new_config['syslogservers']}
-        return orig_items_set != new_items_set
+    async def do_update(self, data: SystemAdvancedUpdate) -> SystemAdvancedEntry:
+        old_config = await self.config()
+        old_sed = await self.sed_global_password()
 
-    @api_method(SystemAdvancedUpdateArgs, SystemAdvancedUpdateResult, audit='System advanced update')
-    async def do_update(self, data):
-        """
-        Update System Advanced Service Configuration.
-        """
+        update = data.model_dump(context={"expose_secrets": True})
+        new_sed = update.pop('sed_passwd', old_sed)
+
         consolemsg = None
-        if 'consolemsg' in data:
-            consolemsg = data.pop('consolemsg')
+        if 'consolemsg' in update:
+            consolemsg = update.pop('consolemsg')
             warnings.warn("`consolemsg` has been deprecated and moved to `system.general`", DeprecationWarning)
 
-        for server in data.get('syslogservers', []):
+        for server in update.get('syslogservers', []):
             if server['transport'] != 'TLS':
                 server['tls_certificate'] = None
 
-        config_data = await self.config()
-        config_data['sed_passwd'] = await self.sed_global_password()
-        config_data.pop('consolemsg')
-        original_data = deepcopy(config_data)
-        config_data.update(data)
+        merged = old_config.model_dump()
+        merged.update(update)
+        new_config = SystemAdvancedEntry(**merged)
 
-        await settings.validate(self, 'system_advanced_update', original_data, config_data)
+        await settings.validate(self, 'system_advanced_update', old_config.model_dump(), new_config.model_dump())
 
-        if config_data != original_data:
-            if original_data.get('sed_user'):
-                original_data['sed_user'] = original_data['sed_user'].lower()
-            if config_data.get('sed_user'):
-                config_data['sed_user'] = config_data['sed_user'].lower()
-            if not config_data['sed_passwd'] and config_data['sed_passwd'] != original_data['sed_passwd']:
+        if new_config != old_config or new_sed != old_sed:
+            write = new_config.model_dump()
+            write.pop('id', None)
+            write.pop('consolemsg', None)
+            write['sed_user'] = write['sed_user'].lower()
+            write['sed_passwd'] = new_sed
+
+            if not new_sed and new_sed != old_sed:
                 # We want to make sure kmip uid is None in this case
-                adv_config = await self.middleware.call('datastore.config', self._config.datastore)
-                self.middleware.create_task(
-                    self.middleware.call('kmip.reset_sed_global_password', adv_config['adv_kmip_uid'])
-                )
-                config_data['kmip_uid'] = None
+                adv_kmip_uid = (await self.middleware.call(
+                    'datastore.config', self._datastore, {'prefix': self._datastore_prefix}
+                ))['kmip_uid']
+                self.create_task(self.middleware.call('kmip.reset_sed_global_password', adv_kmip_uid))
+                write['kmip_uid'] = None
 
             await self.middleware.call(
-                'datastore.update',
-                self._config.datastore,
-                config_data['id'],
-                config_data,
-                {'prefix': self._config.datastore_prefix}
+                'datastore.update', self._datastore, old_config.id, write, {'prefix': self._datastore_prefix}
             )
 
-            if original_data['boot_scrub'] != config_data['boot_scrub']:
+            if old_config.boot_scrub != new_config.boot_scrub:
                 await (await self.call2(self.s.service.control, 'RESTART', 'cron')).wait(raise_error=True)
 
-            generate_grub = original_data['kernel_extra_options'] != config_data['kernel_extra_options']
-            if original_data['motd'] != config_data['motd']:
+            generate_grub = old_config.kernel_extra_options != new_config.kernel_extra_options
+            if old_config.motd != new_config.motd:
                 await self.middleware.call('etc.generate', 'motd')
 
-            if original_data['login_banner'] != config_data['login_banner']:
+            if old_config.login_banner != new_config.login_banner:
                 await (await self.call2(self.s.service.control, 'RELOAD', 'ssh')).wait(raise_error=True)
 
-            if original_data['powerdaemon'] != config_data['powerdaemon']:
+            if old_config.powerdaemon != new_config.powerdaemon:
                 await (await self.call2(self.s.service.control, 'RESTART', 'powerd')).wait(raise_error=True)
 
-            if self._syslogd_changes(original_data, config_data):
+            if syslogd_changes(old_config.model_dump(), new_config.model_dump()):
                 await (await self.call2(self.s.service.control, 'RESTART', 'syslogd')).wait(raise_error=True)
 
-            if config_data['sed_passwd'] and original_data['sed_passwd'] != config_data['sed_passwd']:
+            if new_sed and old_sed != new_sed:
                 await self.middleware.call('kmip.sync_sed_keys')
 
-            if config_data['kdump_enabled'] != original_data['kdump_enabled']:
+            if new_config.kdump_enabled != old_config.kdump_enabled:
                 # kdump changes require a reboot to take effect. So just generating the kdump config
                 # should be enough
                 await self.middleware.call('etc.generate', 'kdump')
                 generate_grub = True
 
-            if original_data['debugkernel'] != config_data['debugkernel']:
+            if old_config.debugkernel != new_config.debugkernel:
                 generate_grub = True
                 # Keep the on-disk flag in sync on every transition so
                 # truenas-initrd.py reads the right value on the next regen.
                 await asyncio.to_thread(write_initramfs_flags, self.middleware)
 
-            if original_data['nvidia'] != config_data['nvidia']:
-                await self.middleware.call('system.advanced.handle_nvidia_toggle')
+            if old_config.nvidia != new_config.nvidia:
+                await handle_nvidia_toggle(self)
 
-            await self.middleware.call('system.advanced.configure_tty', original_data, config_data, generate_grub)
+            await configure_tty(self, old_config.model_dump(), new_config.model_dump(), generate_grub)
 
-            if config_data['debugkernel'] and not original_data['debugkernel']:
+            if new_config.debugkernel and not old_config.debugkernel:
                 await self.middleware.call('boot.update_initramfs')
 
         if consolemsg is not None:
             await self.middleware.call('system.general.update', {'ui_consolemsg': consolemsg})
 
         return await self.config()
-
-    @api_method(
-        SystemAdvancedSedGlobalPasswordIsSetArgs,
-        SystemAdvancedSedGlobalPasswordIsSetResult,
-        roles=['SYSTEM_ADVANCED_READ']
-    )
-    async def sed_global_password_is_set(self):
-        """Returns a boolean identifying whether or not a global
-        SED password has been set."""
-        return bool(await self.sed_global_password())
-
-    @api_method(
-        SystemAdvancedSedGlobalPasswordArgs,
-        SystemAdvancedSedGlobalPasswordResult,
-        roles=['SYSTEM_ADVANCED_READ']
-    )
-    async def sed_global_password(self):
-        """Returns configured global SED password in clear-text if one
-        is configured, otherwise an empty string."""
-        passwd = (await self.middleware.call(
-            'datastore.config', 'system.advanced', {'prefix': self._config.datastore_prefix}
-        ))['sed_passwd']
-        return passwd if passwd else await self.middleware.call('kmip.sed_global_password')
-
-    @api_method(SystemAdvancedLoginBannerArgs, SystemAdvancedLoginBannerResult, authentication_required=False)
-    def login_banner(self):
-        """Returns user set login banner."""
-        # NOTE: This endpoint doesn't require authentication because
-        # it is used by UI on the login page
-        return self.middleware.call_sync('datastore.config', 'system.advanced')['adv_login_banner']

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -1,179 +1,160 @@
-import asyncio
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from truenas_pylibvirt.utils.gpu import get_gpus
 
 from middlewared.alert.source.gpu_isolation import InvalidGpuPciIdsAlert
-from middlewared.api import api_method
-from middlewared.api.current import (
-    SystemAdvancedGetGpuPciChoicesArgs,
-    SystemAdvancedGetGpuPciChoicesResult,
-    SystemAdvancedUpdateGpuPciIdsArgs,
-    SystemAdvancedUpdateGpuPciIdsResult,
-)
 from middlewared.plugins.initramfs import write_initramfs_flags
 from middlewared.plugins.system.reboot import RebootReason
-from middlewared.service import Service, ValidationErrors, private
+from middlewared.service import ValidationErrors
+
+if TYPE_CHECKING:
+    from middlewared.service import ServiceContext
 
 
-class SystemAdvancedService(Service):
+def get_gpu_pci_choices(context: ServiceContext) -> dict[str, Any]:
+    configured_value = context.call_sync2(context.s.system.advanced.config).isolated_gpu_pci_ids
+    gpus: dict[str, Any] = {}
+    gpu_slots = []
+    for gpu in get_gpus():
+        gpus[f'{gpu["description"]} [{gpu["addr"]["pci_slot"]}]'] = {
+            'pci_slot': gpu['addr']['pci_slot'],
+            'uses_system_critical_devices': gpu['uses_system_critical_devices'],
+            'critical_reason': gpu['critical_reason'],
+        }
+        gpu_slots.append(gpu['addr']['pci_slot'])
 
-    class Config:
-        namespace = 'system.advanced'
-        cli_namespace = 'system.advanced'
+    # uses_system_critical_devices
+    for slot in filter(lambda gpu: gpu not in gpu_slots, configured_value):
+        gpus[f'Unknown {slot!r} slot'] = {
+            'pci_slot': slot,
+            'uses_system_critical_devices': False,
+            'critical_reason': None,
+        }
 
-    @api_method(
-        SystemAdvancedGetGpuPciChoicesArgs,
-        SystemAdvancedGetGpuPciChoicesResult,
-        roles=['SYSTEM_ADVANCED_READ']
+    return gpus
+
+
+async def update_gpu_pci_ids(context: ServiceContext, isolated_gpu_pci_ids: list[str]) -> None:
+    verrors = ValidationErrors()
+    if isolated_gpu_pci_ids:
+        verrors = await validate_gpu_pci_ids(context, isolated_gpu_pci_ids, verrors, 'gpu_settings')
+
+    if await context.middleware.call('system.is_ha_capable') and isolated_gpu_pci_ids:
+        verrors.add(
+            'gpu_settings.isolated_gpu_pci_ids',
+            'HA capable systems do not support PCI passthrough'
+        )
+
+    verrors.check()
+
+    await context.middleware.call(
+        'datastore.update',
+        'system.advanced',
+        (await context.call2(context.s.system.advanced.config)).id,
+        {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
+        {'prefix': 'adv_'}
     )
-    def get_gpu_pci_choices(self):
-        """
-        This endpoint gives all the gpu pci ids/slots that can be isolated.
-        """
-        configured_value = self.middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']
-        gpus = {}
-        gpu_slots = []
-        for gpu in get_gpus():
-            gpus[f'{gpu["description"]} [{gpu["addr"]["pci_slot"]}]'] = {
-                'pci_slot': gpu['addr']['pci_slot'],
-                'uses_system_critical_devices': gpu['uses_system_critical_devices'],
-                'critical_reason': gpu['critical_reason'],
-            }
-            gpu_slots.append(gpu['addr']['pci_slot'])
+    changed = await context.to_thread(write_initramfs_flags, context.middleware)
+    await context.middleware.call('boot.update_initramfs', {'force': changed})
 
-        # uses_system_critical_devices
-        for slot in filter(lambda gpu: gpu not in gpu_slots, configured_value):
-            gpus[f'Unknown {slot!r} slot'] = {
-                'pci_slot': slot,
-                'uses_system_critical_devices': False,
-                'critical_reason': None,
-            }
 
-        return gpus
+async def validate_gpu_pci_ids(
+    context: ServiceContext, isolated_gpu_pci_ids: list[str], verrors: ValidationErrors, schema: str
+) -> ValidationErrors:
+    available = set()
+    critical_gpus = set()
+    for gpu in await context.middleware.call('device.get_gpus'):
+        available.add(gpu['addr']['pci_slot'])
+        if gpu['uses_system_critical_devices']:
+            critical_gpus.add(gpu['addr']['pci_slot'])
 
-    @api_method(
-        SystemAdvancedUpdateGpuPciIdsArgs,
-        SystemAdvancedUpdateGpuPciIdsResult,
-        roles=['SYSTEM_ADVANCED_WRITE']
-    )
-    async def update_gpu_pci_ids(self, isolated_gpu_pci_ids):
-        """
-        Update the list of GPU PCI IDs isolated from the host system.
-        """
-        verrors = ValidationErrors()
-        if isolated_gpu_pci_ids:
-            verrors = await self.validate_gpu_pci_ids(isolated_gpu_pci_ids, verrors, 'gpu_settings')
+    provided = set(isolated_gpu_pci_ids)
+    not_available = provided - available
+    cannot_isolate = provided & critical_gpus
+    if not_available:
+        verrors.add(
+            f'{schema}.isolated_gpu_pci_ids',
+            f'{", ".join(not_available)} GPU pci slot(s) are not available or a GPU is not configured.'
+        )
 
-        if await self.middleware.call('system.is_ha_capable') and isolated_gpu_pci_ids:
-            verrors.add(
-                'gpu_settings.isolated_gpu_pci_ids',
-                'HA capable systems do not support PCI passthrough'
-            )
+    if cannot_isolate:
+        verrors.add(
+            f'{schema}.isolated_gpu_pci_ids',
+            f'{", ".join(cannot_isolate)} GPU pci slot(s) consists of devices '
+            'which cannot be isolated from host.'
+        )
 
-        verrors.check()
+    if len(available - provided) < 1:
+        verrors.add(
+            f'{schema}.isolated_gpu_pci_ids',
+            'A minimum of 1 GPU is required for the host to ensure it functions as desired.'
+        )
 
-        await self.middleware.call(
+    return verrors
+
+
+async def validate_isolated_gpus_on_boot(context: ServiceContext) -> None:
+    """
+    Validates that isolated GPU PCI IDs in the database still point to actual GPUs.
+    If a PCI ID no longer points to a GPU (e.g., GPU was removed and PCI ID reassigned),
+    it is automatically removed from the isolation configuration and an alert is generated.
+
+    This prevents situations where:
+    1. GPU with PCI ID 1 is isolated
+    2. GPU is physically removed
+    3. On reboot, PCI ID 1 now points to a different device
+    4. System incorrectly isolates the wrong device
+
+    Pure validation/cleanup — does not write files or trigger initramfs
+    rebuilds. The initramfs.py system.ready handler runs this first, then
+    materializes flag files (which will reflect any DB cleanup done here).
+    """
+    try:
+        config = await context.call2(context.s.system.advanced.config)
+        isolated_pci_ids = set(config.isolated_gpu_pci_ids)
+
+        if not isolated_pci_ids:
+            await context.call2(context.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
+            return
+
+        current_gpu_pci_slots = {
+            gpu['addr']['pci_slot'] for gpu in await context.middleware.call('device.get_gpus')
+        }
+        invalid_pci_ids = isolated_pci_ids - current_gpu_pci_slots
+
+        if not invalid_pci_ids:
+            await context.call2(context.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
+            return
+
+        context.logger.warning(
+            'Found isolated GPU PCI IDs that no longer point to GPUs: %s', ', '.join(invalid_pci_ids)
+        )
+
+        valid_pci_ids = isolated_pci_ids - invalid_pci_ids
+        await context.middleware.call(
             'datastore.update',
             'system.advanced',
-            (await self.middleware.call('system.advanced.config'))['id'],
-            {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
+            config.id,
+            {'isolated_gpu_pci_ids': list(valid_pci_ids)},
             {'prefix': 'adv_'}
         )
-        changed = await asyncio.to_thread(write_initramfs_flags, self.middleware)
-        await self.middleware.call('boot.update_initramfs', {'force': changed})
+        context.logger.info(
+            'Removed invalid GPU PCI IDs from isolation configuration: %s',
+            ', '.join(invalid_pci_ids)
+        )
 
-    @private
-    async def validate_gpu_pci_ids(self, isolated_gpu_pci_ids, verrors, schema):
-        available = set()
-        critical_gpus = set()
-        for gpu in await self.middleware.call('device.get_gpus'):
-            available.add(gpu['addr']['pci_slot'])
-            if gpu['uses_system_critical_devices']:
-                critical_gpus.add(gpu['addr']['pci_slot'])
+        await context.call2(
+            context.s.alert.oneshot_create,
+            InvalidGpuPciIdsAlert(pci_ids=', '.join(invalid_pci_ids))
+        )
+        await context.middleware.call(
+            'system.reboot.add_reason',
+            RebootReason.GPU_ISOLATION.name,
+            RebootReason.GPU_ISOLATION.value,
+        )
+        context.logger.info('Created alert and added reboot reason for invalid GPU PCI IDs')
 
-        provided = set(isolated_gpu_pci_ids)
-        not_available = provided - available
-        cannot_isolate = provided & critical_gpus
-        if not_available:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                f'{", ".join(not_available)} GPU pci slot(s) are not available or a GPU is not configured.'
-            )
-
-        if cannot_isolate:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                f'{", ".join(cannot_isolate)} GPU pci slot(s) consists of devices '
-                'which cannot be isolated from host.'
-            )
-
-        if len(available - provided) < 1:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                'A minimum of 1 GPU is required for the host to ensure it functions as desired.'
-            )
-
-        return verrors
-
-    @private
-    async def validate_isolated_gpus_on_boot(self):
-        """
-        Validates that isolated GPU PCI IDs in the database still point to actual GPUs.
-        If a PCI ID no longer points to a GPU (e.g., GPU was removed and PCI ID reassigned),
-        it is automatically removed from the isolation configuration and an alert is generated.
-
-        This prevents situations where:
-        1. GPU with PCI ID 1 is isolated
-        2. GPU is physically removed
-        3. On reboot, PCI ID 1 now points to a different device
-        4. System incorrectly isolates the wrong device
-
-        Pure validation/cleanup — does not write files or trigger initramfs
-        rebuilds. The initramfs.py system.ready handler runs this first, then
-        materializes flag files (which will reflect any DB cleanup done here).
-        """
-        try:
-            config = await self.middleware.call('system.advanced.config')
-            isolated_pci_ids = set(config.get('isolated_gpu_pci_ids', []))
-
-            if not isolated_pci_ids:
-                await self.call2(self.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
-                return
-
-            current_gpu_pci_slots = {gpu['addr']['pci_slot'] for gpu in await self.middleware.call('device.get_gpus')}
-            invalid_pci_ids = isolated_pci_ids - current_gpu_pci_slots
-
-            if not invalid_pci_ids:
-                await self.call2(self.s.alert.oneshot_delete, 'InvalidGpuPciIds', None)
-                return
-
-            self.logger.warning(
-                'Found isolated GPU PCI IDs that no longer point to GPUs: %s', ', '.join(invalid_pci_ids)
-            )
-
-            valid_pci_ids = isolated_pci_ids - invalid_pci_ids
-            await self.middleware.call(
-                'datastore.update',
-                'system.advanced',
-                config['id'],
-                {'isolated_gpu_pci_ids': list(valid_pci_ids)},
-                {'prefix': 'adv_'}
-            )
-            self.logger.info(
-                'Removed invalid GPU PCI IDs from isolation configuration: %s',
-                ', '.join(invalid_pci_ids)
-            )
-
-            await self.call2(
-                self.s.alert.oneshot_create,
-                InvalidGpuPciIdsAlert(pci_ids=', '.join(invalid_pci_ids))
-            )
-            await self.middleware.call(
-                'system.reboot.add_reason',
-                RebootReason.GPU_ISOLATION.name,
-                RebootReason.GPU_ISOLATION.value,
-            )
-            self.logger.info('Created alert and added reboot reason for invalid GPU PCI IDs')
-
-        except Exception as e:
-            self.logger.error('Error validating isolated GPU PCI IDs on boot: %s', e, exc_info=True)
+    except Exception as e:
+        context.logger.error('Error validating isolated GPU PCI IDs on boot: %s', e, exc_info=True)

--- a/src/middlewared/middlewared/plugins/system_advanced/nvidia.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/nvidia.py
@@ -1,89 +1,70 @@
+from __future__ import annotations
+
 import os
 import subprocess
+from typing import TYPE_CHECKING
 
 from truenas_pylibvirt.utils.gpu import get_gpus
 
-from middlewared.api import api_method
-from middlewared.api.current import (
-    SystemAdvancedNvidiaPresentArgs,
-    SystemAdvancedNvidiaPresentResult,
-)
-from middlewared.service import Service, private
 from middlewared.utils.rootfs_protection import rootfs_protection_lock
 
+if TYPE_CHECKING:
+    from middlewared.service import ServiceContext
 
-class SystemAdvancedService(Service):
 
-    class Config:
-        namespace = 'system.advanced'
-        cli_namespace = 'system.advanced'
+def nvidia_present(context: ServiceContext) -> bool:
+    adv_config = context.call_sync2(context.s.system.advanced.config)
+    for gpu in get_gpus():
+        if gpu['addr']['pci_slot'] in adv_config.isolated_gpu_pci_ids:
+            continue
+        if gpu['vendor'] == 'NVIDIA':
+            return True
+    return False
 
-    @api_method(
-        SystemAdvancedNvidiaPresentArgs,
-        SystemAdvancedNvidiaPresentResult,
-        roles=['SYSTEM_ADVANCED_READ'],
-    )
-    def nvidia_present(self):
-        """Returns whether a non-isolated NVIDIA GPU is present in the system."""
-        adv_config = self.middleware.call_sync('system.advanced.config')
-        for gpu in get_gpus():
-            if gpu['addr']['pci_slot'] in adv_config['isolated_gpu_pci_ids']:
-                continue
-            if gpu['vendor'] == 'NVIDIA':
-                return True
-        return False
 
-    @private
-    async def handle_nvidia_toggle(self):
-        # this only gets called if nvidia setting was toggled
-        # which means we need to restart apps once we have run our configuration logic
-        await self.middleware.call('system.advanced.configure_nvidia')
-        if (await self.middleware.call('docker.config')).pool:
-            # We explicitly have it non-blocking here as docker restart on HDD based systems can take
-            # decent amount of time
-            self.middleware.create_task(self.middleware.call('docker.restart_service'))
+async def handle_nvidia_toggle(context: ServiceContext) -> None:
+    # this only gets called if nvidia setting was toggled
+    # which means we need to restart apps once we have run our configuration logic
+    await context.to_thread(configure_nvidia, context)
+    if (await context.middleware.call('docker.config')).pool:
+        # We explicitly have it non-blocking here as docker restart on HDD based systems can take
+        # decent amount of time
+        context.create_task(context.middleware.call('docker.restart_service'))
 
-    @private
-    def configure_nvidia(self):
-        config = self.middleware.call_sync('system.advanced.config')
-        nvidia_sysext_path = '/run/extensions/nvidia.raw'
-        if config['nvidia'] and not os.path.exists(nvidia_sysext_path):
-            os.makedirs('/run/extensions', exist_ok=True)
-            os.symlink('/usr/share/truenas/sysext-extensions/nvidia.raw', nvidia_sysext_path)
-            refresh = True
-        elif not config['nvidia'] and os.path.exists(nvidia_sysext_path):
-            os.unlink(nvidia_sysext_path)
-            refresh = True
+
+def configure_nvidia(context: ServiceContext) -> None:
+    config = context.call_sync2(context.s.system.advanced.config)
+    nvidia_sysext_path = '/run/extensions/nvidia.raw'
+    if config.nvidia and not os.path.exists(nvidia_sysext_path):
+        os.makedirs('/run/extensions', exist_ok=True)
+        os.symlink('/usr/share/truenas/sysext-extensions/nvidia.raw', nvidia_sysext_path)
+        refresh = True
+    elif not config.nvidia and os.path.exists(nvidia_sysext_path):
+        os.unlink(nvidia_sysext_path)
+        refresh = True
+    else:
+        refresh = False
+
+    if refresh:
+        # systemd-sysext refresh re-overlays /usr; hold the rootfs lock so it
+        # can't race the initramfs rebuild or disable-rootfs-protection.
+        with rootfs_protection_lock():
+            subprocess.run(['systemd-sysext', 'refresh'], capture_output=True, check=True, text=True)
+            subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
+
+    if config.nvidia:
+        cp = subprocess.run(
+            ['modprobe', '-a', 'nvidia', 'nvidia_drm', 'nvidia_modeset'],
+            capture_output=True,
+            text=True
+        )
+        if cp.returncode != 0:
+            context.logger.error('Error loading nvidia driver: %s', cp.stderr)
         else:
-            refresh = False
-
-        if refresh:
-            # systemd-sysext refresh re-overlays /usr; hold the rootfs lock so it
-            # can't race the initramfs rebuild or disable-rootfs-protection.
-            with rootfs_protection_lock():
-                subprocess.run(['systemd-sysext', 'refresh'], capture_output=True, check=True, text=True)
-                subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
-
-        if config['nvidia']:
-            cp = subprocess.run(
-                ['modprobe', '-a', 'nvidia', 'nvidia_drm', 'nvidia_modeset'],
+            # Needed to verify that NVIDIA character devices are present and functioning correctly.
+            smi_cp = subprocess.run(
+                ['nvidia-smi'],
                 capture_output=True,
-                text=True
             )
-            if cp.returncode != 0:
-                self.logger.error('Error loading nvidia driver: %s', cp.stderr)
-            else:
-                # Needed to verify that NVIDIA character devices are present and functioning correctly.
-                cp = subprocess.run(
-                    ['nvidia-smi'],
-                    capture_output=True,
-                )
-                if cp.returncode != 0:
-                    self.logger.error('Error while setting up nvidia gpu: %s', cp.stderr)
-
-
-async def setup(middleware):
-    try:
-        await middleware.call('system.advanced.configure_nvidia')
-    except Exception:
-        middleware.logger.error('Unhandled exception configuring nvidia', exc_info=True)
+            if smi_cp.returncode != 0:
+                context.logger.error('Error while setting up nvidia gpu: %s', smi_cp.stderr)

--- a/src/middlewared/middlewared/plugins/system_advanced/serial.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/serial.py
@@ -1,71 +1,69 @@
-from middlewared.api import api_method
-from middlewared.api.current import SystemAdvancedSerialPortChoicesArgs, SystemAdvancedSerialPortChoicesResult
-from middlewared.service import Service, private
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from middlewared.utils import run
 
+if TYPE_CHECKING:
+    from middlewared.service import ServiceContext
 
-class SystemAdvancedService(Service):
 
-    class Config:
-        namespace = 'system.advanced'
-        cli_namespace = 'system.advanced'
+async def serial_port_choices(context: ServiceContext) -> dict[str, str]:
+    ports: dict[str, str] = {
+        e['name']: e['name'] for e in await context.middleware.call('device.get_info', {'type': 'SERIAL'})
+    }
+    if not ports or (await context.call2(context.s.system.advanced.config)).serialport == 'ttyS0':
+        # We should always add ttyS0 if ports is false or current value is the default one in db
+        # i.e ttyS0
+        ports['ttyS0'] = 'ttyS0'
 
-    @api_method(SystemAdvancedSerialPortChoicesArgs, SystemAdvancedSerialPortChoicesResult, roles=['READONLY_ADMIN'])
-    async def serial_port_choices(self):
-        """
-        Get available choices for ``serialport``.
-        """
-        ports = {e['name']: e['name'] for e in await self.middleware.call('device.get_info', {'type': 'SERIAL'})}
-        if not ports or (await self.middleware.call('system.advanced.config'))['serialport'] == 'ttyS0':
-            # We should always add ttyS0 if ports is false or current value is the default one in db
-            # i.e ttyS0
-            ports['ttyS0'] = 'ttyS0'
+    return ports
 
-        return ports
 
-    @private
-    async def configure_tty(self, old, new, generate_grub=False):
-        restart_ttys = any(old[k] != new[k] for k in ('serialconsole', 'serialspeed', 'serialport'))
+async def configure_tty(
+    context: ServiceContext, old: dict[str, Any], new: dict[str, Any], generate_grub: bool = False
+) -> None:
+    restart_ttys = any(old[k] != new[k] for k in ('serialconsole', 'serialspeed', 'serialport'))
 
-        if old['serialconsole'] != new['serialconsole']:
-            if old['serialport'] == new['serialport']:
-                action = 'enable' if new['serialconsole'] else 'disable'
-                cp = await run(
-                    ['systemctl', action, f'serial-getty@{old["serialport"]}.service'], check=False
-                )
-                if cp.returncode:
-                    self.logger.error('Failed to %r serialconsole: %r', action, cp.stderr.decode())
-
-        if old['serialport'] != new['serialport']:
-            for command in [
-                ['systemctl', 'disable', f'serial-getty@{old["serialport"]}.service'],
-                ['systemctl', 'stop', f'serial-getty@{old["serialport"]}.service'],
-            ] + (
-                [['systemctl', 'enable', f'serial-getty@{new["serialport"]}.service']] if new['serialconsole'] else []
-            ):
-                cp = await run(command, check=False)
-                if cp.returncode:
-                    self.logger.error(
-                        'Failed to %r %r serialport service: %r', command[1], command[2], cp.stderr.decode()
-                    )
-
-        if restart_ttys or old['consolemenu'] != new['consolemenu']:
-            serial_action = 'restart' if new['serialconsole'] else 'stop'
-            cp = await run(['systemctl', serial_action, f'serial-getty@{new["serialport"]}.service'], check=False)
+    if old['serialconsole'] != new['serialconsole']:
+        if old['serialport'] == new['serialport']:
+            action = 'enable' if new['serialconsole'] else 'disable'
+            cp = await run(
+                ['systemctl', action, f'serial-getty@{old["serialport"]}.service'], check=False
+            )
             if cp.returncode:
-                self.middleware.logger.error(
-                    'Failed to %r %r serial port: %r', serial_action, new['serialport'], cp.stderr.decode()
+                context.logger.error('Failed to %r serialconsole: %r', action, cp.stderr.decode())
+
+    if old['serialport'] != new['serialport']:
+        for command in [
+            ['systemctl', 'disable', f'serial-getty@{old["serialport"]}.service'],
+            ['systemctl', 'stop', f'serial-getty@{old["serialport"]}.service'],
+        ] + (
+            [['systemctl', 'enable', f'serial-getty@{new["serialport"]}.service']] if new['serialconsole'] else []
+        ):
+            cp = await run(command, check=False)
+            if cp.returncode:
+                context.logger.error(
+                    'Failed to %r %r serialport service: %r', command[1], command[2], cp.stderr.decode()
                 )
 
-        if old['consolemenu'] != new['consolemenu']:
-            cp = await run(['systemctl', 'restart', 'getty@tty1.service'], check=False)
-            if cp.returncode:
-                self.middleware.logger.error('Failed to restart tty service: %r', cp.stderr.decode())
+    if restart_ttys or old['consolemenu'] != new['consolemenu']:
+        serial_action = 'restart' if new['serialconsole'] else 'stop'
+        cp = await run(['systemctl', serial_action, f'serial-getty@{new["serialport"]}.service'], check=False)
+        if cp.returncode:
+            context.logger.error(
+                'Failed to %r %r serial port: %r', serial_action, new['serialport'], cp.stderr.decode()
+            )
 
-        if generate_grub or restart_ttys:
-            await self.middleware.call('etc.generate', 'grub')
-            if await self.middleware.call('failover.licensed'):
-                try:
-                    await self.middleware.call('failover.call_remote', 'etc.generate', ['grub'])
-                except Exception:
-                    self.logger.exception('failed to render grub.cfg on remote node')
+    if old['consolemenu'] != new['consolemenu']:
+        cp = await run(['systemctl', 'restart', 'getty@tty1.service'], check=False)
+        if cp.returncode:
+            context.logger.error('Failed to restart tty service: %r', cp.stderr.decode())
+
+    if generate_grub or restart_ttys:
+        await context.middleware.call('etc.generate', 'grub')
+        if await context.middleware.call('failover.licensed'):
+            try:
+                await context.middleware.call('failover.call_remote', 'etc.generate', ['grub'])
+            except Exception:
+                context.logger.exception('failed to render grub.cfg on remote node')

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -1,55 +1,27 @@
-from middlewared.api import api_method
-from middlewared.api.current import (
-    SystemAdvancedSyslogCertificateAuthorityChoicesArgs,
-    SystemAdvancedSyslogCertificateAuthorityChoicesResult,
-    SystemAdvancedSyslogCertificateChoicesArgs,
-    SystemAdvancedSyslogCertificateChoicesResult,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from middlewared.api.base import EmptyDict
 from middlewared.plugins.truenas_connect.utils import TNC_CERT_PREFIX
-from middlewared.service import Service
+
+if TYPE_CHECKING:
+    from middlewared.service import ServiceContext
 
 
-class SystemAdvancedService(Service):
+async def syslog_certificate_choices(context: ServiceContext) -> dict[int, str]:
+    return {
+        i.id: i.name
+        for i in await context.call2(
+            context.s.certificate.query,
+            [
+                ['cert_type_CSR', '=', False],
+                ['cert_type_CA', '=', False],
+                ['name', '!^', TNC_CERT_PREFIX],
+            ],
+        )
+    }
 
-    class Config:
-        namespace = 'system.advanced'
-        cli_namespace = 'system.advanced'
 
-    @api_method(
-        SystemAdvancedSyslogCertificateChoicesArgs,
-        SystemAdvancedSyslogCertificateChoicesResult,
-        roles=['READONLY_ADMIN']
-    )
-    async def syslog_certificate_choices(self):
-        """
-        Return choices of certificates which can be used for ``syslogservers.N.tls_certificate``.
-        """
-        return {
-            i.id: i.name
-            for i in await self.middleware.call2(
-                self.s.certificate.query,
-                [
-                    ['cert_type_CSR', '=', False],
-                    ['cert_type_CA', '=', False],
-                    ['name', '!^', TNC_CERT_PREFIX],
-                ],
-            )
-        }
-
-    @api_method(
-        SystemAdvancedSyslogCertificateAuthorityChoicesArgs,
-        SystemAdvancedSyslogCertificateAuthorityChoicesResult,
-        authorization_required=False
-    )
-    async def syslog_certificate_authority_choices(self):
-        """
-        Return choices of certificate authorities which can be used for ``syslog_tls_certificate_authority``.
-
-        .. deprecated:: 25.10
-            This method is no longer used and will be removed after the UI is updated.
-        """
-        # return {
-        #     i['id']: i['name']
-        #     for i in await self.middleware.call('certificateauthority.query', [['revoked', '=', False]])
-        # }
-        return {}
+def syslog_certificate_authority_choices() -> EmptyDict:
+    return EmptyDict()

--- a/src/middlewared/middlewared/plugins/ups/__init__.py
+++ b/src/middlewared/middlewared/plugins/ups/__init__.py
@@ -60,8 +60,8 @@ class UPSService(SystemServiceService[UPSEntry]):
         """
         Returns available UPS device ports for the system (serial ports, USB HID devices, and "auto").
         """
-        adv_config = self.middleware.call_sync('system.advanced.config')
-        return port_choices(adv_config['serialconsole'], adv_config['serialport'])
+        adv_config = self.call_sync2(self.s.system.advanced.config)
+        return port_choices(adv_config.serialconsole, adv_config.serialport)
 
     @private
     async def dismiss_alerts(self) -> None:

--- a/src/middlewared/middlewared/plugins/ups/config.py
+++ b/src/middlewared/middlewared/plugins/ups/config.py
@@ -72,9 +72,9 @@ class UPSServicePart(SystemServicePart[UPSEntry]):
                 )
 
         if data.port:
-            adv_config = await self.middleware.call('system.advanced.config')
-            serial_port = os.path.join('/dev', adv_config['serialport'])
-            if adv_config['serialconsole'] and serial_port == data.port:
+            adv_config = await self.call2(self.s.system.advanced.config)
+            serial_port = os.path.join('/dev', adv_config.serialport)
+            if adv_config.serialconsole and serial_port == data.port:
                 verrors.add(
                     'ups_update.port',
                     'UPS port must be different then the port specified for '

--- a/src/middlewared/middlewared/pytest/unit/plugins/docker/test_docker_config_change_detection.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/docker/test_docker_config_change_detection.py
@@ -2,7 +2,13 @@ import logging
 
 import pytest
 
-from middlewared.api.current import DockerAddressPool, DockerEntry, DockerRegistryMirror, DockerUpdate
+from middlewared.api.current import (
+    DockerAddressPool,
+    DockerEntry,
+    DockerRegistryMirror,
+    DockerUpdate,
+    SystemAdvancedEntry,
+)
 from middlewared.plugins.docker.config import DockerConfigServicePart
 from middlewared.pytest.unit.middleware import Middleware
 from middlewared.service.context import ServiceContext
@@ -26,7 +32,7 @@ DB_DEFAULTS = dict(
 @pytest.mark.asyncio
 async def test_extend_constructs_typed_address_pools():
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     data = dict(DB_DEFAULTS)
@@ -37,7 +43,7 @@ async def test_extend_constructs_typed_address_pools():
 @pytest.mark.asyncio
 async def test_extend_constructs_typed_registry_mirrors():
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     data = dict(DB_DEFAULTS, registry_mirrors=[
@@ -51,7 +57,7 @@ async def test_extend_constructs_typed_registry_mirrors():
 async def test_address_pools_equal_after_updated_with_same_values():
     """old_config (from extend+model_construct) and new_config (from updated with DockerUpdate) compare equal."""
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     data = dict(DB_DEFAULTS)
@@ -70,7 +76,7 @@ async def test_address_pools_equal_after_updated_with_same_values():
 @pytest.mark.asyncio
 async def test_address_pools_not_equal_after_updated_with_different_values():
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     data = dict(DB_DEFAULTS)
@@ -88,7 +94,7 @@ async def test_address_pools_not_equal_after_updated_with_different_values():
 async def test_address_pool_base_normalized_to_canonical():
     """A base with host bits set is stored/returned in canonical network form (172.17.0.0/12 -> 172.16.0.0/12)."""
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     # read path (extend / model_validate of stored value)
@@ -108,7 +114,7 @@ async def test_no_spurious_address_pools_change_on_noncanonical_resubmit():
     re-submitted as its non-canonical equivalent 172.17.0.0/12 must compare equal.
     """
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     stored = dict(DB_DEFAULTS, address_pools=[
@@ -128,7 +134,7 @@ async def test_no_spurious_address_pools_change_on_noncanonical_resubmit():
 @pytest.mark.asyncio
 async def test_registry_mirrors_equal_after_updated_with_same_values():
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     mirrors = [{'url': 'https://mirror.example.com', 'insecure': False}]
@@ -144,7 +150,7 @@ async def test_registry_mirrors_equal_after_updated_with_same_values():
 @pytest.mark.asyncio
 async def test_registry_mirrors_not_equal_after_updated_with_different_values():
     m = Middleware()
-    m['system.advanced.config'] = lambda *a: {'nvidia': False}
+    m.services.system.advanced.config = lambda *a: SystemAdvancedEntry.model_construct(nvidia=False)
     svc = make_svc_part(m)
 
     data = dict(DB_DEFAULTS, registry_mirrors=[

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_isolation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_isolation.py
@@ -1,7 +1,10 @@
+import logging
+
 import pytest
 
-from middlewared.pytest.unit.helpers import load_compound_service
+from middlewared.plugins.system_advanced.gpu import validate_gpu_pci_ids
 from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service.context import ServiceContext
 from middlewared.service_exception import ValidationErrors
 
 AVAILABLE_GPUS = [
@@ -44,7 +47,6 @@ AVAILABLE_GPUS = [
         'available_to_host': True
     }
 ]
-ADVANCED_SVC = load_compound_service('system.advanced')
 
 
 @pytest.mark.parametrize('gpu_pci_ids,errors', [
@@ -57,7 +59,7 @@ async def test_valid_isolated_gpu(gpu_pci_ids, errors):
     m = Middleware()
     m['device.get_gpus'] = lambda *args: AVAILABLE_GPUS
 
-    system_advance_svc = ADVANCED_SVC(m)
+    context = ServiceContext(m, logging.getLogger('test'))
     verrors = ValidationErrors()
-    verrors = await system_advance_svc.validate_gpu_pci_ids(gpu_pci_ids, verrors, 'test')
+    verrors = await validate_gpu_pci_ids(context, gpu_pci_ids, verrors, 'test')
     assert [e.errmsg for e in verrors.errors] == errors

--- a/src/middlewared/middlewared/utils/libvirt/gpu.py
+++ b/src/middlewared/middlewared/utils/libvirt/gpu.py
@@ -35,7 +35,8 @@ class GPUDelegate(DeviceDelegate):
                 'GPU is not available to host for consumption'
             )
 
-        if gpu_type == 'NVIDIA' and self.middleware.call_sync('system.advanced.config')['nvidia'] is False:
+        adv_config = self.middleware.call_sync2(self.middleware.services.system.advanced.config)
+        if gpu_type == 'NVIDIA' and adv_config.nvidia is False:
             verrors.add(
                 'attribute.gpu_type',
                 'NVIDIA drivers must be enabled in system advanced settings before using nvidia gpu for containers'

--- a/src/middlewared/middlewared/utils/service/settings.py
+++ b/src/middlewared/middlewared/utils/service/settings.py
@@ -1,10 +1,8 @@
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Concatenate
 
 from middlewared.service import ValidationErrors
 
-# Validators are registered with the field values appended positionally, so the concrete
-# per-validator signature varies; keep the callable type permissive on its arguments.
-FieldsValidator = Callable[..., Awaitable[None]]
+FieldsValidator = Callable[Concatenate[Any, ValidationErrors, ...], Awaitable[None]]
 
 
 class SettingsHelper:

--- a/src/middlewared/middlewared/utils/service/settings.py
+++ b/src/middlewared/middlewared/utils/service/settings.py
@@ -1,8 +1,10 @@
-from typing import Any, Awaitable, Callable, Concatenate
+from typing import Any, Awaitable, Callable
 
 from middlewared.service import ValidationErrors
 
-FieldsValidator = Callable[Concatenate[Any, ValidationErrors, ...], Awaitable[None]]
+# Validators are registered with the field values appended positionally, so the concrete
+# per-validator signature varies; keep the callable type permissive on its arguments.
+FieldsValidator = Callable[..., Awaitable[None]]
 
 
 class SettingsHelper:


### PR DESCRIPTION
## Problem
`system.advanced` was an old dict-based CompoundService — five files each declaring the same service over one namespace — whose `config()`/`update()` returned untyped dicts. Neither its API surface nor its many in-process consumers were type-checked, and dict-vs-model breaks could only be caught at runtime.

## Solution
Reworked the plugin into the typesafe shape and fixed every internal caller:

- **Lean service + part.** `SystemAdvancedService` is now a `GenericConfigService[SystemAdvancedEntry]` delegating to `SystemAdvancedConfigServicePart`; the non-config methods (serial/syslog/gpu/nvidia) became plain, fully-typed module functions. Every public method is `@api_method(..., check_annotations=True)`.
- **do_update.** Model-first (`old_config`/`new_config` as `SystemAdvancedEntry`), but preserves the existing "validate only the fields that actually changed" semantics by keeping the shared `SettingsHelper` and feeding it `model_dump()` of old/new. Deprecated `consolemsg` and the `sed_passwd`/`kmip_uid` side-channels (not on the Entry) are handled explicitly; the side-effect cascade (service restarts, etc.generate, kmip, initramfs, tty/grub, nvidia) is unchanged.
- **Consumers.** Fixed every in-process caller on both axes — dict access to attribute access, and string `middleware.call('system.advanced.*')` to typed `call2`/`call_sync2` — across boot, docker, pool, ups, disk SED (now unwrapping the `Secret` result), audit, device, grub/initramfs, the cert-attachment delegate, libvirt gpu, and the motd/kdump/cron/docker/syslog-ng renderers. Raw `adv_`-prefixed `datastore.config`/`update` callers stay dicts.
- **Registration + CI.** Registered `system.advanced` in `main.py`'s `SystemServicesContainer`, added the plugin to `mypy.yml`, and loosened the shared `SettingsHelper` validator type so concrete validator signatures type-check. Updated the two unit tests that constructed the old compound service / mocked the config as a dict.

Custom build: http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/361/