### PR TITLE
NAS-141771 / 25.10.5 / bump ntb0 back to 64K MTU (by yocalebo)

### DIFF
--- a/src/freenas/etc/systemd/network/10-persistent-net.link
+++ b/src/freenas/etc/systemd/network/10-persistent-net.link
@@ -4,12 +4,4 @@ Driver=ntb_netdev
 
 [Link]
 Name=ntb0
-# TODO: at time of writing, ntb on SCALE has pathological
-# behavior related TCP/IP Window size calculation whereby
-# the receiving side clamps the window size to 0 causing
-# recalculation which, ultimately, ends with behavior
-# described in https://en.wikipedia.org/wiki/Silly_window_syndrome
-# The work-around is to drop MTU size a bit which fixes
-# the scenario altogether. When we discover why this is
-# happening, we should remove the MTUBytes line.
 MTUBytes=64000


### PR DESCRIPTION
cf. https://github.com/truenas/linux/pull/312

I hope we can finally lay this issue to bed....

Original PR: https://github.com/truenas/middleware/pull/19300
