### PR TITLE
NAS-141468 / 26.0.0-RC.1 / Enable IPv6 forwarding for the container bridge (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/bridge.py
+++ b/src/middlewared/middlewared/plugins/container/bridge.py
@@ -116,9 +116,35 @@ def _start_dnsmasq(ctx, dnsmasq_args) -> None:
         )
 
 
-def _configure_nft(ipv4_masquerade, ipv6_masquerade):
-    with open("/proc/sys/net/ipv4/ip_forward", "w") as f:
+def _enable_ipv6_forwarding() -> None:
+    # Enabling forwarding makes the kernel ignore router advertisements on any
+    # interface still at accept_ra=1, which can strip a SLAAC-derived address
+    # from the host's own uplink. Bump those interfaces to accept_ra=2 first so
+    # the host keeps honouring RAs while forwarding is on. Leave 0 (RA disabled
+    # on purpose) and 2 (already safe) untouched.
+    conf_dir = "/proc/sys/net/ipv6/conf"
+    with os.scandir(conf_dir) as it:
+        for entry in it:
+            accept_ra_path = os.path.join(entry.path, "accept_ra")
+            try:
+                with open(accept_ra_path) as f:
+                    current = f.read().strip()
+                if current == "1":
+                    with open(accept_ra_path, "w") as f:
+                        f.write("2\n")
+            except (FileNotFoundError, PermissionError):
+                continue
+
+    with open(f"{conf_dir}/all/forwarding", "w") as f:
         f.write("1\n")
+
+
+def _configure_nft(ipv4_masquerade: str, ipv6_masquerade: str) -> None:
+    if ipv4_masquerade:
+        with open("/proc/sys/net/ipv4/ip_forward", "w") as f:
+            f.write("1\n")
+    if ipv6_masquerade:
+        _enable_ipv6_forwarding()
 
     icmp_type = "destination-unreachable, time-exceeded, parameter-problem"
     icmpv6_type = (


### PR DESCRIPTION
## Problem
On a clean install, LXC containers on the default `truenasbr0` bridge get an IPv6 address and default route via the host's RAs but cannot route IPv6 out. The bridge sets up full IPv6 masquerade and forward nft rules, yet only the IPv4 forwarding sysctl was enabled, so the kernel never forwards IPv6. Docker enables IPv6 forwarding as a side effect, so only LXC-only (Docker-disabled) setups hit this.

## Solution
Enable `net.ipv6.conf.all.forwarding` when the bridge has an IPv6 network. Before doing so, bump `accept_ra` from 1 to 2 on interfaces that still have it, mirroring incus, so the host keeps honouring router advertisements while forwarding is on and doesn't lose a SLAAC-derived address on its own uplink. The IPv4 write is likewise gated on having an IPv4 network.

Original PR: https://github.com/truenas/middleware/pull/19257
