### PR TITLE
NAS-141803 / 27.0.0-BETA.1 / Use `pytest.fail` when CI is misconfigured

### DIFF
--- a/tests/api2/test_dedup_pool_table_quota.py
+++ b/tests/api2/test_dedup_pool_table_quota.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.utils import call
 def dedup_pool_payload(dedup_table_quota: str | None, dedup_table_quota_value: int | None) -> dict:
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 2:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     return {
         'deduplication': 'ON',

--- a/tests/api2/test_draid.py
+++ b/tests/api2/test_draid.py
@@ -21,7 +21,7 @@ POOL_NAME = 'test_draid_pool'
 def test_valid_draid_pool_creation(n_data, n_spare, n_parity):
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 5:
-        pytest.skip('Insufficient number of disk to perform these test')
+        pytest.fail('Insufficient number of disk to perform these test')
 
     children = n_data + n_parity + n_spare
     with another_pool({
@@ -69,7 +69,7 @@ def test_valid_draid_pool_creation(n_data, n_spare, n_parity):
 def test_invalid_draid_pool_creation(n_data, n_spare, n_parity, minimum_disk):
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 3:
-        pytest.skip('Insufficient number of disk to perform these test')
+        pytest.fail('Insufficient number of disk to perform these test')
 
     children = n_data + n_parity + n_spare
 

--- a/tests/api2/test_draid_record_and_block_size.py
+++ b/tests/api2/test_draid_record_and_block_size.py
@@ -10,7 +10,7 @@ from auto_config import ha
 @pytest.fixture(scope='module')
 def check_unused_disks():
     if len(call('disk.get_unused')) < 4:
-        pytest.skip('Insufficient number of disks to perform these tests')
+        pytest.fail('Insufficient number of disks to perform these tests')
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_reporting_realtime.py
+++ b/tests/api2/test_reporting_realtime.py
@@ -173,7 +173,7 @@ def test_realtime_event_matches_internal_stats_call():
 def test_realtime_pool_keys_match_pool_query(realtime_event):
     pool_names = frozenset(pool["name"] for pool in call("pool.query"))
     if not pool_names:
-        pytest.skip("no imported pools — cannot validate event pool keys")
+        pytest.fail("no imported pools — cannot validate event pool keys")
     # The realtime event is sourced from query_imported_fast_impl(), which
     # reports every imported pool including the boot pool; pool.query only
     # returns data pools. Allow the boot pool so it isn't flagged unexpected.

--- a/tests/api2/test_service_announcement.py
+++ b/tests/api2/test_service_announcement.py
@@ -577,7 +577,7 @@ class TestNutService:
             "service.query", [["service", "=", "ups"]], {"get": True},
         )
         if svc.get("state") == "RUNNING" or svc.get("enable"):
-            pytest.skip("ups service is active; negative gating N/A")
+            pytest.fail("ups service is active; negative gating N/A")
         status = get_discovery_status()
         assert status is not None
         nut = [

--- a/tests/api2/test_special_vdev.py
+++ b/tests/api2/test_special_vdev.py
@@ -15,7 +15,7 @@ def test_multiple_special_vdevs_same_type():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 8:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with another_pool({
         'name': POOL_NAME,
@@ -50,7 +50,7 @@ def test_special_vdev_mixed_types_is_allowed():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 7:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with another_pool({
         'name': POOL_NAME,
@@ -84,7 +84,7 @@ def test_special_vdev_draid_is_rejected():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 5:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with pytest.raises(ValidationErrors) as ve:
         call('pool.create', {
@@ -114,7 +114,7 @@ def test_non_redundant_special_on_redundant_data_is_rejected():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 3:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with pytest.raises(ValidationErrors) as ve:
         call('pool.create', {
@@ -143,7 +143,7 @@ def test_non_redundant_special_on_striped_data_is_allowed():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 2:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with another_pool({
         'name': POOL_NAME,
@@ -169,7 +169,7 @@ def test_dedicated_spares_coexist_with_draid_data():
     """
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 4:
-        pytest.skip('Insufficient number of disks to perform this test')
+        pytest.fail('Insufficient number of disks to perform this test')
 
     with another_pool({
         'name': POOL_NAME,

--- a/tests/api2/test_webui_crypto_service.py
+++ b/tests/api2/test_webui_crypto_service.py
@@ -29,7 +29,7 @@ def test_ui_crypto_profiles_readonly_role(role, endpoint, valid_role):
 def test_ui_crypto_domain_names_readonly_role(role, valid_role):
     default_certificate = call('certificate.query', [('name', '=', 'truenas_default')])
     if not default_certificate:
-        pytest.skip('Default certificate does not exist which is required for this test')
+        pytest.fail('Default certificate does not exist which is required for this test')
     else:
         default_certificate = default_certificate[0]
 

--- a/tests/api2/test_zfs_resource_rename.py
+++ b/tests/api2/test_zfs_resource_rename.py
@@ -12,7 +12,7 @@ def rename_test_pool():
     """Create a dedicated pool for rename tests."""
     unused_disks = call("disk.get_unused")
     if len(unused_disks) < 1:
-        pytest.skip("Insufficient number of disks to perform this test")
+        pytest.fail("Insufficient number of disks to perform this test")
 
     with another_pool({"name": POOL_NAME}) as pool:
         yield pool

--- a/tests/api2/test_zpool_status.py
+++ b/tests/api2/test_zpool_status.py
@@ -226,7 +226,7 @@ def get_pool_status(unused_disks, real_paths=False, replaced=False):
 def test_pool():
     unused_disks = call('disk.get_unused')
     if len(unused_disks) < 7:
-        pytest.skip('Insufficient number of disks to perform these tests')
+        pytest.fail('Insufficient number of disks to perform these tests')
 
     with another_pool({
         'name': POOL_NAME,

--- a/tests/api2/zfs_tier/conftest.py
+++ b/tests/api2/zfs_tier/conftest.py
@@ -21,11 +21,12 @@ from middlewared.test.integration.utils.system import reset_systemd_svcs
 @pytest.fixture(scope="module")
 def tier_pool():
     """A pool with a SPECIAL vdev, with tiering globally enabled."""
-    unused = call("disk.get_unused")
-    if len(unused) < 6:
-        pytest.skip("Need at least 6 unused disks for a 3+3 RAIDZ1 tier pool")
     if not call("system.is_enterprise"):
         pytest.skip("ZFS tiering requires an Enterprise license")
+
+    unused = call("disk.get_unused")
+    if len(unused) < 6:
+        pytest.fail("Need at least 6 unused disks for a 3+3 RAIDZ1 tier pool")
 
     data_disks = [d["name"] for d in unused[:3]]
     special_disks = [d["name"] for d in unused[3:6]]

--- a/tests/unit/test_get_disks.py
+++ b/tests/unit/test_get_disks.py
@@ -89,7 +89,7 @@ def test__format_disk():
     with Client() as c:
         unused_disks = c.call("disk.get_unused")
         if not unused_disks:
-            pytest.skip("No unused disks available for testing")
+            pytest.fail("No unused disks available for testing")
 
         for disk_class in DiskService(None).get_disks(
             name_filters=[unused_disks[0]["name"]]

--- a/tests/unit/test_realtime_reporting.py
+++ b/tests/unit/test_realtime_reporting.py
@@ -75,7 +75,7 @@ def netdata_metrics():
     with Client(private_methods=True) as c:
         data = c.call("netdata.get_all_metrics")
     if not data:
-        pytest.skip("netdata returned no metrics — service may be down or warming up")
+        pytest.fail("netdata returned no metrics — service may be down or warming up")
     return data
 
 
@@ -187,7 +187,7 @@ def test_interface_empty_inputs_safe():
 
 def test_interface_live_shape(netdata_metrics, interface_names):
     if not interface_names:
-        pytest.skip("no network interfaces reported by interface.query")
+        pytest.fail("no network interfaces reported by interface.query")
     result = get_interface_stats(netdata_metrics, interface_names)
     assert result.keys() == frozenset(interface_names)
     for name, sub in result.items():


### PR DESCRIPTION
Use `pytest.fail` when CI is misconfigured. Skipped tests just go unnoticed in our Jenkins.

We can still use `pytest.skip` to skip, for example, Enterprise-related tests on a non-Enterprise system.

However, if CI lacks disks or the system is in an unexpected state, it is safer to mark the test as failed so that we are informed and can take the necessary action.

Everything above is just my opinion. The PR can still be modified based on the team’s feedback, so I am open to adjusting the implementation if we agree that a different approach would be more appropriate.