### PR TITLE
NAS-141797 / 26.0.0-RC.1 / Ensure block_hooks unblocks hooks when the with body raises (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -741,11 +741,12 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
             for name in names:
                 self.__blocked_hooks[name] += 1
 
-        yield
-
-        with self.__blocked_hooks_lock:
-            for name in names:
-                self.__blocked_hooks[name] -= 1
+        try:
+            yield
+        finally:
+            with self.__blocked_hooks_lock:
+                for name in names:
+                    self.__blocked_hooks[name] -= 1
 
     def _call_hook_base(self, name, *args, **kwargs):
         if self.__blocked_hooks[name] > 0:


### PR DESCRIPTION
The decrement after yield was not in a finally block, so an exception inside a `with block_hooks(...)` body left the counters incremented permanently, silently disabling those hooks until the daemon restarted.

Original PR: https://github.com/truenas/middleware/pull/19325
