### PR TITLE
NAS-141848 / 26.0.0-RC.1 / Handle type-safe snapshot-task attachments in pool export/import

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -108,7 +108,10 @@ class PoolService(Service):
                     await delegate.disable(attachments)
                     enable_on_import[delegate.name] = list(
                         set(enable_on_import.get(delegate.name, [])) |
-                        {attachment['id'] for attachment in attachments}
+                        {
+                            attachment['id'] if isinstance(attachment, dict) else attachment.id
+                            for attachment in attachments
+                        }
                     )
 
         if enable_on_import:

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -220,7 +220,10 @@ class PoolService(Service):
                 for delegate in await self.middleware.call('pool.dataset.get_attachment_delegates_for_start'):
                     if delegate.name == name:
                         attachments = await delegate.query(pool['path'], False)
-                        attachments = [attachment for attachment in attachments if attachment['id'] in ids]
+                        attachments = [
+                            attachment for attachment in attachments
+                            if (attachment['id'] if isinstance(attachment, dict) else attachment.id) in ids
+                        ]
                         if attachments:
                             await delegate.toggle(attachments, True)
             await self.call2(self.s.keyvalue.delete, key)


### PR DESCRIPTION
Non-cascade `pool.export` crashed with `'PeriodicSnapshotTaskQueryResultItem' object is not subscriptable`, aborting the export after it had already disabled the pool's shares/services and its snapshot tasks.

The export/import attachment loops iterate every delegate's `query()` results and subscript them as dicts (`attachment['id']`). [NAS-139294](https://ixsystems.atlassian.net/browse/NAS-139294) made `pool.snapshottask` return type-safe Pydantic models, so the snapshot-task delegate now yields model objects that aren't subscriptable. Guard both call sites (`pool_/export.py` and `pool_/import_pool.py`) to fall back to attribute access, matching the fix already on master in [#19278](https://github.com/truenas/middleware/pull/19278).
