### PR TITLE
NAS-141801 / 27.0.0-BETA.1 / Remove `config.py` requirement in `runtest.py`

### DIFF
--- a/src/middlewared/middlewared/test/integration/runner/run.py
+++ b/src/middlewared/middlewared/test/integration/runner/run.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 from .args import parse
@@ -10,16 +9,6 @@ from .pytest_command import get_pytest_command
 
 
 def run(workdir: str) -> None:
-    ixautomation_dot_conf_url = (
-        "https://raw.githubusercontent.com/iXsystems/ixautomation/master/src/etc/ixautomation.conf.dist"
-    )  # fmt: skip
-    config_file_msg = (
-        f"Please add config.py to freenas/tests which can be empty or contain settings from {ixautomation_dot_conf_url}"
-    )  # fmt: skip
-    if not os.path.exists("config.py"):
-        print(config_file_msg)
-        exit(1)
-
     ctx = context_from_args(parse(), workdir)
     set_env(ctx)
     write_config(ctx)


### PR DESCRIPTION
Do not require `config.py` to exist in order to run `runtest.py`. Nothing really changes if it does not exist.