### PR TITLE
NAS-141446 / 26.0.0-RC.1 / Wait for the default route to appear during docker startup check (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_interface_util.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_interface_util.py
@@ -1,0 +1,56 @@
+import unittest.mock
+
+from middlewared.utils import interface
+from middlewared.utils.interface import (
+    IFACE_LINK_STATE_MAX_WAIT,
+    wait_for_default_interface_link_state_up,
+)
+
+
+def test_default_interface_already_present():
+    # Route is there on the first read, link comes up: no polling needed.
+    with (
+        unittest.mock.patch.object(interface, "get_default_interface", return_value="br1") as gdi,
+        unittest.mock.patch.object(interface, "wait_on_interface_link_state_up", return_value=True),
+        unittest.mock.patch.object(interface.time, "sleep") as sleep,
+    ):
+        assert wait_for_default_interface_link_state_up() == ("br1", True)
+        gdi.assert_called_once()
+        sleep.assert_not_called()
+
+
+def test_default_interface_appears_late():
+    # The boot race: no default route for the first couple of reads (DHCP/bridge still
+    # converging), then it shows up. We must keep polling rather than give up immediately.
+    with (
+        unittest.mock.patch.object(interface, "get_default_interface", side_effect=[None, None, "br1"]) as gdi,
+        unittest.mock.patch.object(interface, "wait_on_interface_link_state_up", return_value=True),
+        unittest.mock.patch.object(interface.time, "sleep") as sleep,
+    ):
+        assert wait_for_default_interface_link_state_up() == ("br1", True)
+        assert gdi.call_count == 3
+        assert sleep.call_count == 2
+
+
+def test_no_default_interface_within_window():
+    # Genuinely network-less box: never find a route, return (None, False) after the full window.
+    with (
+        unittest.mock.patch.object(interface, "get_default_interface", return_value=None) as gdi,
+        unittest.mock.patch.object(interface, "wait_on_interface_link_state_up") as wlsu,
+        unittest.mock.patch.object(interface.time, "sleep") as sleep,
+    ):
+        assert wait_for_default_interface_link_state_up() == (None, False)
+        assert gdi.call_count == IFACE_LINK_STATE_MAX_WAIT
+        assert sleep.call_count == IFACE_LINK_STATE_MAX_WAIT
+        wlsu.assert_not_called()
+
+
+def test_default_interface_present_but_link_never_up():
+    # Route exists but the interface never reaches operstate=up.
+    with (
+        unittest.mock.patch.object(interface, "get_default_interface", return_value="br1"),
+        unittest.mock.patch.object(interface, "wait_on_interface_link_state_up", return_value=False),
+        unittest.mock.patch.object(interface.time, "sleep") as sleep,
+    ):
+        assert wait_for_default_interface_link_state_up() == ("br1", False)
+        sleep.assert_not_called()

--- a/src/middlewared/middlewared/utils/interface.py
+++ b/src/middlewared/middlewared/utils/interface.py
@@ -37,8 +37,26 @@ def wait_on_interface_link_state_up(interface: str) -> bool:
 
 
 def wait_for_default_interface_link_state_up() -> tuple[str | None, bool]:
-    default_interface = get_default_interface()
-    if default_interface is None:
-        return default_interface, False
+    """
+    Wait for the default interface to appear and come up.
 
-    return default_interface, wait_on_interface_link_state_up(default_interface)
+    Polls get_default_interface() for up to IFACE_LINK_STATE_MAX_WAIT seconds so we tolerate the
+    boot-time window where the default route is not installed yet -- e.g. DHCP is still acquiring
+    a lease, or a bridge is still converging through STP forward-delay. A single read here would
+    otherwise abort docker/apps startup with "Unable to determine default interface" whenever
+    system.ready beats the route.
+
+    Returns (interface_name, success): interface_name is None if no default interface appears
+    within the window; success is whether that interface reached link-state up.
+    """
+    sleep_interval = 1
+    time_waited = 0
+    while time_waited < IFACE_LINK_STATE_MAX_WAIT:
+        default_interface = get_default_interface()
+        if default_interface is not None:
+            return default_interface, wait_on_interface_link_state_up(default_interface)
+
+        time.sleep(sleep_interval)
+        time_waited += sleep_interval
+
+    return None, False


### PR DESCRIPTION
## Problem
Apps fail to start on every boot with "Unable to determine default interface" whenever the default route is installed asynchronously -- e.g. a DHCP bridge that has to converge through STP forward-delay before dhcpcd can acquire a lease and install the route. `validate_interfaces` read the route table exactly once at system.ready and gave up immediately if no default route was present yet, so the check lost the race by a few seconds. Unsetting and re-setting the apps pool only worked around it because that re-runs the check later, after the route already exists.

## Solution
`wait_for_default_interface_link_state_up` now polls `get_default_interface()` once a second within the existing IFACE_LINK_STATE_MAX_WAIT budget instead of reading once, so a late-arriving default route is picked up rather than aborting startup. Returns (None, False) only if no default interface shows up within the whole window.

Original PR: https://github.com/truenas/middleware/pull/19279
