### PR TITLE
NAS-138474 / 26.0.0-RC.1 / Require DNS updates for the IPA directory service (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -477,6 +477,15 @@ class DirectoryServices(ConfigService):
 
     @private
     def validate_ipa(self, old, new, verrors, revert):
+        if not new['enable_dns_updates']:
+            verrors.add(
+                f'{SCHEMA}.enable_dns_updates',
+                'DNS updates are currently required for the IPA directory service in order to properly support '
+                'Kerberized services. TrueNAS must be able to register its host record in the IPA-managed DNS so '
+                'that the SMB and NFS service principals can be created.'
+            )
+            return
+
         validate_ldap_credential(SCHEMA, new, verrors, revert)
         self.validate_dns(old, new, verrors, revert)
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -79,6 +79,23 @@ class IPAJoinMixin:
         self.middleware.call_sync('directoryservices.reset')
         self._ipa_remove_kerberos_cert_config(job, ds_config)
 
+    def _ipa_rollback_join(self, job: Job | None, ds_config: dict) -> None:
+        """ Undo the local configuration written during a partial IPA join (host keytab,
+        kerberos realm, CA certificate, and the on-disk IPA config files). Without this a
+        failed join leaves behind the host keytab and realm, which would cause the next
+        attempt to short-circuit as already-joined and never retry registration. The
+        remote IPA host account, if it was created, is reused via ipa-join re-enrollment
+        on the next attempt. """
+        self._ipa_remove_kerberos_cert_config(job, ds_config)
+        for p in (
+            ipa_constants.IPAPath.DEFAULTCONF.path,
+            ipa_constants.IPAPath.CACERT.path
+        ):
+            try:
+                os.remove(p)
+            except FileNotFoundError:
+                pass
+
     def _ipa_leave(self, job: Job, ds_config: dict):
         """
         Leave the IPA domain
@@ -463,6 +480,21 @@ class IPAJoinMixin:
         # resp includes `cacert` for domain and `keytab` for our host principal to use
         # in future.
 
+        # The host account now exists in the IPA domain. Everything below writes local
+        # configuration and registers the host and its services with the domain; if any
+        # of it fails, roll the local state back so that a later attempt starts clean
+        # instead of short-circuiting as already-joined.
+        try:
+            self._ipa_configure_and_register(job, ds_config, resp)
+        except Exception:
+            self._ipa_rollback_join(job, ds_config)
+            raise
+
+    def _ipa_configure_and_register(self, job: Job, ds_config: dict, resp: dict):
+        """ Store the joined IPA domain's details on TrueNAS (host keytab, realm, CA
+        cert), obtain our host kerberos credential, then register DNS and the SMB / NFS
+        service principals and activate the service. On failure the caller rolls back the
+        partial configuration via _ipa_rollback_join. """
         # insert the IPA host principal keytab into our database
         job.set_progress(description='Updating TrueNAS configuration with IPA domain details.')
         self._ipa_insert_keytab(ipa_constants.IpaConfigName.IPA_HOST_KEYTAB, resp['keytab'])
@@ -530,25 +562,12 @@ class IPAJoinMixin:
         except KRB5Error as err:
             match err.krb5_code:
                 case KRB5ErrCode.KRB5_REALM_UNKNOWN:
-                    # DNS is broken in the IPA domain and so we need to roll back our config
-                    # changes.
-
+                    # DNS is likely broken in the IPA domain. The partial join is rolled
+                    # back by the caller; log a hint about the probable cause here.
                     self.logger.warning(
                         'Unable to resolve kerberos realm via DNS. This may indicate misconfigured '
                         'nameservers on the TrueNAS server or a misconfigured IPA domain.', exc_info=True
                     )
-
-                    self._ipa_remove_kerberos_cert_config(None, ds_config)
-
-                    # remove any configuration files we have written
-                    for p in (
-                        ipa_constants.IPAPath.DEFAULTCONF.path,
-                        ipa_constants.IPAPath.CACERT.path
-                    ):
-                        try:
-                            os.remove(p)
-                        except FileNotFoundError:
-                            pass
                 case _:
                     # Log the complete error message so that we have opportunity to improve error
                     # handling for weird kerberos errors.

--- a/tests/directory_services/test_ipa_join_no_dns_updates.py
+++ b/tests/directory_services/test_ipa_join_no_dns_updates.py
@@ -4,11 +4,11 @@ from middlewared.test.integration.assets.directory_service import directoryservi
 
 
 def test_ipa_join_requires_dns_updates():
-    """ Joining an IPA domain requires the TrueNAS host to register its DNS record so
+    """Joining an IPA domain requires the TrueNAS host to register its DNS record so
     that the SMB and NFS Kerberos service principals can be created (FreeIPA refuses to
     add a service to a host that has no A/AAAA record). Attempting to join with DNS
     updates disabled must be rejected with a validation error rather than completing a
-    join that leaves kerberized services non-functional. """
-    with pytest.raises(Exception, match='DNS updates are currently required'):
-        with directoryservice('IPA', dns_updates=False):
+    join that leaves kerberized services non-functional."""
+    with pytest.raises(Exception, match="DNS updates are currently required"):
+        with directoryservice("IPA", dns_updates=False):
             pass

--- a/tests/directory_services/test_ipa_join_no_dns_updates.py
+++ b/tests/directory_services/test_ipa_join_no_dns_updates.py
@@ -1,0 +1,14 @@
+import pytest
+
+from middlewared.test.integration.assets.directory_service import directoryservice
+
+
+def test_ipa_join_requires_dns_updates():
+    """ Joining an IPA domain requires the TrueNAS host to register its DNS record so
+    that the SMB and NFS Kerberos service principals can be created (FreeIPA refuses to
+    add a service to a host that has no A/AAAA record). Attempting to join with DNS
+    updates disabled must be rejected with a validation error rather than completing a
+    join that leaves kerberized services non-functional. """
+    with pytest.raises(Exception, match='DNS updates are currently required'):
+        with directoryservice('IPA', dns_updates=False):
+            pass


### PR DESCRIPTION
Creating the SMB and NFS Kerberos service principals during an IPA
join uses FreeIPA's service-add, which refuses to add a service to a
host that has no DNS A/AAAA record. register_dns() creates that
record, so it is a prerequisite for service-principal setup rather
than an optional step.

With DNS updates disabled the join aborted at register_dns() before
 the service principals were created, leaving smbd unable to start:

```
        krb5_kt_start_seq_get on FILE:/etc/ipa/smb.keytab failed
        (No such file or directory)
```

Reject enable_dns_updates=False for IPA at validation time with a
clear message, since DNS updates are currently required to properly
support kerberized services.

Original PR: https://github.com/truenas/middleware/pull/19263
