### PR TITLE
NAS-141755 / 26.0.0-RC.1 / Redact app.image.pull registry credentials in job history and logs (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/app_image.py
+++ b/src/middlewared/middlewared/api/v26_0_0/app_image.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, LongString, NonEmptyString, single_argument_args, single_argument_result
 
@@ -64,8 +64,8 @@ class ContainerImagesDockerhubRateLimitResult(BaseModel):
 
 
 class AppImageAuthConfig(BaseModel):
-    username: str = Field(description="Username for container registry authentication.")
-    password: str = Field(description="Password or access token for container registry authentication.")
+    username: Secret[str] = Field(description="Username for container registry authentication.")
+    password: Secret[str] = Field(description="Password or access token for container registry authentication.")
     registry_uri: str | None = Field(
         default=None,
         description="Container registry URI or `null` to use default registry.",


### PR DESCRIPTION
## Problem
The `auth_config` username/password accepted by `app.image.pull` were typed as plain `str`, so the secret scrubber never masked them. Any registry credentials supplied for a private image pull landed in cleartext in `core.get_jobs` arguments (which get bundled into support debugs) and in `middlewared.log`.

## Solution
Wrapped `username`/`password` in `Secret[str]` in the current and 26.0 API models, matching what `app.registry` already does, and unwrapped them with `.get_secret_value()` in the pull plugin so the real values still reach the registry. Job arguments and logs now show `********`.

Original PR: https://github.com/truenas/middleware/pull/19293
