### PR TITLE
NAS-141839 / 27.0.0-BETA.1 / Stop a VM before destroying its backing zvols on delete

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm.py
@@ -217,7 +217,12 @@ class VMUpdateResult(BaseModel):
 
 class VMDeleteOptions(BaseModel):
     zvols: bool = Field(default=False, description="Delete associated ZFS volumes when deleting the VM.")
-    force: bool = Field(default=False, description="Force deletion even if the VM is currently running.")
+    force: bool = Field(
+        default=False,
+        description="Delete a running or suspended VM by stopping it first. Without this, deleting an active VM is "
+                    "rejected. Also causes failures to destroy associated ZFS volumes to be logged and ignored rather "
+                    "than aborting the deletion."
+    )
 
 
 class VMDeleteArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import errno
-import itertools
 import re
 import typing
 import uuid
 
 from middlewared.api.current import (
     VMCreate,
+    VMDeleteOptions,
     VMDeviceCreate,
     VMDeviceEntry,
     ZFSResourceQuery,
@@ -21,7 +21,7 @@ from middlewared.service import CallError, ServiceContext
 from middlewared.service_exception import ValidationErrors
 from middlewared.utils.libvirt.nic import NICDelegate
 
-from .utils import copy_vm_state, delete_vm_state, vm_state_missing_sources
+from .utils import copy_vm_state, vm_state_missing_sources
 
 if typing.TYPE_CHECKING:
     from middlewared.utils.types import AuditCallback
@@ -135,7 +135,6 @@ async def clone_vm(context: ServiceContext, id_: int, name: str | None, *, audit
 
     created_snaps: list[str] = []
     created_clones: list[str] = []
-    state_copied = False
     new_vm = None
     try:
         new_vm = await context.call2(context.s.vm.create, create_data)
@@ -154,7 +153,6 @@ async def clone_vm(context: ServiceContext, id_: int, name: str | None, *, audit
                 f'Failed to copy VM state for {vm.name!r} -> {new_vm.name!r}: '
                 f'{oe.strerror or oe} (errno={oe.errno}).'
             ) from oe
-        state_copied = True
 
         missing = await context.to_thread(
             vm_state_missing_sources, vm.id, vm.name,
@@ -190,32 +188,38 @@ async def clone_vm(context: ServiceContext, id_: int, name: str | None, *, audit
                 continue
 
             await context.call2(context.s.vm.device.create, VMDeviceCreate.model_validate(device_dict))
-    except Exception as e:
-        for clone, snap in itertools.zip_longest(reversed(created_clones), reversed(created_snaps)):
-            if clone is not None:
-                try:
-                    context.call_sync2(context.s.zfs.resource.destroy_impl, clone)
-                except Exception:
-                    context.logger.exception('Failed to destroy cloned zvol %r', clone)
-                    continue
-                else:
-                    if snap is not None:
-                        try:
-                            await context.call2(
-                                context.s.zfs.resource.snapshot.destroy_impl,
-                                ZFSResourceSnapshotDestroyQuery(path=snap),
-                            )
-                        except Exception:
-                            context.logger.exception('Failed to destroy snapshot %r for zvol %r', snap, clone)
-        if state_copied and new_vm is not None:
+    except Exception:
+        # Destroy clones before their origin snapshots: a clone pins the snapshot it
+        # was created from, so the snapshot can only be removed once every clone is gone.
+        # The two lists can differ in length if _clone_zvol failed between creating the
+        # snapshot and the clone, so unwinding them separately.
+        for clone in reversed(created_clones):
             try:
-                await context.to_thread(delete_vm_state, new_vm.id, new_vm.name)
+                await context.call2(context.s.zfs.resource.destroy_impl, clone)
+            except Exception:
+                context.logger.exception('clone rollback: failed to destroy cloned zvol %r', clone)
+        for snap in reversed(created_snaps):
+            try:
+                await context.call2(
+                    context.s.zfs.resource.snapshot.destroy_impl,
+                    ZFSResourceSnapshotDestroyQuery(path=snap),
+                )
+            except Exception:
+                context.logger.exception('clone rollback: failed to destroy snapshot %r', snap)
+        if new_vm is not None:
+            # Remove the partially-created VM: its datastore row, any device rows already
+            # created, and copied NVRAM/TPM state. zvols=False since the clone datasets are
+            # handled above; force=True skips the running-VM guard (it was never started).
+            try:
+                await context.call2(
+                    context.s.vm.delete, new_vm.id, VMDeleteOptions(zvols=False, force=True),
+                )
             except Exception:
                 context.logger.error(
-                    '%s: failed to clean up cloned NVRAM/TPM state after clone failure',
+                    '%s: clone rollback failed to remove partially-created VM record',
                     new_vm.name, exc_info=True,
                 )
-        raise e
+        raise
 
     context.logger.info('VM cloned from %r to %r', origin_name, clone_name)
     return True

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -249,6 +249,21 @@ class VMServicePart(CRUDServicePart[VMEntry]):
         vm = self.get_instance__sync(id_)
         audit_callback(vm.name)
 
+        if vm.status.state in ACTIVE_STATES and not data.force:
+            raise CallError(
+                f'{vm.name!r} is {vm.status.state.lower()}; stop the VM first or pass force to delete it.',
+                errno.EBUSY,
+            )
+
+        # Stop and undefine the domain before destroying any backing zvols so qemu
+        # releases the block devices first; destroying a zvol under a live domain
+        # risks guest corruption and fails with EBUSY.
+        pylibvirt_vm_obj = pylibvirt_vm(self, vm.model_dump(expose_secrets=True))
+        try:
+            self.middleware.libvirt_domains_manager.vms.delete(pylibvirt_vm_obj)
+        except DomainDoesNotExistError:
+            pass
+
         if data.zvols:
             disk_devices = self.call_sync2(
                 self.s.vm.device.query,
@@ -270,12 +285,6 @@ class VMServicePart(CRUDServicePart[VMEntry]):
                     self.logger.error(
                         'Failed to delete %r volume when removing %r VM', disk_name, vm.name, exc_info=True
                     )
-
-        pylibvirt_vm_obj = pylibvirt_vm(self, vm.model_dump(expose_secrets=True))
-        try:
-            self.middleware.libvirt_domains_manager.vms.delete(pylibvirt_vm_obj)
-        except DomainDoesNotExistError:
-            pass
 
         for device in vm.devices:
             self.call_sync2(self.s.vm.device.delete, device.id, VMDeviceDeleteOptions(force=False))

--- a/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
@@ -12,6 +12,7 @@ from middlewared.api.current import FilesystemStatData, VMDeviceConvert, VMDiskD
 from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.service import CallError, ServiceContext
 from middlewared.service_exception import InstanceNotFound, ValidationError
+from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -123,7 +124,7 @@ def validate_convert_disk_image(
     if not converting_from_image_to_zvol:
         sp = os.path.dirname(dip)
         try:
-            dst = context.middleware.call_sync('filesystem.stat', os.path.dirname(sp))
+            dst = context.middleware.call_sync('filesystem.stat', sp)
             if dst.type != 'DIRECTORY':
                 raise ValidationError(schema, f'{sp!r} is not a directory', errno.EINVAL)
 
@@ -167,10 +168,11 @@ def validate_convert_zvol(
         if vmzv and vmzv == ntp:
             try:
                 vm = context.call_sync2(context.s.vm.get_instance, device.vm)
-                if vm.status.state == 'RUNNING':
+                if vm.status.state in ACTIVE_STATES:
                     raise ValidationError(
                         schema,
-                        f'{vmzv!r} is part of running VM. {vm.name!r} must be stopped first',
+                        f'{vmzv!r} is attached to {vm.status.state.lower()} VM {vm.name!r}; '
+                        'it must be stopped first',
                         errno.EBUSY
                     )
             except InstanceNotFound:

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
@@ -1,0 +1,107 @@
+import errno
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from middlewared.api.current import VMDiskDevice
+from middlewared.plugins.vm import vm_device_convert
+from middlewared.plugins.vm.vm_device_convert import validate_convert_disk_image, validate_convert_zvol
+from middlewared.service import CallError
+from middlewared.service_exception import ValidationError
+
+SCHEMA = "vm.device.convert.destination"
+
+
+# validate_convert_disk_image checks the destination directory, not its parent
+
+
+def _disk_image_context(dip, sp, source):
+    """Mock context whose filesystem.stat/statfs answer only for `dip` and `sp`.
+
+    Any stat of a different path (e.g. the grandparent `/mnt`) trips an
+    AssertionError, which is exactly the off-by-one regression we are guarding.
+    """
+
+    def fake_call_sync(method, path):
+        if method == "filesystem.stat":
+            if path == dip:
+                # zvol -> image: the destination file need not exist yet.
+                raise CallError(f"{dip} does not exist", errno.ENOENT)
+            if path == sp:
+                return SimpleNamespace(type="DIRECTORY", realpath=sp, uid=0, gid=0)
+            raise AssertionError(f"unexpected filesystem.stat of {path!r}")
+        if method == "filesystem.statfs":
+            assert path == sp, f"statfs should target {sp!r}, got {path!r}"
+            return SimpleNamespace(source=source)
+        raise AssertionError(f"unexpected call {method!r}")
+
+    context = Mock()
+    context.middleware.call_sync = Mock(side_effect=fake_call_sync)
+    context.logger = Mock()
+    return context
+
+
+def test_zvol_to_image_pool_root_destination_is_allowed():
+    # /mnt/tank/foo.qcow2 must validate the pool dir /mnt/tank, not the boot-pool /mnt.
+    dip, sp = "/mnt/tank/foo.qcow2", "/mnt/tank"
+    context = _disk_image_context(dip, sp, source="tank")
+
+    assert validate_convert_disk_image(context, dip, SCHEMA, converting_from_image_to_zvol=False) is None
+
+    stat_paths = [c.args[1] for c in context.middleware.call_sync.call_args_list if c.args[0] == "filesystem.stat"]
+    assert sp in stat_paths
+    assert "/mnt" not in stat_paths  # the grandparent must never be checked
+
+
+def test_zvol_to_image_internal_dataset_destination_is_rejected():
+    # /mnt/tank/ix-apps/foo.qcow2 sits in an internal dataset and must be rejected,
+    # which the old grandparent check (statting /mnt/tank) would have missed.
+    dip, sp = "/mnt/tank/ix-apps/foo.qcow2", "/mnt/tank/ix-apps"
+    context = _disk_image_context(dip, sp, source="tank/ix-apps")
+
+    with pytest.raises(ValidationError) as exc:
+        validate_convert_disk_image(context, dip, SCHEMA, converting_from_image_to_zvol=False)
+    assert exc.value.errno == errno.EACCES
+
+
+# validate_convert_zvol blocks conversion of any active VM's zvol
+
+
+def _zvol_context(state):
+    zv = [{"type": "VOLUME", "name": "tank/foo", "properties": {"volsize": {"value": 1024**3}}}]
+    device = SimpleNamespace(attributes=VMDiskDevice(dtype="DISK", path="/dev/zvol/tank/foo"), vm=1)
+    vm = SimpleNamespace(name="myvm", status=SimpleNamespace(state=state))
+
+    context = Mock()
+
+    def fake_call_sync2(target, *args, **kwargs):
+        if target is context.s.zfs.resource.query_impl:
+            return zv
+        if target is context.s.vm.device.query:
+            return [device]
+        if target is context.s.vm.get_instance:
+            return vm
+        raise AssertionError(f"unexpected call_sync2 target: {target!r}")
+
+    context.call_sync2 = Mock(side_effect=fake_call_sync2)
+    context.logger = Mock()
+    return context
+
+
+@pytest.mark.parametrize("state", ["RUNNING", "SUSPENDED"])
+def test_convert_zvol_blocked_for_active_vm(state):
+    context = _zvol_context(state)
+    with patch.object(vm_device_convert.os.path, "exists", return_value=True):
+        with pytest.raises(ValidationError) as exc:
+            validate_convert_zvol(context, "/dev/zvol/tank/foo", SCHEMA)
+    assert exc.value.errno == errno.EBUSY
+    assert state.lower() in exc.value.errmsg
+
+
+def test_convert_zvol_allowed_for_stopped_vm():
+    context = _zvol_context("STOPPED")
+    with patch.object(vm_device_convert.os.path, "exists", return_value=True):
+        zv, ntp = validate_convert_zvol(context, "/dev/zvol/tank/foo", SCHEMA)
+    assert zv["type"] == "VOLUME"
+    assert ntp == "/dev/zvol/tank/foo"

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -234,7 +234,7 @@ def ubuntu_vm(image_info, options=None):
 
             yield {**vm, "ip": ip_address, "password": _vm_password}
         finally:
-            call("vm.delete", vm["id"])
+            call("vm.delete", vm["id"], {"force": True})
     finally:
         call("pool.dataset.delete", vm_dataset)
 


### PR DESCRIPTION
Deleting a VM with `zvols=true` tore down the backing zvols before stopping the domain, so ZFS could be pulled out from under a live qemu process — risking in-flight corruption and leaving zvols that fail to destroy with EBUSY. The `force` option also didn't really gate deleting a running VM despite what its description implied.

Reject deleting an active (running/suspended) VM unless `force` is set, and stop/undefine the domain before touching its zvols so the block devices are released first; the `force` field description now matches that behaviour. Picked up a few smaller VM-plugin tidy-ups along the way: clone rollback unwinds the snapshots/clones (and half-created VM record) it made if something fails partway, the disk-convert guard treats suspended VMs like running ones, and the convert path check looks at the real destination directory rather than its parent — with unit tests for the convert checks.