### PR TITLE
NAS-141711 / 26.0.0-RC.1 / Ensure truenas_zfstierd state on failover (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/zfs_tier.py
+++ b/src/middlewared/middlewared/alert/source/zfs_tier.py
@@ -130,7 +130,12 @@ class TierJobAlertSource(ThreadedAlertSource):
     def _check_jobs(self) -> None:
         current_terminal: set[str] = set()
 
-        for job in enum_jobs():
+        # Materialize first: enum_jobs() holds an LMDB read transaction open for
+        # the life of the iterator, and _fire_job_alert() -> get_info() below opens
+        # another read transaction on the same thread. LMDB permits one read
+        # transaction per thread, so reading inside the live iterator raises
+        # MDB_BAD_RSLOT.
+        for job in list(enum_jobs()):
             tier_job_id = f"{job.dataset_name}@{job.job_uuid}"
 
             if job.status in _TERMINAL_STATUSES:

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -841,6 +841,15 @@ class FailoverEventsService(Service):
         self.run_call('service.control', 'RESTART', 'netdata', job=True)
         logger.info('Done restarting reporting metrics')
 
+        # Regenerate /etc/truenas_zfstierd.conf and restart the tier daemon. The
+        # standby never runs zfs.tier.do_update, so its on-disk config is stale or
+        # absent (leaving the daemon disabled) until it is regenerated on service
+        # start. Restart rather than reload so the daemon also reopens its LMDB job
+        # store against the just-remounted system dataset.
+        logger.info('Restarting ZFS tier daemon')
+        self.run_call('service.control', 'RESTART', 'truenas_zfstierd', job=True)
+        logger.info('Done restarting ZFS tier daemon')
+
         logger.info('Updating replication tasks')
         self.run_call('zettarepl.update_tasks')
         logger.info('Done updating replication tasks')

--- a/src/middlewared/middlewared/plugins/service_/services/truenas_zfstierd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/truenas_zfstierd.py
@@ -5,5 +5,6 @@ class TruenasZfstierdService(SimpleService):
     name = "truenas_zfstierd"
 
     systemd_unit = "truenas_zfstierd"
+    etc = ["truenas_zfstierd"]
     reloadable = True
     restartable = True


### PR DESCRIPTION
Regenerate the truenas_zfstierd config on the promoted node.

Materialize enum_jobs() in the tier alert source so per-job get_info() no longer opens a second read transaction inside the live iterator (MDB_BAD_RSLOT; LMDB allows one read txn per thread per db).

Original PR: https://github.com/truenas/middleware/pull/19280
