### PR TITLE
NAS-141755 / 25.10.5 / Redact app.image.pull registry credentials in job history and logs (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_5/app_image.py
+++ b/src/middlewared/middlewared/api/v25_10_5/app_image.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import Secret
+
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
 __all__ = [
@@ -65,9 +67,9 @@ class ContainerImagesDockerhubRateLimitResult(BaseModel):
 
 
 class AppImageAuthConfig(BaseModel):
-    username: str
+    username: Secret[str]
     """Username for container registry authentication."""
-    password: str
+    password: Secret[str]
     """Password or access token for container registry authentication."""
     registry_uri: str | None = None
     """Container registry URI or `null` to use default registry."""


### PR DESCRIPTION
## Problem
The `auth_config` username/password accepted by `app.image.pull` were typed as plain `str`, so the secret scrubber never masked them. Any registry credentials supplied for a private image pull landed in cleartext in `core.get_jobs` arguments (which get bundled into support debugs) and in `middlewared.log`.

## Solution
Wrapped `username`/`password` in `Secret[str]` in the current and 26.0 API models, matching what `app.registry` already does, and unwrapped them with `.get_secret_value()` in the pull plugin so the real values still reach the registry. Job arguments and logs now show `********`.

Original PR: https://github.com/truenas/middleware/pull/19293
