### PR TITLE
NAS-141814 / 27.0.0-BETA.1 / Report fine-grained app job progress from docker compose events

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/__init__.py
+++ b/src/middlewared/middlewared/plugins/apps/__init__.py
@@ -200,7 +200,7 @@ class AppService(GenericCRUDService[AppEntry, str]):
         roles=['APPS_WRITE'],
         check_annotations=True,
     )
-    @job(lock=lambda args: f'app_create_{args[0].get("app_name")}', logs=True)
+    @job(lock=lambda args: f'app_create_{args[0].get("app_name")}', logs=True, abortable=True)
     def do_create(self, job: Job, data: AppCreate) -> AppEntry:
         """Create an app with ``app_name`` using ``catalog_app`` with ``train`` and ``version``."""
         return create_app(self.context, job, data)
@@ -212,7 +212,7 @@ class AppService(GenericCRUDService[AppEntry, str]):
         roles=['APPS_WRITE'],
         check_annotations=True,
     )
-    @job(lock=lambda args: f'app_update_{args[0]}')
+    @job(lock=lambda args: f'app_update_{args[0]}', abortable=True)
     def do_update(self, job: Job, app_name: str, data: AppUpdate) -> AppEntry:
         """Update ``app_name`` app with new configuration."""
         return update_app(self.context, job, app_name, data)
@@ -376,7 +376,7 @@ class AppService(GenericCRUDService[AppEntry, str]):
         roles=['APPS_WRITE'],
         check_annotations=True,
     )
-    @job(lock=lambda args: f'pull_images_{args[0]}')
+    @job(lock=lambda args: f'pull_images_{args[0]}', abortable=True)
     def pull_images(self, job: Job, app_name: str, options: AppPullImages) -> None:
         """Pulls docker images for the specified app ``name``."""
         return pull_images_for_app(self.context, job, app_name, options)
@@ -388,7 +388,7 @@ class AppService(GenericCRUDService[AppEntry, str]):
         roles=['APPS_WRITE'],
         check_annotations=True,
     )
-    @job(lock=lambda args: f'app_redeploy_{args[0]}')
+    @job(lock=lambda args: f'app_redeploy_{args[0]}', abortable=True)
     def redeploy(self, job: Job, app_name: str) -> AppEntry:
         """Redeploy ``app_name`` app."""
         return redeploy_app(self.context, job, app_name)
@@ -445,7 +445,7 @@ class AppService(GenericCRUDService[AppEntry, str]):
         roles=['APPS_WRITE'],
         check_annotations=True,
     )
-    @job(lock=lambda args: f'app_upgrade_{args[0]}')
+    @job(lock=lambda args: f'app_upgrade_{args[0]}', abortable=True)
     async def upgrade(self, job: Job, app_name: str, options: AppUpgradeOptions) -> AppEntry:
         """
         Upgrade ``app_name`` app to ``app_version``.

--- a/src/middlewared/middlewared/plugins/apps/compose_progress.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_progress.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import time
+import typing
+
+from middlewared.utils.size import format_size
+
+ProgressCallback = typing.Callable[[float, str], None]
+
+# Within a single layer pull, how much of the layer's work is attributed to
+# downloading vs extracting it
+LAYER_DOWNLOAD_WEIGHT = 0.75
+# When resource (network/container/volume) events are expected ('up' actions),
+# how much of the overall work is attributed to pulling images
+PULL_PORTION_WITH_RESOURCES = 0.9
+
+
+class ComposeProgressTracker:
+    """
+    Aggregate `docker compose --progress=json` events into a monotonically increasing
+    overall fraction reported through `progress_callback(fraction, description)`.
+
+    Compose emits one JSON object per stderr line. The events of interest are:
+    - image pull layer events, carrying `parent_id` ('Image <tag>') and byte-level
+      `current`/`total` for 'Downloading'/'Extracting' phases
+    - image events (`id` = 'Image <tag>'), 'Pulled' marking an image done
+    - resource events (Network/Container/Volume create/start), which follow pulls
+      during 'up' actions
+
+    Layer sizes are only announced as each layer starts downloading, so the byte
+    denominator grows over time; reported progress is clamped to never decrease.
+    """
+
+    def __init__(
+        self, progress_callback: ProgressCallback, resources_expected: bool, min_interval: float = 1.0,
+    ):
+        self.progress_callback = progress_callback
+        self.resources_expected = resources_expected
+        self.min_interval = min_interval
+        # image id -> {'done': bool, 'layers': {layer id -> layer state}}
+        self.images: dict[str, dict[str, typing.Any]] = {}
+        # resource id (e.g. 'Container myapp-web-1') -> done
+        self.resources: dict[str, bool] = {}
+        self._max_fraction = 0.0
+        self._last_emitted: tuple[float, str] | None = None
+        self._last_emit_at = float('-inf')
+        self._resource_description = ''
+
+    def feed_line(self, line: str) -> None:
+        line = line.strip()
+        if not line.startswith('{'):
+            return
+
+        try:
+            event = json.loads(line)
+        except ValueError:
+            return
+
+        if not isinstance(event, dict) or event.get('error'):
+            return
+
+        ident = event.get('id')
+        if not isinstance(ident, str) or event.get('status') not in ('Working', 'Done'):
+            return
+
+        if parent_id := event.get('parent_id'):
+            self._feed_layer(parent_id, ident, event)
+        elif ident.startswith('Image '):
+            self._feed_image(ident, event)
+        else:
+            self._feed_resource(ident, event)
+
+        self._emit()
+
+    def flush(self) -> None:
+        """Emit the current state, bypassing throttling. Call after the event stream ends so the
+        final events, which usually land within the throttle interval of the previous emission,
+        are not lost."""
+        self._emit(force=True)
+
+    def _feed_layer(self, image_id: str, layer_id: str, event: dict[str, typing.Any]) -> None:
+        image = self.images.setdefault(image_id, {'done': False, 'layers': {}})
+        layer = image['layers'].setdefault(layer_id, {'total': 0, 'download': 0.0, 'extract': 0.0, 'done': False})
+        text, phase_fraction = event.get('text'), None
+        current, total = event.get('current'), event.get('total')
+        if isinstance(current, (int, float)) and isinstance(total, (int, float)) and total > 0:
+            layer['total'] = total
+            phase_fraction = min(current / total, 1.0)
+
+        if text == 'Downloading':
+            if phase_fraction is not None:
+                layer['download'] = phase_fraction
+        elif text == 'Extracting':
+            layer['download'] = 1.0
+            if phase_fraction is not None:
+                layer['extract'] = phase_fraction
+        elif text == 'Download complete':
+            layer['download'] = 1.0
+        elif text in ('Pull complete', 'Already exists'):
+            layer['done'] = True
+
+    def _feed_image(self, image_id: str, event: dict[str, typing.Any]) -> None:
+        image = self.images.setdefault(image_id, {'done': False, 'layers': {}})
+        if event.get('status') == 'Done':
+            image['done'] = True
+
+    def _feed_resource(self, resource_id: str, event: dict[str, typing.Any]) -> None:
+        done = event.get('status') == 'Done'
+        self.resources[resource_id] = self.resources.get(resource_id) or done
+        if done:
+            self._resource_description = f'{event.get("text")} {resource_id}'
+
+    @staticmethod
+    def _layer_fraction(layer: dict[str, typing.Any]) -> float:
+        if layer['done']:
+            return 1.0
+        return LAYER_DOWNLOAD_WEIGHT * layer['download'] + (1 - LAYER_DOWNLOAD_WEIGHT) * layer['extract']
+
+    def _image_fraction(self, image: dict[str, typing.Any]) -> float:
+        if image['done']:
+            return 1.0
+
+        layers = image['layers'].values()
+        known_sizes = [layer['total'] for layer in layers if layer['total'] > 0]
+        if not known_sizes:
+            return 0.0
+
+        # Layer sizes are announced lazily as each layer starts downloading. Weighing layers of
+        # still-unknown size as if they were average-sized keeps an early small completed layer
+        # from inflating the overall fraction.
+        default_weight = sum(known_sizes) / len(known_sizes)
+        denominator = sum(layer['total'] or default_weight for layer in layers)
+        return sum(
+            (layer['total'] or default_weight) * self._layer_fraction(layer) for layer in layers
+        ) / denominator
+
+    def _pull_fraction(self) -> float:
+        if not self.images:
+            return 0.0
+        return sum(map(self._image_fraction, self.images.values())) / len(self.images)
+
+    def _compute(self) -> tuple[float, str]:
+        pull_fraction = self._pull_fraction()
+        if self.resources_expected:
+            resources_fraction = sum(self.resources.values()) / len(self.resources) if self.resources else 0.0
+            if self.images:
+                fraction = (
+                    PULL_PORTION_WITH_RESOURCES * pull_fraction
+                    + (1 - PULL_PORTION_WITH_RESOURCES) * resources_fraction
+                )
+            else:
+                # All images were already present, no pull happened - resource
+                # (network/container) events are the whole operation
+                fraction = resources_fraction
+        else:
+            fraction = pull_fraction
+
+        if self.images and not all(image['done'] for image in self.images.values()):
+            description = 'Pulling app images'
+            layers = [
+                layer for image in self.images.values() for layer in image['layers'].values() if layer['total'] > 0
+            ]
+            if total_bytes := sum(layer['total'] for layer in layers):
+                downloaded_bytes = sum(layer['total'] * layer['download'] for layer in layers)
+                description += f' ({format_size(int(downloaded_bytes))} / {format_size(int(total_bytes))})'
+        elif self._resource_description:
+            description = self._resource_description
+        else:
+            description = 'Deploying app resources' if self.resources_expected else 'Pulling app images'
+
+        return fraction, description
+
+    def _emit(self, force: bool = False) -> None:
+        fraction, description = self._compute()
+        fraction = self._max_fraction = max(fraction, self._max_fraction)
+        now = time.monotonic()
+        if self._last_emitted == (fraction, description) or (
+            not force and now - self._last_emit_at < self.min_interval
+        ):
+            return
+
+        self._last_emitted = (fraction, description)
+        self._last_emit_at = now
+        self.progress_callback(fraction, description)

--- a/src/middlewared/middlewared/plugins/apps/compose_progress.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_progress.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 import time
 import typing
@@ -14,6 +15,20 @@ LAYER_DOWNLOAD_WEIGHT = 0.75
 # When resource (network/container/volume) events are expected ('up' actions),
 # how much of the overall work is attributed to pulling images
 PULL_PORTION_WITH_RESOURCES = 0.9
+
+
+@dataclasses.dataclass
+class _LayerState:
+    total: int = 0
+    download: float = 0.0
+    extract: float = 0.0
+    done: bool = False
+
+
+@dataclasses.dataclass
+class _ImageState:
+    done: bool = False
+    layers: dict[str, _LayerState] = dataclasses.field(default_factory=dict)
 
 
 class ComposeProgressTracker:
@@ -33,23 +48,25 @@ class ComposeProgressTracker:
     """
 
     def __init__(
-        self, progress_callback: ProgressCallback, resources_expected: bool, min_interval: float = 1.0,
+        self,
+        progress_callback: ProgressCallback,
+        resources_expected: bool,
+        min_interval: float = 1.0,
     ):
         self.progress_callback = progress_callback
         self.resources_expected = resources_expected
         self.min_interval = min_interval
-        # image id -> {'done': bool, 'layers': {layer id -> layer state}}
-        self.images: dict[str, dict[str, typing.Any]] = {}
+        self.images: dict[str, _ImageState] = {}
         # resource id (e.g. 'Container myapp-web-1') -> done
         self.resources: dict[str, bool] = {}
         self._max_fraction = 0.0
         self._last_emitted: tuple[float, str] | None = None
-        self._last_emit_at = float('-inf')
-        self._resource_description = ''
+        self._last_emit_at = float("-inf")
+        self._resource_description = ""
 
     def feed_line(self, line: str) -> None:
         line = line.strip()
-        if not line.startswith('{'):
+        if not line.startswith("{"):
             return
 
         try:
@@ -57,16 +74,16 @@ class ComposeProgressTracker:
         except ValueError:
             return
 
-        if not isinstance(event, dict) or event.get('error'):
+        if not isinstance(event, dict) or event.get("error"):
             return
 
-        ident = event.get('id')
-        if not isinstance(ident, str) or event.get('status') not in ('Working', 'Done'):
+        ident = event.get("id")
+        if not isinstance(ident, str) or event.get("status") not in ("Working", "Done"):
             return
 
-        if parent_id := event.get('parent_id'):
+        if parent_id := event.get("parent_id"):
             self._feed_layer(parent_id, ident, event)
-        elif ident.startswith('Image '):
+        elif ident.startswith("Image "):
             self._feed_image(ident, event)
         else:
             self._feed_resource(ident, event)
@@ -80,49 +97,49 @@ class ComposeProgressTracker:
         self._emit(force=True)
 
     def _feed_layer(self, image_id: str, layer_id: str, event: dict[str, typing.Any]) -> None:
-        image = self.images.setdefault(image_id, {'done': False, 'layers': {}})
-        layer = image['layers'].setdefault(layer_id, {'total': 0, 'download': 0.0, 'extract': 0.0, 'done': False})
-        text, phase_fraction = event.get('text'), None
-        current, total = event.get('current'), event.get('total')
+        image = self.images.setdefault(image_id, _ImageState())
+        layer = image.layers.setdefault(layer_id, _LayerState())
+        text, phase_fraction = event.get("text"), None
+        current, total = event.get("current"), event.get("total")
         if isinstance(current, (int, float)) and isinstance(total, (int, float)) and total > 0:
-            layer['total'] = total
+            layer.total = int(total)
             phase_fraction = min(current / total, 1.0)
 
-        if text == 'Downloading':
+        if text == "Downloading":
             if phase_fraction is not None:
-                layer['download'] = phase_fraction
-        elif text == 'Extracting':
-            layer['download'] = 1.0
+                layer.download = phase_fraction
+        elif text == "Extracting":
+            layer.download = 1.0
             if phase_fraction is not None:
-                layer['extract'] = phase_fraction
-        elif text == 'Download complete':
-            layer['download'] = 1.0
-        elif text in ('Pull complete', 'Already exists'):
-            layer['done'] = True
+                layer.extract = phase_fraction
+        elif text == "Download complete":
+            layer.download = 1.0
+        elif text in ("Pull complete", "Already exists"):
+            layer.done = True
 
     def _feed_image(self, image_id: str, event: dict[str, typing.Any]) -> None:
-        image = self.images.setdefault(image_id, {'done': False, 'layers': {}})
-        if event.get('status') == 'Done':
-            image['done'] = True
+        image = self.images.setdefault(image_id, _ImageState())
+        if event.get("status") == "Done":
+            image.done = True
 
     def _feed_resource(self, resource_id: str, event: dict[str, typing.Any]) -> None:
-        done = event.get('status') == 'Done'
+        done = event.get("status") == "Done"
         self.resources[resource_id] = self.resources.get(resource_id) or done
         if done:
-            self._resource_description = f'{event.get("text")} {resource_id}'
+            self._resource_description = f"{event.get('text')} {resource_id}"
 
     @staticmethod
-    def _layer_fraction(layer: dict[str, typing.Any]) -> float:
-        if layer['done']:
+    def _layer_fraction(layer: _LayerState) -> float:
+        if layer.done:
             return 1.0
-        return LAYER_DOWNLOAD_WEIGHT * layer['download'] + (1 - LAYER_DOWNLOAD_WEIGHT) * layer['extract']
+        return LAYER_DOWNLOAD_WEIGHT * layer.download + (1 - LAYER_DOWNLOAD_WEIGHT) * layer.extract
 
-    def _image_fraction(self, image: dict[str, typing.Any]) -> float:
-        if image['done']:
+    def _image_fraction(self, image: _ImageState) -> float:
+        if image.done:
             return 1.0
 
-        layers = image['layers'].values()
-        known_sizes = [layer['total'] for layer in layers if layer['total'] > 0]
+        layers = image.layers.values()
+        known_sizes = [layer.total for layer in layers if layer.total > 0]
         if not known_sizes:
             return 0.0
 
@@ -130,10 +147,8 @@ class ComposeProgressTracker:
         # still-unknown size as if they were average-sized keeps an early small completed layer
         # from inflating the overall fraction.
         default_weight = sum(known_sizes) / len(known_sizes)
-        denominator = sum(layer['total'] or default_weight for layer in layers)
-        return sum(
-            (layer['total'] or default_weight) * self._layer_fraction(layer) for layer in layers
-        ) / denominator
+        denominator = sum(layer.total or default_weight for layer in layers)
+        return sum((layer.total or default_weight) * self._layer_fraction(layer) for layer in layers) / denominator
 
     def _pull_fraction(self) -> float:
         if not self.images:
@@ -146,8 +161,7 @@ class ComposeProgressTracker:
             resources_fraction = sum(self.resources.values()) / len(self.resources) if self.resources else 0.0
             if self.images:
                 fraction = (
-                    PULL_PORTION_WITH_RESOURCES * pull_fraction
-                    + (1 - PULL_PORTION_WITH_RESOURCES) * resources_fraction
+                    PULL_PORTION_WITH_RESOURCES * pull_fraction + (1 - PULL_PORTION_WITH_RESOURCES) * resources_fraction
                 )
             else:
                 # All images were already present, no pull happened - resource
@@ -156,18 +170,16 @@ class ComposeProgressTracker:
         else:
             fraction = pull_fraction
 
-        if self.images and not all(image['done'] for image in self.images.values()):
-            description = 'Pulling app images'
-            layers = [
-                layer for image in self.images.values() for layer in image['layers'].values() if layer['total'] > 0
-            ]
-            if total_bytes := sum(layer['total'] for layer in layers):
-                downloaded_bytes = sum(layer['total'] * layer['download'] for layer in layers)
-                description += f' ({format_size(int(downloaded_bytes))} / {format_size(int(total_bytes))})'
+        if self.images and not all(image.done for image in self.images.values()):
+            description = "Pulling app images"
+            layers = [layer for image in self.images.values() for layer in image.layers.values() if layer.total > 0]
+            if total_bytes := sum(layer.total for layer in layers):
+                downloaded_bytes = sum(layer.total * layer.download for layer in layers)
+                description += f" ({format_size(int(downloaded_bytes))} / {format_size(total_bytes)})"
         elif self._resource_description:
             description = self._resource_description
         else:
-            description = 'Deploying app resources' if self.resources_expected else 'Pulling app images'
+            description = "Deploying app resources" if self.resources_expected else "Pulling app images"
 
         return fraction, description
 

--- a/src/middlewared/middlewared/plugins/apps/compose_progress.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_progress.py
@@ -93,8 +93,9 @@ class ComposeProgressTracker:
     def flush(self) -> None:
         """Emit the current state, bypassing throttling. Call after the event stream ends so the
         final events, which usually land within the throttle interval of the previous emission,
-        are not lost."""
-        self._emit(force=True)
+        are not lost. Marks the resource set complete so the last resources are no longer held
+        back for undiscovered ones."""
+        self._emit(force=True, final=True)
 
     def _feed_layer(self, image_id: str, layer_id: str, event: dict[str, typing.Any]) -> None:
         image = self.images.setdefault(image_id, _ImageState())
@@ -155,10 +156,20 @@ class ComposeProgressTracker:
             return 0.0
         return sum(map(self._image_fraction, self.images.values())) / len(self.images)
 
-    def _compute(self) -> tuple[float, str]:
+    def _resources_fraction(self, final: bool) -> float:
+        if not self.resources:
+            return 0.0
+        # Resource ids are discovered as their events arrive, and compose creates the network
+        # before any container - so the network completing alone would read as 1/1 and peg the
+        # fraction at 100% while the slow container recreate is still running. Until the event
+        # stream ends (final), reserve room for at least one resource still to be discovered.
+        denominator = len(self.resources) if final else len(self.resources) + 1
+        return sum(self.resources.values()) / denominator
+
+    def _compute(self, final: bool = False) -> tuple[float, str]:
         pull_fraction = self._pull_fraction()
         if self.resources_expected:
-            resources_fraction = sum(self.resources.values()) / len(self.resources) if self.resources else 0.0
+            resources_fraction = self._resources_fraction(final)
             if self.images:
                 fraction = (
                     PULL_PORTION_WITH_RESOURCES * pull_fraction + (1 - PULL_PORTION_WITH_RESOURCES) * resources_fraction
@@ -183,8 +194,8 @@ class ComposeProgressTracker:
 
         return fraction, description
 
-    def _emit(self, force: bool = False) -> None:
-        fraction, description = self._compute()
+    def _emit(self, force: bool = False, final: bool = False) -> None:
+        fraction, description = self._compute(final)
         fraction = self._max_fraction = max(fraction, self._max_fraction)
         now = time.monotonic()
         if self._last_emitted == (fraction, description) or (

--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import os
@@ -12,6 +14,9 @@ from .ix_apps.lifecycle import get_rendered_templates_of_app
 from .ix_apps.path import get_installed_app_rendered_dir_path
 from .utils import PROJECT_PREFIX, run, run_streaming
 
+if typing.TYPE_CHECKING:
+    from middlewared.job import Job
+
 logger = logging.getLogger('app_lifecycle')
 
 
@@ -20,6 +25,7 @@ def compose_action(
     force_recreate: bool = False, remove_orphans: bool = False, remove_images: bool = False,
     remove_volumes: bool = False, pull_images: bool = False,
     progress_callback: ProgressCallback | None = None,
+    job: Job | None = None,
 ) -> None:
     compose_files = list(itertools.chain(
         *[('-f', item) for item in get_rendered_templates_of_app(app_name, app_version)]
@@ -60,7 +66,7 @@ def compose_action(
         tracker = ComposeProgressTracker(progress_callback, resources_expected=action == 'up')
         cp = run_streaming(
             ['docker', '--config', '/etc/docker', 'compose', '--progress', 'json'] + compose_files + args,
-            line_callback=tracker.feed_line, timeout=1200,
+            line_callback=tracker.feed_line, timeout=1200, job=job,
         )
         if cp.returncode == 0:
             try:

--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -7,9 +7,10 @@ import typing
 
 from middlewared.service_exception import CallError
 
+from .compose_progress import ComposeProgressTracker, ProgressCallback
 from .ix_apps.lifecycle import get_rendered_templates_of_app
 from .ix_apps.path import get_installed_app_rendered_dir_path
-from .utils import PROJECT_PREFIX, run
+from .utils import PROJECT_PREFIX, run, run_streaming
 
 logger = logging.getLogger('app_lifecycle')
 
@@ -18,6 +19,7 @@ def compose_action(
     app_name: str, app_version: str, action: typing.Literal['up', 'down', 'pull'], *,
     force_recreate: bool = False, remove_orphans: bool = False, remove_images: bool = False,
     remove_volumes: bool = False, pull_images: bool = False,
+    progress_callback: ProgressCallback | None = None,
 ) -> None:
     compose_files = list(itertools.chain(
         *[('-f', item) for item in get_rendered_templates_of_app(app_name, app_version)]
@@ -54,7 +56,19 @@ def compose_action(
         raise CallError(f'Invalid action {action!r} for app {app_name!r}')
 
     # TODO: We will likely have a configurable timeout on this end
-    cp = run(['docker', '--config', '/etc/docker', 'compose'] + compose_files + args, timeout=1200)
+    if progress_callback is not None:
+        tracker = ComposeProgressTracker(progress_callback, resources_expected=action == 'up')
+        cp = run_streaming(
+            ['docker', '--config', '/etc/docker', 'compose', '--progress', 'json'] + compose_files + args,
+            line_callback=tracker.feed_line, timeout=1200,
+        )
+        if cp.returncode == 0:
+            try:
+                tracker.flush()
+            except Exception:
+                logger.warning('%s: failed to emit final compose progress', app_name, exc_info=True)
+    else:
+        cp = run(['docker', '--config', '/etc/docker', 'compose'] + compose_files + args, timeout=1200)
     if cp.returncode != 0:
         logger.error('Failed %r action for %r app: %s', action, app_name, cp.stderr)
         err_msg = f'Failed {action!r} action for {app_name!r} app.'

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -213,7 +213,7 @@ def create_internal(
         if dry_run is False:
             compose_action(
                 app_name, version, 'up', force_recreate=True, remove_orphans=True,
-                progress_callback=band_progress(job, 60, 95),
+                progress_callback=band_progress(job, 60, 95), job=job,
             )
     except Exception as e:
         job.set_progress(80, f'Failure occurred while installing {app_name!r}, cleaning up')
@@ -274,7 +274,7 @@ def update_internal(
         job.set_progress(70, 'Updating docker resources')
         compose_action(
             app_name, app.version, 'up', force_recreate=True, remove_orphans=True,
-            progress_callback=band_progress(job, 70, 99),
+            progress_callback=band_progress(job, 70, 99), job=job,
         )
 
     job.set_progress(100, f'{progress_keyword} completed for {app_name!r}')

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -26,7 +26,7 @@ from .ix_apps.query import list_apps
 from .ix_apps.setup import setup_install_app_dir
 from .resources import delete_internal_resources, get_app_volume_ds, remove_failed_resources
 from .schema_normalization import normalize_and_validate_values
-from .utils import to_entries
+from .utils import band_progress, to_entries
 from .version_utils import get_latest_version_from_app_versions
 
 if TYPE_CHECKING:
@@ -211,7 +211,10 @@ def create_internal(
 
         job.set_progress(60, 'App installation in progress, pulling images')
         if dry_run is False:
-            compose_action(app_name, version, 'up', force_recreate=True, remove_orphans=True)
+            compose_action(
+                app_name, version, 'up', force_recreate=True, remove_orphans=True,
+                progress_callback=band_progress(job, 60, 95),
+            )
     except Exception as e:
         job.set_progress(80, f'Failure occurred while installing {app_name!r}, cleaning up')
         if logs := collect_logs(app_name, version):
@@ -269,7 +272,10 @@ def update_internal(
     )
     if trigger_compose:
         job.set_progress(70, 'Updating docker resources')
-        compose_action(app_name, app.version, 'up', force_recreate=True, remove_orphans=True)
+        compose_action(
+            app_name, app.version, 'up', force_recreate=True, remove_orphans=True,
+            progress_callback=band_progress(job, 70, 99),
+        )
 
     job.set_progress(100, f'{progress_keyword} completed for {app_name!r}')
     return get_instance(context, app_name)

--- a/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
@@ -72,6 +72,7 @@ def create_custom_app(
         compose_action(
             app_name, version, 'up', force_recreate=True, remove_orphans=True,
             progress_callback=lambda fraction, description: update_progress(60 + int(35 * fraction), description),
+            job=job,
         )
     except Exception as e:
         assert job.logs_fd is not None

--- a/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
@@ -69,7 +69,10 @@ def create_custom_app(
         else:
             msg = 'App installation in progress, pulling images'
         update_progress(60, msg)
-        compose_action(app_name, version, 'up', force_recreate=True, remove_orphans=True)
+        compose_action(
+            app_name, version, 'up', force_recreate=True, remove_orphans=True,
+            progress_callback=lambda fraction, description: update_progress(60 + int(35 * fraction), description),
+        )
     except Exception as e:
         assert job.logs_fd is not None
         if logs := collect_logs(app_name, version):

--- a/src/middlewared/middlewared/plugins/apps/pull_images.py
+++ b/src/middlewared/middlewared/plugins/apps/pull_images.py
@@ -8,6 +8,7 @@ from middlewared.service import ServiceContext
 
 from .compose_utils import compose_action
 from .crud import get_instance
+from .utils import band_progress, child_job_progress
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -32,10 +33,12 @@ def pull_images_for_app(context: ServiceContext, job: Job, app_name: str, option
 def pull_images_internal(
     context: ServiceContext, app_name: str, app: AppEntry, options: AppPullImages, job: Job | None = None,
 ) -> None:
+    progress_callback = None
     if job is not None:
         job.set_progress(20, 'Pulling app images')
+        progress_callback = band_progress(job, 20, 75 if options.redeploy else 99)
 
-    compose_action(app_name, app.version, action='pull')
+    compose_action(app_name, app.version, action='pull', progress_callback=progress_callback)
     if job is not None:
         job.set_progress(80 if options.redeploy else 100, 'Images pulled successfully')
 
@@ -47,6 +50,9 @@ def pull_images_internal(
         context.call_sync2(context.s.app.image.clear_update_flag_for_tag, image_tag)
 
     if options.redeploy:
-        context.call_sync2(context.s.app.redeploy, app_name).wait_sync(raise_error=True)
+        context.call_sync2(
+            context.s.app.redeploy, app_name,
+            job_on_progress_cb=child_job_progress(job, 80, 100) if job is not None else None,
+        ).wait_sync(raise_error=True)
         if job is not None:
             job.set_progress(100, 'App redeployed successfully')

--- a/src/middlewared/middlewared/plugins/apps/pull_images.py
+++ b/src/middlewared/middlewared/plugins/apps/pull_images.py
@@ -38,7 +38,7 @@ def pull_images_internal(
         job.set_progress(20, 'Pulling app images')
         progress_callback = band_progress(job, 20, 75 if options.redeploy else 99)
 
-    compose_action(app_name, app.version, action='pull', progress_callback=progress_callback)
+    compose_action(app_name, app.version, action='pull', progress_callback=progress_callback, job=job)
     if job is not None:
         job.set_progress(80 if options.redeploy else 100, 'Images pulled successfully')
 

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -114,7 +115,14 @@ async def upgrade_bulk(
 
 
 async def upgrade_app(context: ServiceContext, job: Job, app_name: str, options: AppUpgradeOptions) -> AppEntry:
-    app_instance = await job.wrap(await context.call2(context.s.app.upgrade_impl, app_name, options))
+    upgrade_job = await context.call2(context.s.app.upgrade_impl, app_name, options)
+    try:
+        app_instance = await job.wrap(upgrade_job)
+    except asyncio.CancelledError:
+        # Aborting this job only cancels the wrapping coroutine; forward the abort to the child
+        # job actually performing the upgrade instead of letting it run to completion unobserved
+        upgrade_job.abort()
+        raise
     if app_instance.upgrade_available is False or app_instance.custom_app:
         # Refresh alerts when app reached latest version (remove from upgrade list) or
         # for custom apps where upgrade_available may not reflect image update status.
@@ -213,7 +221,7 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
     try:
         compose_action(
             app_name, upgrade_version['version'], 'up', force_recreate=True, remove_orphans=True, pull_images=True,
-            progress_callback=band_progress(job, 50, 99),
+            progress_callback=band_progress(job, 50, 99), job=job,
         )
     finally:
         context.call_sync2(context.s.app.metadata_generate).wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -39,7 +39,7 @@ from .migration_utils import get_migration_scripts
 from .pull_images import pull_images_internal
 from .resources import get_app_volume_ds, get_hostpaths_datasets
 from .schema_normalization import normalize_and_validate_values
-from .utils import get_upgrade_snap_name, upgrade_summary_info
+from .utils import band_progress, child_job_progress, get_upgrade_snap_name, upgrade_summary_info
 from .version_utils import get_latest_version_from_app_versions
 
 if TYPE_CHECKING:
@@ -95,7 +95,12 @@ async def upgrade_bulk(
     for i, entry in enumerate(apps):
         app_name = entry.app_name
         job.set_progress(int(100 * i / total) if total else 0, f'Upgrading {app_name} [{i + 1} / {total}]')
-        upgrade_job = await context.call2(context.s.app.upgrade_impl, app_name, entry.options)
+        upgrade_job = await context.call2(
+            context.s.app.upgrade_impl, app_name, entry.options,
+            job_on_progress_cb=child_job_progress(
+                job, 100 * i / total, 100 * (i + 1) / total, f'Upgrading {app_name} [{i + 1} / {total}]: ',
+            ),
+        )
         result = await upgrade_job.wait(raise_error=False)
         results.append(AppBulkUpgradeJobResult(
             app_name=app_name,
@@ -131,7 +136,12 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
     if app.custom_app or app.metadata['name'] == IX_APP_NAME:
         job.set_progress(10, 'Pulling app images')
         try:
-            pull_images_internal(context, app_name, app, AppPullImages(redeploy=True))
+            # Custom apps always complete their upgrade here, so the job can be handed over for
+            # precise progress reporting. ix-apps may only have image updates and can still fall
+            # through to a version upgrade below, which would rewind an already-completed progress.
+            pull_images_internal(
+                context, app_name, app, AppPullImages(redeploy=True), job=job if app.custom_app else None,
+            )
         finally:
             app = context.call_sync2(context.s.app.get_instance, app_name)
             if app.upgrade_available is False or app.custom_app:
@@ -203,6 +213,7 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
     try:
         compose_action(
             app_name, upgrade_version['version'], 'up', force_recreate=True, remove_orphans=True, pull_images=True,
+            progress_callback=band_progress(job, 50, 99),
         )
     finally:
         context.call_sync2(context.s.app.metadata_generate).wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -114,14 +114,19 @@ def run_streaming(
         for line in proc.stdout:
             stdout_lines.append(line)
 
+    def kill_process_group() -> None:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
     def on_timeout() -> None:
         nonlocal timed_out
         if proc.poll() is None:
+            # Written here before the kill and read in the finally block below. The kill is what
+            # ends the readline loop (EOF), which happens-before that read, so no lock is needed.
             timed_out = True
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+            kill_process_group()
 
     drain_thread = threading.Thread(target=drain_stdout, daemon=True)
     drain_thread.start()
@@ -140,10 +145,13 @@ def run_streaming(
                 except Exception:
                     logger.warning('%r: line callback failed, output streaming disabled', args[0], exc_info=True)
                     callback_usable = False
-
-        proc.wait()
     finally:
         timer.cancel()
+        # Reap in finally so an unexpected error in the read loop cannot leave the child (and its
+        # process group) running; kill first if it somehow outlived the loop without timing out.
+        if proc.poll() is None:
+            kill_process_group()
+        proc.wait()
         drain_thread.join(timeout=10)
 
     if timed_out:

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
 import subprocess
 import threading
 from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, cast
@@ -97,9 +98,12 @@ def run_streaming(
     Like `run`, but invokes `line_callback` with each line of stderr as it is produced
     instead of buffering output until the process exits.
     """
+    # Run in its own session so the timeout can signal the whole process group. `docker compose`
+    # spawns the compose plugin as a child, and killing only the direct process would orphan it,
+    # leaving it holding the stderr pipe open and blocking the readline loop below past the timeout.
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        encoding='utf8', errors='ignore', env=env or dict(os.environ),
+        encoding='utf8', errors='ignore', env=env or dict(os.environ), start_new_session=True,
     )
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
@@ -114,7 +118,10 @@ def run_streaming(
         nonlocal timed_out
         if proc.poll() is None:
             timed_out = True
-            proc.kill()
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
 
     drain_thread = threading.Thread(target=drain_stdout, daemon=True)
     drain_thread.start()

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
+import logging
 import os
 import subprocess
-from typing import IO, Any, TypeVar, cast
+import threading
+from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from middlewared.api.base import BaseModel
 from middlewared.api.current import AppEntry, AppUpgradeSummary
@@ -12,6 +16,12 @@ from middlewared.plugins.docker.state_utils import (  # noqa: F401,I250
 )
 
 from .ix_apps.utils import PROJECT_PREFIX as PROJECT_PREFIX  # noqa: F401,I250
+
+if TYPE_CHECKING:
+    from middlewared.job import Job
+    from middlewared.utils.types import JobProgressCallback
+
+logger = logging.getLogger('app_lifecycle')
 
 T = TypeVar('T', bound=BaseModel)
 UPGRADE_SNAP_PREFIX = 'ix-app-upgrade-'
@@ -74,3 +84,91 @@ def run(
     if check and cp.returncode:
         raise subprocess.CalledProcessError(cp.returncode, cp.args, stderr=err)
     return cp
+
+
+def run_streaming(
+    args: list[str],
+    *,
+    line_callback: Callable[[str], None],
+    timeout: int = 60,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """
+    Like `run`, but invokes `line_callback` with each line of stderr as it is produced
+    instead of buffering output until the process exits.
+    """
+    proc = subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        encoding='utf8', errors='ignore', env=env or dict(os.environ),
+    )
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    timed_out = False
+
+    def drain_stdout() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            stdout_lines.append(line)
+
+    def on_timeout() -> None:
+        nonlocal timed_out
+        if proc.poll() is None:
+            timed_out = True
+            proc.kill()
+
+    drain_thread = threading.Thread(target=drain_stdout, daemon=True)
+    drain_thread.start()
+    timer = threading.Timer(timeout, on_timeout)
+    timer.start()
+    callback_usable = True
+    try:
+        assert proc.stderr is not None
+        # iter(readline) instead of direct file iteration: the latter's read-ahead buffering
+        # would deliver lines in large batches, defeating real-time streaming
+        for line in iter(proc.stderr.readline, ''):
+            stderr_lines.append(line)
+            if callback_usable:
+                try:
+                    line_callback(line)
+                except Exception:
+                    logger.warning('%r: line callback failed, output streaming disabled', args[0], exc_info=True)
+                    callback_usable = False
+
+        proc.wait()
+    finally:
+        timer.cancel()
+        drain_thread.join(timeout=10)
+
+    if timed_out:
+        return subprocess.CompletedProcess(args, -1, stdout='', stderr='Timed out waiting for response')
+
+    return subprocess.CompletedProcess(
+        args, proc.returncode, stdout=''.join(stdout_lines), stderr=''.join(stderr_lines),
+    )
+
+
+def band_progress(job: Job, start: float, end: float) -> Callable[[float, str], None]:
+    """
+    Return a callback mapping a 0.0-1.0 completion fraction of a sub-operation into
+    `job` progress within the [start, end] band.
+    """
+    def callback(fraction: float, description: str) -> None:
+        job.set_progress(start + (end - start) * min(max(fraction, 0.0), 1.0), description)
+
+    return callback
+
+
+def child_job_progress(job: Job, start: float, end: float, description_prefix: str = '') -> JobProgressCallback:
+    """
+    Return a `job_on_progress_cb` callback for `call2`/`call_sync2` that maps a child
+    job's 0-100 progress into `job` progress within the [start, end] band.
+    """
+    def callback(encoded: dict[str, Any]) -> None:
+        progress = encoded['progress']
+        percent = min(max(progress['percent'] or 0, 0), 100)
+        job.set_progress(
+            start + (end - start) * (percent / 100),
+            f'{description_prefix}{progress["description"] or ""}',
+        )
+
+    return callback

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -5,10 +5,12 @@ import os
 import signal
 import subprocess
 import threading
+import time
 from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from middlewared.api.base import BaseModel
 from middlewared.api.current import AppEntry, AppUpgradeSummary
+from middlewared.job import JobCancelledException
 from middlewared.plugins.docker.state_utils import (
     IX_APPS_MOUNT_PATH as IX_APPS_MOUNT_PATH,
 )
@@ -93,48 +95,31 @@ def run_streaming(
     line_callback: Callable[[str], None],
     timeout: int = 60,
     env: dict[str, str] | None = None,
+    job: Job | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """
     Like `run`, but invokes `line_callback` with each line of stderr as it is produced
-    instead of buffering output until the process exits.
+    instead of buffering output until the process exits. If `job` is given, aborting it
+    kills the process and raises `JobCancelledException`.
     """
-    # Run in its own session so the timeout can signal the whole process group. `docker compose`
+    # Run in its own session so timeout/abort can signal the whole process group. `docker compose`
     # spawns the compose plugin as a child, and killing only the direct process would orphan it,
-    # leaving it holding the stderr pipe open and blocking the readline loop below past the timeout.
+    # leaving it running and holding the output pipes open past the timeout.
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         encoding='utf8', errors='ignore', env=env or dict(os.environ), start_new_session=True,
     )
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
-    timed_out = False
 
-    def drain_stdout() -> None:
+    def read_stdout() -> None:
         assert proc.stdout is not None
         for line in proc.stdout:
             stdout_lines.append(line)
 
-    def kill_process_group() -> None:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-
-    def on_timeout() -> None:
-        nonlocal timed_out
-        if proc.poll() is None:
-            # Written here before the kill and read in the finally block below. The kill is what
-            # ends the readline loop (EOF), which happens-before that read, so no lock is needed.
-            timed_out = True
-            kill_process_group()
-
-    drain_thread = threading.Thread(target=drain_stdout, daemon=True)
-    drain_thread.start()
-    timer = threading.Timer(timeout, on_timeout)
-    timer.start()
-    callback_usable = True
-    try:
+    def read_stderr() -> None:
         assert proc.stderr is not None
+        callback_usable = True
         # iter(readline) instead of direct file iteration: the latter's read-ahead buffering
         # would deliver lines in large batches, defeating real-time streaming
         for line in iter(proc.stderr.readline, ''):
@@ -145,15 +130,36 @@ def run_streaming(
                 except Exception:
                     logger.warning('%r: line callback failed, output streaming disabled', args[0], exc_info=True)
                     callback_usable = False
-    finally:
-        timer.cancel()
-        # Reap in finally so an unexpected error in the read loop cannot leave the child (and its
-        # process group) running; kill first if it somehow outlived the loop without timing out.
-        if proc.poll() is None:
-            kill_process_group()
-        proc.wait()
-        drain_thread.join(timeout=10)
 
+    def kill_process_group() -> None:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    readers = [threading.Thread(target=read_stdout, daemon=True), threading.Thread(target=read_stderr, daemon=True)]
+    for reader in readers:
+        reader.start()
+
+    abort_event = job.aborted_event if job is not None else threading.Event()
+    deadline = time.monotonic() + timeout
+    aborted = timed_out = False
+    while proc.poll() is None:
+        if abort_event.wait(timeout=0.2):
+            aborted = True
+            kill_process_group()
+            break
+        if time.monotonic() > deadline:
+            timed_out = True
+            kill_process_group()
+            break
+
+    proc.wait()
+    for reader in readers:
+        reader.join(timeout=10)
+
+    if aborted:
+        raise JobCancelledException()
     if timed_out:
         return subprocess.CompletedProcess(args, -1, stdout='', stderr='Timed out waiting for response')
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
@@ -87,18 +87,47 @@ def test_up_reserves_progress_for_resources():
 
     fractions = [fraction for fraction, _ in emitted]
     assert fractions == sorted(fractions), fractions
-    assert fractions[-1] == 1.0
+    # The reserved band climbs but does not collapse to 100% while containers are still deploying
+    assert 0.9 < emitted[-1][0] < 1.0
     assert emitted[-1][1] == "Started Container myapp-web-1"
 
+    tracker.flush()
+    assert emitted[-1][0] == 1.0
 
-def test_up_without_pull_tracks_resources_at_full_weight():
+
+def test_up_without_pull_does_not_peg_at_network_creation():
+    # Real compose ordering for a config-only update: no image events (image already present),
+    # the network is created before the container, then the container is recreated and started.
     tracker, emitted = make_tracker(resources_expected=True)
-    # All images already present: compose emits no image events at all
-    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Creating"})
-    feed(tracker, {"id": "Container myapp-db-1", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Network myapp_default", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Network myapp_default", "status": "Done", "text": "Created"})
+    # The network finishing must not read as 100% - the slow container recreate is still to come
+    assert emitted[-1][0] < 1.0
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Recreate"})
     feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
-    assert emitted[-1][0] == pytest.approx(0.5)
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Starting"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Started"})
+
+    fractions = [fraction for fraction, _ in emitted]
+    assert fractions == sorted(fractions), fractions
+    assert emitted[-1][0] < 1.0
+    tracker.flush()
+    assert emitted[-1][0] == 1.0
+
+
+def test_up_multi_container_progresses_incrementally():
+    # The first container to finish must not read as 100% while another is still pending
+    tracker, emitted = make_tracker(resources_expected=True)
+    feed(tracker, {"id": "Network myapp_default", "status": "Done", "text": "Created"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
+    after_first = emitted[-1][0]
+    assert after_first < 1.0
     feed(tracker, {"id": "Container myapp-db-1", "status": "Done", "text": "Created"})
+    fractions = [fraction for fraction, _ in emitted]
+    assert fractions == sorted(fractions), fractions
+    assert emitted[-1][0] > after_first
+    assert emitted[-1][0] < 1.0
+    tracker.flush()
     assert emitted[-1][0] == 1.0
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
@@ -95,46 +95,41 @@ def test_up_reserves_progress_for_resources():
     assert emitted[-1][0] == 1.0
 
 
-def test_up_without_pull_does_not_peg_at_network_creation():
+def test_up_without_pull_progresses_incrementally():
     # Real compose ordering for a config-only update: no image events (image already present),
-    # the network is created before the container, then the container is recreated and started.
+    # the network is created before the containers, which are then recreated and started.
     tracker, emitted = make_tracker(resources_expected=True)
     feed(tracker, {"id": "Network myapp_default", "status": "Working", "text": "Creating"})
     feed(tracker, {"id": "Network myapp_default", "status": "Done", "text": "Created"})
-    # The network finishing must not read as 100% - the slow container recreate is still to come
-    assert emitted[-1][0] < 1.0
+    # The network finishing must not read as 100% - the slow container recreates are still to come
+    after_network = emitted[-1][0]
+    assert after_network < 1.0
     feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Recreate"})
     feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
     feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Starting"})
     feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Started"})
-
-    fractions = [fraction for fraction, _ in emitted]
-    assert fractions == sorted(fractions), fractions
-    assert emitted[-1][0] < 1.0
-    tracker.flush()
-    assert emitted[-1][0] == 1.0
-
-
-def test_up_multi_container_progresses_incrementally():
-    # The first container to finish must not read as 100% while another is still pending
-    tracker, emitted = make_tracker(resources_expected=True)
-    feed(tracker, {"id": "Network myapp_default", "status": "Done", "text": "Created"})
-    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
+    # The first container finishing advances progress but must not read as 100%
+    # while another is still pending
     after_first = emitted[-1][0]
-    assert after_first < 1.0
+    assert after_network < after_first < 1.0
     feed(tracker, {"id": "Container myapp-db-1", "status": "Done", "text": "Created"})
+
     fractions = [fraction for fraction, _ in emitted]
     assert fractions == sorted(fractions), fractions
-    assert emitted[-1][0] > after_first
-    assert emitted[-1][0] < 1.0
+    assert after_first < emitted[-1][0] < 1.0
     tracker.flush()
     assert emitted[-1][0] == 1.0
 
 
-def test_cached_layers_pull_completes():
+def test_cached_layers_count_as_complete():
+    # Mixed pull: one layer already present locally, one still downloading. The cached layer
+    # must count as complete (weighted as average-sized, its size is never announced), not as
+    # not-started.
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, {"id": IMAGE, "status": "Working", "text": "Pulling"})
     feed(tracker, layer_event("aaa", "Already exists", status="Done"))
+    feed(tracker, layer_event("bbb", "Downloading", 0, 1000))
+    assert emitted[-1][0] == pytest.approx(0.5)
+    feed(tracker, layer_event("bbb", "Pull complete", status="Done"))
     feed(tracker, {"id": IMAGE, "status": "Done", "text": "Pulled"})
     assert emitted[-1][0] == 1.0
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
@@ -1,0 +1,153 @@
+import json
+
+import pytest
+
+from middlewared.plugins.apps.compose_progress import ComposeProgressTracker
+
+
+IMAGE = 'Image nginx:1.27-alpine'
+
+
+def make_tracker(resources_expected):
+    emitted = []
+    tracker = ComposeProgressTracker(
+        lambda fraction, description: emitted.append((fraction, description)),
+        resources_expected=resources_expected,
+        min_interval=0,
+    )
+    return tracker, emitted
+
+
+def feed(tracker, event):
+    tracker.feed_line(json.dumps(event))
+
+
+def layer_event(layer_id, text, current=None, total=None, status='Working'):
+    event = {'id': layer_id, 'parent_id': IMAGE, 'status': status, 'text': text}
+    if current is not None:
+        event.update(current=current, total=total)
+    return event
+
+
+def test_pull_progress_is_monotonic_and_completes():
+    tracker, emitted = make_tracker(resources_expected=False)
+    feed(tracker, {'id': IMAGE, 'status': 'Working', 'text': 'Pulling'})
+    feed(tracker, layer_event('aaa', 'Pulling fs layer'))
+    feed(tracker, layer_event('bbb', 'Pulling fs layer'))
+    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
+    feed(tracker, layer_event('bbb', 'Downloading', 2000, 4000))
+    feed(tracker, layer_event('aaa', 'Extracting', 500, 1000))
+    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
+    feed(tracker, layer_event('bbb', 'Downloading', 4000, 4000))
+    feed(tracker, layer_event('bbb', 'Extracting', 4000, 4000))
+    feed(tracker, layer_event('bbb', 'Pull complete', status='Done'))
+    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+
+    fractions = [fraction for fraction, _ in emitted]
+    assert fractions, 'no progress was emitted'
+    assert fractions == sorted(fractions), fractions
+    assert fractions[-1] == 1.0
+    assert any(0 < fraction < 1 for fraction in fractions), fractions
+
+
+def test_late_layer_size_announcement_does_not_regress():
+    tracker, emitted = make_tracker(resources_expected=False)
+    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
+    high_water = emitted[-1][0]
+    # A second, much larger layer announcing its size grows the denominator
+    feed(tracker, layer_event('bbb', 'Downloading', 1, 10_000_000))
+    fractions = [fraction for fraction, _ in emitted]
+    assert fractions == sorted(fractions), fractions
+    assert fractions[-1] >= high_water
+
+
+def test_unsized_layers_damp_early_progress():
+    tracker, emitted = make_tracker(resources_expected=False)
+    for layer_id in ('aaa', 'bbb', 'ccc', 'ddd'):
+        feed(tracker, layer_event(layer_id, 'Pulling fs layer'))
+    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
+    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
+    # One of four layers complete is roughly a quarter of the image, not almost all of it
+    assert emitted[-1][0] == pytest.approx(0.25)
+
+
+def test_up_reserves_progress_for_resources():
+    tracker, emitted = make_tracker(resources_expected=True)
+    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
+    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
+    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    assert emitted[-1][0] == pytest.approx(0.9)
+
+    feed(tracker, {'id': 'Network myapp_default', 'status': 'Working', 'text': 'Creating'})
+    feed(tracker, {'id': 'Network myapp_default', 'status': 'Done', 'text': 'Created'})
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Creating'})
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Created'})
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Starting'})
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Started'})
+
+    fractions = [fraction for fraction, _ in emitted]
+    assert fractions == sorted(fractions), fractions
+    assert fractions[-1] == 1.0
+    assert emitted[-1][1] == 'Started Container myapp-web-1'
+
+
+def test_up_without_pull_tracks_resources_at_full_weight():
+    tracker, emitted = make_tracker(resources_expected=True)
+    # All images already present: compose emits no image events at all
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Creating'})
+    feed(tracker, {'id': 'Container myapp-db-1', 'status': 'Working', 'text': 'Creating'})
+    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Created'})
+    assert emitted[-1][0] == pytest.approx(0.5)
+    feed(tracker, {'id': 'Container myapp-db-1', 'status': 'Done', 'text': 'Created'})
+    assert emitted[-1][0] == 1.0
+
+
+def test_cached_layers_pull_completes():
+    tracker, emitted = make_tracker(resources_expected=False)
+    feed(tracker, {'id': IMAGE, 'status': 'Working', 'text': 'Pulling'})
+    feed(tracker, layer_event('aaa', 'Already exists', status='Done'))
+    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    assert emitted[-1][0] == 1.0
+
+
+def test_description_reports_downloaded_bytes():
+    tracker, emitted = make_tracker(resources_expected=False)
+    feed(tracker, layer_event('aaa', 'Downloading', 512 * 1024, 1024 * 1024))
+    assert emitted[-1][1] == 'Pulling app images (512 KiB / 1 MiB)'
+
+
+def test_malformed_input_is_ignored():
+    tracker, emitted = make_tracker(resources_expected=False)
+    tracker.feed_line('')
+    tracker.feed_line('plain text output')
+    tracker.feed_line('{"truncated json')
+    tracker.feed_line('[1, 2, 3]')
+    tracker.feed_line(json.dumps({'error': True, 'message': 'pull access denied'}))
+    tracker.feed_line(json.dumps({'id': IMAGE, 'status': 'Error', 'text': 'Error', 'details': 'denied'}))
+    tracker.feed_line(json.dumps({'id': 42, 'status': 'Done', 'text': 'Pulled'}))
+    assert emitted == []
+
+
+def test_duplicate_progress_not_reemitted():
+    tracker, emitted = make_tracker(resources_expected=False)
+    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    assert len(emitted) == 1
+
+
+def test_flush_bypasses_throttle():
+    emitted = []
+    tracker = ComposeProgressTracker(
+        lambda fraction, description: emitted.append((fraction, description)),
+        resources_expected=False,
+        min_interval=3600,
+    )
+    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    # Final events land within the throttle interval and are suppressed
+    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
+    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    assert emitted[-1][0] < 1.0
+
+    tracker.flush()
+    assert emitted[-1][0] == 1.0

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_compose_progress.py
@@ -4,8 +4,7 @@ import pytest
 
 from middlewared.plugins.apps.compose_progress import ComposeProgressTracker
 
-
-IMAGE = 'Image nginx:1.27-alpine'
+IMAGE = "Image nginx:1.27-alpine"
 
 
 def make_tracker(resources_expected):
@@ -22,8 +21,8 @@ def feed(tracker, event):
     tracker.feed_line(json.dumps(event))
 
 
-def layer_event(layer_id, text, current=None, total=None, status='Working'):
-    event = {'id': layer_id, 'parent_id': IMAGE, 'status': status, 'text': text}
+def layer_event(layer_id, text, current=None, total=None, status="Working"):
+    event = {"id": layer_id, "parent_id": IMAGE, "status": status, "text": text}
     if current is not None:
         event.update(current=current, total=total)
     return event
@@ -31,21 +30,21 @@ def layer_event(layer_id, text, current=None, total=None, status='Working'):
 
 def test_pull_progress_is_monotonic_and_completes():
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, {'id': IMAGE, 'status': 'Working', 'text': 'Pulling'})
-    feed(tracker, layer_event('aaa', 'Pulling fs layer'))
-    feed(tracker, layer_event('bbb', 'Pulling fs layer'))
-    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
-    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
-    feed(tracker, layer_event('bbb', 'Downloading', 2000, 4000))
-    feed(tracker, layer_event('aaa', 'Extracting', 500, 1000))
-    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
-    feed(tracker, layer_event('bbb', 'Downloading', 4000, 4000))
-    feed(tracker, layer_event('bbb', 'Extracting', 4000, 4000))
-    feed(tracker, layer_event('bbb', 'Pull complete', status='Done'))
-    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    feed(tracker, {"id": IMAGE, "status": "Working", "text": "Pulling"})
+    feed(tracker, layer_event("aaa", "Pulling fs layer"))
+    feed(tracker, layer_event("bbb", "Pulling fs layer"))
+    feed(tracker, layer_event("aaa", "Downloading", 500, 1000))
+    feed(tracker, layer_event("aaa", "Downloading", 1000, 1000))
+    feed(tracker, layer_event("bbb", "Downloading", 2000, 4000))
+    feed(tracker, layer_event("aaa", "Extracting", 500, 1000))
+    feed(tracker, layer_event("aaa", "Pull complete", status="Done"))
+    feed(tracker, layer_event("bbb", "Downloading", 4000, 4000))
+    feed(tracker, layer_event("bbb", "Extracting", 4000, 4000))
+    feed(tracker, layer_event("bbb", "Pull complete", status="Done"))
+    feed(tracker, {"id": IMAGE, "status": "Done", "text": "Pulled"})
 
     fractions = [fraction for fraction, _ in emitted]
-    assert fractions, 'no progress was emitted'
+    assert fractions, "no progress was emitted"
     assert fractions == sorted(fractions), fractions
     assert fractions[-1] == 1.0
     assert any(0 < fraction < 1 for fraction in fractions), fractions
@@ -53,10 +52,10 @@ def test_pull_progress_is_monotonic_and_completes():
 
 def test_late_layer_size_announcement_does_not_regress():
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
+    feed(tracker, layer_event("aaa", "Downloading", 1000, 1000))
     high_water = emitted[-1][0]
     # A second, much larger layer announcing its size grows the denominator
-    feed(tracker, layer_event('bbb', 'Downloading', 1, 10_000_000))
+    feed(tracker, layer_event("bbb", "Downloading", 1, 10_000_000))
     fractions = [fraction for fraction, _ in emitted]
     assert fractions == sorted(fractions), fractions
     assert fractions[-1] >= high_water
@@ -64,75 +63,75 @@ def test_late_layer_size_announcement_does_not_regress():
 
 def test_unsized_layers_damp_early_progress():
     tracker, emitted = make_tracker(resources_expected=False)
-    for layer_id in ('aaa', 'bbb', 'ccc', 'ddd'):
-        feed(tracker, layer_event(layer_id, 'Pulling fs layer'))
-    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
-    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
+    for layer_id in ("aaa", "bbb", "ccc", "ddd"):
+        feed(tracker, layer_event(layer_id, "Pulling fs layer"))
+    feed(tracker, layer_event("aaa", "Downloading", 1000, 1000))
+    feed(tracker, layer_event("aaa", "Pull complete", status="Done"))
     # One of four layers complete is roughly a quarter of the image, not almost all of it
     assert emitted[-1][0] == pytest.approx(0.25)
 
 
 def test_up_reserves_progress_for_resources():
     tracker, emitted = make_tracker(resources_expected=True)
-    feed(tracker, layer_event('aaa', 'Downloading', 1000, 1000))
-    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
-    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    feed(tracker, layer_event("aaa", "Downloading", 1000, 1000))
+    feed(tracker, layer_event("aaa", "Pull complete", status="Done"))
+    feed(tracker, {"id": IMAGE, "status": "Done", "text": "Pulled"})
     assert emitted[-1][0] == pytest.approx(0.9)
 
-    feed(tracker, {'id': 'Network myapp_default', 'status': 'Working', 'text': 'Creating'})
-    feed(tracker, {'id': 'Network myapp_default', 'status': 'Done', 'text': 'Created'})
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Creating'})
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Created'})
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Starting'})
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Started'})
+    feed(tracker, {"id": "Network myapp_default", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Network myapp_default", "status": "Done", "text": "Created"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Starting"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Started"})
 
     fractions = [fraction for fraction, _ in emitted]
     assert fractions == sorted(fractions), fractions
     assert fractions[-1] == 1.0
-    assert emitted[-1][1] == 'Started Container myapp-web-1'
+    assert emitted[-1][1] == "Started Container myapp-web-1"
 
 
 def test_up_without_pull_tracks_resources_at_full_weight():
     tracker, emitted = make_tracker(resources_expected=True)
     # All images already present: compose emits no image events at all
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Working', 'text': 'Creating'})
-    feed(tracker, {'id': 'Container myapp-db-1', 'status': 'Working', 'text': 'Creating'})
-    feed(tracker, {'id': 'Container myapp-web-1', 'status': 'Done', 'text': 'Created'})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Container myapp-db-1", "status": "Working", "text": "Creating"})
+    feed(tracker, {"id": "Container myapp-web-1", "status": "Done", "text": "Created"})
     assert emitted[-1][0] == pytest.approx(0.5)
-    feed(tracker, {'id': 'Container myapp-db-1', 'status': 'Done', 'text': 'Created'})
+    feed(tracker, {"id": "Container myapp-db-1", "status": "Done", "text": "Created"})
     assert emitted[-1][0] == 1.0
 
 
 def test_cached_layers_pull_completes():
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, {'id': IMAGE, 'status': 'Working', 'text': 'Pulling'})
-    feed(tracker, layer_event('aaa', 'Already exists', status='Done'))
-    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    feed(tracker, {"id": IMAGE, "status": "Working", "text": "Pulling"})
+    feed(tracker, layer_event("aaa", "Already exists", status="Done"))
+    feed(tracker, {"id": IMAGE, "status": "Done", "text": "Pulled"})
     assert emitted[-1][0] == 1.0
 
 
 def test_description_reports_downloaded_bytes():
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, layer_event('aaa', 'Downloading', 512 * 1024, 1024 * 1024))
-    assert emitted[-1][1] == 'Pulling app images (512 KiB / 1 MiB)'
+    feed(tracker, layer_event("aaa", "Downloading", 512 * 1024, 1024 * 1024))
+    assert emitted[-1][1] == "Pulling app images (512 KiB / 1 MiB)"
 
 
 def test_malformed_input_is_ignored():
     tracker, emitted = make_tracker(resources_expected=False)
-    tracker.feed_line('')
-    tracker.feed_line('plain text output')
+    tracker.feed_line("")
+    tracker.feed_line("plain text output")
     tracker.feed_line('{"truncated json')
-    tracker.feed_line('[1, 2, 3]')
-    tracker.feed_line(json.dumps({'error': True, 'message': 'pull access denied'}))
-    tracker.feed_line(json.dumps({'id': IMAGE, 'status': 'Error', 'text': 'Error', 'details': 'denied'}))
-    tracker.feed_line(json.dumps({'id': 42, 'status': 'Done', 'text': 'Pulled'}))
+    tracker.feed_line("[1, 2, 3]")
+    tracker.feed_line(json.dumps({"error": True, "message": "pull access denied"}))
+    tracker.feed_line(json.dumps({"id": IMAGE, "status": "Error", "text": "Error", "details": "denied"}))
+    tracker.feed_line(json.dumps({"id": 42, "status": "Done", "text": "Pulled"}))
     assert emitted == []
 
 
 def test_duplicate_progress_not_reemitted():
     tracker, emitted = make_tracker(resources_expected=False)
-    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
-    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    feed(tracker, layer_event("aaa", "Downloading", 500, 1000))
+    feed(tracker, layer_event("aaa", "Downloading", 500, 1000))
     assert len(emitted) == 1
 
 
@@ -143,10 +142,10 @@ def test_flush_bypasses_throttle():
         resources_expected=False,
         min_interval=3600,
     )
-    feed(tracker, layer_event('aaa', 'Downloading', 500, 1000))
+    feed(tracker, layer_event("aaa", "Downloading", 500, 1000))
     # Final events land within the throttle interval and are suppressed
-    feed(tracker, layer_event('aaa', 'Pull complete', status='Done'))
-    feed(tracker, {'id': IMAGE, 'status': 'Done', 'text': 'Pulled'})
+    feed(tracker, layer_event("aaa", "Pull complete", status="Done"))
+    feed(tracker, {"id": IMAGE, "status": "Done", "text": "Pulled"})
     assert emitted[-1][0] < 1.0
 
     tracker.flush()

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_run_streaming.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_run_streaming.py
@@ -1,0 +1,65 @@
+import threading
+import time
+from types import SimpleNamespace
+import typing
+
+import pytest
+
+from middlewared.job import Job, JobCancelledException
+from middlewared.plugins.apps.utils import run_streaming
+
+
+def make_job():
+    return typing.cast("Job", SimpleNamespace(aborted_event=threading.Event()))
+
+
+def test_streams_lines_before_process_exits(tmp_path):
+    # The script blocks after its first line until the callback creates the flag file, so the
+    # test deadlocks (and times out) unless lines are delivered while the process still runs.
+    flag = tmp_path / "flag"
+    script = f"echo first >&2; until [ -f {flag} ]; do sleep 0.05; done; echo second >&2"
+    lines = []
+
+    def callback(line):
+        lines.append(line)
+        flag.touch()
+
+    cp = run_streaming(["bash", "-c", script], line_callback=callback, timeout=30)
+
+    assert cp.returncode == 0
+    assert lines == ["first\n", "second\n"]
+    assert cp.stderr == "first\nsecond\n"
+
+
+def test_timeout_kills_whole_process_group():
+    # The grandchild inherits stderr; unless the whole process group is killed on timeout, it
+    # keeps the pipe open and the stderr reader (joined with its own timeout) stalls the return.
+    script = "(sleep 30; echo late >&2) & sleep 30"
+    start = time.monotonic()
+
+    cp = run_streaming(["bash", "-c", script], line_callback=lambda _: None, timeout=1)
+
+    assert cp.returncode == -1
+    assert cp.stderr == "Timed out waiting for response"
+    assert time.monotonic() - start < 5
+
+
+def test_abort_kills_process_and_raises():
+    job = make_job()
+    threading.Timer(0.3, job.aborted_event.set).start()
+    start = time.monotonic()
+
+    with pytest.raises(JobCancelledException):
+        run_streaming(["bash", "-c", "sleep 30"], line_callback=lambda _: None, timeout=30, job=job)
+
+    assert time.monotonic() - start < 5
+
+
+def test_callback_failure_does_not_interrupt_streaming():
+    def callback(line):
+        raise ValueError(line)
+
+    cp = run_streaming(["bash", "-c", "echo first >&2; echo second >&2"], line_callback=callback, timeout=30)
+
+    assert cp.returncode == 0
+    assert cp.stderr == "first\nsecond\n"

--- a/src/middlewared/middlewared/test/integration/utils/job.py
+++ b/src/middlewared/middlewared/test/integration/utils/job.py
@@ -28,31 +28,12 @@ def assert_creates_job(method):
     job.id = jobs[-1]["id"]
 
 
-def busy_wait_on_job(jobid: int, max_timeout: int = 600, delay: int = 5, /, call_fn=call, stall_timeout=None):
-    """
-    Poll `jobid` until it succeeds (returning True) or fails (raising ValueError).
-
-    Raises after `max_timeout` seconds overall or, if `stall_timeout` is set, after that many
-    seconds without any change in the job's reported progress. Jobs that report continuous
-    progress (e.g. app operations streaming docker compose pull events) can use a small
-    `stall_timeout` to fail fast on genuine hangs while still tolerating slow-but-alive
-    operations that would need a generous `max_timeout`.
-    """
-    start_time = stall_start = time.monotonic()
-    last_progress = None
+def busy_wait_on_job(jobid: int, max_timeout: int = 600, delay: int = 5, /, call_fn=call):
+    start_time = time.monotonic()
     while time.monotonic() - start_time < max_timeout:
         jobs = call_fn('core.get_jobs', [['id', '=', jobid]])
         job_state = jobs[0]['state']
         if job_state in ('RUNNING', 'WAITING'):
-            # Stall detection only applies to running jobs; a job waiting on a lock or queue
-            # slot legitimately reports no progress
-            if stall_timeout is not None and job_state == 'RUNNING':
-                now = time.monotonic()
-                if jobs[0]['progress'] != last_progress:
-                    last_progress = jobs[0]['progress']
-                    stall_start = now
-                elif now - stall_start >= stall_timeout:
-                    raise ValueError(f'Job {jobid} made no progress for {stall_timeout} seconds: {jobs[0]}')
             time.sleep(delay)
         elif job_state == 'SUCCESS':
             return True

--- a/src/middlewared/middlewared/test/integration/utils/job.py
+++ b/src/middlewared/middlewared/test/integration/utils/job.py
@@ -28,12 +28,31 @@ def assert_creates_job(method):
     job.id = jobs[-1]["id"]
 
 
-def busy_wait_on_job(jobid: int, max_timeout: int = 600, delay: int = 5, /, call_fn=call):
-    start_time = time.monotonic()
+def busy_wait_on_job(jobid: int, max_timeout: int = 600, delay: int = 5, /, call_fn=call, stall_timeout=None):
+    """
+    Poll `jobid` until it succeeds (returning True) or fails (raising ValueError).
+
+    Raises after `max_timeout` seconds overall or, if `stall_timeout` is set, after that many
+    seconds without any change in the job's reported progress. Jobs that report continuous
+    progress (e.g. app operations streaming docker compose pull events) can use a small
+    `stall_timeout` to fail fast on genuine hangs while still tolerating slow-but-alive
+    operations that would need a generous `max_timeout`.
+    """
+    start_time = stall_start = time.monotonic()
+    last_progress = None
     while time.monotonic() - start_time < max_timeout:
         jobs = call_fn('core.get_jobs', [['id', '=', jobid]])
         job_state = jobs[0]['state']
         if job_state in ('RUNNING', 'WAITING'):
+            # Stall detection only applies to running jobs; a job waiting on a lock or queue
+            # slot legitimately reports no progress
+            if stall_timeout is not None and job_state == 'RUNNING':
+                now = time.monotonic()
+                if jobs[0]['progress'] != last_progress:
+                    last_progress = jobs[0]['progress']
+                    stall_start = now
+                elif now - stall_start >= stall_timeout:
+                    raise ValueError(f'Job {jobid} made no progress for {stall_timeout} seconds: {jobs[0]}')
             time.sleep(delay)
         elif job_state == 'SUCCESS':
             return True

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 from middlewared.test.integration.utils import call, client, ssh
@@ -165,11 +167,17 @@ def test_create_custom_app_compose_progress(docker_pool):
     """
     def install_capturing_progress(c):
         progress = []
+        progress_lock = threading.Lock()
 
         def callback(job):
-            item = (job["progress"]["percent"], job["progress"]["description"])
-            if not progress or progress[-1] != item:
-                progress.append(item)
+            # api_client dispatches each job event to this callback in its own daemon thread,
+            # all sharing one mutable job dict. Serialize read+append so concurrent threads
+            # cannot interleave into an out-of-order capture; since progress only advances, the
+            # captured percents stay sorted under the lock.
+            with progress_lock:
+                item = (job["progress"]["percent"], job["progress"]["description"])
+                if not progress or progress[-1] != item:
+                    progress.append(item)
 
         c.call(
             "app.create",

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -163,14 +163,14 @@ def test_create_custom_app_compose_progress(docker_pool):
     event format, the progress tracker goes silent and this test fails loudly
     instead of app job progress silently freezing mid-operation.
     """
-    progress = []
+    def install_capturing_progress(c):
+        progress = []
 
-    def callback(job):
-        item = (job["progress"]["percent"], job["progress"]["description"])
-        if not progress or progress[-1] != item:
-            progress.append(item)
+        def callback(job):
+            item = (job["progress"]["percent"], job["progress"]["description"])
+            if not progress or progress[-1] != item:
+                progress.append(item)
 
-    with client(py_exceptions=False) as c:
         c.call(
             "app.create",
             {
@@ -181,15 +181,26 @@ def test_create_custom_app_compose_progress(docker_pool):
             job=True,
             callback=callback,
         )
-    try:
         percents = [percent for percent, _ in progress if percent is not None]
         assert percents == sorted(percents), progress
         # Compose resource events are emitted whether or not images needed pulling
         assert any(
             "Container" in description for _, description in progress if description
         ), progress
-    finally:
-        call("app.delete", "progress-probe", {"remove_images": True}, job=True)
+        return progress
+
+    with client(py_exceptions=False) as c:
+        try:
+            install_capturing_progress(c)
+            # Reinstalling with the image kept must reuse it: byte-level pull progress
+            # (only reported while layers actually download) must not appear
+            call("app.delete", "progress-probe", {"remove_images": False}, job=True)
+            progress = install_capturing_progress(c)
+            assert not any(
+                description.startswith("Pulling app images (") for _, description in progress if description
+            ), progress
+        finally:
+            call("app.delete", "progress-probe", {"remove_images": True}, job=True)
 
 
 def test_create_custom_app_validation_error(docker_pool):

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -155,6 +155,43 @@ def test_create_custom_app(docker_pool):
         assert app_info["state"] == "DEPLOYING"
 
 
+def test_create_custom_app_compose_progress(docker_pool):
+    """
+    App installation streams fine-grained progress parsed from `docker compose
+    --progress=json` events (image pulls, container creation) instead of jumping
+    between fixed milestones. If a docker compose upgrade ever changes the JSON
+    event format, the progress tracker goes silent and this test fails loudly
+    instead of app job progress silently freezing mid-operation.
+    """
+    progress = []
+
+    def callback(job):
+        item = (job["progress"]["percent"], job["progress"]["description"])
+        if not progress or progress[-1] != item:
+            progress.append(item)
+
+    with client(py_exceptions=False) as c:
+        c.call(
+            "app.create",
+            {
+                "app_name": "progress-probe",
+                "custom_app": True,
+                "custom_compose_config": {"services": {"nginx": {"image": "nginx:1.27-alpine"}}},
+            },
+            job=True,
+            callback=callback,
+        )
+    try:
+        percents = [percent for percent, _ in progress if percent is not None]
+        assert percents == sorted(percents), progress
+        # Compose resource events are emitted whether or not images needed pulling
+        assert any(
+            "Container" in description for _, description in progress if description
+        ), progress
+    finally:
+        call("app.delete", "progress-probe", {"remove_images": True}, job=True)
+
+
 def test_create_custom_app_validation_error(docker_pool):
     with pytest.raises(ValidationErrors):
         with app(


### PR DESCRIPTION
## Motivation

App install/update/upgrade/pull jobs currently jump between fixed progress milestones — on upgrade, everything between 50% and 100% (the entire image pull and container recreation, i.e. most of the wall-clock time) happens silently.

## Changes

- `compose_action()` accepts an optional `progress_callback`. When set, it runs `docker compose --progress=json` with line-streamed stderr, and the new `ComposeProgressTracker` aggregates per-layer download/extract bytes and container/network events into a monotonic fraction with descriptions like `Pulling app images (27.35 MiB / 69.03 MiB)`. Wired into install, update/redeploy, upgrade, custom app create, and `app.pull_images`, each mapped into its own band of the job's progress.
- Child job progress now proxies into parent jobs via `job_on_progress_cb`: `app.upgrade_bulk` maps each app's upgrade into its `[i/total, (i+1)/total]` slice (with per-app descriptions), and the redeploy triggered by `app.pull_images` maps into 80–100%.

Error handling is unchanged (return-code checks, `toomanyrequests` detection, timeout semantics), progress-path failures cannot fail the underlying operation (callbacks and the final flush are guarded), and code paths without a job in scope are untouched. If a future compose release changes the JSON event format, progress degrades to the old milestone behavior while operations proceed — and the new integration test fails loudly.

## Testing

- 10 new unit tests for the tracker; full apps unit suite passes.
- New integration test asserts monotonic, compose-derived progress during custom app install, and that reinstalling with kept images reports no byte-level pull (verifying image reuse). Passed against a test system.
- Live-verified on 27.0-MASTER: install and update show byte-level pull progress; `app.pull_images` with redeploy shows the child job's progress mapped into 80–100%; bulk upgrade of `actual-budget` + `syncthing` produced 19 distinct updates across correct per-app slices (previously 3).
- Performance: cached pull/up wall-clock medians are identical with and without streaming; the tracker costs ~1–2ms CPU per second of pull at compose's self-throttled event rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://github.com/user-attachments/assets/9a00c886-6f29-42c5-a2d6-2fdf23cc17f7