### PR TITLE
NAS-141699 / 27.0.0-BETA.1 / fix duplicate From header in email

### DIFF
--- a/src/middlewared/middlewared/plugins/mail/send_queue.py
+++ b/src/middlewared/middlewared/plugins/mail/send_queue.py
@@ -17,8 +17,9 @@ def send_mail_queue(context: ServiceContext, queue: MailQueue) -> None:
 
                 # Update `From` address from currently used config because if the SMTP user changes,
                 # already queued messages might not be sent due to (553, b"Relaying disallowed as xxx")
-                # error
-                item.message["From"] = from_addr(config)
+                # error. `replace_header` because `__setitem__` appends a second `From` header instead
+                # of replacing the existing one.
+                item.message.replace_header("From", from_addr(config))
 
                 sendmail(context, item.message, config)
             except NetworkActivityDisabled:


### PR DESCRIPTION
`send_mail_queue()` updates the `From` address of queued messages with `item.message["From"] = ...`, but `Message.__setitem__` *appends* a second From header instead of replacing the existing one set by `send_raw()`. The resulting message violates RFC 5322 and Gmail rejects it with 550-5.7.1 "There are multiple From headers". Use `replace_header()` so the flushed message keeps a single From header.