### PR TITLE
Fix FreeIPA SMB machine password handling during domain join

### DIFF
--- a/src/freenas/usr/local/libexec/ipa_ctl.py
+++ b/src/freenas/usr/local/libexec/ipa_ctl.py
@@ -272,7 +272,7 @@ def get_keytab(
             cmd.append('-P')
             res = subprocess.run(
                 cmd, check=False,
-                input=b'{password}\n{password}',
+                input=f'{password}\n{password}'.encode(),
                 capture_output=True
             )
         else:

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -323,7 +323,7 @@ class IPAJoinMixin:
             self.middleware.call_sync(
                 'directoryservices.secrets.set_ipa_secret',
                 domain_info['netbios_name'],
-                base64.b64encode(password.encode())
+                password.encode()
             )
 
             self.middleware.call_sync('directoryservices.secrets.backup')


### PR DESCRIPTION
## Summary

Fix two password-handling errors in the FreeIPA SMB join path that cause Samba's machine-account secret to differ from the password assigned to the FreeIPA CIFS service principal.

The mismatch prevents Samba/Winbind from establishing the NETLOGON secure channel even though the TrueNAS host successfully joins FreeIPA and DNS, LDAP, Kerberos, and keytab operations otherwise succeed.

## Root cause

TrueNAS generates one random password that must be used consistently for both sides of the SMB machine trust:

1. `ipa-getkeytab -P` uses the password to set the FreeIPA CIFS service-principal credentials and create the corresponding keytab.
2. `net changesecretpw`, through `directoryservices.secrets.set_ipa_secret`, stores the same password in Samba's `secrets.tdb`.

The current code changes that value independently in both paths.

### 1. `ipa_ctl.py` sends a literal placeholder to `ipa-getkeytab`

The existing subprocess input is:

```python
input=b'{password}\n{password}'
```

Because this is an ordinary bytes literal, `ipa-getkeytab` receives the literal text `{password}` twice rather than the value of the generated `password` variable.

The function then returns the unrelated generated password to middleware, so the password returned to Samba does not match the password used by FreeIPA.

This change formats the generated value before encoding it:

```python
input=f'{password}\n{password}'.encode()
```

### 2. `ipa_join_mixin.py` Base64-encodes the password before storing it in Samba

The current code calls:

```python
base64.b64encode(password.encode())
```

before passing the result to `directoryservices.secrets.set_ipa_secret`.

`set_ipa_secret` passes the supplied bytes to Samba's `net changesecretpw`; it does not decode this additional Base64 layer first. Samba therefore stores `Base64(password)` rather than the actual password assigned to the FreeIPA CIFS service principal.

This change passes the generated password bytes directly:

```python
password.encode()
```

The existing `base64` import remains required elsewhere in `ipa_join_mixin.py` for decoding the IPA host keytab.

## User-visible failure

On an affected system, the FreeIPA join can appear successful, while the secure-channel test fails:

```text
wbinfo --ping-dc
checking the NETLOGON for domain[DOMAIN] dc connection to "" failed
failed to call wbcPingDc: WBC_ERR_DOMAIN_NOT_FOUND
```

Samba logs can also contain messages such as:

```text
NT_STATUS_DOMAIN_CONTROLLER_NOT_FOUND
fork_domain_child called without domain
dc_info : NULL
```

The `WBC_ERR_DOMAIN_NOT_FOUND` result is misleading in this case because domain-controller discovery is working. The actual failure is the mismatched machine secret.

## Reproduction

1. Configure a FreeIPA domain with SMB support.
2. Join TrueNAS to the FreeIPA domain with SMB integration enabled.
3. Confirm that the IPA host join and Kerberos configuration complete successfully.
4. Run:

   ```bash
   wbinfo --ping-dc
   ```

5. Observe that Winbind cannot establish the NETLOGON secure channel.

## Verification

The issue was reproduced using:

- TrueNAS SCALE 25.10.4
- FreeIPA with SMB support enabled
- Samba using the `SSS` idmap backend

After correcting both password paths and repairing the machine secret previously written by the affected code, the secure-channel test succeeded:

```text
wbinfo --ping-dc
checking the NETLOGON for domain[DOMAIN] dc connection to "ipa.example.com" succeeded
```

FreeIPA-backed SMB authentication then succeeded.

## Existing installations

This change prevents future IPA joins from creating mismatched Samba and FreeIPA credentials.

It does not retroactively repair a machine password already stored in `secrets.tdb`. Systems joined while running the affected code may need to leave and rejoin the IPA domain, or otherwise regenerate the Samba machine secret, after installing the fix.
