### PR TITLE
NAS-141804 / 26.0.0-RC.1 / Fix pool disk operations crash when disk is missing at pool import

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zpool_query.py
@@ -67,6 +67,15 @@ class ZPoolVdev(BaseModel):
     stats: ZPoolVdevStats = Field(description="Vdev I/O statistics.")
     children: list["ZPoolVdev"] = Field(description="Child vdevs.")
     top_guid: int | None = Field(default=None, description="GUID of the top-level vdev this belongs to.")
+    path: str | None = Field(
+        default=None,
+        description=(
+            "Device path stored in the vdev config (e.g. '/dev/disk/by-partuuid/<uuid>'). Unlike `name`, this is "
+            "preserved for devices that were missing at pool import time. dRAID distributed spares store their "
+            "synthetic spare name as the config path. `null` for interior vdevs (mirror, raidz, draid) that have "
+            "no config path."
+        ),
+    )
 
 
 class ZPoolTopology(BaseModel):

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -29,7 +29,9 @@ class PoolService(Service):
             root, children = check.pop()
             for c in children:
                 if c['type'] == 'DISK':
-                    if label in (c['path'].replace('/dev/', ''), c['guid']):
+                    # `path` is None when the disk was missing at pool import time
+                    # and libzfs only reports the vdev guid as its name.
+                    if label == c['guid'] or (c['path'] and label == c['path'].replace('/dev/', '')):
                         found = (root, c)
                         break
                 elif include_top_level_vdev and c['guid'] == label:

--- a/src/middlewared/middlewared/plugins/pool_/pool_disk_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool_disk_operations.py
@@ -51,14 +51,16 @@ class PoolService(Service):
             verrors.add('options.label', f'Label {options["label"]} not found on this pool.')
         verrors.check()
 
-        disk = await self.middleware.call(
-            'disk.label_to_disk', found[1]['path'].replace('/dev/', '')
-        )
+        disk = None
+        if found[1]['path']:
+            disk = await self.middleware.call(
+                'disk.label_to_disk', found[1]['path'].replace('/dev/', '')
+            )
 
         if found[1]['type'] != 'DISK':
-            disk_paths = [d['path'] for d in found[1]['children']]
+            disk_paths = [d['path'] or d['guid'] for d in found[1]['children']]
         else:
-            disk_paths = [found[1]['path']]
+            disk_paths = [found[1]['path'] or found[1]['guid']]
         audit_callback(f'{", ".join(disk_paths)} from {pool["name"]!r} pool')
 
         await self.middleware.call('zfs.pool.detach', pool['name'], found[1]['guid'])
@@ -105,9 +107,9 @@ class PoolService(Service):
         verrors.check()
 
         if found[1]['type'] != 'DISK':
-            disk_paths = [d['path'] for d in found[1]['children']]
+            disk_paths = [d['path'] or d['guid'] for d in found[1]['children']]
         else:
-            disk_paths = [found[1]['path']]
+            disk_paths = [found[1]['path'] or found[1]['guid']]
         audit_callback(f'{", ".join(disk_paths)} in {pool["name"]!r} pool')
 
         await self.middleware.call('zfs.pool.offline', pool['name'], found[1]['guid'])
@@ -149,9 +151,9 @@ class PoolService(Service):
         verrors.check()
 
         if found[1]['type'] != 'DISK':
-            disk_paths = [d['path'] for d in found[1]['children']]
+            disk_paths = [d['path'] or d['guid'] for d in found[1]['children']]
         else:
-            disk_paths = [found[1]['path']]
+            disk_paths = [found[1]['path'] or found[1]['guid']]
         audit_callback(f'{", ".join(disk_paths)} in {pool["name"]!r} pool')
 
         await self.middleware.call('zfs.pool.online', pool['name'], found[1]['guid'])
@@ -215,9 +217,9 @@ class PoolService(Service):
         job.set_progress(60, 'Removal of ZFS device complete')
 
         if found[1]['type'] != 'DISK':
-            disk_paths = [d['path'] for d in found[1]['children']]
+            disk_paths = [d['path'] or d['guid'] for d in found[1]['children']]
         else:
-            disk_paths = [found[1]['path']]
+            disk_paths = [found[1]['path'] or found[1]['guid']]
         audit_callback(f'{", ".join(disk_paths)} from {pool["name"]!r} pool')
 
         job.set_progress(70, 'Wiping disks')

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_find_disk_from_topology.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_find_disk_from_topology.py
@@ -1,0 +1,54 @@
+from middlewared.plugins.pool_.info import PoolService
+
+
+def make_pool():
+    return {
+        'topology': {
+            'data': [
+                {
+                    'type': 'RAIDZ2',
+                    'guid': '100',
+                    'path': None,
+                    'children': [
+                        {'type': 'DISK', 'guid': '200', 'path': '/dev/sda2', 'children': []},
+                        {'type': 'DISK', 'guid': '201', 'path': '/dev/sdb2', 'children': []},
+                        # Disk that was missing at pool import time: libzfs reports
+                        # the vdev guid as its name so no path is available.
+                        {'type': 'DISK', 'guid': '463852628436549533', 'path': None, 'children': []},
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def test_find_by_guid_when_path_is_none():
+    found = PoolService(None).find_disk_from_topology('463852628436549533', make_pool())
+    assert found is not None
+    assert found[1]['guid'] == '463852628436549533'
+
+
+def test_find_by_path():
+    found = PoolService(None).find_disk_from_topology('sdb2', make_pool())
+    assert found is not None
+    assert found[1]['guid'] == '201'
+
+
+def test_include_siblings_with_missing_disk():
+    found = PoolService(None).find_disk_from_topology(
+        '463852628436549533', make_pool(), {'include_siblings': True}
+    )
+    assert found is not None
+    assert [c['guid'] for c in found[2]] == ['200', '201', '463852628436549533']
+
+
+def test_include_top_level_vdev():
+    found = PoolService(None).find_disk_from_topology(
+        '100', make_pool(), {'include_top_level_vdev': True}
+    )
+    assert found is not None
+    assert found[1]['guid'] == '100'
+
+
+def test_not_found():
+    assert PoolService(None).find_disk_from_topology('nonexistent', make_pool()) is None

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_find_disk_from_topology.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_find_disk_from_topology.py
@@ -3,18 +3,18 @@ from middlewared.plugins.pool_.info import PoolService
 
 def make_pool():
     return {
-        'topology': {
-            'data': [
+        "topology": {
+            "data": [
                 {
-                    'type': 'RAIDZ2',
-                    'guid': '100',
-                    'path': None,
-                    'children': [
-                        {'type': 'DISK', 'guid': '200', 'path': '/dev/sda2', 'children': []},
-                        {'type': 'DISK', 'guid': '201', 'path': '/dev/sdb2', 'children': []},
+                    "type": "RAIDZ2",
+                    "guid": "100",
+                    "path": None,
+                    "children": [
+                        {"type": "DISK", "guid": "200", "path": "/dev/sda2", "children": []},
+                        {"type": "DISK", "guid": "201", "path": "/dev/sdb2", "children": []},
                         # Disk that was missing at pool import time: libzfs reports
                         # the vdev guid as its name so no path is available.
-                        {'type': 'DISK', 'guid': '463852628436549533', 'path': None, 'children': []},
+                        {"type": "DISK", "guid": "463852628436549533", "path": None, "children": []},
                     ],
                 },
             ],
@@ -23,32 +23,28 @@ def make_pool():
 
 
 def test_find_by_guid_when_path_is_none():
-    found = PoolService(None).find_disk_from_topology('463852628436549533', make_pool())
+    found = PoolService(None).find_disk_from_topology("463852628436549533", make_pool())
     assert found is not None
-    assert found[1]['guid'] == '463852628436549533'
+    assert found[1]["guid"] == "463852628436549533"
 
 
 def test_find_by_path():
-    found = PoolService(None).find_disk_from_topology('sdb2', make_pool())
+    found = PoolService(None).find_disk_from_topology("sdb2", make_pool())
     assert found is not None
-    assert found[1]['guid'] == '201'
+    assert found[1]["guid"] == "201"
 
 
 def test_include_siblings_with_missing_disk():
-    found = PoolService(None).find_disk_from_topology(
-        '463852628436549533', make_pool(), {'include_siblings': True}
-    )
+    found = PoolService(None).find_disk_from_topology("463852628436549533", make_pool(), {"include_siblings": True})
     assert found is not None
-    assert [c['guid'] for c in found[2]] == ['200', '201', '463852628436549533']
+    assert [c["guid"] for c in found[2]] == ["200", "201", "463852628436549533"]
 
 
 def test_include_top_level_vdev():
-    found = PoolService(None).find_disk_from_topology(
-        '100', make_pool(), {'include_top_level_vdev': True}
-    )
+    found = PoolService(None).find_disk_from_topology("100", make_pool(), {"include_top_level_vdev": True})
     assert found is not None
-    assert found[1]['guid'] == '100'
+    assert found[1]["guid"] == "100"
 
 
 def test_not_found():
-    assert PoolService(None).find_disk_from_topology('nonexistent', make_pool()) is None
+    assert PoolService(None).find_disk_from_topology("nonexistent", make_pool()) is None


### PR DESCRIPTION
When a leaf vdev cannot be opened during pool import, the kernel marks it ZPOOL_CONFIG_NOT_PRESENT and libzfs degrades its display name to the bare guid instead of a device path. pool.transform_topology derives `path` from that name, so the vdev ends up with `path: None`, and pool.find_disk_from_topology crashed with AttributeError on `c['path'].replace(...)` before it could match the vdev by guid. This broke pool.replace (and detach/offline/online/remove) for exactly the disks that most need replacing (physically failed ones).

- find_disk_from_topology: match by guid first and only touch `path` when it is set.
- detach/offline/online/remove: tolerate `path: None` in the label_to_disk lookup and audit messages (fall back to the vdev guid, matching zpool status display).
- ZPoolVdev API model: add nullable `path` field for the upcoming truenas_pylibzfs [change](https://github.com/truenas/truenas_pylibzfs/pull/270) that exposes the raw ZPOOL_CONFIG_PATH (which is preserved for missing devices). Defaults to null, so it is compatible with both old and new pylibzfs.
- Add unit tests for find_disk_from_topology covering the missing-disk (path=None) regression.