### PR TITLE
NAS-141800 / 27.0.0-BETA.1 / Fix some pytest warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+pytest.register_assert_rewrite("middlewared.test")
+
 from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
 from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.pytest import failed
@@ -12,8 +14,6 @@ from middlewared.test.integration.utils.pytest import failed
 # See: https://stackoverflow.com/questions/75647682/how-can-i-resolve-flake8-unused-import-error-for-pytest-fixture-imported-from
 from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
 from middlewared.test.integration.assets.account import test_user  # noqa
-
-pytest.register_assert_rewrite("middlewared.test")
 
 # When STIG is active we are not able to call test.notify_test_start
 # or test.notify_test_end

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
/root/freenas/freenas/tests/conftest.py:16: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: middlewared.test

/usr/lib/python3/dist-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"