### PR TITLE
NAS-141627 / 26.0.0-RC.1 / Skip SYSTEM audit test if non-enterprise (by anodos325)

### DIFF
--- a/tests/api2/test_audit_system.py
+++ b/tests/api2/test_audit_system.py
@@ -1,8 +1,20 @@
 from time import sleep
+
+import pytest
+
 from middlewared.test.integration.utils import call, ssh
 
 
-def test_audit_system_escalation():
+@pytest.fixture(scope='module')
+def require_enterprise():
+    # SYSTEM audit events are produced by the tnaudit handler daemon, which only
+    # processes auditd events on Enterprise systems (it no-ops on Community
+    # Edition). Skip these tests where the pipeline is intentionally inactive.
+    if call('system.product_type') != 'ENTERPRISE':
+        pytest.skip('SYSTEM auditing is only active on Enterprise systems')
+
+
+def test_audit_system_escalation(require_enterprise):
     """Generate an ESCALATION event and find it in the TrueNAS audit log."""
 
     # Run an ESCALATION command as root
@@ -28,7 +40,7 @@ def test_audit_system_escalation():
     assert len(results) > 0, "Did not find escalation event"
 
 
-def test_audit_system_rin_operator_simple():
+def test_audit_system_rin_operator_simple(require_enterprise):
     """Test the 'rin' (contains) operator for substring matching."""
 
     # Generate a system event with a known proctitle
@@ -61,7 +73,7 @@ def test_audit_system_rin_operator_simple():
         assert 'systemctl' in proctitle, f"proctitle '{proctitle}' does not contain 'systemctl'"
 
 
-def test_audit_system_rin_operator_with_or():
+def test_audit_system_rin_operator_with_or(require_enterprise):
     """Test the 'rin' operator with OR filters."""
 
     # Generate a system event


### PR DESCRIPTION
This commit changes the tests/api2 test for system audit log entries so that they only run on enterprise-licensed systems.

The practical impact is that they will only be run on nightly CI runs rather than our incrementals.

Original PR: https://github.com/truenas/middleware/pull/19244
