### PR TITLE
NAS-141802 / 27.0.0-BETA.1 / Fail tests if some config variables do not exist

### DIFF
--- a/tests/cloud/test_cloud_backup.py
+++ b/tests/cloud/test_cloud_backup.py
@@ -21,8 +21,10 @@ try:
         AWS_SECRET_ACCESS_KEY,
         AWS_BUCKET,
     )
-except ImportError:
-    pytestmark = pytest.mark.skip(reason="AWS credential are missing in config.py")
+except ImportError as e:
+    @pytest.fixture(autouse=True)
+    def fail_all_tests():
+        pytest.fail(str(e))
 
 
 def clean():

--- a/tests/cloud/test_cloud_backup_storj.py
+++ b/tests/cloud/test_cloud_backup_storj.py
@@ -6,11 +6,16 @@ from middlewared.test.integration.assets.cloud_backup import task
 from middlewared.test.integration.assets.cloud_sync import credential
 from middlewared.test.integration.assets.pool import dataset
 
-from config import (
-    STORJ_IX_AWS_ACCESS_KEY_ID,
-    STORJ_IX_AWS_SECRET_ACCESS_KEY,
-    STORJ_IX_BUCKET,
-)
+try:
+    from config import (
+        STORJ_IX_AWS_ACCESS_KEY_ID,
+        STORJ_IX_AWS_SECRET_ACCESS_KEY,
+        STORJ_IX_BUCKET,
+    )
+except ImportError as e:
+    @pytest.fixture(autouse=True)
+    def fail_all_tests():
+        pytest.fail(str(e))
 
 
 CREDENTIAL = {

--- a/tests/cloud/test_cloud_sync_crud.py
+++ b/tests/cloud/test_cloud_sync_crud.py
@@ -11,9 +11,10 @@ try:
         AWS_SECRET_ACCESS_KEY,
         AWS_BUCKET
     )
-except ImportError:
-    Reason = 'AWS credential are missing in config.py'
-    pytestmark = pytest.mark.skip(reason=Reason)
+except ImportError as e:
+    @pytest.fixture(autouse=True)
+    def fail_all_tests():
+        pytest.fail(str(e))
 
 
 @pytest.fixture(scope='module')

--- a/tests/cloud/test_cloud_sync_storj.py
+++ b/tests/cloud/test_cloud_sync_storj.py
@@ -1,13 +1,19 @@
 import pytest
 
-from config import (
-    STORJ_IX_AWS_ACCESS_KEY_ID,
-    STORJ_IX_AWS_SECRET_ACCESS_KEY,
-    STORJ_IX_BUCKET,
-)
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.cloud_sync import credential, task, run_task
 from middlewared.test.integration.assets.pool import dataset
+
+try:
+    from config import (
+        STORJ_IX_AWS_ACCESS_KEY_ID,
+        STORJ_IX_AWS_SECRET_ACCESS_KEY,
+        STORJ_IX_BUCKET,
+    )
+except ImportError as e:
+    @pytest.fixture(autouse=True)
+    def fail_all_tests():
+        pytest.fail(str(e))
 
 
 CREDENTIAL = {

--- a/tests/sharing_protocols/iscsi/test_260_iscsi.py
+++ b/tests/sharing_protocols/iscsi/test_260_iscsi.py
@@ -14,11 +14,10 @@ from middlewared.test.integration.utils.legacy_functions import SSH_TEST
 
 try:
     from config import BSD_HOST, BSD_PASSWORD, BSD_USERNAME
-    have_bsd_host_cfg = True
-except ImportError:
-    have_bsd_host_cfg = False
-
-pytestmark = pytest.mark.skipif(not have_bsd_host_cfg, reason='BSD host configuration is missing in ixautomation.conf')
+except ImportError as e:
+    @pytest.fixture(autouse=True)
+    def fail_all_tests():
+        pytest.fail(str(e))
 
 digit = ''.join(random.choices(string.digits, k=2))
 


### PR DESCRIPTION
Currently, some of the tests that lack config variables are just skipped, which can go unnoticed for months in our Jenkins instances.

Others just prematurely stop the tests discovering process. This is better, but still inconvenient for the development purposes.