### PR TITLE
NAS-141755 / 27.0.0-BETA.1 / Redact app.image.pull registry credentials in job history and logs

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/app_image.py
+++ b/src/middlewared/middlewared/api/v26_0_0/app_image.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
@@ -64,8 +64,12 @@ class AppImageDockerhubRateLimitResult(BaseModel):
 
 
 class AppImageAuthConfig(BaseModel):
-    username: str = Field(description="Username for container registry authentication.")
-    password: str = Field(description="Password or access token for container registry authentication.")
+    username: Secret[str] = Field(
+        description="Username for container registry authentication (masked for security).",
+    )
+    password: Secret[str] = Field(
+        description="Password or access token for container registry authentication (masked for security).",
+    )
     registry_uri: str | None = Field(
         default=None,
         description="Container registry URI or `null` to use default registry.",

--- a/src/middlewared/middlewared/api/v27_0_0/app_image.py
+++ b/src/middlewared/middlewared/api/v27_0_0/app_image.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, LongString, NonEmptyString
 
@@ -45,8 +45,12 @@ class AppImageEntry(BaseModel):
 
 
 class AppImageAuthConfig(BaseModel):
-    username: str = Field(description="Username for container registry authentication.")
-    password: str = Field(description="Password or access token for container registry authentication.")
+    username: Secret[str] = Field(
+        description="Username for container registry authentication (masked for security).",
+    )
+    password: Secret[str] = Field(
+        description="Password or access token for container registry authentication (masked for security).",
+    )
     registry_uri: str | None = Field(
         default=None,
         description="Container registry URI or `null` to use default registry.",

--- a/src/middlewared/middlewared/plugins/apps_images/pull.py
+++ b/src/middlewared/middlewared/plugins/apps_images/pull.py
@@ -43,8 +43,8 @@ def pull_image_action(
     context.call_sync2(context.s.docker.validate_state)
     image_tag = data.image
     if data.auth_config is not None:
-        username: str | None = data.auth_config.username
-        password: str | None = data.auth_config.password
+        username: str | None = data.auth_config.username.get_secret_value()
+        password: str | None = data.auth_config.password.get_secret_value()
         registry_uri: str | None = data.auth_config.registry_uri
     else:
         # If user has not provided any auth creds, try to see if the registry to which the image


### PR DESCRIPTION
## Problem
The `auth_config` username/password accepted by `app.image.pull` were typed as plain `str`, so the secret scrubber never masked them. Any registry credentials supplied for a private image pull landed in cleartext in `core.get_jobs` arguments (which get bundled into support debugs) and in `middlewared.log`.

## Solution
Wrapped `username`/`password` in `Secret[str]` in the current and 26.0 API models, matching what `app.registry` already does, and unwrapped them with `.get_secret_value()` in the pull plugin so the real values still reach the registry. Job arguments and logs now show `********`.