### PR TITLE
NAS-141699 / 26.0.0-RC.1 / fix duplicate From header and SMTP crash

### DIFF
--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -282,17 +282,7 @@ class MailService(ConfigService):
                     # This is because FreeNAS doesn't run a full MTA.
                     # else:
                     #    server.connect()
-                    server.sendmail(
-                        # `from_addr` is a `Header` instance, not `str`, so `encode` is not `str.encode`, it's a
-                        # different method.
-                        # Then we do `decode` because `sendmail` crashes on certain invalid byte sequences
-                        # (like b'"TrueNAS SCALE<user@domaincom>" <user@domain.com>')
-                        # Same byte sequences passed as strings work fine and result in invalid from address being
-                        # sanitized properly.
-                        from_addr if isinstance(from_addr, str) else from_addr.encode().decode(),
-                        to,
-                        msg.as_string(),
-                    )
+                    server.sendmail(from_addr, to, msg.as_string())
         except NetworkActivityDisabled:
             self.logger.warning('Sending email denied')
             raise
@@ -364,8 +354,9 @@ class MailService(ConfigService):
                             # Update `From` address from currently used config because if the SMTP user changes,
                             # already queued messages might not be sent due to (553, b'Relaying disallowed as xxx')
                             # error
-                            queue.message['From'] = self._from_addr(config)
-                            server.sendmail(queue.message['From'].encode(),
+                            from_addr = self._from_addr(config)
+                            queue.message.replace_header('From', from_addr)
+                            server.sendmail(from_addr,
                                             queue.message['To'].split(', '),
                                             queue.message.as_string())
                 except NetworkActivityDisabled:
@@ -395,7 +386,7 @@ class MailService(ConfigService):
             else:
                 from_addr = Header(config['fromemail'], 'ascii')
 
-            return from_addr
+            return from_addr.encode()
 
     @private
     async def local_administrators_emails(self):


### PR DESCRIPTION
Two related bugs caused alert/test emails to be RFC 5322 non-compliant (double From: header), which Gmail now rejects with 550-5.7.1:

1. When `fromname` is empty, `_from_addr()` returned an `email.header.Header`; `Header.encode()` returns `str`, so the `.encode().decode()` in `send_raw()` raised `AttributeError: 'str' object has no attribute 'decode'` on every direct SMTP send. `_from_addr()` now always returns `str`.
2. The failed message was then queued, and `send_mail_queue()` did `queue.message['From'] = ...`, which *appends* a second From header instead of replacing the existing one. Use `replace_header()` so the flushed message keeps a single From header.