### PR TITLE
NAS-141844 / 27.0.0-BETA.1 / Accept a pydantic model or dict in pylibvirt_vm/pylibvirt_container

### DIFF
--- a/src/middlewared/middlewared/plugins/container/crud.py
+++ b/src/middlewared/middlewared/plugins/container/crud.py
@@ -97,21 +97,41 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
 
     def extend_context_sync(self, rows: list[dict[str, Any]], extra: dict[str, Any]) -> dict[str, Any]:
         return {
+            'devices': self.devices_by_container(rows),
             'states': gather_pylibvirt_domains_states(
                 self.middleware,
                 rows,
                 self.middleware.libvirt_domains_manager.containers_connection,
-                lambda container: pylibvirt_container(self, self.extend_container(container)),
+                lambda container: pylibvirt_container(self, self.state_entry(container)),
             ),
             'bridge_name': container_bridge_name(self),
         }
 
-    async def extend(self, data: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
-        devices = await self.call2(
+    def devices_by_container(self, rows: list[dict[str, Any]]) -> dict[int, list[Any]]:
+        devices_by_container: dict[int, list[Any]] = {}
+        if not rows:
+            return devices_by_container
+
+        for device in self.call_sync2(
             self.s.container.device.query,
-            [('container', '=', data['id'])],
+            [['container', 'in', [row['id'] for row in rows]]],
             QueryOptions(force_sql_filters=True),
-        )
+        ):
+            devices_by_container.setdefault(device.container, []).append(device)
+
+        return devices_by_container
+
+    def state_entry(self, row: dict[str, Any]) -> ContainerEntry:
+        # State gathering only reads the container's identity to find its libvirt domain, so
+        # the runtime-only fields are filled with placeholders just to satisfy the model.
+        return ContainerEntry(**{
+            **self.extend_container(dict(row)),
+            'devices': [],
+            'status': {'state': 'STOPPED', 'pid': None, 'domain_state': None},
+        })
+
+    async def extend(self, data: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+        devices = context['devices'].get(data['id'], [])
         has_nic = any(d.attributes.dtype == 'NIC' for d in devices)
 
         data.update({
@@ -257,7 +277,7 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
     def delete_container_from_db_and_libvirt(self, container: ContainerEntry) -> None:
-        pylibvirt_container_obj = pylibvirt_container(self, container.model_dump())
+        pylibvirt_container_obj = pylibvirt_container(self, container)
         try:
             self.middleware.libvirt_domains_manager.containers.delete(pylibvirt_container_obj)
         except DomainDoesNotExistError:

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -15,7 +15,7 @@ from truenas_pylibvirt import (
     Time,
 )
 
-from middlewared.api.current import ContainerStopOptions, QueryOptions, ZFSResourceQuery
+from middlewared.api.current import ContainerEntry, ContainerStopOptions, QueryOptions, ZFSResourceQuery
 from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID, IDMAP_COUNT
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.filesystem.perms import enforce_dir_perms
@@ -119,7 +119,7 @@ def start(context: ServiceContext, id_: int) -> None:
     container = context.run_coroutine(context.call2(context.s.container.get_instance, id_))
     configure_container_bridge(context)
 
-    pylibvirt_obj = pylibvirt_container(context, container.model_dump(), True)
+    pylibvirt_obj = pylibvirt_container(context, container, True)
 
     # Configure hostname files before start so init reads correct values
     try:
@@ -133,7 +133,7 @@ def start(context: ServiceContext, id_: int) -> None:
 
 def stop(context: ServiceContext, id_: int, options: ContainerStopOptions) -> None:
     container = context.run_coroutine(context.call2(context.s.container.get_instance, id_))
-    pylibvirt_container_obj = pylibvirt_container(context, container.model_dump())
+    pylibvirt_container_obj = pylibvirt_container(context, container)
     if options.force:
         context.middleware.libvirt_domains_manager.containers.destroy(pylibvirt_container_obj)
         return
@@ -147,17 +147,18 @@ def stop(context: ServiceContext, id_: int, options: ContainerStopOptions) -> No
 
 
 def pylibvirt_container(
-    context: ServiceContext, container: dict[str, typing.Any], check_ds: bool = False
+    context: ServiceContext, container: ContainerEntry, check_ds: bool = False
 ) -> ContainerDomain:
-    container = container.copy()
-    container.pop("id", None)
-    container.pop("status", None)
-    container.pop("autostart", None)
-    container.pop("default_network", None)
+    data = container.model_dump()
 
-    dataset = container.pop("dataset")
+    data.pop("id", None)
+    data.pop("status", None)
+    data.pop("autostart", None)
+    data.pop("default_network", None)
+
+    dataset = data.pop("dataset")
     pool = dataset.split("/")[0]
-    container["root"] = f"/mnt/{container_instance_dataset_mountpoint(pool, container['name'])}"
+    data["root"] = f"/mnt/{container_instance_dataset_mountpoint(pool, data['name'])}"
     if check_ds:
         datasets = context.call_sync2(
             context.s.zfs.resource.query_impl,
@@ -166,11 +167,11 @@ def pylibvirt_container(
         if not datasets:
             raise CallError(f"Dataset {dataset!r} not found", errno.ENOTDIR)
 
-    container["time"] = Time(container["time"])
+    data["time"] = Time(data["time"])
     device_factory = context.middleware.services.container.device.device_factory
     devices = []
     has_nic_device = False
-    for device in container.get("devices", []):
+    for device in data.get("devices", []):
         if device["attributes"]["dtype"] == "NIC":
             has_nic_device = True
 
@@ -189,26 +190,26 @@ def pylibvirt_container(
             )
         )
 
-    container["devices"] = devices
+    data["devices"] = devices
 
-    if container['idmap']:
-        match container['idmap']['type']:
+    if data['idmap']:
+        match data['idmap']['type']:
             case 'DEFAULT':
                 uid_items, gid_items = _build_default_idmap_items(context)
             case 'ISOLATED':
-                base_target = CONTAINER_ROOT_UID + container['idmap']['slice'] * IDMAP_COUNT
+                base_target = CONTAINER_ROOT_UID + data['idmap']['slice'] * IDMAP_COUNT
                 single = ContainerIdmapConfigurationItem(start=0, target=base_target, count=IDMAP_COUNT)
                 uid_items, gid_items = [single], [single]
             case _:
-                raise CallError(f"Unsupported idmap type {container['idmap']['type']!r}")
+                raise CallError(f"Unsupported idmap type {data['idmap']['type']!r}")
 
         try:
-            container['idmap'] = ContainerIdmapConfiguration(uid=uid_items, gid=gid_items)
+            data['idmap'] = ContainerIdmapConfiguration(uid=uid_items, gid=gid_items)
         except ValueError as e:
             raise CallError(f'Invalid idmap configuration: {e}')
 
-    if container["capabilities_policy"]:
-        container["capabilities_policy"] = ContainerCapabilitiesPolicy[container["capabilities_policy"]]
+    if data["capabilities_policy"]:
+        data["capabilities_policy"] = ContainerCapabilitiesPolicy[data["capabilities_policy"]]
 
     # For a privileged (no user namespace) container, "allow all" keeps every
     # capability in the bounding set but libvirt only widens the cgroup device
@@ -219,16 +220,16 @@ def pylibvirt_container(
     # skipped for user-namespaced containers, where the device ACL is not the
     # operative gate (the user namespace is) and the element would be a no-op.
     if (
-        container["capabilities_policy"] == ContainerCapabilitiesPolicy.ALLOW
-        and container["idmap"] is None
-        and "mknod" not in container["capabilities_state"]
+        data["capabilities_policy"] == ContainerCapabilitiesPolicy.ALLOW
+        and data["idmap"] is None
+        and "mknod" not in data["capabilities_state"]
     ):
-        container["capabilities_state"] = {**container["capabilities_state"], "mknod": True}
+        data["capabilities_state"] = {**data["capabilities_state"], "mknod": True}
 
     # We add this to configuration because for cpu related attrs, we need them if cpuset on
     # container is actually set
     # For memory, lxc does not respect it but libvirt requires it in the xml to be defined
-    container.update(
+    data.update(
         {
             "vcpus": None,
             "cores": None,
@@ -237,7 +238,7 @@ def pylibvirt_container(
         }
     )
 
-    return ContainerDomain(ContainerDomainConfiguration(**container))
+    return ContainerDomain(ContainerDomainConfiguration(**data))
 
 
 def _build_default_idmap_items(

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -99,18 +99,41 @@ class VMServicePart(CRUDServicePart[VMEntry]):
 
     def extend_context_sync(self, rows: list[dict[str, Any]], extra: dict[str, Any]) -> dict[str, Any]:
         return {
+            'devices': self.devices_by_vm(rows),
             'states': gather_pylibvirt_domains_states(
                 self.middleware,
                 rows,
                 self.middleware.libvirt_domains_manager.vms_connection,
-                lambda vm: pylibvirt_vm(self, vm),
+                lambda vm: pylibvirt_vm(self, self.state_entry(vm)),
             ),
         }
 
+    def devices_by_vm(self, rows: list[dict[str, Any]]) -> dict[int, list[Any]]:
+        devices_by_vm: dict[int, list[Any]] = {}
+        if not rows:
+            return devices_by_vm
+
+        for device in self.call_sync2(
+            self.s.vm.device.query,
+            [['vm', 'in', [row['id'] for row in rows]]],
+            QueryOptions(force_sql_filters=True),
+        ):
+            devices_by_vm.setdefault(device.vm, []).append(device)
+
+        return devices_by_vm
+
+    def state_entry(self, row: dict[str, Any]) -> VMEntry:
+        # State gathering only reads the VM's identity to find its libvirt domain, so the
+        # runtime-only fields are filled with placeholders just to satisfy the model.
+        return VMEntry(**{
+            **row,
+            'devices': [],
+            'display_available': False,
+            'status': {'state': 'STOPPED', 'pid': None, 'domain_state': None},
+        })
+
     async def extend(self, data: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
-        vm_devices = await self.call2(
-            self.s.vm.device.query, [['vm', '=', data['id']]], QueryOptions(force_sql_filters=True)
-        )
+        vm_devices = context['devices'].get(data['id'], [])
         data.update({
             'devices': vm_devices,
             'display_available': any(device.attributes.dtype == 'DISPLAY' for device in vm_devices),
@@ -258,7 +281,7 @@ class VMServicePart(CRUDServicePart[VMEntry]):
         # Stop and undefine the domain before destroying any backing zvols so qemu
         # releases the block devices first; destroying a zvol under a live domain
         # risks guest corruption and fails with EBUSY.
-        pylibvirt_vm_obj = pylibvirt_vm(self, vm.model_dump(expose_secrets=True))
+        pylibvirt_vm_obj = pylibvirt_vm(self, vm)
         try:
             self.middleware.libvirt_domains_manager.vms.delete(pylibvirt_vm_obj)
         except DomainDoesNotExistError:

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -6,7 +6,7 @@ import typing
 
 from truenas_pylibvirt import VmBootloader, VmCpuMode
 
-from middlewared.api.current import QueryOptions, VMStartOptions, VMStopOptions
+from middlewared.api.current import QueryOptions, VMEntry, VMStartOptions, VMStopOptions
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
@@ -40,7 +40,7 @@ def start_vm(context: ServiceContext, id_: int, options: VMStartOptions) -> None
 
     # Start the VM using pylibvirt
     context.middleware.libvirt_domains_manager.vms.start(
-        pylibvirt_vm(context, vm.model_dump(expose_secrets=True), options.model_dump())
+        pylibvirt_vm(context, vm, options)
     )
 
     # Reload HTTP service for display device changes
@@ -49,7 +49,7 @@ def start_vm(context: ServiceContext, id_: int, options: VMStartOptions) -> None
 
 def stop_vm(context: ServiceContext, id_: int, options: VMStopOptions) -> None:
     vm = context.call_sync2(context.s.vm.get_instance, id_)
-    libvirt_domain = pylibvirt_vm(context, vm.model_dump(expose_secrets=True))
+    libvirt_domain = pylibvirt_vm(context, vm)
     if options.force:
         context.middleware.libvirt_domains_manager.vms.destroy(libvirt_domain)
         return
@@ -65,21 +65,21 @@ def stop_vm(context: ServiceContext, id_: int, options: VMStopOptions) -> None:
 def poweroff_vm(context: ServiceContext, id_: int) -> None:
     vm = context.call_sync2(context.s.vm.get_instance, id_)
     context.middleware.libvirt_domains_manager.vms.destroy(
-        pylibvirt_vm(context, vm.model_dump(expose_secrets=True))
+        pylibvirt_vm(context, vm)
     )
 
 
 def suspend_vm(context: ServiceContext, id_: int) -> None:
     vm = context.call_sync2(context.s.vm.get_instance, id_)
     context.middleware.libvirt_domains_manager.vms.suspend(
-        pylibvirt_vm(context, vm.model_dump(expose_secrets=True))
+        pylibvirt_vm(context, vm)
     )
 
 
 def resume_vm(context: ServiceContext, id_: int) -> None:
     vm = context.call_sync2(context.s.vm.get_instance, id_)
     context.middleware.libvirt_domains_manager.vms.resume(
-        pylibvirt_vm(context, vm.model_dump(expose_secrets=True))
+        pylibvirt_vm(context, vm)
     )
 
 
@@ -94,27 +94,31 @@ def restart_vm(context: ServiceContext, id_: int) -> None:
 
 
 def pylibvirt_vm(
-    context: ServiceContext, vm: dict[str, typing.Any], start_config: dict[str, typing.Any] | None = None,
+    context: ServiceContext, vm: VMEntry, start_config: VMStartOptions | None = None,
 ) -> VmDomain:
-    vm = vm.copy()
-    vm.pop('display_available', None)
-    vm.pop('status', None)
-    vm.pop('autostart', None)
+    data = vm.model_dump(expose_secrets=True)
+    data.pop('display_available', None)
+    data.pop('status', None)
+    data.pop('autostart', None)
 
     device_factory = context.s.vm.device.device_factory
     devices = []
-    for device in sorted(vm.get('devices', []), key=lambda x: (x['order'], x['id'])):
+    for device in sorted(data.get('devices', []), key=lambda x: (x['order'], x['id'])):
         devices.append(device_factory.get_device(device))
 
-    vm.update({
-        'bootloader': VmBootloader(vm['bootloader']),
-        'cpu_mode': VmCpuMode(vm['cpu_mode']),
-        'nvram_path': os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(vm['id'], vm['name'])),
-        'tpm_path': os.path.join(SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name(vm['id'], vm['name'])),
+    data.update({
+        'bootloader': VmBootloader(data['bootloader']),
+        'cpu_mode': VmCpuMode(data['cpu_mode']),
+        'nvram_path': os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(data['id'], data['name'])),
+        'tpm_path': os.path.join(SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name(data['id'], data['name'])),
         'devices': devices,
     })
 
-    return VmDomain(VmDomainConfiguration(**vm), context.middleware, start_config)
+    return VmDomain(
+        VmDomainConfiguration(**data),
+        context.middleware,
+        start_config.model_dump() if start_config is not None else None,
+    )
 
 
 def resume_suspended_vms(context: ServiceContext, vm_ids: list[int]) -> None:


### PR DESCRIPTION
## Context
Every lifecycle and delete caller had to hand-dump its model before calling these helpers, and for VMs that dump had to pass `expose_secrets=True` or the display device's `Secret` password would be silently redacted and a broken domain shipped. Leaking that invariant to each call site was repetitive and easy to get wrong.

## Solution
`pylibvirt_vm` and `pylibvirt_container` now accept either a pydantic model or a dict and do the `model_dump` internally — VMs with `expose_secrets=True`, containers with a plain dump. Callers pass the model directly, so the secret-exposure rule lives in one place. The state-gathering factories in `extend_context_sync` keep passing their raw pre-extend rows through the dict branch, since no full model exists yet at that point.