### PR TITLE
NAS-141798 / 27.0.0-BETA.1 / Await plugin setup results based on the returned value

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -674,10 +674,10 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
             name, f = setup_func
             self._console_write(f'setting up plugins ({name}) [{i + 1}/{setup_total}]')
             self.__notify_startup_progress()
-            call = f(self)
+            result = f(self)
             # Allow setup to be a coroutine
-            if asyncio.iscoroutinefunction(f):
-                await call
+            if inspect.isawaitable(result):
+                await result
 
         self.logger.debug('All plugins loaded')
 


### PR DESCRIPTION
__plugins_setup decided whether to await by checking asyncio.iscoroutinefunction on the setup function after already calling it. A sync setup function that returns an awaitable would have its result silently dropped and never run, with no error at startup.

No current setup function is affected: all 112 async setups behave identically under both checks, and none of the 8 sync setups returns anything. This is hardening against a future setup taking that shape, plus the more correct idiom for "allow setup to be a coroutine".