### PR TITLE
NAS-141786 / 27.0.0-BETA.1 / Merge catalog update onto current config before persisting

### DIFF
--- a/src/middlewared/middlewared/plugins/catalog/config.py
+++ b/src/middlewared/middlewared/plugins/catalog/config.py
@@ -39,15 +39,18 @@ class CatalogConfigPart(ConfigServicePart[CatalogEntry]):
         return data
 
     async def do_update(self, data: CatalogUpdate) -> CatalogEntry:
+        old = await self.config()
+        new = old.updated(data)
+
         verrors = ValidationErrors()
-        if not data.preferred_trains:
+        if not new.preferred_trains:
             verrors.add(
                 'catalog_update.preferred_trains',
                 'At least 1 preferred train must be specified.'
             )
         if (
             await self.middleware.call('system.product_type') == ProductType.ENTERPRISE and
-            OFFICIAL_ENTERPRISE_TRAIN not in data.preferred_trains
+            OFFICIAL_ENTERPRISE_TRAIN not in new.preferred_trains
         ):
             verrors.add(
                 'catalog_update.preferred_trains',
@@ -60,7 +63,7 @@ class CatalogConfigPart(ConfigServicePart[CatalogEntry]):
             'datastore.update',
             self._datastore,
             OFFICIAL_LABEL,
-            data.model_dump(),
+            {'preferred_trains': new.preferred_trains},
         )
 
         return await self.config()


### PR DESCRIPTION
## Problem
`catalog.update` wrote the raw partial request straight to the datastore and validated it directly. Because `CatalogUpdate` is a for-update model, a call that omits `preferred_trains` left the field as the `undefined` sentinel — so on ENTERPRISE systems `OFFICIAL_ENTERPRISE_TRAIN not in data.preferred_trains` raised a TypeError, and any partial write could drop the existing trains.

## Solution
Read the current config, merge the incoming update onto it, then validate and persist the merged result so partial updates keep untouched fields. Only `preferred_trains` is written back, since it's the sole stored column.