### PR TITLE
NAS-141717 / 27.0.0-BETA.1 / Document HA failover fields on InterfaceEntry

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/interface.py
+++ b/src/middlewared/middlewared/api/v27_0_0/interface.py
@@ -219,10 +219,38 @@ class InterfaceEntry(BaseModel):
     bridge_members: list[str] = Field(
         default=[],
         description="List of interface names that are members of this bridge.",
-    )  # FIXME: Please document fields for HA Hardware
+    )
     enable_learning: bool = Field(
         default=NotRequired,
         description="Whether MAC address learning is enabled for bridge interfaces.",
+    )
+    failover_critical: bool = Field(
+        default=NotRequired,
+        description="Whether this interface is critical for failover. Only present on HA-capable systems.",
+    )
+    failover_group: int | None = Field(
+        default=NotRequired,
+        description="Failover group identifier for clustering. Only present on HA-capable systems.",
+    )
+    failover_vhid: int | None = Field(
+        default=NotRequired,
+        description="VRRP Virtual Host ID for failover. Only present on HA-capable systems.",
+    )
+    failover_aliases: list[InterfaceEntryAlias] = Field(
+        default=NotRequired,
+        description=(
+            "Standby node IP aliases for failover. Only present on HA-capable systems. Unlike the "
+            "`failover_aliases` accepted by `interface.create` and `interface.update`, each entry here also "
+            "includes a `netmask`."
+        ),
+    )
+    failover_virtual_aliases: list[InterfaceEntryAlias] = Field(
+        default=NotRequired,
+        description=(
+            "Virtual (floating) IP aliases shared between nodes during failover. Only present on HA-capable "
+            "systems. Unlike the `failover_virtual_aliases` accepted by `interface.create` and "
+            "`interface.update`, each entry here also includes a `netmask`."
+        ),
     )
 
     class Config:


### PR DESCRIPTION
Declare the HA-only failover fields (`failover_critical`, `failover_group`, `failover_vhid`, `failover_aliases`, `failover_virtual_aliases`) that `interface.query` already emits on `InterfaceEntry`, and drop the `# FIXME: Please document fields for HA Hardware`. They previously slipped through only via `extra = "allow"`, which hid that `interface.query` returns each failover alias with a `netmask` while `interface.create`/`interface.update` reject it — the divergence behind the console-menu save failure this documents against. Documentation/typing only; no behavior change.