### PR TITLE
NAS-141687 / 26.0.0-BETA.3 / Update vfs module reference in middleware (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -56,7 +56,7 @@ class TrueNASVfsObjects(enum.StrEnum):
     SHADOW_COPY_ZFS = 'shadow_copy_zfs'
     IXNAS = 'ixnas'
     WINMSA = 'winmsa'
-    RECYCLE = 'recycle'
+    RECYCLE = 'truenas_recycle'
     ZFS_CORE = 'zfs_core'
     IO_URING = 'io_uring'
     WORM = 'worm'
@@ -221,6 +221,8 @@ def __apply_purpose_and_options(
 
             if opts[share_field.RECYCLE]:
                 vfs_objects.add(TrueNASVfsObjects.RECYCLE)
+                # The Samba module is forked as truenas_recycle, but its parametric
+                # options are still read under the recycle: prefix. Do not rename.
                 out.update({
                     'recycle:repository': '.recycle/%D/%U' if ds_type is DSType.AD else '.recycle/%U',
                     'recycle:keeptree': True,

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -269,6 +269,13 @@ def test__with_recyclebin_ad(nfsacl_dataset, enabled):
         assert not any([k.startswith('recycle') for k in conf.keys()])
 
 
+def test__recycle_module_name():
+    # Middleware must emit the TrueNAS fork, otherwise shares silently fall
+    # back to upstream's recycle without the per-user ACL'd bins. The
+    # parametric options are still read under the recycle: prefix, though.
+    assert TrueNASVfsObjects.RECYCLE == 'truenas_recycle'
+
+
 @pytest.mark.parametrize('enabled', [True, False])
 def test__durablehandle(nfsacl_dataset, enabled):
     conf = generate_smb_share_conf_dict(DSType.AD, DEFAULT_SHARE | {


### PR DESCRIPTION
In order to simplify maintenance of truenas-specific ZFS-specific recycle bin code, we've forked the module to truenas_recycle. This commit updates the name assigned to it in middleware code that generates the smb.conf file.

Original PR: https://github.com/truenas/middleware/pull/19267
