### PR TITLE
NAS-141794 / 27.0.0-BETA.1 / Wrap all `Secret` defaults in `Secret`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: flake8
+name: lint
 
 on:
   pull_request:

--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 import inspect
-from types import NoneType
+from types import NoneType, new_class
 from typing import Annotated, Any, Literal, Self, get_args, get_origin
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -11,7 +11,7 @@ from pydantic.fields import FieldInfo
 from pydantic.json_schema import SkipJsonSchema
 from pydantic.main import IncEx, ModelT
 from pydantic.types import SecretType
-from pydantic_core import SchemaSerializer, core_schema
+from pydantic_core import PydanticUndefined, SchemaSerializer, core_schema
 
 from middlewared.api.base.types.string import SECRET_VALUE
 from middlewared.utils.lang import Undefined, undefined
@@ -135,6 +135,7 @@ class _BaseModelMetaclass(ModelMetaclass):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
 
         has_not_required = False
+        wrapped_secret_default = False
         for field in cls.model_fields.values():  # type: ignore[attr-defined]
             if field.default is NotRequired:
                 # Update annotation of any field with a default of `NotRequired` since fields
@@ -146,10 +147,28 @@ class _BaseModelMetaclass(ModelMetaclass):
                 field.annotation = _annotate_not_required(field.annotation, field.metadata)
                 field.metadata = []
                 has_not_required = True
+            elif (
+                get_origin(field.annotation) is Secret
+                and field.default is not PydanticUndefined
+                and field.default is not undefined
+                and not isinstance(field.default, Secret)
+            ):
+                # Pydantic does not validate defaults, so a bare default on a `Secret` field (e.g.
+                # `Secret[str] = Field(default="")`) stays an unwrapped value, which is inconsistent with explicitly
+                # specified values. Wrap it so model instances are consistent.
+                field.default = new_class(
+                    "Secret",
+                    (Secret[get_args(field.annotation)[0]],),  # type: ignore[misc]
+                )(field.default)
+                wrapped_secret_default = True
 
         if has_not_required:
             # If any field has a default of `NotRequired`, apply the serializer to the model.
+            # This rebuilds the model, which is also required for the wrapped `Secret` defaults above.
             _apply_model_serializer(cls, _not_required_serializer)  # type: ignore[arg-type]
+        elif wrapped_secret_default:
+            # A mutated `field.default` only takes effect on instantiation after the model is rebuilt.
+            cls.model_rebuild(force=True)  # type: ignore[attr-defined]
 
         return cls
 

--- a/src/middlewared/middlewared/pytest/unit/api/base/test_secret_default_wrap.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/test_secret_default_wrap.py
@@ -1,0 +1,49 @@
+from pydantic import Field, Secret
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.model import NotRequired
+from middlewared.api.base.types.string import SECRET_VALUE
+
+
+class SecretDefaults(BaseModel):
+    required: Secret[str]
+    bare: Secret[str] = Field(default="")
+    already_wrapped: Secret[str] = Field(default=Secret("keep"))
+    not_required: Secret[str] = Field(default=NotRequired)
+    plain: str = Field(default="plain")
+
+
+def test_bare_secret_default_is_wrapped():
+    """A concrete default on a `Secret` field is auto-wrapped into a `Secret` instance."""
+    default = SecretDefaults.model_fields["bare"].default
+    assert isinstance(default, Secret)
+    assert default.get_secret_value() == ""
+
+
+def test_wrapped_secret_default_is_preserved():
+    """An already-`Secret` default is left untouched (not double-wrapped)."""
+    default = SecretDefaults.model_fields["already_wrapped"].default
+    assert isinstance(default, Secret)
+    assert default.get_secret_value() == "keep"
+
+
+def test_required_secret_field_untouched():
+    """A required `Secret` field keeps no default."""
+    assert SecretDefaults.model_fields["required"].is_required()
+
+
+def test_not_required_secret_default_untouched():
+    """The `NotRequired` sentinel is not wrapped."""
+    assert SecretDefaults.model_fields["not_required"].default is NotRequired
+
+
+def test_plain_field_default_untouched():
+    """Non-`Secret` fields are unaffected."""
+    assert SecretDefaults.model_fields["plain"].default == "plain"
+
+
+def test_wrapped_default_redacts_on_serialization():
+    """The auto-wrapped default redacts on serialization instead of leaking a bare value."""
+    dumped = SecretDefaults(required="r").model_dump()
+    assert dumped["bare"] == SECRET_VALUE
+    assert SecretDefaults(required="r").model_dump(expose_secrets=True)["bare"] == ""


### PR DESCRIPTION
Otherwise, explicitly set values and default values will be handled differently