### PR TITLE
NAS-141839 / 26.0.0-RC.1 / Stop a VM before destroying its backing zvols on delete (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm.py
@@ -193,7 +193,12 @@ class VMUpdateResult(BaseModel):
 
 class VMDeleteOptions(BaseModel):
     zvols: bool = Field(default=False, description="Delete associated ZFS volumes when deleting the VM.")
-    force: bool = Field(default=False, description="Force deletion even if the VM is currently running.")
+    force: bool = Field(
+        default=False,
+        description="Delete a running or suspended VM by stopping it first. Without this, deleting an active VM is "
+                    "rejected. Also causes failures to destroy associated ZFS volumes to be logged and ignored rather "
+                    "than aborting the deletion."
+    )
 
 
 class VMDeleteArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -1,5 +1,4 @@
 import errno
-import itertools
 import re
 import uuid
 
@@ -12,7 +11,7 @@ from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.service import CallError, Service, private
 from middlewared.service_exception import ValidationErrors
 
-from .utils import copy_vm_state, delete_vm_state, vm_state_missing_sources
+from .utils import copy_vm_state, vm_state_missing_sources
 
 
 ZVOL_CLONE_SUFFIX = '_clone'
@@ -124,7 +123,6 @@ class VMService(Service):
         # In case we need to rollback
         created_snaps = []
         created_clones = []
-        state_copied = False
         new_vm = None
         try:
             new_vm = await self.middleware.call('vm.do_create', vm)
@@ -145,7 +143,6 @@ class VMService(Service):
                     f'Failed to copy VM state for {origin_name!r} -> {new_vm["name"]!r}: '
                     f'{oe.strerror or oe} (errno={oe.errno}).'
                 ) from oe
-            state_copied = True
 
             missing = await self.middleware.run_in_thread(
                 vm_state_missing_sources, origin_id, origin_name,
@@ -180,38 +177,38 @@ class VMService(Service):
                     continue
 
                 await self.middleware.call('vm.device.create', item)
-        except Exception as e:
-            for clone, snap in itertools.zip_longest(reversed(created_clones), reversed(created_snaps)):
-                # order is important here. the clone is dependent on snap so destroy
-                # the clone first before destroying the snap
-                if clone is not None:
-                    try:
-                        self.call_sync2(self.s.zfs.resource.destroy_impl, clone)
-                    except Exception:
-                        self.logger.exception('Failed to destroy cloned zvol %r', clone)
-                        # failing to destroy the clone means destroying the snap will
-                        # also fail since we're not recursively destroying anything
-                        continue
-                    else:
-                        if snap is not None:
-                            try:
-                                await self.call2(
-                                    self.s.zfs.resource.snapshot.destroy_impl,
-                                    ZFSResourceSnapshotDestroyQuery(path=snap),
-                                )
-                            except Exception:
-                                self.logger.exception('Failed to destroy snapshot %r for zvol %r', snap, clone)
-            if state_copied and new_vm is not None:
+        except Exception:
+            # Destroy clones before their origin snapshots: a clone pins the snapshot it
+            # was created from, so the snapshot can only be removed once every clone is gone.
+            # The two lists can differ in length if __clone_zvol failed between creating the
+            # snapshot and the clone, so unwinding them separately.
+            for clone in reversed(created_clones):
                 try:
-                    await self.middleware.run_in_thread(
-                        delete_vm_state, new_vm['id'], new_vm['name'],
+                    await self.call2(self.s.zfs.resource.destroy_impl, clone)
+                except Exception:
+                    self.logger.exception('clone rollback: failed to destroy cloned zvol %r', clone)
+            for snap in reversed(created_snaps):
+                try:
+                    await self.call2(
+                        self.s.zfs.resource.snapshot.destroy_impl,
+                        ZFSResourceSnapshotDestroyQuery(path=snap),
+                    )
+                except Exception:
+                    self.logger.exception('clone rollback: failed to destroy snapshot %r', snap)
+            if new_vm is not None:
+                # Remove the partially-created VM: its datastore row, any device rows already
+                # created, and copied NVRAM/TPM state. zvols=False since the clone datasets are
+                # handled above; force=True skips the running-VM guard (it was never started).
+                try:
+                    await self.middleware.call(
+                        'vm.delete', new_vm['id'], {'zvols': False, 'force': True},
                     )
                 except Exception:
                     self.logger.error(
-                        '%s: failed to clean up cloned NVRAM/TPM state after clone failure',
+                        '%s: clone rollback failed to remove partially-created VM record',
                         new_vm['name'], exc_info=True,
                     )
-            raise e
+            raise
 
         self.logger.info('VM cloned from %r to %r', origin_name, vm['name'])
         return True

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -34,6 +34,7 @@ from middlewared.service import CallError, CRUDService, job, private
 from middlewared.service_exception import InstanceNotFound, ValidationError
 from middlewared.utils.libvirt.device_factory import DeviceFactory
 from middlewared.utils.libvirt.mixin import DeviceMixin
+from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
 
 VALID_DISK_FORMATS = ('qcow2', 'qed', 'raw', 'vdi', 'vhdx', 'vmdk')
@@ -165,7 +166,7 @@ class VMDeviceService(CRUDService, DeviceMixin):
         if not converting_from_image_to_zvol:
             sp = os.path.dirname(dip)
             try:
-                dst = self.middleware.call_sync('filesystem.stat', os.path.dirname(sp))
+                dst = self.middleware.call_sync('filesystem.stat', sp)
                 if dst['type'] != 'DIRECTORY':
                     raise ValidationError(schema, f'{sp!r} is not a directory', errno.EINVAL)
 
@@ -205,10 +206,11 @@ class VMDeviceService(CRUDService, DeviceMixin):
             if vmzv and vmzv == ntp:
                 try:
                     vm = self.middleware.call_sync('vm.get_instance', i['vm'])
-                    if vm['status']['state'] == 'RUNNING':
+                    if vm['status']['state'] in ACTIVE_STATES:
                         raise ValidationError(
                             schema,
-                            f'{vmzv!r} is part of running VM. {vm["name"]!r} must be stopped first',
+                            f'{vmzv!r} is attached to {vm["status"]["state"].lower()} VM {vm["name"]!r}; '
+                            'it must be stopped first',
                             errno.EBUSY
                         )
                 except InstanceNotFound:

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -421,6 +421,21 @@ class VMService(CRUDService):
         audit_callback(vm['name'])
         force_delete = data.get('force')
 
+        if vm['status']['state'] in ACTIVE_STATES and not force_delete:
+            raise CallError(
+                f'{vm["name"]!r} is {vm["status"]["state"].lower()}; stop the VM first or pass force to delete it.',
+                errno.EBUSY,
+            )
+
+        # Stop and undefine the domain before destroying any backing zvols so qemu
+        # releases the block devices first; destroying a zvol under a live domain
+        # risks guest corruption and fails with EBUSY.
+        pylibvirt_vm = self.middleware.call_sync("vm.pylibvirt_vm", vm)
+        try:
+            self.middleware.libvirt_domains_manager.vms.delete(pylibvirt_vm)
+        except DomainDoesNotExistError:
+            pass
+
         if data['zvols']:
             devices = self.middleware.call_sync('vm.device.query', [
                 ('vm', '=', id_), ('attributes.dtype', '=', 'DISK')
@@ -440,12 +455,6 @@ class VMService(CRUDService):
                         self.logger.error(
                             'Failed to delete %r volume when removing %r VM', disk_name, vm['name'], exc_info=True
                         )
-
-        pylibvirt_vm = self.middleware.call_sync("vm.pylibvirt_vm", vm)
-        try:
-            self.middleware.libvirt_domains_manager.vms.delete(pylibvirt_vm)
-        except DomainDoesNotExistError:
-            pass
 
         # We remove vm devices first
         for device in vm['devices']:

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
@@ -1,0 +1,109 @@
+import errno
+from unittest.mock import Mock, patch
+
+import pytest
+
+from middlewared.plugins.vm import vm_devices
+from middlewared.plugins.vm.vm_devices import VMDeviceService
+from middlewared.service import CallError
+from middlewared.service_exception import ValidationError
+
+SCHEMA = "vm.device.convert.destination"
+
+
+# validate_convert_disk_image checks the destination directory, not its parent
+
+
+def _disk_image_service(dip, sp, source):
+    """Mock service whose filesystem.stat/statfs answer only for `dip` and `sp`.
+
+    Any stat of a different path (e.g. the grandparent `/mnt`) trips an
+    AssertionError, which is exactly the off-by-one regression we are guarding.
+    """
+
+    def fake_call_sync(method, path):
+        if method == "filesystem.stat":
+            if path == dip:
+                # zvol -> image: the destination file need not exist yet.
+                raise CallError(f"{dip} does not exist", errno.ENOENT)
+            if path == sp:
+                return {"type": "DIRECTORY", "realpath": sp, "uid": 0, "gid": 0}
+            raise AssertionError(f"unexpected filesystem.stat of {path!r}")
+        if method == "filesystem.statfs":
+            assert path == sp, f"statfs should target {sp!r}, got {path!r}"
+            return {"source": source}
+        raise AssertionError(f"unexpected call {method!r}")
+
+    svc = Mock()
+    svc.middleware.call_sync = Mock(side_effect=fake_call_sync)
+    svc.logger = Mock()
+    return svc
+
+
+def test_zvol_to_image_pool_root_destination_is_allowed():
+    # /mnt/tank/foo.qcow2 must validate the pool dir /mnt/tank, not the boot-pool /mnt.
+    dip, sp = "/mnt/tank/foo.qcow2", "/mnt/tank"
+    svc = _disk_image_service(dip, sp, source="tank")
+
+    assert VMDeviceService.validate_convert_disk_image(svc, dip, SCHEMA, converting_from_image_to_zvol=False) is None
+
+    stat_paths = [c.args[1] for c in svc.middleware.call_sync.call_args_list if c.args[0] == "filesystem.stat"]
+    assert sp in stat_paths
+    assert "/mnt" not in stat_paths  # the grandparent must never be checked
+
+
+def test_zvol_to_image_internal_dataset_destination_is_rejected():
+    # /mnt/tank/ix-apps/foo.qcow2 sits in an internal dataset and must be rejected,
+    # which the old grandparent check (statting /mnt/tank) would have missed.
+    dip, sp = "/mnt/tank/ix-apps/foo.qcow2", "/mnt/tank/ix-apps"
+    svc = _disk_image_service(dip, sp, source="tank/ix-apps")
+
+    with pytest.raises(ValidationError) as exc:
+        VMDeviceService.validate_convert_disk_image(svc, dip, SCHEMA, converting_from_image_to_zvol=False)
+    assert exc.value.errno == errno.EACCES
+
+
+# validate_convert_zvol blocks conversion of any active VM's zvol
+
+
+def _zvol_service(state):
+    zv = [{"type": "VOLUME", "name": "tank/foo", "properties": {"volsize": {"value": 1024**3}}}]
+    device = {"attributes": {"dtype": "DISK", "path": "/dev/zvol/tank/foo"}, "vm": 1}
+    vm = {"name": "myvm", "status": {"state": state}}
+
+    svc = Mock()
+
+    def fake_call_sync2(target, *args, **kwargs):
+        if target is svc.s.zfs.resource.query_impl:
+            return zv
+        raise AssertionError(f"unexpected call_sync2 target: {target!r}")
+
+    def fake_call_sync(method, *args, **kwargs):
+        if method == "vm.device.query":
+            return [device]
+        if method == "vm.get_instance":
+            return vm
+        raise AssertionError(f"unexpected call_sync {method!r}")
+
+    svc.call_sync2 = Mock(side_effect=fake_call_sync2)
+    svc.middleware.call_sync = Mock(side_effect=fake_call_sync)
+    svc.logger = Mock()
+    return svc
+
+
+@pytest.mark.parametrize("state", ["RUNNING", "SUSPENDED"])
+def test_convert_zvol_blocked_for_active_vm(state):
+    svc = _zvol_service(state)
+    with patch.object(vm_devices.os.path, "exists", return_value=True):
+        with pytest.raises(ValidationError) as exc:
+            VMDeviceService.validate_convert_zvol(svc, "/dev/zvol/tank/foo", SCHEMA)
+    assert exc.value.errno == errno.EBUSY
+    assert state.lower() in exc.value.errmsg
+
+
+def test_convert_zvol_allowed_for_stopped_vm():
+    svc = _zvol_service("STOPPED")
+    with patch.object(vm_devices.os.path, "exists", return_value=True):
+        zv, ntp = VMDeviceService.validate_convert_zvol(svc, "/dev/zvol/tank/foo", SCHEMA)
+    assert zv["type"] == "VOLUME"
+    assert ntp == "/dev/zvol/tank/foo"

--- a/tests/vm/test_vm.py
+++ b/tests/vm/test_vm.py
@@ -144,7 +144,7 @@ def ubuntu_vm(ubuntu_image_snapshot, options=None):
 
             yield {**vm, "ip": ip_address}
         finally:
-            call("vm.delete", vm["id"])
+            call("vm.delete", vm["id"], {"force": True})
     finally:
         call("pool.dataset.delete", dataset)
 


### PR DESCRIPTION
Deleting a VM with `zvols=true` tore down the backing zvols before stopping the domain, so ZFS could be pulled out from under a live qemu process — risking in-flight corruption and leaving zvols that fail to destroy with EBUSY. The `force` option also didn't really gate deleting a running VM despite what its description implied.

Reject deleting an active (running/suspended) VM unless `force` is set, and stop/undefine the domain before touching its zvols so the block devices are released first; the `force` field description now matches that behaviour. Picked up a few smaller VM-plugin tidy-ups along the way: clone rollback unwinds the snapshots/clones (and half-created VM record) it made if something fails partway, the disk-convert guard treats suspended VMs like running ones, and the convert path check looks at the real destination directory rather than its parent — with unit tests for the convert checks.

Original PR: https://github.com/truenas/middleware/pull/19346
