### PR TITLE
NAS-141666 / 26.0.0-RC.1 / Relocate migrated container origins out of legacy .ix-virt

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -44,7 +44,7 @@ IdmapConfiguration = Annotated[
 
 
 class ContainerStatus(BaseModel):
-    state: Literal["RUNNING", "STOPPED"] = Field(description="Container state.")
+    state: Literal["RUNNING", "STOPPED", "SUSPENDED"] = Field(description="Container state.")
     pid: int | None = Field(
         description=(
             "Container host PID (if running). Informational only do not rely on this value to identify the container's "
@@ -163,8 +163,18 @@ class ContainerUpdateResult(BaseModel):
     result: ContainerEntry = Field(description="Updated container.")
 
 
+class ContainerDeleteOptions(BaseModel):
+    force: bool = Field(
+        default=False,
+        description="Force deletion even if the container is currently running by stopping it first.",
+    )
+
+
 class ContainerDeleteArgs(BaseModel):
     id: int = Field(description="Container ID.")
+    options: ContainerDeleteOptions = Field(
+        default=ContainerDeleteOptions(), description="Container deletion options."
+    )
 
 
 class ContainerDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -166,7 +166,9 @@ class ContainerUpdateResult(BaseModel):
 class ContainerDeleteOptions(BaseModel):
     force: bool = Field(
         default=False,
-        description="Force deletion even if the container is currently running by stopping it first.",
+        description=(
+            "Force deletion of a container that is not stopped (running or suspended) by stopping it first."
+        ),
     )
 
 

--- a/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
+++ b/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from middlewared.main import Middleware
+
+
+async def migrate(middleware: Middleware) -> None:
+    """Relocate migrated containers' origin images out of legacy ``.ix-virt``.
+
+    Systems that ran the incus->container migration before the origin-relocation
+    fix have containers under ``.truenas_containers`` whose ``origin`` snapshot
+    still lives inside ``.ix-virt``; deleting ``.ix-virt`` would cascade into
+    them and destroy them. Move each such origin image into the native images
+    tree so that dependency is severed.
+
+    Fresh upgraders have no ``container.container`` rows yet when this runs (the
+    incus migration fires later, on ``system.ready``), so this is a no-op for
+    them - they are handled inside the migration itself. Best-effort: any row
+    that cannot be repaired is logged and skipped.
+    """
+    for container in await middleware.call("datastore.query", "container.container"):
+        dataset = container["dataset"]
+        try:
+            status = await middleware.call("container.relocate_container_origin", dataset)
+        except Exception:
+            middleware.logger.error(
+                "Failed to relocate origin image for container %r (dataset %r)",
+                container["name"],
+                dataset,
+                exc_info=True,
+            )
+            continue
+
+        if status == "RELOCATED":
+            middleware.logger.info(
+                "Relocated origin image for container %r out of .ix-virt",
+                container["name"],
+            )

--- a/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
+++ b/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
@@ -8,20 +8,27 @@ if typing.TYPE_CHECKING:
 
 
 async def migrate(middleware: Middleware) -> None:
-    """Relocate migrated containers' origin images out of legacy ``.ix-virt``.
+    """Repair what an incus->container migration run on an older build left behind.
 
-    Systems that ran the incus->container migration before the origin-relocation
-    fix have containers under ``.truenas_containers`` whose ``origin`` snapshot
-    still lives inside ``.ix-virt``; deleting ``.ix-virt`` would cascade into
-    them and destroy them. Move each such origin image into the native images
-    tree so that dependency is severed.
+    Two things need fixing on those systems:
+
+    Containers under ``.truenas_containers`` whose ``origin`` snapshot still lives
+    inside ``.ix-virt``. Deleting ``.ix-virt`` would cascade into them and destroy
+    them, so each such origin image is moved into the native images tree.
+
+    The legacy parents' mountpoint. That migration gave ``.ix-virt`` and its
+    ``containers`` child an inherited mountpoint and never put it back, so the whole
+    legacy tree - children included, since they inherit it - stays mounted under
+    ``/mnt/<pool>/.ix-virt`` on every boot with nothing managing it.
 
     Fresh upgraders have no ``container.container`` rows yet when this runs (the
-    incus migration fires later, on ``system.ready``), so this is a no-op for
-    them - they are handled inside the migration itself. Best-effort: any row
-    that cannot be repaired is logged and skipped.
+    incus migration fires later, on ``system.ready``), so this is a no-op for them -
+    they are handled inside the migration itself. Best-effort throughout: nothing
+    here raises, so a system that cannot be repaired is left as it was rather than
+    having the migration re-run on every subsequent boot.
     """
-    for container in await middleware.call("datastore.query", "container.container"):
+    containers = await middleware.call("datastore.query", "container.container")
+    for container in containers:
         dataset = container["dataset"]
         try:
             status = await middleware.call("container.relocate_container_origin", dataset)
@@ -39,3 +46,18 @@ async def migrate(middleware: Middleware) -> None:
                 "Relocated origin image for container %r out of .ix-virt",
                 container["name"],
             )
+        elif status != "ALREADY_SATISFIED":
+            middleware.logger.warning(
+                "Could not relocate origin image for container %r (dataset %r): %s",
+                container["name"],
+                dataset,
+                status,
+            )
+
+    for pool in sorted({container["dataset"].split("/")[0] for container in containers}):
+        # Skipped when the pool is not imported or the legacy tree is already gone,
+        # so this does not log a failure for every dataset it cannot reach.
+        if not await middleware.call("zfs.resource.query", {"paths": [f"{pool}/.ix-virt"], "properties": None}):
+            continue
+
+        await middleware.call("container.restore_legacy_parent_mountpoints", pool)

--- a/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
+++ b/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import typing
 
+from middlewared.api.current import ZFSResourceQuery
+
 
 if typing.TYPE_CHECKING:
     from middlewared.main import Middleware
@@ -23,10 +25,16 @@ async def migrate(middleware: Middleware) -> None:
 
     Fresh upgraders have no ``container.container`` rows yet when this runs (the
     incus migration fires later, on ``system.ready``), so this is a no-op for them -
-    they are handled inside the migration itself. Best-effort throughout: nothing
-    here raises, so a system that cannot be repaired is left as it was rather than
-    having the migration re-run on every subsequent boot.
+    they are handled inside the migration itself. Best-effort throughout: a row that
+    cannot be repaired is logged and skipped rather than failing the migration.
     """
+    if await middleware.call("system.is_ha_capable"):
+        # Gated on the hardware rather than the HA license, so this never runs on a
+        # controller that can be paired. A licensed system has nothing to repair in any
+        # case: the incus migration hangs off `system.ready`, which HA ignores, so it
+        # never ran there, and its pools are not imported yet when migrations do.
+        return
+
     containers = await middleware.call("datastore.query", "container.container")
     for container in containers:
         dataset = container["dataset"]
@@ -57,7 +65,10 @@ async def migrate(middleware: Middleware) -> None:
     for pool in sorted({container["dataset"].split("/")[0] for container in containers}):
         # Skipped when the pool is not imported or the legacy tree is already gone,
         # so this does not log a failure for every dataset it cannot reach.
-        if not await middleware.call("zfs.resource.query", {"paths": [f"{pool}/.ix-virt"], "properties": None}):
+        if not await middleware.call2(
+            middleware.services.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[f"{pool}/.ix-virt"], properties=None),
+        ):
             continue
 
         await middleware.call("container.restore_legacy_parent_mountpoints", pool)

--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -106,7 +106,8 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
         for attachment in attachments:
             try:
                 container = await self.middleware.call('container.get_instance', attachment['id'])
-                await self.middleware.call('container.delete_container_from_db_and_libvirt', container)
+                await self.middleware.call('container.delete_container_from_libvirt', container)
+                await self.middleware.call('container.delete_container_from_db', container)
             except Exception:
                 self.logger.warning('Unable to delete %r container', attachment['id'])
         else:

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -369,9 +369,10 @@ class ContainerService(CRUDService):
                     f'Container {container["name"]!r} is {container["status"]["state"].lower()}. Stop it first, '
                     f'or pass force=True to stop and delete it.'
                 )
-            self.middleware.call_sync('container.stop', id_, {'force': True}).wait_sync(raise_error=True)
 
-        # Destroy the dataset first and only remove the DB/libvirt records once it is
+        self.delete_container_from_libvirt(container)
+
+        # Destroy the dataset first and only remove the DB records once it is
         # actually gone, so a failed destroy never orphans the dataset with no
         # container row pointing at it. recursive=True mirrors the apps stack so a
         # container that has snapshots can still be removed - note it also takes
@@ -388,17 +389,19 @@ class ContainerService(CRUDService):
         if failed is not None:
             raise CallError(f'Failed to delete container {container["name"]!r} dataset: {failed}')
 
-        self.delete_container_from_db_and_libvirt(container)
+        self.delete_container_from_db(container)
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
     @private
-    def delete_container_from_db_and_libvirt(self, container):
+    def delete_container_from_libvirt(self, container):
         pylibvirt_container = self.middleware.call_sync("container.pylibvirt_container", container)
         try:
             self.middleware.libvirt_domains_manager.containers.delete(pylibvirt_container)
         except DomainDoesNotExistError:
             pass
 
+    @private
+    def delete_container_from_db(self, container):
         for device in container['devices']:
             self.middleware.call_sync('datastore.delete', 'container.device', device['id'])
 

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -374,8 +374,9 @@ class ContainerService(CRUDService):
         # Destroy the dataset first and only remove the DB/libvirt records once it is
         # actually gone, so a failed destroy never orphans the dataset with no
         # container row pointing at it. recursive=True mirrors the apps stack so a
-        # container that has snapshots can still be removed; bypass=True because the
-        # dataset lives under the now delete-guarded .truenas_containers.
+        # container that has snapshots can still be removed - note it also takes
+        # anything cloned from those snapshots; bypass=True because the dataset lives
+        # under the now delete-guarded .truenas_containers.
         try:
             failed = self.call_sync2(
                 self.s.zfs.resource.destroy_impl, container['dataset'], recursive=True, bypass=True,

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -380,7 +380,7 @@ class ContainerService(CRUDService):
         # under the now delete-guarded .truenas_containers.
         try:
             failed = self.call_sync2(
-                self.s.zfs.resource.destroy_impl, container['dataset'], recursive=True, bypass=True,
+                self.s.zfs.resource.destroy_impl, container['dataset'], bypass=True,
             )[0]
         except ZFSPathNotFoundException:
             # Dataset already gone (e.g. a victim of a legacy .ix-virt deletion);

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -17,8 +17,10 @@ from middlewared.api.current import (
     ContainerDeleteArgs, ContainerDeleteResult,
     ContainerPoolChoicesArgs, ContainerPoolChoicesResult,
     ZFSResourceQuery,
+    ZFSResourceSnapshotCloneQuery,
     ZFSResourceSnapshotDestroyQuery,
 )
+from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
 from middlewared.plugins.zfs.utils import get_encryption_info
 from middlewared.pylibvirt import gather_pylibvirt_domains_states, get_pylibvirt_domain_state
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
@@ -259,10 +261,18 @@ class ContainerService(CRUDService):
         # Populate dataset
         if pool == image_snapshot.split('@')[0].split('/')[0]:  # noqa
             # The container is in the same pool as images. We can just clone the image.
-            await self.middleware.call("pool.snapshot.clone", {
-                "snapshot": image_snapshot,  # noqa
-                "dataset_dst": data['dataset']
-            })
+            # Both the image snapshot and the destination live under
+            # .truenas_containers, which is an internal (delete-guarded) path, and
+            # pool.snapshot.clone has no bypass passthrough - so clone directly.
+            await self.call2(
+                self.s.zfs.resource.snapshot.clone_impl,
+                ZFSResourceSnapshotCloneQuery(
+                    snapshot=image_snapshot,  # noqa
+                    dataset=data['dataset'],
+                    bypass=True,
+                ),
+            )
+            await self.call2(self.s.zfs.resource.mount, data['dataset'])
         else:
             # The container is on the different pool. Let's replicate the image.
             source_dataset, source_snapshot = image_snapshot.split('@', 1)  # noqa
@@ -281,7 +291,7 @@ class ContainerService(CRUDService):
             ))
             await self.call2(
                 self.s.zfs.resource.snapshot.destroy_impl,
-                ZFSResourceSnapshotDestroyQuery(path=f'{data["dataset"]}@{source_snapshot}'),
+                ZFSResourceSnapshotDestroyQuery(path=f'{data["dataset"]}@{source_snapshot}', bypass=True),
             )
 
         return await self.create_with_dataset(data)
@@ -320,7 +330,7 @@ class ContainerService(CRUDService):
 
         name_changed = old['name'] != new['name']
         if name_changed:
-            if old['status']['state'] == 'RUNNING':
+            if old['status']['state'] != 'STOPPED':
                 raise CallError('Container must be stopped before renaming.')
 
             old_dataset = old['dataset']
@@ -345,14 +355,39 @@ class ContainerService(CRUDService):
         audit='Container delete',
         audit_callback=True,
     )
-    def do_delete(self, audit_callback, id_):
+    @job(lock=lambda args: f'container_delete:{args[0]}')
+    def do_delete(self, job, audit_callback, id_, options):
         """
         Delete a Container.
         """
         container = self.middleware.call_sync("container.get_instance", id_)
         audit_callback(container['name'])
+
+        if container['status']['state'] != 'STOPPED':
+            if not options['force']:
+                raise CallError(
+                    f'Container {container["name"]!r} is {container["status"]["state"].lower()}. Stop it first, '
+                    f'or pass force=True to stop and delete it.'
+                )
+            self.middleware.call_sync('container.stop', id_, {'force': True}).wait_sync(raise_error=True)
+
+        # Destroy the dataset first and only remove the DB/libvirt records once it is
+        # actually gone, so a failed destroy never orphans the dataset with no
+        # container row pointing at it. recursive=True mirrors the apps stack so a
+        # container that has snapshots can still be removed; bypass=True because the
+        # dataset lives under the now delete-guarded .truenas_containers.
+        try:
+            failed = self.call_sync2(
+                self.s.zfs.resource.destroy_impl, container['dataset'], recursive=True, bypass=True,
+            )[0]
+        except ZFSPathNotFoundException:
+            # Dataset already gone (e.g. a victim of a legacy .ix-virt deletion);
+            # fall through to clean up the now-dangling records.
+            failed = None
+        if failed is not None:
+            raise CallError(f'Failed to delete container {container["name"]!r} dataset: {failed}')
+
         self.delete_container_from_db_and_libvirt(container)
-        self.call_sync2(self.s.zfs.resource.destroy_impl, container['dataset'])
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
     @private

--- a/src/middlewared/middlewared/plugins/container/image.py
+++ b/src/middlewared/middlewared/plugins/container/image.py
@@ -69,7 +69,7 @@ class ContainerImageService(Service):
                 # Orphan dataset without a snapshot. Probably leftover from a
                 # previous `pull` attempt that failed and did not clean up
                 # properly. Delete it.
-                self.call_sync2(self.s.zfs.resource.destroy_impl, dataset_name)
+                self.call_sync2(self.s.zfs.resource.destroy_impl, dataset_name, bypass=True)
             else:
                 # Image dataset already exists, no action needed.
                 return snapshot_name
@@ -142,7 +142,8 @@ class ContainerImageService(Service):
                 job.set_progress(98, 'Creating ZFS snapshot...')
                 self.call_sync2(self.s.zfs.resource.snapshot.create_impl, ZFSResourceSnapshotCreateQuery(
                     dataset=dataset_name,
-                    name='image'
+                    name='image',
+                    bypass=True,
                 ))
 
                 job.set_progress(100, 'Image pull completed successfully')
@@ -152,7 +153,7 @@ class ContainerImageService(Service):
             except (tarfile.TarError, OSError) as e:
                 raise CallError(f'Failed to extract image tarball: {str(e)}')
         except Exception:
-            self.call_sync2(self.s.zfs.resource.destroy_impl, dataset_name)
+            self.call_sync2(self.s.zfs.resource.destroy_impl, dataset_name, bypass=True)
             raise
 
 

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -90,6 +90,17 @@ async def _stop_one_container(middleware, container):
 class ContainerService(Service):
 
     @private
+    async def migrate_and_start_on_boot(self):
+        """Bring containers up on boot, migrating any legacy incus ones first.
+
+        Shared by the ``system.ready`` path and the failover path so the ordering
+        lives in one place: HA systems ignore ``system.ready`` and would otherwise
+        start containers without ever migrating them.
+        """
+        await self.middleware.call('container.maybe_migrate_legacy')
+        await self.middleware.call('container.start_on_boot')
+
+    @private
     async def start_on_boot(self):
         # Reap orphaned runtime state under /run/truenas_containers/ before any
         # autostart so a fresh start can't collide with a leaked staged path
@@ -331,11 +342,6 @@ def _build_idmap_items(passthroughs):
     return items
 
 
-async def __migrate_and_start(middleware):
-    await middleware.call('container.maybe_migrate_legacy')
-    await middleware.call('container.start_on_boot')
-
-
 async def __event_system_ready(middleware, event_type, args):
     # we ignore the 'ready' event on an HA system since the failover event plugin
     # is responsible for starting this service, however, the containers still need to be
@@ -343,7 +349,7 @@ async def __event_system_ready(middleware, event_type, args):
     if await middleware.call('failover.licensed'):
         return
 
-    middleware.create_task(__migrate_and_start(middleware))
+    middleware.create_task(middleware.call('container.migrate_and_start_on_boot'))
 
 
 async def __event_system_shutdown(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -211,7 +211,16 @@ class ContainerService(Service):
             container["name"]: container for container in await self.middleware.call("container.query")
         }
         for storage_pool in storage_pools:
-            await self.middleware.call("container.migrate_specific_pool", job, storage_pool, existing_containers)
+            # One unusable pool must not stop the pools that come after it.
+            try:
+                await self.middleware.call(
+                    "container.migrate_specific_pool", job, storage_pool, existing_containers
+                )
+            except Exception as e:
+                self.logger.error("Unable to migrate containers on pool %r", storage_pool, exc_info=True)
+                await job.logs_fd_write(
+                    f"Unable to migrate containers on pool {storage_pool!r}: {e!r}.\n".encode()
+                )
 
     @private
     def migrate_specific_pool(self, job, pool, existing_containers):

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -338,6 +338,7 @@ class ContainerService(Service):
                         'cpuset': config.get('limits.cpu', None),
                     },
                 )
+                existing_containers[name] = container_instance
                 self.middleware.call_sync(
                     "container.migrate_devices", job, manifest["container"], container_instance
                 )

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -243,6 +243,18 @@ class ContainerService(Service):
                         )
                     processed_parents_mountpoints = True
 
+                # Relocate this container's origin image out of .ix-virt BEFORE
+                # renaming the container into .truenas_containers, so a later
+                # deletion of .ix-virt cannot cascade into the migrated container.
+                # On failure, skip the container so it stays wholly in .ix-virt.
+                relocate_status = self.relocate_container_origin(dataset["name"])
+                if relocate_status in ("FAILED", "ABSENT"):
+                    job.logs_fd.write((
+                        f"Skipping container {name!r}: could not relocate its base image out of "
+                        f".ix-virt.\n"
+                    ).encode())
+                    continue
+
                 self.middleware.call_sync(
                     "pool.dataset.update_impl",
                     UpdateImplArgs(
@@ -296,3 +308,94 @@ class ContainerService(Service):
                 job.logs_fd.write(f"Unable to migrate container {name!r}: {e!r}.\n".encode())
             else:
                 job.logs_fd.write(f"Successfully migrated container {name!r}.\n".encode())
+
+    @private
+    def relocate_container_origin(self, container_ds):
+        """Relocate a migrated container's origin image out of legacy ``.ix-virt``.
+
+        A migrated container is a ZFS clone whose ``origin`` snapshot may still
+        live inside ``<pool>/.ix-virt``. A recursive destroy of ``.ix-virt``
+        cascades into dependent clones regardless of where they live, so such a
+        container is destroyed if the user later deletes ``.ix-virt``. This moves
+        the origin image dataset into the native ``<pool>/.truenas_containers/images``
+        tree so the container no longer depends on anything under ``.ix-virt``.
+
+        Best-effort. Returns one of:
+          - ``RELOCATED``: the origin image was moved.
+          - ``ALREADY_SATISFIED``: not a clone, or the origin already lives
+            outside ``.ix-virt`` (a fan-out sibling or earlier run moved it);
+            the caller may proceed.
+          - ``FAILED``: could not relocate; the caller should skip the container
+            so it stays wholly inside ``.ix-virt``.
+          - ``ABSENT``: the container dataset (or its pool) is not present.
+        """
+        try:
+            resources = self.call_sync2(
+                self.s.zfs.resource.query_impl,
+                ZFSResourceQuery(paths=[container_ds], properties=["origin"]),
+            )
+        except Exception:
+            self.logger.error("%s: failed to read origin", container_ds, exc_info=True)
+            return "FAILED"
+
+        if not resources:
+            return "ABSENT"
+
+        origin = resources[0]["properties"]["origin"]["value"]
+        if origin in (None, "", "none"):
+            return "ALREADY_SATISFIED"
+
+        origin_dataset = origin.split("@")[0]
+        pool = origin_dataset.split("/")[0]
+        ix_virt = f"{pool}/.ix-virt/"
+        if not origin_dataset.startswith(ix_virt):
+            # Already relocated (fan-out sibling / prior run) or never in .ix-virt.
+            return "ALREADY_SATISFIED"
+
+        if not (
+            origin_dataset.startswith(f"{ix_virt}images/")
+            or origin_dataset.startswith(f"{ix_virt}deleted/images/")
+        ):
+            # Via the supported API a container origin is always an image
+            # snapshot. Anything else under .ix-virt is only reachable through
+            # the raw incus CLI, which we make no promises about.
+            self.logger.warning(
+                "%s: origin %r is under .ix-virt but is not an image dataset; skipping relocation",
+                container_ds, origin_dataset,
+            )
+            return "FAILED"
+
+        self.middleware.call_sync("container.ensure_datasets", pool)
+
+        fingerprint = origin_dataset.rsplit("/", 1)[1]
+        target = os.path.join(container_dataset(pool), f"images/{fingerprint}")
+
+        # EEXIST-tolerance: the same fingerprint can, in crash/manual states,
+        # exist under both images/ and deleted/images/. Same fingerprint means
+        # identical content, so an extra copy is only redundant disk - pick a
+        # free name rather than failing.
+        final_target = target
+        attempt = 0
+        while self.call_sync2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[final_target], properties=None),
+        ):
+            attempt += 1
+            final_target = f"{target}-migrated-{attempt}"
+
+        # canmount is set before the rename so the atomic rename is the last step:
+        # either the image is still wholly in .ix-virt, or it is fully relocated.
+        try:
+            self.middleware.call_sync(
+                "pool.dataset.update_impl",
+                UpdateImplArgs(name=origin_dataset, zprops={"canmount": "noauto"}),
+            )
+            self.call_sync2(self.s.zfs.resource.rename, origin_dataset, final_target)
+        except Exception:
+            self.logger.error(
+                "%s: failed to relocate origin image %r out of .ix-virt",
+                container_ds, origin_dataset, exc_info=True,
+            )
+            return "FAILED"
+
+        return "RELOCATED"

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -261,6 +261,11 @@ class ContainerService(Service):
             container_instance = None
             try:
                 if not processed_parents_mountpoints:
+                    # Armed before the properties are touched, for the same reason the
+                    # per-container revert is: this flag also decides whether the parents
+                    # get restored at the end, and the first of the two can be applied
+                    # before the second one fails.
+                    processed_parents_mountpoints = True
                     for ds in (f"{pool}/.ix-virt", f"{pool}/.ix-virt/containers"):
                         self.middleware.call_sync(
                             "pool.dataset.update_impl",
@@ -270,7 +275,6 @@ class ContainerService(Service):
                                 iprops={"mountpoint"}
                             )
                         )
-                    processed_parents_mountpoints = True
 
                 # Armed before the properties are touched: a partial apply has to be
                 # reverted too, and update_impl can fail between the two of them.

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -142,6 +142,20 @@ class ContainerService(Service):
             return
 
         legacy_config = legacy_config[0]
+        if await self.middleware.call("system.is_ha_capable"):
+            # Legacy containers were never migrated on a controller that can be paired, so
+            # there is no established path here and no reason to take the risk of inventing
+            # one during a failover event. The pool is cleared so this is not reconsidered
+            # on every boot; nothing on disk is touched, the legacy datasets stay as they
+            # are under `.ix-virt` if some user somehow was still using it.
+            self.logger.warning(
+                "Legacy virt pool was found set but this system is HA capable; migration skipped."
+            )
+            await self.middleware.call(
+                "datastore.update", "virt.global", legacy_config["id"], {"pool": None},
+            )
+            return
+
         if not await self.middleware.call("container.license_active"):
             # Returning before virt_global.pool is cleared leaves the legacy
             # configuration intact, so the migration runs on a later boot once

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -257,6 +257,8 @@ class ContainerService(Service):
 
             dst_dataset = os.path.join(container_dataset(pool), f"containers/{name}")
             needs_mount_revert = False
+            renamed = False
+            container_instance = None
             try:
                 if not processed_parents_mountpoints:
                     for ds in (f"{pool}/.ix-virt", f"{pool}/.ix-virt/containers"):
@@ -324,6 +326,7 @@ class ContainerService(Service):
                 # From here on the dataset lives in its native location, where the mount
                 # properties set above are the correct ones to keep.
                 needs_mount_revert = False
+                renamed = True
 
                 container_instance = self.middleware.call_sync(
                     "container.create_with_dataset",
@@ -339,6 +342,21 @@ class ContainerService(Service):
                     "container.migrate_devices", job, manifest["container"], container_instance
                 )
             except Exception as e:
+                if renamed and container_instance is None:
+                    # The dataset was moved but no container row was created. Left there it
+                    # is invisible: the migration only ever looks under .ix-virt, and the
+                    # native tree is hidden from dataset queries and refuses deletion. Move
+                    # it back so it stays something the user can see and act on.
+                    try:
+                        self.call_sync2(self.s.zfs.resource.rename, dst_dataset, dataset["name"])
+                    except Exception:
+                        self.logger.error(
+                            "%s: failed to move back after an incomplete migration", dst_dataset,
+                            exc_info=True,
+                        )
+                    else:
+                        needs_mount_revert = True
+
                 self.logger.error("Unable to migrate container %r", name, exc_info=True)
                 job.logs_fd.write(f"Unable to migrate container {name!r}: {e!r}.\n".encode())
             else:

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -270,6 +270,9 @@ class ContainerService(Service):
                         )
                     processed_parents_mountpoints = True
 
+                # Armed before the properties are touched: a partial apply has to be
+                # reverted too, and update_impl can fail between the two of them.
+                needs_mount_revert = True
                 self.middleware.call_sync(
                     "pool.dataset.update_impl",
                     UpdateImplArgs(
@@ -279,7 +282,6 @@ class ContainerService(Service):
                     )
                 )
                 self.call_sync2(self.s.zfs.resource.mount, dataset["name"])
-                needs_mount_revert = True
 
                 try:
                     with open(f"/mnt/{dataset['name']}/backup.yaml") as f:

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -230,6 +230,7 @@ class ContainerService(Service):
                 continue
 
             dst_dataset = os.path.join(container_dataset(pool), f"containers/{name}")
+            needs_mount_revert = False
             try:
                 if not processed_parents_mountpoints:
                     for ds in (f"{pool}/.ix-virt", f"{pool}/.ix-virt/containers"):
@@ -243,18 +244,6 @@ class ContainerService(Service):
                         )
                     processed_parents_mountpoints = True
 
-                # Relocate this container's origin image out of .ix-virt BEFORE
-                # renaming the container into .truenas_containers, so a later
-                # deletion of .ix-virt cannot cascade into the migrated container.
-                # On failure, skip the container so it stays wholly in .ix-virt.
-                relocate_status = self.relocate_container_origin(dataset["name"])
-                if relocate_status in ("FAILED", "ABSENT"):
-                    job.logs_fd.write((
-                        f"Skipping container {name!r}: could not relocate its base image out of "
-                        f".ix-virt.\n"
-                    ).encode())
-                    continue
-
                 self.middleware.call_sync(
                     "pool.dataset.update_impl",
                     UpdateImplArgs(
@@ -264,6 +253,7 @@ class ContainerService(Service):
                     )
                 )
                 self.call_sync2(self.s.zfs.resource.mount, dataset["name"])
+                needs_mount_revert = True
 
                 try:
                     with open(f"/mnt/{dataset['name']}/backup.yaml") as f:
@@ -272,6 +262,20 @@ class ContainerService(Service):
                     job.logs_fd.write(
                         f"Failed to read backup.yaml for container {name!r}, skipping.\n".encode()
                     )
+                    continue
+
+                # Relocate the origin image out of .ix-virt before renaming the container
+                # into .truenas_containers, so a later deletion of .ix-virt cannot cascade
+                # into the migrated container. This runs only once the dataset is known to
+                # be a real container: an image kept alive solely by a leftover clone that
+                # is not one stays inside .ix-virt and is reclaimed along with it.
+                if self.relocate_container_origin(dataset["name"]) in ("FAILED", "ABSENT"):
+                    # Skip it. Migrating a container whose origin is still inside .ix-virt
+                    # would produce something that looks healthy right up until .ix-virt is
+                    # deleted and takes it with it; leaving it untouched keeps it whole.
+                    job.logs_fd.write((
+                        f"Skipping container {name!r}: could not relocate its base image out of .ix-virt.\n"
+                    ).encode())
                     continue
 
                 config = manifest["container"]["config"]
@@ -289,6 +293,9 @@ class ContainerService(Service):
                 os.rmdir(rootfs_path)
 
                 self.call_sync2(self.s.zfs.resource.rename, dataset["name"], dst_dataset)
+                # From here on the dataset lives in its native location, where the mount
+                # properties set above are the correct ones to keep.
+                needs_mount_revert = False
 
                 container_instance = self.middleware.call_sync(
                     "container.create_with_dataset",
@@ -308,6 +315,40 @@ class ContainerService(Service):
                 job.logs_fd.write(f"Unable to migrate container {name!r}: {e!r}.\n".encode())
             else:
                 job.logs_fd.write(f"Successfully migrated container {name!r}.\n".encode())
+            finally:
+                if needs_mount_revert:
+                    self.revert_incus_mount_properties(dataset["name"])
+
+    @private
+    def revert_incus_mount_properties(self, container_ds):
+        """Restore the mount properties incus set on a container dataset that stays put.
+
+        Inspecting a legacy container means mounting it, which means replacing the
+        ``canmount=noauto``/``mountpoint=legacy`` pair incus relies on with a real
+        mountpoint. A container that is not migrated must not keep that: it would be
+        left mounted under ``/mnt/<pool>/.ix-virt`` and remounted on every boot, with
+        nothing left on the system that manages it.
+        """
+        try:
+            self.call_sync2(self.s.zfs.resource.unmount, container_ds)
+        except Exception:
+            self.logger.warning(
+                "%s: failed to unmount after skipping migration", container_ds, exc_info=True,
+            )
+
+        try:
+            self.middleware.call_sync(
+                "pool.dataset.update_impl",
+                UpdateImplArgs(
+                    name=container_ds,
+                    zprops={"canmount": "noauto", "mountpoint": "legacy"},
+                ),
+            )
+        except Exception:
+            self.logger.warning(
+                "%s: failed to restore mount properties after skipping migration",
+                container_ds, exc_info=True,
+            )
 
     @private
     def relocate_container_origin(self, container_ds):
@@ -325,8 +366,8 @@ class ContainerService(Service):
           - ``ALREADY_SATISFIED``: not a clone, or the origin already lives
             outside ``.ix-virt`` (a fan-out sibling or earlier run moved it);
             the caller may proceed.
-          - ``FAILED``: could not relocate; the caller should skip the container
-            so it stays wholly inside ``.ix-virt``.
+          - ``FAILED``: could not relocate; the container still depends on
+            something inside ``.ix-virt``.
           - ``ABSENT``: the container dataset (or its pool) is not present.
         """
         try:

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -367,7 +367,8 @@ class ContainerService(Service):
             outside ``.ix-virt`` (a fan-out sibling or earlier run moved it);
             the caller may proceed.
           - ``FAILED``: could not relocate; the container still depends on
-            something inside ``.ix-virt``.
+            something inside ``.ix-virt``, or it is a clone of another
+            container rather than of an image.
           - ``ABSENT``: the container dataset (or its pool) is not present.
         """
         try:
@@ -389,6 +390,20 @@ class ContainerService(Service):
         origin_dataset = origin.split("@")[0]
         pool = origin_dataset.split("/")[0]
         ix_virt = f"{pool}/.ix-virt/"
+        if any(
+            origin_dataset.startswith(f"{prefix}containers/")
+            for prefix in (ix_virt, f"{container_dataset(pool)}/")
+        ):
+            # A container cloned from another container would arrive in the native
+            # tree still linked to that sibling, where deleting either one destroys
+            # the other: container deletion destroys dependent clones along with the
+            # dataset. The sibling may already have migrated, hence the native path.
+            self.logger.warning(
+                "%s: origin %r is another container; skipping relocation",
+                container_ds, origin_dataset,
+            )
+            return "FAILED"
+
         if not origin_dataset.startswith(ix_virt):
             # Already relocated (fan-out sibling / prior run) or never in .ix-virt.
             return "ALREADY_SATISFIED"

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -142,6 +142,16 @@ class ContainerService(Service):
             return
 
         legacy_config = legacy_config[0]
+        if not await self.middleware.call("container.license_active"):
+            # Returning before virt_global.pool is cleared leaves the legacy
+            # configuration intact, so the migration runs on a later boot once
+            # the license is in place. Nothing on disk is touched meanwhile.
+            self.logger.warning(
+                "Legacy incus containers found but this system is not licensed to use containers; "
+                "migration deferred."
+            )
+            return
+
         self.logger.info("Legacy incus container configuration found, starting migration")
         try:
             migration_job = await self.middleware.call("container.migrate")
@@ -187,6 +197,13 @@ class ContainerService(Service):
         legacy_configuration = await self.middleware.call("datastore.query", "virt.global")
         if not legacy_configuration or legacy_configuration[0]["pool"] is None:
             raise CallError("Legacy containers configuration pool is not set.")
+
+        # Every migrated container has to pass container.validate, which fails
+        # without a license. Bailing out here leaves the legacy datasets untouched
+        # instead of moving them somewhere no container row can point at.
+        if not await self.middleware.call("container.license_active"):
+            raise CallError("System is not licensed to use containers.")
+
         pool = legacy_configuration[0]["pool"]
 
         storage_pools = {pool} | set(filter(bool, (legacy_configuration[0]["storage_pools"] or "").split()))

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -364,10 +364,13 @@ class ContainerService(Service):
                 job.logs_fd.write(f"Successfully migrated container {name!r}.\n".encode())
             finally:
                 if needs_mount_revert:
-                    self.revert_incus_mount_properties(dataset["name"])
+                    self.revert_incus_mount_properties(job, dataset["name"])
+
+        if processed_parents_mountpoints:
+            self.restore_legacy_parent_mountpoints(pool)
 
     @private
-    def revert_incus_mount_properties(self, container_ds):
+    def revert_incus_mount_properties(self, job, container_ds):
         """Restore the mount properties incus set on a container dataset that stays put.
 
         Inspecting a legacy container means mounting it, which means replacing the
@@ -382,6 +385,7 @@ class ContainerService(Service):
             self.logger.warning(
                 "%s: failed to unmount after skipping migration", container_ds, exc_info=True,
             )
+            job.logs_fd.write(f"Failed to unmount {container_ds!r} after skipping it.\n".encode())
 
         try:
             self.middleware.call_sync(
@@ -396,6 +400,27 @@ class ContainerService(Service):
                 "%s: failed to restore mount properties after skipping migration",
                 container_ds, exc_info=True,
             )
+            job.logs_fd.write(
+                f"Failed to restore mount properties on {container_ds!r} after skipping it.\n".encode()
+            )
+
+    @private
+    def restore_legacy_parent_mountpoints(self, pool):
+        """Put the legacy parent datasets back the way incus had them.
+
+        Migrating a container needs its parents mounted, so they are given an inherited
+        mountpoint. Leaving them that way keeps the whole legacy tree mounted under
+        ``/mnt/<pool>/.ix-virt`` for good, even on a run where nothing was migrated.
+        Children first, so the parent is not unmounted out from under one of them.
+        """
+        for ds in (f"{pool}/.ix-virt/containers", f"{pool}/.ix-virt"):
+            try:
+                self.middleware.call_sync(
+                    "pool.dataset.update_impl",
+                    UpdateImplArgs(name=ds, zprops={"mountpoint": "legacy"}),
+                )
+            except Exception:
+                self.logger.warning("%s: failed to restore mountpoint after migration", ds, exc_info=True)
 
     @private
     def relocate_container_origin(self, container_ds):

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -1161,7 +1161,7 @@ class FailoverEventsService(Service):
 
     def start_containers(self):
         logger.info('Starting Containers which are set to start on boot')
-        self.middleware.create_task(self.middleware.call('container.start_on_boot'))
+        self.middleware.create_task(self.middleware.call('container.migrate_and_start_on_boot'))
 
     def stop_containers(self):
         logger.info('Trying to gracefully stop Containers')

--- a/src/middlewared/middlewared/plugins/zfs/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs/utils.py
@@ -20,7 +20,8 @@ __all__ = (
 INTERNAL_PATHS = (
     "ix-apps",
     "ix-applications",
-    ".system"
+    ".system",
+    ".truenas_containers",
 )
 
 

--- a/src/middlewared/middlewared/plugins/zfs/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs/utils.py
@@ -21,7 +21,6 @@ INTERNAL_PATHS = (
     "ix-apps",
     "ix-applications",
     ".system",
-    ".truenas_containers",
 )
 
 

--- a/src/middlewared/middlewared/test/integration/assets/container.py
+++ b/src/middlewared/middlewared/test/integration/assets/container.py
@@ -89,7 +89,7 @@ def container(image, options=None, start=False, startup_script=None, name="test"
     finally:
         # A test may legitimately delete the container itself.
         if call("container.query", [["id", "=", container["id"]]]):
-            if call("container.get_instance", container["id"])["status"]["state"] == "RUNNING":
+            if call("container.get_instance", container["id"])["status"]["state"] != "STOPPED":
                 call("container.stop", container["id"], {"force": True}, job=True)
             call("container.delete", container["id"], job=True)
 

--- a/src/middlewared/middlewared/test/integration/assets/container.py
+++ b/src/middlewared/middlewared/test/integration/assets/container.py
@@ -87,9 +87,11 @@ def container(image, options=None, start=False, startup_script=None, name="test"
 
         yield container
     finally:
-        if call("container.get_instance", container["id"])["status"]["state"] == "RUNNING":
-            call("container.stop", container["id"], {"force": True}, job=True)
-        call("container.delete", container["id"])
+        # A test may legitimately delete the container itself.
+        if call("container.query", [["id", "=", container["id"]]]):
+            if call("container.get_instance", container["id"])["status"]["state"] == "RUNNING":
+                call("container.stop", container["id"], {"force": True}, job=True)
+            call("container.delete", container["id"], job=True)
 
         #  Id   Name   State
         # --------------------

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -8,7 +8,7 @@ import time
 import pytest
 import websocket
 
-from truenas_api_client import ValidationErrors
+from truenas_api_client import ClientException, ValidationErrors
 from middlewared.test.integration.assets.account import (
     group as account_group,
     user as account_user,
@@ -16,6 +16,7 @@ from middlewared.test.integration.assets.account import (
 from middlewared.test.integration.assets.container import (
     ALPINE_IMAGE_NAME,
     UBUNTU_IMAGE_NAME,
+    VIRSH,
     configure_bridge,
     container,
     filesystem_device,
@@ -136,6 +137,38 @@ def test_container_rename(ubuntu_container):
         {"paths": [expected_dataset], "properties": ["mountpoint"]},
     )
     assert result, f"ZFS dataset {expected_dataset!r} does not exist after rename"
+
+
+def test_container_delete_running_refused(started_ubuntu_container):
+    with pytest.raises(ClientException) as exc_info:
+        call("container.delete", started_ubuntu_container["id"], job=True)
+
+    assert "Stop it first" in str(exc_info.value)
+
+    container = call("container.get_instance", started_ubuntu_container["id"])
+    assert container["status"]["state"] == "RUNNING"
+    assert call("zfs.resource.query", {"paths": [container["dataset"]], "properties": None})
+
+
+def test_container_delete_running_force(started_ubuntu_container):
+    container = started_ubuntu_container
+
+    call("container.delete", container["id"], {"force": True}, job=True)
+
+    assert not call("container.query", [["id", "=", container["id"]]])
+    assert not call("zfs.resource.query", {"paths": [container["dataset"]], "properties": None})
+    assert container["uuid"] not in ssh(f"{VIRSH} list --all")
+
+
+def test_container_delete_with_snapshot(ubuntu_container):
+    # The snapshot is taken over ssh because .truenas_containers is an internal
+    # path and the snapshot API refuses to operate on it.
+    ssh(f"zfs snapshot {ubuntu_container['dataset']}@test")
+
+    call("container.delete", ubuntu_container["id"], job=True)
+
+    assert not call("container.query", [["id", "=", ubuntu_container["id"]]])
+    assert not call("zfs.resource.query", {"paths": [ubuntu_container["dataset"]], "properties": None})
 
 
 def test_container_stop_force_after_timeout(ubuntu_container):


### PR DESCRIPTION
## Problem

Incus containers are ZFS clones of an image snapshot. The incus->container auto-migration relocated each container from `<pool>/.ix-virt/containers/<name>` to `<pool>/.truenas_containers/containers/<name>` with a bare `zfs rename` and did nothing else. A `zfs rename` does not change a clone's `origin`, so a migrated container stayed a clone of a snapshot still living inside `.ix-virt`. `.ix-virt` was visible in the UI and not delete-guarded, so deleting it recursively destroyed those origin snapshots and cascaded into the dependent migrated clones — silently destroying migrated containers.

This is also the release that made `.ix-virt` deletable in the first place, so the window between "your containers migrated fine" and "you reclaimed the old dataset and lost them" is exactly this upgrade.

## Solution

Relocate each container's origin image dataset out of `.ix-virt` before renaming the container, so no migrated container depends on anything under `.ix-virt`. Once relocated the image stays put for good, exactly like a natively pulled one — reclaiming either is the job of the `container.image.*` management API landing separately in this release, not of this fix.

- **Shared relocation helper** — `container.relocate_container_origin` reads a container's live `origin`; if it points at an image under `.ix-virt/images` or `.ix-virt/deleted/images`, it sets `canmount=noauto` on that image dataset and then renames it into the native `.truenas_containers/images/` tree. The rename goes last so it is the single atomic commit point: the image is either wholly still in `.ix-virt` or wholly relocated, never half-way, and the helper's return value describes reality. All fan-out clones auto-repoint on the rename; an origin already outside `.ix-virt` is left alone; a relocation failure leaves the container wholly inside `.ix-virt` (best-effort, skip). A container whose origin is another container rather than an image is refused outright — relocating it would carry a dependency into the native tree where deleting either one destroys the other. The same fingerprint arriving twice (it can exist under both `images/` and `deleted/images/`) lands as `<fp>-migrated-N` rather than failing.
- **Migration path** — the incus->container migration calls the helper immediately before renaming each container, and skips any container whose base image cannot be relocated.
- **Repair migration** — new `0020_repair_incus_clone_origins` runs the same relocation over existing `container.container` rows for systems that already ran the old migration, and puts those systems' legacy mountpoints back as well.
- **The legacy tree is left as it was found** — inspecting a legacy container means mounting it, which means replacing the `canmount`/`mountpoint` pair it was stored with. That is now undone: a container that is skipped rather than migrated gets its properties restored, and the legacy parents get their `mountpoint` back at the end of the run. Without this the whole `.ix-virt` tree stays mounted under `/mnt` and is remounted on every boot, with nothing left on the system that manages it.
- **HA is left out of it** — legacy containers were never migrated on an HA system, because the migration hangs off `system.ready`, which HA deliberately ignores. Rather than inventing that path here and running it for the first time during a failover event, both the migration and the repair migration now bail out on `system.is_ha_capable()` — gated on the hardware, not the failover license, so a controller that *can* be paired is never migrated behind the user's back. The migration clears `virt.global.pool` on the way out so this is not reconsidered on every boot; nothing on disk is touched, and the legacy datasets stay where they are under `.ix-virt`. The repair migration has nothing to do there in any case: the old migration never ran, and pools are not imported yet when migrations do. Migration and start-on-boot do still get folded into one `container.migrate_and_start_on_boot` entry point that the failover path calls too, so the ordering lives in one place instead of two.
- **Licensing** — a system that is not licensed for containers no longer migrates, because every migrated container has to pass `container.validate`, which fails without a license. The legacy configuration is left intact rather than cleared, so the migration runs on a later boot once the license is in place; nothing on disk is touched meanwhile.
- **Failures are contained** — one unusable pool no longer stops the pools after it. A container whose dataset was renamed but whose database row could not be created is moved back where it came from, rather than being left in a tree that nothing enumerates and nothing can delete. Containers created during the run are recorded as they are created, so a same-named container on a second pool is skipped instead of colliding with the one already migrated.
- **Delete guard** — `.truenas_containers` is added to `INTERNAL_PATHS` so neither it nor anything under it — the relocated images included — can be destroyed through `pool.dataset.delete` or `zfs.resource.destroy`; the plugin's own snapshot/clone/destroy calls that touch it now pass `bypass=True`. Same-pool container creation clones the image snapshot through `zfs.resource.snapshot.clone_impl` directly and mounts the result itself, since `pool.snapshot.clone` has no bypass passthrough to offer.
- **Safer deletion** — `do_delete` now tears the libvirt domain down first (it holds the dataset), destroys the dataset next, and only removes the database rows once the dataset is confirmed gone, so a failed destroy never orphans the dataset with no row pointing at it; an already-missing dataset is tolerated so a container whose data was lost to the old cascade can still be removed cleanly. The destroy is recursive, matching the apps stack, so a container that has snapshots is deletable — which also means anything cloned from those snapshots goes with it. `delete_container_from_db_and_libvirt` splits into the two halves this ordering needs, and the pool-dataset attachment delegate calls both.
- **Active-instance guards** — deleting or renaming a container that is not stopped (running or suspended) is refused; delete additionally accepts `force=True`, which stops it first, mirroring the VM delete flow. The container status model now includes the `SUSPENDED` state it can actually report.
- **Delete locking** — delete becomes a job so it can stop the container and wait on the destroy, and its lock is keyed per container id: a constant lock string would hit `@job`'s default `lock_queue_size` of 5 and, past five queued deletes, silently fold a new request into a queued delete of a *different* container and hand that job back to the caller, who would then see SUCCESS for a container nobody deleted.
