### PR TITLE
NAS-141470 / 26.0.0-RC.1 / Inject mknod for privileged Allow-All containers (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -216,6 +216,21 @@ class ContainerService(Service):
         if container["capabilities_policy"]:
             container["capabilities_policy"] = ContainerCapabilitiesPolicy[container["capabilities_policy"]]
 
+        # For a privileged (no user namespace) container, "allow all" keeps every
+        # capability in the bounding set but libvirt only widens the cgroup device
+        # ACL — which permits creating device nodes such as the overlayfs whiteouts
+        # produced during container-image extraction — when an explicit
+        # <mknod state='on'/> is emitted. Inject it so "allow all" also allows
+        # device-node creation, unless the user set mknod explicitly. This is
+        # skipped for user-namespaced containers, where the device ACL is not the
+        # operative gate (the user namespace is) and the element would be a no-op.
+        if (
+            container["capabilities_policy"] == ContainerCapabilitiesPolicy.ALLOW
+            and container["idmap"] is None
+            and "mknod" not in container["capabilities_state"]
+        ):
+            container["capabilities_state"] = {**container["capabilities_state"], "mknod": True}
+
         # We add this to configuration because for cpu related attrs, we need them if cpuset on
         # container is actually set
         # For memory, lxc does not respect it but libvirt requires it in the xml to be defined

--- a/tests/api2/test_container_mknod.py
+++ b/tests/api2/test_container_mknod.py
@@ -1,0 +1,60 @@
+import time
+
+import pytest
+
+from middlewared.test.integration.assets.container import (
+    UBUNTU_IMAGE_NAME,
+    configure_bridge,
+    container,
+    nsenter,
+    resolve_image,
+)
+from middlewared.test.integration.utils import ssh
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    configure_bridge()
+
+
+@pytest.fixture(scope="module")
+def ubuntu_image():
+    yield resolve_image(UBUNTU_IMAGE_NAME)
+
+
+def test_privileged_allow_container_can_create_device_nodes(ubuntu_image):
+    """A privileged "Allow All" container can create device nodes via mknod.
+
+    ``capabilities_policy=ALLOW`` on a privileged (``idmap=None``) container
+    injects ``<mknod state='on'/>``, which makes libvirt widen the LXC cgroup
+    device ACL. That widening is what lets a nested container runtime create the
+    device nodes it needs when extracting image layers (overlay whiteouts):
+    without it the cgroup device controller denies ``mknod`` of a
+    non-whitelisted device with EPERM, even though CAP_MKNOD is in the bounding
+    set. This checks that gating operation directly rather than by pulling a
+    whole image.
+
+    The device controller is enforced by cgroup membership, so the ``mknod``
+    must run under the container's OWN cgroup. A bare ``nsenter`` from the host
+    enters the namespaces but stays in the host cgroup and would bypass the ACL
+    (a false pass), so the probe is launched via ``systemd-run`` inside the
+    container, which places it under the container's cgroup.
+    """
+    with container(
+        ubuntu_image,
+        {"idmap": None, "capabilities_policy": "ALLOW"},
+        start=True,
+    ) as c:
+        probe = (
+            "systemd-run --scope --quiet /bin/sh -c "
+            "'rm -f /tmp/mknod-probe; mknod /tmp/mknod-probe b 7 0'"
+        )
+        # Retry briefly: the container's systemd (which systemd-run talks to)
+        # may still be coming up right after start.
+        for _ in range(15):
+            result = ssh(nsenter(c, probe), check=False, complete_response=True)
+            if result["returncode"] == 0:
+                break
+            time.sleep(2)
+
+        assert result["returncode"] == 0, result["output"]


### PR DESCRIPTION
## Problem
A privileged container with `capabilities_policy` "ALLOW" keeps every capability in the bounding set, but libvirt only widens the LXC cgroup device ACL when an explicit `<mknod state='on'/>` child is emitted. As a result "Allow All" can't create device nodes, so Docker fails to extract images whose layers contain overlay whiteouts (character 0:0 nodes made via mknod) even though CAP_MKNOD is present.

## Solution
For privileged containers (idmap None) under an ALLOW policy, inject the mknod capability unless the user set it explicitly, so libvirt emits `<mknod state='on'/>` and widens the device ACL — making "Allow All" actually allow device-node creation. Adds an api2 integration test that pulls and runs a complex image inside such a container.

Original PR: https://github.com/truenas/middleware/pull/19319
