### PR TITLE
NAS-141765 / 27.0.0-BETA.1 / Add /s suffix to per-second ARC/L2ARC chart units

### DIFF
--- a/src/freenas/usr/libexec/netdata/python.d/truenas_arcstats.chart.py
+++ b/src/freenas/usr/libexec/netdata/python.d/truenas_arcstats.chart.py
@@ -77,19 +77,19 @@ CHARTS = {
         ]
     },
     'dmhit': {
-        'options': [None, 'dmhit', 'dmhit', 'dmhit', ArcStatDescriptions['dmhit'], 'line'],
+        'options': [None, 'dmhit', 'dmhit/s', 'dmhit', ArcStatDescriptions['dmhit'], 'line'],
         'lines': [
             ['dmhit', 'dmhit', 'incremental'],
         ]
     },
     'dmioh': {
-        'options': [None, 'dmioh', 'dmioh', 'dmioh', ArcStatDescriptions['dmioh'], 'line'],
+        'options': [None, 'dmioh', 'dmioh/s', 'dmioh', ArcStatDescriptions['dmioh'], 'line'],
         'lines': [
             ['dmioh', 'dmioh', 'incremental'],
         ]
     },
     'dmmis': {
-        'options': [None, 'dmmis', 'dmmis', 'dmmis', ArcStatDescriptions['dmmis'], 'line'],
+        'options': [None, 'dmmis', 'dmmis/s', 'dmmis', ArcStatDescriptions['dmmis'], 'line'],
         'lines': [
             ['dmmis', 'dmmis', 'incremental'],
         ]
@@ -113,19 +113,19 @@ CHARTS = {
         ]
     },
     'l2hits': {
-        'options': [None, 'l2hits', 'l2hits', 'l2hits', ArcStatDescriptions['l2hits'], 'line'],
+        'options': [None, 'l2hits', 'l2hits/s', 'l2hits', ArcStatDescriptions['l2hits'], 'line'],
         'lines': [
             ['l2hits', 'l2hits', 'incremental'],
         ]
     },
     'l2miss': {
-        'options': [None, 'l2miss', 'l2miss', 'l2miss', ArcStatDescriptions['l2miss'], 'line'],
+        'options': [None, 'l2miss', 'l2miss/s', 'l2miss', ArcStatDescriptions['l2miss'], 'line'],
         'lines': [
             ['l2miss', 'l2miss', 'incremental'],
         ]
     },
     'l2read': {
-        'options': [None, 'l2read', 'l2read', 'l2read', ArcStatDescriptions['l2read'], 'line'],
+        'options': [None, 'l2read', 'l2read/s', 'l2read', ArcStatDescriptions['l2read'], 'line'],
         'lines': [
             ['l2read', 'l2read', 'incremental'],
         ]
@@ -143,13 +143,13 @@ CHARTS = {
         ]
     },
     'l2bytes': {
-        'options': [None, 'l2bytes', 'l2bytes', 'l2bytes', ArcStatDescriptions['l2bytes'], 'line'],
+        'options': [None, 'l2bytes', 'l2bytes/s', 'l2bytes', ArcStatDescriptions['l2bytes'], 'line'],
         'lines': [
             ['l2bytes', 'l2bytes', 'incremental'],
         ]
     },
     'l2wbytes': {
-        'options': [None, 'l2wbytes', 'l2wbytes', 'l2wbytes', ArcStatDescriptions['l2wbytes'], 'line'],
+        'options': [None, 'l2wbytes', 'l2wbytes/s', 'l2wbytes', ArcStatDescriptions['l2wbytes'], 'line'],
         'lines': [
             ['l2wbytes', 'l2wbytes', 'incremental'],
         ]


### PR DESCRIPTION
## Problem
Eight ARC/L2ARC charts in truenas_arcstats.chart.py (dmhit, dmioh, dmmis, l2hits, l2miss, l2read, l2bytes, l2wbytes) use netdata's incremental algorithm, which plots the counter delta divided by the collection interval, i.e. a per-second rate. Their units strings were bare names (e.g. l2bytes) with no /s, so the label read like a raw total even though the value is a rate. This was inconsistent with the sibling incremental charts (dread, ddread, dmread, ddhit, ddioh, ddmis) that already use /s, and with the chart context strings that already say "per second".

## Solution
Appended /s to the units string of those eight charts so every incremental chart's units label reflects the per-second rate it actually plots. Label-only change; the plotted values are unaffected, and there is no user-facing regression since the TrueNAS UI sources its axis labels from the reporting graphs' vertical_label, not from this netdata units field.