### PR TITLE
NAS-141710 / 27.0.0-BETA.1 / Add ISCSI_DISK device type to VM API

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm_device.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    IPvAnyAddress,
     MACAddress,
     NonEmptyString,
     excluded_field,
@@ -14,6 +15,8 @@ from middlewared.api.base import (
 __all__ = [
     "VMCDROMDevice",
     "VMDisplayDevice",
+    "VMISCSIDiskDevice",
+    "VMISCSIDiskTarget",
     "VMNICDevice",
     "VMNICPciAddress",
     "VMPCIDevice",
@@ -249,8 +252,42 @@ class VMUSBDevice(BaseModel):
     )
 
 
+class VMISCSIDiskTarget(BaseModel):
+    iqn: NonEmptyString = Field(description="iSCSI Qualified Name of the target.")
+    luns: list[int] = Field(
+        default=[0],
+        min_length=1,
+        description="LUN numbers to access on this target.",
+    )
+
+
+class VMISCSIDiskDevice(BaseModel):
+    dtype: Literal['ISCSI_DISK'] = Field(description="Device type identifier for iSCSI disk devices.")
+    portal_address: IPvAnyAddress = Field(
+        description="IP address of the iSCSI target portal.",
+    )
+    targets: list[VMISCSIDiskTarget] = Field(
+        min_length=1,
+        description="iSCSI targets to attach, one entry per target IQN.",
+    )
+    initiator_iqn: NonEmptyString = Field(
+        description="IQN identifying this VM as an iSCSI initiator.",
+    )
+    controller_slot: int = Field(
+        default=0x15,
+        ge=1,
+        le=30,
+        description=(
+            "PCI slot for the virtio-scsi-pci controller on the root bus (pcie.0 on q35/aarch64, "
+            "pci.0 on i440fx). Conflicts with other explicitly-placed devices are detected at "
+            "device creation time."
+        ),
+    )
+
+
 VMDeviceType: TypeAlias = Annotated[
-    VMCDROMDevice | VMDisplayDevice | VMNICDevice | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
+    VMCDROMDevice | VMDisplayDevice | VMISCSIDiskDevice | VMNICDevice
+    | VMPCIDevice | VMRAWDevice | VMDiskDevice | VMUSBDevice,
     Discriminator('dtype')
 ]
 

--- a/src/middlewared/middlewared/api/v27_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm_device.py
@@ -101,10 +101,16 @@ class VMDisplayDevice(BaseModel):
 
 
 class VMNICPciAddress(BaseModel):
-    bus: int = Field(ge=1, description="PCI bus number. Must be >= 1; bus 0 is the root complex.")
-    slot: int = Field(default=0, ge=0, le=31, description="PCI slot number (0–31).")
-    function: int = Field(default=0, ge=0, le=7, description="PCI function number (0–7).")
-    domain: int = Field(default=0, ge=0, description="PCI domain number.")
+    bus: int = Field(ge=1, le=255, description="PCI bus number. Must be >= 1; bus 0 is the root complex.")
+    slot: int = Field(
+        ge=0, le=31,
+        description="PCI slot number (0-31). No default: correct value depends on machine type.",
+    )
+    function: int = Field(default=0, ge=0, le=7, description="PCI function number (0-7).")
+    domain: int = Field(
+        default=0, ge=0, le=0,
+        description="PCI domain number. Must be 0; multi-segment topologies are not supported.",
+    )
 
 
 class VMNICDevice(BaseModel):
@@ -129,8 +135,7 @@ class VMNICDevice(BaseModel):
     pci_address: VMNICPciAddress | None = Field(
         default=None,
         description=(
-            "Pin this NIC to a specific PCI address in the guest. "
-            "For example, `bus=1, slot=0` causes the interface to appear as `enp1s0`. "
+            "Pin this NIC to a specific PCI controller bus rather than letting libvirt auto-assign an address. "
             "`null` for automatic assignment."
         ),
     )

--- a/src/middlewared/middlewared/plugins/vm/factory.py
+++ b/src/middlewared/middlewared/plugins/vm/factory.py
@@ -12,6 +12,7 @@ from truenas_pylibvirt.device import (
     RawStorageDevice,
     USBDevice,
 )
+from truenas_pylibvirt.domain.start_validator import pci_slot_error_for_machine
 
 from middlewared.api.current import (
     VMCDROMDevice,
@@ -88,6 +89,24 @@ class VMNICDelegate(NICDelegate):
     @property
     def schema_model(self) -> type[VMNICDevice]:
         return VMNICDevice
+
+    def validate_middleware(
+        self,
+        device: dict[str, Any],
+        verrors: ValidationErrors,
+        old: dict[str, Any] | None = None,
+        instance: dict[str, Any] | None = None,
+        update: bool = True,
+    ) -> None:
+        super().validate_middleware(device, verrors, old, instance, update)
+        # Validate pci_address slot against the VM's machine topology.
+        # PCIe (q35/virt): point-to-point ports require slot == 0.
+        # i440fx: slot 0 is SHPC-reserved, usable slots start at 1.
+        pci = device['attributes'].get('pci_address')
+        if pci and instance:
+            machine_type = instance.get('machine_type')
+            if msg := pci_slot_error_for_machine(pci['slot'], machine_type):
+                verrors.add('attributes.pci_address.slot', msg)
 
 
 class VMPCIDelegate(PCIDelegate):

--- a/src/middlewared/middlewared/plugins/vm/factory.py
+++ b/src/middlewared/middlewared/plugins/vm/factory.py
@@ -6,6 +6,7 @@ from truenas_pylibvirt.device import (
     CDROMDevice,
     DiskStorageDevice,
     DisplayDevice,
+    ISCSIDiskDevice,
     NICDevice,
     PCIDevice,
     RawStorageDevice,
@@ -16,6 +17,7 @@ from middlewared.api.current import (
     VMCDROMDevice,
     VMDiskDevice,
     VMDisplayDevice,
+    VMISCSIDiskDevice,
     VMNICDevice,
     VMPCIDevice,
     VMRAWDevice,
@@ -24,6 +26,7 @@ from middlewared.api.current import (
 from middlewared.service_exception import ValidationErrors
 from middlewared.utils.crypto import generate_string
 from middlewared.utils.libvirt.cdrom import CDROMDelegate
+from middlewared.utils.libvirt.delegate import DeviceDelegate
 from middlewared.utils.libvirt.display import DisplayDelegate
 from middlewared.utils.libvirt.nic import NICDelegate
 from middlewared.utils.libvirt.pci import PCIDelegate
@@ -148,6 +151,13 @@ class VMUSBDelegate(USBDelegate):
         return VMUSBDevice
 
 
+class VMISCSIDiskDelegate(DeviceDelegate):
+
+    @property
+    def schema_model(self) -> type[VMISCSIDiskDevice]:
+        return VMISCSIDiskDevice
+
+
 async def setup(middleware: Middleware) -> None:
     device_factory = middleware.services.vm.device.device_factory
     for device_key, device_klass, delegate_klass in (
@@ -158,5 +168,6 @@ async def setup(middleware: Middleware) -> None:
         ('USB', USBDevice, VMUSBDelegate),
         ('PCI', PCIDevice, VMPCIDelegate),
         ('DISPLAY', DisplayDevice, VMDisplayDelegate),
+        ('ISCSI_DISK', ISCSIDiskDevice, VMISCSIDiskDelegate),
     ):
         device_factory.register(device_key, device_klass, delegate_klass)

--- a/src/middlewared/middlewared/plugins/vm/vm_device_crud.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_device_crud.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any
 
+from truenas_pylibvirt.domain.start_validator import check_pci_slot_conflicts
+
 from middlewared.api.base.handler.accept import validate_model
 from middlewared.api.current import (
     QueryOptions,
@@ -138,6 +140,32 @@ class VMDeviceServicePart(CRUDServicePart[VMDeviceEntry]):
         verrors.check()
         device_adapter = self.device_factory.get_device_adapter(device)
         await self.middleware.run_in_thread(device_adapter.validate, old, svc_instance, update)
+        await self.middleware.run_in_thread(self._check_pci_slot_conflicts, device, svc_instance)
+
+    def _check_pci_slot_conflicts(
+        self, device: dict[str, Any], vm_instance: dict[str, Any],
+    ) -> None:
+        # Build pylibvirt Device objects for all devices on this VM, replacing
+        # the device being updated (matched by id) with the new version.
+        device_id = device.get('id')
+        pylibvirt_devices = []
+        for existing in vm_instance.get('devices', []):
+            if existing.get('id') == device_id:
+                continue
+            try:
+                pylibvirt_devices.append(self.device_factory.get_device(existing))
+            except Exception:
+                continue
+        try:
+            pylibvirt_devices.append(self.device_factory.get_device(device))
+        except Exception:
+            return
+        errors = check_pci_slot_conflicts(pylibvirt_devices)
+        if errors:
+            verrors = ValidationErrors()
+            for field, msg in errors:
+                verrors.add(field, msg)
+            verrors.check()
 
     async def _update_device(
         self, data: dict[str, Any], old: dict[str, Any] | None = None,

--- a/src/middlewared/middlewared/utils/libvirt/factory_utils.py
+++ b/src/middlewared/middlewared/utils/libvirt/factory_utils.py
@@ -9,6 +9,8 @@ from truenas_pylibvirt.device import (
     DisplayDeviceType,
     FilesystemDevice,
     GPUDevice,
+    ISCSIDiskDevice,
+    ISCSIDiskTarget,
     NICDevice,
     NICDeviceModel,
     NICDeviceType,
@@ -125,6 +127,20 @@ def get_device(device: dict[str, Any], delegate: DeviceDelegate) -> Device:
             return GPUDevice(
                 gpu_type=device['attributes']['gpu_type'],
                 pci_address=device['attributes']['pci_address'],
+                device_delegate=delegate,
+            )
+        case 'ISCSI_DISK':
+            return ISCSIDiskDevice(
+                portal_address=str(device['attributes']['portal_address']),
+                targets=[
+                    ISCSIDiskTarget(
+                        iqn=t['iqn'],
+                        luns=t.get('luns', [0]),
+                    )
+                    for t in device['attributes']['targets']
+                ],
+                initiator_iqn=device['attributes']['initiator_iqn'],
+                controller_slot=device['attributes'].get('controller_slot', 0x15),
                 device_delegate=delegate,
             )
         case _:


### PR DESCRIPTION
Adds VMISCSIDiskDevice and VMISCSIDiskTarget to the v27 API model, wires the ISCSI_DISK dtype through factory_utils, and calls
check_pci_slot_conflicts() from _validate_device() so PCI slot collisions are caught at vm.device.create/update time rather than failing silently at VM start.

Also:
- Add NIC pci_address slot validation
Override VMNICDelegate.validate_middleware() to enforce machine-topology slot rules using pci_slot_error_for_machine(): PCIe machines (q35 / aarch64 virt) require slot == 0 on point-to-point ports; i440fx PCI bridges reserve slot 0 for the SHPC controller so usable slots start at 1. Machine type is read from the VM instance, which is already in hand at create/update time.
- Tighten VMNICPciAddress constraints

----
Requires https://github.com/truenas/truenas_pylibvirt/pull/67