### PR TITLE
NAS-141692 / 27.0.0-BETA.1 / Fix UPS Input Load graph showing Watts on a percentage axis

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -478,7 +478,7 @@ class UPSLoadPlugin(UPSBase):
     uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return f'upsd_{self.UPS_IDENTIFIER}.load_usage'
+        return f'upsd_{self.UPS_IDENTIFIER}.load_percentage'
 
 
 class UPSTemperaturePlugin(UPSBase):


### PR DESCRIPTION
## Problem
The "UPS Input Load" report has `vertical_label = 'Percentage'` but pointed `get_chart_name()` at Netdata's `upsd_<id>.load_usage` chart, whose units are Watts (`ups.realpower`, or `ups.load/100 × ups.realpower.nominal`). So the graph rendered absolute power draw (e.g. ~117W for a ~30% load on a 390W UPS) under a "Percentage" axis. This regressed in the python.d→go.d Netdata migration, which renamed the chart from `nut_<id>.load` to `load_usage` without updating the label — the migration picked the wrong sibling chart.

## Solution
Point the chart at `upsd_<id>.load_percentage` (units: percentage), which maps to the raw NUT `ups.load` variable and matches both the existing label and title. This chart is gated on the same `ups.load` variable as `load_usage`, so it's available under identical conditions, and it populates even on UPSes that don't report realpower — where `load_usage` would be empty.