### PR TITLE
NAS-141716 / 27.0.0-BETA.1 / enforce vdev topology limits and add force_topology (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/pool.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool.py
@@ -277,6 +277,16 @@ class PoolCreate(BaseModel):
         description="Whether to allow disks with duplicate serial numbers in the pool.",
     )
     all_sed: bool = Field(default=False, description="When set, all disks in the pool must be SED based.")
+    force_topology: bool = Field(
+        default=False,
+        description=(
+            "Bypass topology policy validation. Allows data vdevs that differ in type or width from "
+            "the rest of the pool, RAIDZ/mirror vdevs wider than the recommended maximum, and special "
+            "or dedup vdevs whose redundancy does not match the data vdevs. Structural requirements "
+            "(minimum disks per vdev type, dRAID configuration) still apply. This option is not "
+            "permitted on Enterprise-licensed systems."
+        ),
+    )
 
 
 class PoolDetachOptions(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/pool.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool.py
@@ -272,6 +272,16 @@ class PoolCreate(BaseModel):
         description="Whether to allow disks with duplicate serial numbers in the pool.",
     )
     all_sed: bool = Field(default=False, description="When set, all disks in the pool must be SED based.")
+    force_topology: bool = Field(
+        default=False,
+        description=(
+            "Bypass topology policy validation. Allows data vdevs that differ in type or width from "
+            "the rest of the pool, RAIDZ/mirror vdevs wider than the recommended maximum, and special "
+            "or dedup vdevs whose redundancy does not match the data vdevs. Structural requirements "
+            "(minimum disks per vdev type, dRAID configuration) still apply. This option is not "
+            "permitted on Enterprise-licensed systems."
+        ),
+    )
 
 
 class PoolDetachOptions(BaseModel):

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -39,6 +39,31 @@ VDEV_PARITY = MappingProxyType({
 })
 
 
+# Minimum number of disks per vdev type.
+VDEV_MIN_DISKS = MappingProxyType({
+    'STRIPE': 1,
+    'MIRROR': 2,
+    'DRAID1': 2,
+    'DRAID2': 3,
+    'DRAID3': 4,
+    'RAIDZ1': 3,
+    'RAIDZ2': 4,
+    'RAIDZ3': 5,
+})
+
+
+# Maximum vdev width for the redundant types we cap, mirroring truenas_pylibzfs's
+# PYLIBZFS_MAX_MIRROR_WIDTH (4) and PYLIBZFS_MAX_RAIDZ_WIDTH (15); keep in sync
+# with that binding. STRIPE is uncapped; dRAID is bounded by
+# validate_draid_configuration.
+VDEV_MAX_DISKS = MappingProxyType({
+    'MIRROR': 4,
+    'RAIDZ1': 15,
+    'RAIDZ2': 15,
+    'RAIDZ3': 15,
+})
+
+
 class PoolPoolNormalizeInfo(PoolEntry):
     id: Excluded = excluded_field()
     guid: Excluded = excluded_field()
@@ -409,41 +434,23 @@ class PoolService(CRUDService):
                     continue
 
                 numdisks = len(vdev['disks'])
-                minmap = {
-                    'STRIPE': 1,
-                    'MIRROR': 2,
-                    'DRAID1': 2,
-                    'DRAID2': 3,
-                    'DRAID3': 4,
-                    'RAIDZ1': 3,
-                    'RAIDZ2': 4,
-                    'RAIDZ3': 5,
-                }
-                mindisks = minmap[vdev['type']]
+                mindisks = VDEV_MIN_DISKS[vdev['type']]
                 if numdisks < mindisks:
                     verrors.add(
                         f'topology.{topology_type}.{i}.disks',
                         f'You need at least {mindisks} disk(s) for this vdev type.',
                     )
 
-                # Maximum width, mirroring truenas_pylibzfs's PYLIBZFS_MAX_MIRROR_WIDTH (4)
-                # and PYLIBZFS_MAX_RAIDZ_WIDTH (15); keep in sync with that binding. Only
-                # newly supplied data vdevs are capped (i < num_new_vdevs), matching
-                # truenas_pylibzfs which caps the vdevs being added, not existing geometry.
-                # STRIPE is uncapped; dRAID is bounded by validate_draid_configuration.
-                maxmap = {
-                    'MIRROR': 4,
-                    'RAIDZ1': 15,
-                    'RAIDZ2': 15,
-                    'RAIDZ3': 15,
-                }
+                # Cap the width of newly supplied data vdevs only (i < num_new_vdevs),
+                # matching truenas_pylibzfs, which caps the vdevs being added and not the
+                # pool's existing geometry.
                 if (
                     not force_topology and topology_type == 'data' and i < num_new_vdevs
-                    and vdev['type'] in maxmap and numdisks > maxmap[vdev['type']]
+                    and vdev['type'] in VDEV_MAX_DISKS and numdisks > VDEV_MAX_DISKS[vdev['type']]
                 ):
                     verrors.add(
                         f'topology.{topology_type}.{i}.disks',
-                        f'You can have at most {maxmap[vdev["type"]]} disk(s) for this vdev type.',
+                        f'You can have at most {VDEV_MAX_DISKS[vdev["type"]]} disk(s) for this vdev type.',
                     )
 
                 if vdev['type'].startswith('DRAID'):

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -344,6 +344,21 @@ class PoolService(CRUDService):
     async def _validate_topology(self, data, old=None):
         verrors = ValidationErrors()
 
+        # When force_topology is set, TrueNAS topology policy checks are skipped:
+        # data vdev type/width matching, the RAIDZ/mirror width caps, and the
+        # special/dedup redundancy floor (mirroring truenas_pylibzfs's force flag).
+        # Structural checks (minimum disks, dRAID configuration) always apply.
+        force_topology = data.get('force_topology', False)
+
+        # force_topology is a footgun; it is not permitted on Enterprise-licensed
+        # systems, which are expected to use supported topologies.
+        if force_topology and await self.middleware.call('system.is_enterprise'):
+            verrors.add(
+                'force_topology',
+                'Bypassing pool topology validation is not supported on '
+                'Enterprise-licensed systems.',
+            )
+
         def disk_to_stripe(topology_type):
             """
             We need to convert the original topology to use STRIPE
@@ -379,7 +394,9 @@ class PoolService(CRUDService):
         data_redundant = False
         for topology_type in ('data', 'special', 'dedup'):
             lastdatatype = None
+            lastnumdisks = None
             topology_data = list(data['topology'].get(topology_type) or [])
+            num_new_vdevs = len(topology_data)
             if old and old['topology']:
                 topology_data += disk_to_stripe(topology_type)
             for i, vdev in enumerate(topology_data):
@@ -409,6 +426,26 @@ class PoolService(CRUDService):
                         f'You need at least {mindisks} disk(s) for this vdev type.',
                     )
 
+                # Maximum width, mirroring truenas_pylibzfs's PYLIBZFS_MAX_MIRROR_WIDTH (4)
+                # and PYLIBZFS_MAX_RAIDZ_WIDTH (15); keep in sync with that binding. Only
+                # newly supplied data vdevs are capped (i < num_new_vdevs), matching
+                # truenas_pylibzfs which caps the vdevs being added, not existing geometry.
+                # STRIPE is uncapped; dRAID is bounded by validate_draid_configuration.
+                maxmap = {
+                    'MIRROR': 4,
+                    'RAIDZ1': 15,
+                    'RAIDZ2': 15,
+                    'RAIDZ3': 15,
+                }
+                if (
+                    not force_topology and topology_type == 'data' and i < num_new_vdevs
+                    and vdev['type'] in maxmap and numdisks > maxmap[vdev['type']]
+                ):
+                    verrors.add(
+                        f'topology.{topology_type}.{i}.disks',
+                        f'You can have at most {maxmap[vdev["type"]]} disk(s) for this vdev type.',
+                    )
+
                 if vdev['type'].startswith('DRAID'):
                     nparity = int(vdev['type'][-1:])
                     verrors.extend(await self.middleware.call(
@@ -418,7 +455,12 @@ class PoolService(CRUDService):
                 if topology_type == 'data' and VDEV_PARITY[vdev['type']] >= 1:
                     data_redundant = True
 
-                if topology_type == 'special':
+                if force_topology:
+                    # force_topology bypasses the topology policy checks below (special/data
+                    # redundancy match and data vdev type/width matching). Structural checks
+                    # (min disks, dRAID config) above always run.
+                    pass
+                elif topology_type == 'special':
                     # Special vdevs may mix types (matching truenas_pylibzfs), so no
                     # same-type check is applied here. A non-redundant special vdev is
                     # still rejected when the data class is redundant, because losing
@@ -434,7 +476,22 @@ class PoolService(CRUDService):
                         f'You are not allowed to create a pool with different {topology_type} vdev types '
                         f'({lastdatatype} and {vdev["type"]}).',
                     )
+                elif (
+                    topology_type == 'data' and lastdatatype
+                    and vdev['type'] != 'STRIPE' and numdisks != lastnumdisks
+                ):
+                    # All redundant data vdevs must be the same width. Mixing widths (for
+                    # example a 7-wide and a 30-wide RAIDZ2) leaves capacity and fault
+                    # tolerance uneven across the pool and cannot be corrected without
+                    # recreating it. STRIPE is exempt as it has no geometry to match.
+                    # This mirrors the child-count match enforced by truenas_pylibzfs.
+                    verrors.add(
+                        f'topology.{topology_type}.{i}.disks',
+                        f'You are not allowed to create a pool with {topology_type} vdevs of '
+                        f'different widths ({lastnumdisks} and {numdisks} disks).',
+                    )
                 lastdatatype = vdev['type']
+                lastnumdisks = numdisks
 
         for i in ('cache', 'log'):
             value = data['topology'].get(i)

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
@@ -7,28 +7,28 @@ from middlewared.pytest.unit.middleware import Middleware
 
 def _new_vdev(vdev_type, num_disks):
     """A vdev spec as it arrives in data['topology'] on create/update."""
-    return {'type': vdev_type, 'disks': [f'sd{i}' for i in range(num_disks)]}
+    return {"type": vdev_type, "disks": [f"sd{i}" for i in range(num_disks)]}
 
 
 def _existing_vdev(vdev_type, num_disks):
     """An existing vdev in a pool's stored topology (disk_to_stripe form)."""
-    return {'type': vdev_type, 'children': [{'type': 'DISK'} for _ in range(num_disks)]}
+    return {"type": vdev_type, "children": [{"type": "DISK"} for _ in range(num_disks)]}
 
 
 def _pool_data(data, *, special=None, dedup=None, force_topology=False):
     return {
-        'topology': {'data': data, 'special': special or [], 'dedup': dedup or []},
-        'force_topology': force_topology,
+        "topology": {"data": data, "special": special or [], "dedup": dedup or []},
+        "force_topology": force_topology,
     }
 
 
 def _pool_old(data, *, special=None, dedup=None):
-    return {'topology': {'data': data, 'special': special or [], 'dedup': dedup or []}}
+    return {"topology": {"data": data, "special": special or [], "dedup": dedup or []}}
 
 
 def _service(is_enterprise=False):
     middleware = Middleware()
-    middleware['system.is_enterprise'] = Mock(return_value=is_enterprise)
+    middleware["system.is_enterprise"] = Mock(return_value=is_enterprise)
     return PoolService(middleware)
 
 
@@ -39,24 +39,22 @@ def _service(is_enterprise=False):
 
 @pytest.mark.asyncio
 async def test_uniform_raidz2_is_valid():
-    verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 7)])
-    )
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 7), _new_vdev("RAIDZ2", 7)]))
     assert verrors.errors == []
 
 
 @pytest.mark.asyncio
 async def test_stripe_width_is_not_capped():
     # STRIPE has no geometry to match and no maximum width.
-    verrors = await _service()._validate_topology(_pool_data([_new_vdev('STRIPE', 20)]))
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("STRIPE", 20)]))
     assert verrors.errors == []
 
 
 @pytest.mark.asyncio
 async def test_extend_matching_width_is_valid():
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7)]),
-        _pool_old([_existing_vdev('RAIDZ2', 7)]),
+        _pool_data([_new_vdev("RAIDZ2", 7)]),
+        _pool_old([_existing_vdev("RAIDZ2", 7)]),
     )
     assert verrors.errors == []
 
@@ -69,20 +67,18 @@ async def test_extend_matching_width_is_valid():
 @pytest.mark.asyncio
 async def test_mismatched_data_width_rejected_on_create():
     # Both within the width cap, so only the consistency check fires.
-    verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 10)])
-    )
-    assert [e.attribute for e in verrors.errors] == ['topology.data.1.disks']
-    assert 'different widths' in verrors.errors[0].errmsg
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 7), _new_vdev("RAIDZ2", 10)]))
+    assert [e.attribute for e in verrors.errors] == ["topology.data.1.disks"]
+    assert "different widths" in verrors.errors[0].errmsg
 
 
 @pytest.mark.asyncio
 async def test_mismatched_data_width_rejected_on_extend():
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 10)]),
-        _pool_old([_existing_vdev('RAIDZ2', 7)]),
+        _pool_data([_new_vdev("RAIDZ2", 10)]),
+        _pool_old([_existing_vdev("RAIDZ2", 7)]),
     )
-    assert any('different widths' in e.errmsg for e in verrors.errors)
+    assert any("different widths" in e.errmsg for e in verrors.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -92,26 +88,26 @@ async def test_mismatched_data_width_rejected_on_extend():
 
 @pytest.mark.asyncio
 async def test_raidz_width_cap_rejected():
-    verrors = await _service()._validate_topology(_pool_data([_new_vdev('RAIDZ2', 16)]))
-    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
-    assert verrors.errors[0].errmsg == 'You can have at most 15 disk(s) for this vdev type.'
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 16)]))
+    assert [e.attribute for e in verrors.errors] == ["topology.data.0.disks"]
+    assert verrors.errors[0].errmsg == "You can have at most 15 disk(s) for this vdev type."
 
 
 @pytest.mark.asyncio
 async def test_mirror_width_cap_rejected():
-    verrors = await _service()._validate_topology(_pool_data([_new_vdev('MIRROR', 5)]))
-    assert verrors.errors[0].errmsg == 'You can have at most 4 disk(s) for this vdev type.'
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("MIRROR", 5)]))
+    assert verrors.errors[0].errmsg == "You can have at most 4 disk(s) for this vdev type."
 
 
 @pytest.mark.asyncio
 async def test_max_width_only_applies_to_new_vdevs_on_extend():
     # An over-wide existing vdev is not re-flagged; the matching new vdev passes.
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 16)]),
-        _pool_old([_existing_vdev('RAIDZ2', 16)]),
+        _pool_data([_new_vdev("RAIDZ2", 16)]),
+        _pool_old([_existing_vdev("RAIDZ2", 16)]),
     )
-    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
-    assert verrors.errors[0].errmsg == 'You can have at most 15 disk(s) for this vdev type.'
+    assert [e.attribute for e in verrors.errors] == ["topology.data.0.disks"]
+    assert verrors.errors[0].errmsg == "You can have at most 15 disk(s) for this vdev type."
 
 
 # ---------------------------------------------------------------------------
@@ -121,29 +117,26 @@ async def test_max_width_only_applies_to_new_vdevs_on_extend():
 
 @pytest.mark.asyncio
 async def test_mixed_data_types_rejected():
-    verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('MIRROR', 2)])
-    )
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 7), _new_vdev("MIRROR", 2)]))
     assert any(
-        e.attribute == 'topology.data.1.type' and 'different data vdev types' in e.errmsg
-        for e in verrors.errors
+        e.attribute == "topology.data.1.type" and "different data vdev types" in e.errmsg for e in verrors.errors
     )
 
 
 @pytest.mark.asyncio
 async def test_raidz2_below_minimum_disks_rejected():
-    verrors = await _service()._validate_topology(_pool_data([_new_vdev('RAIDZ2', 3)]))
-    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
-    assert verrors.errors[0].errmsg == 'You need at least 4 disk(s) for this vdev type.'
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 3)]))
+    assert [e.attribute for e in verrors.errors] == ["topology.data.0.disks"]
+    assert verrors.errors[0].errmsg == "You need at least 4 disk(s) for this vdev type."
 
 
 @pytest.mark.asyncio
 async def test_special_without_redundancy_rejected():
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7)], special=[_new_vdev('STRIPE', 1)])
+        _pool_data([_new_vdev("RAIDZ2", 7)], special=[_new_vdev("STRIPE", 1)])
     )
     assert any(
-        e.errmsg == 'A special vdev with no redundancy is not allowed when data vdevs are redundant.'
+        e.errmsg == "A special vdev with no redundancy is not allowed when data vdevs are redundant."
         for e in verrors.errors
     )
 
@@ -156,7 +149,7 @@ async def test_special_without_redundancy_rejected():
 @pytest.mark.asyncio
 async def test_force_topology_bypasses_width_and_cap():
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 30)], force_topology=True)
+        _pool_data([_new_vdev("RAIDZ2", 7), _new_vdev("RAIDZ2", 30)], force_topology=True)
     )
     assert verrors.errors == []
 
@@ -164,7 +157,7 @@ async def test_force_topology_bypasses_width_and_cap():
 @pytest.mark.asyncio
 async def test_force_topology_bypasses_special_redundancy():
     verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7)], special=[_new_vdev('STRIPE', 1)], force_topology=True)
+        _pool_data([_new_vdev("RAIDZ2", 7)], special=[_new_vdev("STRIPE", 1)], force_topology=True)
     )
     assert verrors.errors == []
 
@@ -172,11 +165,9 @@ async def test_force_topology_bypasses_special_redundancy():
 @pytest.mark.asyncio
 async def test_force_topology_does_not_bypass_minimum_disks():
     # Minimum disks is structural and still applies under force_topology.
-    verrors = await _service()._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 3)], force_topology=True)
-    )
-    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
-    assert verrors.errors[0].errmsg == 'You need at least 4 disk(s) for this vdev type.'
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev("RAIDZ2", 3)], force_topology=True))
+    assert [e.attribute for e in verrors.errors] == ["topology.data.0.disks"]
+    assert verrors.errors[0].errmsg == "You need at least 4 disk(s) for this vdev type."
 
 
 # ---------------------------------------------------------------------------
@@ -187,12 +178,11 @@ async def test_force_topology_does_not_bypass_minimum_disks():
 @pytest.mark.asyncio
 async def test_force_topology_rejected_on_enterprise():
     verrors = await _service(is_enterprise=True)._validate_topology(
-        _pool_data([_new_vdev('RAIDZ2', 7)], force_topology=True)
+        _pool_data([_new_vdev("RAIDZ2", 7)], force_topology=True)
     )
-    assert [e.attribute for e in verrors.errors] == ['force_topology']
+    assert [e.attribute for e in verrors.errors] == ["force_topology"]
     assert verrors.errors[0].errmsg == (
-        'Bypassing pool topology validation is not supported on '
-        'Enterprise-licensed systems.'
+        "Bypassing pool topology validation is not supported on Enterprise-licensed systems."
     )
 
 
@@ -200,6 +190,6 @@ async def test_force_topology_rejected_on_enterprise():
 async def test_force_topology_not_checked_when_unset():
     # system.is_enterprise must not even be consulted when force_topology is off.
     service = _service(is_enterprise=True)
-    verrors = await service._validate_topology(_pool_data([_new_vdev('RAIDZ2', 7)]))
+    verrors = await service._validate_topology(_pool_data([_new_vdev("RAIDZ2", 7)]))
     assert verrors.errors == []
-    service.middleware['system.is_enterprise'].assert_not_called()
+    service.middleware["system.is_enterprise"].assert_not_called()

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
@@ -1,0 +1,205 @@
+import pytest
+from unittest.mock import Mock
+
+from middlewared.plugins.pool_.pool import PoolService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+def _new_vdev(vdev_type, num_disks):
+    """A vdev spec as it arrives in data['topology'] on create/update."""
+    return {'type': vdev_type, 'disks': [f'sd{i}' for i in range(num_disks)]}
+
+
+def _existing_vdev(vdev_type, num_disks):
+    """An existing vdev in a pool's stored topology (disk_to_stripe form)."""
+    return {'type': vdev_type, 'children': [{'type': 'DISK'} for _ in range(num_disks)]}
+
+
+def _pool_data(data, *, special=None, dedup=None, force_topology=False):
+    return {
+        'topology': {'data': data, 'special': special or [], 'dedup': dedup or []},
+        'force_topology': force_topology,
+    }
+
+
+def _pool_old(data, *, special=None, dedup=None):
+    return {'topology': {'data': data, 'special': special or [], 'dedup': dedup or []}}
+
+
+def _service(is_enterprise=False):
+    middleware = Middleware()
+    middleware['system.is_enterprise'] = Mock(return_value=is_enterprise)
+    return PoolService(middleware)
+
+
+# ---------------------------------------------------------------------------
+# Valid topologies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uniform_raidz2_is_valid():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 7)])
+    )
+    assert verrors.errors == []
+
+
+@pytest.mark.asyncio
+async def test_stripe_width_is_not_capped():
+    # STRIPE has no geometry to match and no maximum width.
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev('STRIPE', 20)]))
+    assert verrors.errors == []
+
+
+@pytest.mark.asyncio
+async def test_extend_matching_width_is_valid():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7)]),
+        _pool_old([_existing_vdev('RAIDZ2', 7)]),
+    )
+    assert verrors.errors == []
+
+
+# ---------------------------------------------------------------------------
+# Width consistency (data vdevs must be the same width)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mismatched_data_width_rejected_on_create():
+    # Both within the width cap, so only the consistency check fires.
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 10)])
+    )
+    assert [e.attribute for e in verrors.errors] == ['topology.data.1.disks']
+    assert 'different widths' in verrors.errors[0].errmsg
+
+
+@pytest.mark.asyncio
+async def test_mismatched_data_width_rejected_on_extend():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 10)]),
+        _pool_old([_existing_vdev('RAIDZ2', 7)]),
+    )
+    assert any('different widths' in e.errmsg for e in verrors.errors)
+
+
+# ---------------------------------------------------------------------------
+# Maximum width cap (RAIDZ 15, mirror 4); dRAID/STRIPE exempt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raidz_width_cap_rejected():
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev('RAIDZ2', 16)]))
+    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
+    assert verrors.errors[0].errmsg == 'You can have at most 15 disk(s) for this vdev type.'
+
+
+@pytest.mark.asyncio
+async def test_mirror_width_cap_rejected():
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev('MIRROR', 5)]))
+    assert verrors.errors[0].errmsg == 'You can have at most 4 disk(s) for this vdev type.'
+
+
+@pytest.mark.asyncio
+async def test_max_width_only_applies_to_new_vdevs_on_extend():
+    # An over-wide existing vdev is not re-flagged; the matching new vdev passes.
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 16)]),
+        _pool_old([_existing_vdev('RAIDZ2', 16)]),
+    )
+    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
+    assert verrors.errors[0].errmsg == 'You can have at most 15 disk(s) for this vdev type.'
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing checks that force_topology also bypasses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mixed_data_types_rejected():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('MIRROR', 2)])
+    )
+    assert any(
+        e.attribute == 'topology.data.1.type' and 'different data vdev types' in e.errmsg
+        for e in verrors.errors
+    )
+
+
+@pytest.mark.asyncio
+async def test_raidz2_below_minimum_disks_rejected():
+    verrors = await _service()._validate_topology(_pool_data([_new_vdev('RAIDZ2', 3)]))
+    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
+    assert verrors.errors[0].errmsg == 'You need at least 4 disk(s) for this vdev type.'
+
+
+@pytest.mark.asyncio
+async def test_special_without_redundancy_rejected():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7)], special=[_new_vdev('STRIPE', 1)])
+    )
+    assert any(
+        e.errmsg == 'A special vdev with no redundancy is not allowed when data vdevs are redundant.'
+        for e in verrors.errors
+    )
+
+
+# ---------------------------------------------------------------------------
+# force_topology bypasses the policy checks (but not structural ones)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_topology_bypasses_width_and_cap():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7), _new_vdev('RAIDZ2', 30)], force_topology=True)
+    )
+    assert verrors.errors == []
+
+
+@pytest.mark.asyncio
+async def test_force_topology_bypasses_special_redundancy():
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7)], special=[_new_vdev('STRIPE', 1)], force_topology=True)
+    )
+    assert verrors.errors == []
+
+
+@pytest.mark.asyncio
+async def test_force_topology_does_not_bypass_minimum_disks():
+    # Minimum disks is structural and still applies under force_topology.
+    verrors = await _service()._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 3)], force_topology=True)
+    )
+    assert [e.attribute for e in verrors.errors] == ['topology.data.0.disks']
+    assert verrors.errors[0].errmsg == 'You need at least 4 disk(s) for this vdev type.'
+
+
+# ---------------------------------------------------------------------------
+# force_topology is not permitted on Enterprise-licensed systems
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_topology_rejected_on_enterprise():
+    verrors = await _service(is_enterprise=True)._validate_topology(
+        _pool_data([_new_vdev('RAIDZ2', 7)], force_topology=True)
+    )
+    assert [e.attribute for e in verrors.errors] == ['force_topology']
+    assert verrors.errors[0].errmsg == (
+        'Bypassing pool topology validation is not supported on '
+        'Enterprise-licensed systems.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_topology_not_checked_when_unset():
+    # system.is_enterprise must not even be consulted when force_topology is off.
+    service = _service(is_enterprise=True)
+    verrors = await service._validate_topology(_pool_data([_new_vdev('RAIDZ2', 7)]))
+    assert verrors.errors == []
+    service.middleware['system.is_enterprise'].assert_not_called()

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_validate_topology.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from middlewared.plugins.pool_.pool import PoolService
 from middlewared.pytest.unit.middleware import Middleware


### PR DESCRIPTION
Enforce equal data-vdev width and cap RAIDZ/mirror width at 15/4 in pool.create and pool.update, mirroring truenas_pylibzfs. Add force_topology (26 API) to bypass these topology policy checks and the special/dedup redundancy rule; structural checks still apply. Reject force_topology on Enterprise-licensed systems.

Original PR: https://github.com/truenas/middleware/pull/19282
