### PR TITLE
NAS-141858 / 27.0.0-BETA.1 / Mail plugin test coverage

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/mail.py
+++ b/src/middlewared/middlewared/api/v27_0_0/mail.py
@@ -56,8 +56,6 @@ class MailSendMessage(BaseModel):
     )
     to: list[str] = Field(default=NotRequired, description="Email recipients. Defaults to all local administrators.")
     cc: list[str] = Field(default=NotRequired, description="Email CC recipients, if any.")
-    interval: int | None = Field(default=NotRequired, description="In seconds.")
-    channel: str | None = Field(default=NotRequired, description="Defaults to \"truenas\".")
     timeout: int = Field(default=300, description="Time limit for connecting to the SMTP server in seconds.")
     attachments: bool = Field(
         default=False,

--- a/src/middlewared/middlewared/plugins/mail/config.py
+++ b/src/middlewared/middlewared/plugins/mail/config.py
@@ -25,7 +25,7 @@ class MailModel(sa.Model):
 
 
 def validate_config(data: MailEntry) -> None:
-    if data.smtp and data.user == "":
+    if data.smtp and not data.user:
         raise ValidationError("user", "This field is required when SMTP authentication is enabled")
 
     oauth = data.oauth.get_secret_value()

--- a/src/middlewared/middlewared/plugins/mail/outlook.py
+++ b/src/middlewared/middlewared/plugins/mail/outlook.py
@@ -53,7 +53,7 @@ class Outlook:
 
     def _get_outlook_token(self, email: str, refresh_token: str) -> str | None:
         for key, expired_token in list(self.outlook_tokens.items()):
-            if expired_token.expires_at < time.monotonic() - 5:
+            if expired_token.expires_at < time.monotonic() + 5:
                 self.outlook_tokens.pop(key)
 
         if token := self.outlook_tokens.get(email + refresh_token):

--- a/src/middlewared/middlewared/plugins/mail/queue.py
+++ b/src/middlewared/middlewared/plugins/mail/queue.py
@@ -18,7 +18,10 @@ class MailQueue:
 
     def __init__(self) -> None:
         self.queue: deque[QueueItem] = deque(maxlen=self.MAX_QUEUE_LIMIT)
+        # Guards `queue` itself. Only ever held for the duration of a deque operation.
         self.lock = Lock()
+        # Held for an entire queue flush, so that two of them cannot deliver the same message.
+        self.send_lock = Lock()
 
     def append(self, message: MIMEBase) -> None:
         self.queue.append(QueueItem(message))

--- a/src/middlewared/middlewared/plugins/mail/send.py
+++ b/src/middlewared/middlewared/plugins/mail/send.py
@@ -182,7 +182,11 @@ def build_attachment(index: int, attachment: typing.Any) -> Message:
     """
     m = Message()
     try:
-        m.set_payload(attachment["content"])
+        content = attachment["content"]
+        if not isinstance(content, str):
+            raise ValidationError("attachments", f"Invalid attachment at index {index}: content must be a string")
+
+        m.set_payload(content)
         for header in attachment.get("headers") or []:
             m.add_header(header["name"], header["value"], **(header.get("params") or {}))
     except (AttributeError, KeyError, TypeError) as e:

--- a/src/middlewared/middlewared/plugins/mail/send.py
+++ b/src/middlewared/middlewared/plugins/mail/send.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import base64
-from datetime import datetime, timedelta
 from email.message import Message
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.utils import formatdate, make_msgid
+from email.utils import formatdate, getaddresses, make_msgid
 import errno
 import html
 import json
@@ -20,7 +19,7 @@ import html2text
 from middlewared.api.base.model import _NotRequired
 from middlewared.api.current import MailEntry, MailSendMessage, MailUpdate
 from middlewared.service import CallError, NetworkActivityDisabled, ServiceContext, ValidationError
-from middlewared.utils import BRAND, ProductName
+from middlewared.utils import ProductName
 from middlewared.utils.mako import get_template
 
 from .config import validate_config
@@ -70,28 +69,6 @@ def send(
 
     from_addr_ = from_addr(config)
 
-    interval = message.get("interval")
-    if interval is None:
-        interval = timedelta()
-    else:
-        interval = timedelta(seconds=interval)
-
-    if interval > timedelta():
-        channelfile = f"/run/middleware/.msg.{message.get('channel') or BRAND.lower()}"
-        last_update = datetime.now() - interval
-        try:
-            last_update = datetime.fromtimestamp(os.stat(channelfile).st_mtime)
-        except OSError:
-            pass
-        timediff = datetime.now() - last_update
-        if (timediff >= interval) or (timediff < timedelta()):
-            # Make sure mtime is modified
-            # We could use os.utime but this is simpler!
-            with open(channelfile, "w") as f:
-                f.write("!")
-        else:
-            raise CallError("This message was already sent in the given interval")
-
     validate_config(config)
 
     to = message.get("to")
@@ -114,14 +91,19 @@ def send(
                 data += read
                 i += 1
                 if i > 50:
-                    raise ValueError("Attachments bigger than 50MB not allowed yet")
+                    raise ValidationError("attachments", "Attachments bigger than 50MB not allowed yet")
 
             if data == b"":
                 return None
 
-            return json.loads(data)
+            try:
+                return json.loads(data)
+            except ValueError as e:
+                raise ValidationError("attachments", f"Attachments are not valid JSON: {e}")
 
         attachments = read_json()
+        if attachments is not None and not isinstance(attachments, list):
+            raise ValidationError("attachments", "Attachments must be an array")
     else:
         attachments = None
 
@@ -134,12 +116,8 @@ def send(
             msg2.attach(MIMEText(message["html"], "html", _charset="utf-8"))
             msg.attach(msg2)
         if attachments:
-            for attachment in attachments:
-                m = Message()
-                m.set_payload(attachment["content"])
-                for header in attachment.get("headers"):
-                    m.add_header(header["name"], header["value"], **(header.get("params") or {}))
-                msg.attach(m)
+            for index, attachment in enumerate(attachments):
+                msg.attach(build_attachment(index, attachment))
     else:
         msg = MIMEText(message["text"], _charset="utf-8")
 
@@ -196,6 +174,37 @@ def send(
         raise CallError(f"Failed to send email: {e}")
 
 
+def build_attachment(index: int, attachment: typing.Any) -> Message:
+    """Build a MIME part from one caller-supplied attachment.
+
+    Attachments are uploaded as JSON rather than passed through the API model, so nothing has
+    validated their shape yet.
+    """
+    m = Message()
+    try:
+        m.set_payload(attachment["content"])
+        for header in attachment.get("headers") or []:
+            m.add_header(header["name"], header["value"], **(header.get("params") or {}))
+    except (AttributeError, KeyError, TypeError) as e:
+        raise ValidationError("attachments", f"Invalid attachment at index {index}: {e!r}")
+
+    return m
+
+
+def envelope_recipients(msg: MIMEBase) -> list[str]:
+    """Return every address `msg` should be delivered to, in order and without duplicates.
+
+    SMTP delivers to the envelope recipients, not to the message headers, so `Cc` has to be
+    included here or those recipients would never receive the message.
+    """
+    recipients = []
+    for _, address in getaddresses(msg.get_all("To", []) + msg.get_all("Cc", [])):
+        if address and address not in recipients:
+            recipients.append(address)
+
+    return recipients
+
+
 def sendmail(
     context: ServiceContext,
     msg: MIMEBase,
@@ -216,8 +225,10 @@ def sendmail(
             # This is because we don't run a full MTA.
             # else:
             #    server.connect()
+            # The envelope sender is an address, not the `From` header, which may carry a display
+            # name and be RFC 2047 encoded.
             server.sendmail(
-                msg["From"],
-                msg["To"].split(", "),
+                config.fromemail,
+                envelope_recipients(msg),
                 msg.as_string(),
             )

--- a/src/middlewared/middlewared/plugins/mail/send_queue.py
+++ b/src/middlewared/middlewared/plugins/mail/send_queue.py
@@ -10,8 +10,19 @@ logger = logging.getLogger(__name__)
 
 
 def send_mail_queue(context: ServiceContext, queue: MailQueue) -> None:
-    with queue as mq:
-        for item in list(mq.queue):
+    # `queue.lock` must not be held while delivering, or a `mail.send` that fails would block on it
+    # for as long as this flush takes (up to `MAX_QUEUE_LIMIT` messages, each with its own timeout).
+    # `send_lock` takes over the job of keeping two flushes from delivering the same message twice.
+    if not queue.send_lock.acquire(blocking=False):
+        logger.debug("Mail queue is already being flushed")
+        return
+
+    try:
+        with queue as mq:
+            items = list(mq.queue)
+
+        done = []
+        for item in items:
             try:
                 config = context.call_sync2(context.s.mail.config)
 
@@ -24,11 +35,23 @@ def send_mail_queue(context: ServiceContext, queue: MailQueue) -> None:
                 sendmail(context, item.message, config)
             except NetworkActivityDisabled:
                 # no reason to queue up email since network activity was explicitly denied by end-user
-                mq.queue.remove(item)
+                done.append(item)
             except Exception:
                 logger.debug("Sending message from queue failed", exc_info=True)
                 item.attempts += 1
-                if item.attempts >= mq.MAX_ATTEMPTS:
-                    mq.queue.remove(item)
+                if item.attempts >= queue.MAX_ATTEMPTS:
+                    done.append(item)
             else:
-                mq.queue.remove(item)
+                done.append(item)
+
+        with queue as mq:
+            for item in done:
+                try:
+                    mq.queue.remove(item)
+                except ValueError:
+                    # `queue` holds at most `MAX_QUEUE_LIMIT` messages and drops the oldest to make
+                    # room, so a `mail.send` that failed while we were delivering may already have
+                    # pushed `item` out.
+                    pass
+    finally:
+        queue.send_lock.release()

--- a/src/middlewared/middlewared/plugins/mail/smtp.py
+++ b/src/middlewared/middlewared/plugins/mail/smtp.py
@@ -42,7 +42,7 @@ def get_smtp_server(
             outlook.xoauth2(server, config)
         elif config.smtp:
             username: str = config.user  # type: ignore[assignment]
-            password: str = config.pass_.get_secret_value()  # type: ignore[assignment]
+            password: str = config.pass_.get_secret_value() or ""
             server.login(username, password)
 
         yield server

--- a/src/middlewared/middlewared/test/integration/assets/mail.py
+++ b/src/middlewared/middlewared/test/integration/assets/mail.py
@@ -32,6 +32,11 @@ class FakeSMTPServer:
     host: str
     port: int
 
+    def clear(self) -> None:
+        """Discard every message recorded so far."""
+        # `find` rather than a glob, which the remote shell fails on when the directory is empty.
+        ssh(f"find {_OUTDIR} -type f -delete")
+
     def get_messages(self) -> list[ReceivedMail]:
         result = []
         for name in sorted(ssh(f"ls {_OUTDIR}").split()):

--- a/src/middlewared/middlewared/test/integration/fake_servers/smtp.py
+++ b/src/middlewared/middlewared/test/integration/fake_servers/smtp.py
@@ -6,8 +6,13 @@ JSON file per email in the output directory. It is meant to be uploaded to and
 run on a TrueNAS host so that ``mail.send`` can deliver to it over ``127.0.0.1``
 without a real MTA or outbound network access.
 
+Besides plain delivery it supports ``AUTH PLAIN``/``AUTH LOGIN`` (see ``AUTH_USER``
+and ``AUTH_PASSWORD``) and rejects any envelope address containing ``REFUSE_SENDER``
+or ``REFUSE_RECIPIENT`` so that the SMTP error handling paths can be tested.
+
 Usage: ``python3 smtp.py <output_directory> <port>``
 """
+import base64
 import json
 import os
 import re
@@ -18,10 +23,46 @@ import time
 
 ADDR_RE = re.compile(r"<([^>]*)>")
 
+AUTH_USER = "fakeuser"
+AUTH_PASSWORD = "fakepassword"
+# Envelope addresses containing these markers are rejected by the server.
+REFUSE_SENDER = "refuse-sender"
+REFUSE_RECIPIENT = "refuse-recipient"
+
 
 def _address(command):
     match = ADDR_RE.search(command)
     return match.group(1) if match else command.split(":", 1)[-1].strip()
+
+
+def _decode(line):
+    return base64.b64decode(line.strip()).decode("utf-8", "replace")
+
+
+def _authenticate(command, f, reply):
+    """Run the AUTH exchange for `command`, returning whether the credentials are valid."""
+    parts = command.split()
+    mechanism = parts[1].upper() if len(parts) > 1 else ""
+    try:
+        if mechanism == "PLAIN":
+            if len(parts) > 2:
+                blob = parts[2]
+            else:
+                reply("334 ")
+                blob = f.readline().decode()
+            # The PLAIN payload is "authzid\0authcid\0password".
+            fields = base64.b64decode(blob.strip()).decode("utf-8", "replace").split("\0")
+            return len(fields) == 3 and fields[1] == AUTH_USER and fields[2] == AUTH_PASSWORD
+        elif mechanism == "LOGIN":
+            reply("334 " + base64.b64encode(b"Username:").decode())
+            user = _decode(f.readline())
+            reply("334 " + base64.b64encode(b"Password:").decode())
+            password = _decode(f.readline())
+            return user == AUTH_USER and password == AUTH_PASSWORD
+    except Exception:
+        return False
+
+    return False
 
 
 def handle(conn, outdir):
@@ -38,14 +79,29 @@ def handle(conn, outdir):
             break
         command = raw.decode("utf-8", "replace").rstrip("\r\n")
         upper = command.upper()
-        if upper.startswith(("EHLO", "HELO")):
+        if upper.startswith("EHLO"):
+            reply("250-fakesmtp\r\n250 AUTH PLAIN LOGIN")
+        elif upper.startswith("HELO"):
             reply("250 fakesmtp")
+        elif upper.startswith("AUTH "):
+            if _authenticate(command, f, reply):
+                reply("235 2.7.0 Authentication successful")
+            else:
+                reply("535 5.7.8 Authentication credentials invalid")
         elif upper.startswith("MAIL FROM"):
             mail_from = _address(command)
-            reply("250 OK")
+            if REFUSE_SENDER in mail_from:
+                reply("550 5.7.1 Sender rejected")
+                mail_from = None
+            else:
+                reply("250 OK")
         elif upper.startswith("RCPT TO"):
-            rcpt_to.append(_address(command))
-            reply("250 OK")
+            recipient = _address(command)
+            if REFUSE_RECIPIENT in recipient:
+                reply("550 5.1.1 Recipient rejected")
+            else:
+                rcpt_to.append(recipient)
+                reply("250 OK")
         elif upper == "DATA":
             reply("354 End data with <CR><LF>.<CR><LF>")
             data = b""

--- a/tests/api2/test_mail.py
+++ b/tests/api2/test_mail.py
@@ -1,8 +1,104 @@
+import base64
+import contextlib
+import email.header
 import email.utils
+import io
+import json
 import re
 
+import pytest
+from truenas_api_client import ClientException
+
+from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.mail import fake_smtp_server
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.fake_servers.smtp import (
+    AUTH_PASSWORD,
+    AUTH_USER,
+    REFUSE_RECIPIENT,
+    REFUSE_SENDER,
+)
+from middlewared.test.integration.utils import call, mock, session, url
+# `mail.update` is a plain call, so the client re-raises the original middleware exception, while
+# `mail.send` is a job, whose failures always surface as a `truenas_api_client` exception.
+from middlewared.service_exception import ValidationError
+
+FROM_EMAIL = "truenas@localhost"
+FROM_NAME = "TrueNAS Test"
+TO = "recipient@example.com"
+ADMIN_USER = "mailadmin"
+ADMIN_EMAIL = "mailadmin@ixsystems.com"
+ADMIN_PASSWORD = "abcd1234"
+
+
+def base_config(server, **overrides):
+    """Mail configuration pointing at the fake SMTP `server`, with `overrides` applied."""
+    return {
+        "fromemail": FROM_EMAIL,
+        "fromname": FROM_NAME,
+        "outgoingserver": server.host,
+        "port": server.port,
+        "security": "PLAIN",
+        "smtp": False,  # no authentication needed against the fake server
+        "user": "",
+        "pass": "",
+        **overrides,
+    }
+
+
+def message(**overrides):
+    return {"subject": "test subject", "text": "test body", "to": [TO], "queue": False, **overrides}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_mail_config():
+    original = call("mail.config")
+    try:
+        yield
+    finally:
+        call("mail.update", {k: v for k, v in original.items() if k != "id"})
+
+
+@pytest.fixture(scope="module")
+def smtp_server(restore_mail_config):
+    with fake_smtp_server() as server:
+        yield server
+
+
+@pytest.fixture
+def server(smtp_server):
+    """The fake SMTP server, with the mail configuration pointed at it and no messages recorded."""
+    call("mail.update", base_config(smtp_server))
+    smtp_server.clear()
+    return smtp_server
+
+
+@contextlib.contextmanager
+def no_administrator_emails():
+    """Temporarily strip the email address off every local full administrator."""
+    admins = call("user.query", [["roles", "rin", "FULL_ADMIN"], ["local", "=", True], ["email", "!=", None]])
+    for admin in admins:
+        call("user.update", admin["id"], {"email": None})
+    try:
+        yield
+    finally:
+        for admin in admins:
+            call("user.update", admin["id"], {"email": admin["email"]})
+
+
+@pytest.fixture
+def administrator_email():
+    """`ADMIN_EMAIL` is the only local administrator email address for the duration of the test."""
+    builtin_administrators = call("group.query", [["gid", "=", 544]], {"get": True})["id"]
+    with no_administrator_emails():
+        with user({
+            "username": ADMIN_USER,
+            "full_name": ADMIN_USER,
+            "group_create": False,
+            "group": builtin_administrators,
+            "email": ADMIN_EMAIL,
+            "password": ADMIN_PASSWORD,
+        }):
+            yield ADMIN_EMAIL
 
 
 def test_config_settings():
@@ -21,25 +117,35 @@ def test_config_settings():
     assert payload.items() <= config.items()
 
 
-def test_mail_send():
-    with fake_smtp_server() as server:
-        call("mail.update", {
-            "fromemail": "truenas@localhost",
-            "fromname": "TrueNAS Test",
-            "outgoingserver": server.host,
-            "port": server.port,
-            "security": "PLAIN",
-            "smtp": False,  # no authentication needed against the fake server
-        })
-        call("mail.send", {
-            "subject": "test subject",
-            "text": "test body",
-            "to": ["recipient@example.com"],
-            "cc": ["cc@example.com"],
-            "queue": False,
-            "extra_headers": {"X-Custom": "custom-value"},
-        }, job=True)
-        messages = server.get_messages()
+@pytest.mark.parametrize("user", ["", None])
+def test_update_requires_user_when_smtp_authentication_is_enabled(server, user):
+    with pytest.raises(ValidationError, match="user: This field is required when SMTP authentication is enabled"):
+        call("mail.update", {"smtp": True, "user": user})
+
+
+@pytest.mark.parametrize("password", ["", None])
+def test_mail_send_with_unset_password(server, password):
+    """An unset password is allowed; it just fails to authenticate rather than crashing."""
+    with pytest.raises(ClientException, match=r"Authentication error \(535\)"):
+        call("mail.send", message(), {"smtp": True, "user": AUTH_USER, "pass": password}, job=True)
+
+
+def test_update_requires_fromemail(server):
+    with pytest.raises(ValidationError, match="fromemail: This field is required"):
+        call("mail.update", {"fromemail": ""})
+
+
+def test_update_rejects_non_ascii_password(server):
+    with pytest.raises(ValidationError, match="pass: Only plain text characters"):
+        call("mail.update", {"pass": "пароль"})
+
+
+def test_mail_send(server):
+    call("mail.send", message(
+        cc=["cc@example.com"],
+        extra_headers={"X-Custom": "custom-value"},
+    ), job=True)
+    messages = server.get_messages()
 
     nc = call("network.configuration.config")
     hostname = f"{nc['hostname']}.{nc['domain']}"
@@ -51,9 +157,9 @@ def test_mail_send():
     assert len(messages) == 1
     mail = messages[0]
 
-    # SMTP envelope. Cc recipients are a header only, not part of the envelope.
-    assert mail.mail_from == "truenas@localhost"
-    assert mail.rcpt_to == ["recipient@example.com"]
+    # SMTP envelope. Cc recipients are delivered to as well as being listed in the header.
+    assert mail.mail_from == FROM_EMAIL
+    assert mail.rcpt_to == [TO, "cc@example.com"]
 
     msg = mail.message
 
@@ -65,8 +171,8 @@ def test_mail_send():
     assert msg.get_content_type() == "multipart/mixed"
     assert msg["MIME-Version"] == "1.0"
     assert msg["Subject"] == f"TrueNAS {hostname}: test subject"
-    assert msg["From"] == "TrueNAS Test <truenas@localhost>"
-    assert msg["To"] == "recipient@example.com"
+    assert msg["From"] == f"{FROM_NAME} <{FROM_EMAIL}>"
+    assert msg["To"] == TO
     assert msg["Cc"] == "cc@example.com"
     assert msg["X-Custom"] == "custom-value"
     # Date and Message-ID are generated per-message; assert they are well-formed.
@@ -100,3 +206,319 @@ def test_mail_send():
     assert html_part["MIME-Version"] == "1.0"
     assert html_part["Content-Transfer-Encoding"] == "base64"
     assert html_part.get_payload(decode=True).decode() == expected_html
+
+
+def test_mail_send_cc_recipients_are_in_the_envelope(server):
+    """SMTP delivers to the envelope, so every Cc address must appear in RCPT TO."""
+    call("mail.send", message(
+        to=["first@example.com", "second@example.com"],
+        cc=["third@example.com", "fourth@example.com"],
+    ), job=True)
+
+    mail = server.get_messages()[0]
+    assert mail.rcpt_to == ["first@example.com", "second@example.com", "third@example.com", "fourth@example.com"]
+    assert mail.message["To"] == "first@example.com, second@example.com"
+    assert mail.message["Cc"] == "third@example.com, fourth@example.com"
+
+
+def test_mail_send_duplicate_recipients_are_delivered_to_once(server):
+    """An address in both To and Cc must not be handed to the server twice."""
+    call("mail.send", message(to=[TO], cc=[TO, "cc@example.com"]), job=True)
+
+    assert server.get_messages()[0].rcpt_to == [TO, "cc@example.com"]
+
+
+def test_mail_send_queued_message_keeps_cc_recipients(server):
+    """The Cc envelope recipients survive a trip through the retry queue."""
+    call("mail.update", base_config(server, port=1))
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(cc=["cc@example.com"], queue=True), job=True)
+
+    call("mail.update", base_config(server))
+    call("mail.send_mail_queue")
+
+    assert server.get_messages()[0].rcpt_to == [TO, "cc@example.com"]
+
+
+def test_mail_send_html_only(server):
+    """When only HTML is given, the plain text part is derived from it."""
+    call("mail.send", {
+        "subject": "test subject",
+        "html": "<p>Hello <b>world</b></p>",
+        "to": [TO],
+        "queue": False,
+    }, job=True)
+
+    parts = list(server.get_messages()[0].message.walk())
+    assert [part.get_content_type() for part in parts] == [
+        "multipart/mixed", "multipart/alternative", "text/plain", "text/html",
+    ]
+    assert parts[2].get_payload(decode=True).decode().strip() == "Hello **world**"
+    assert parts[3].get_payload(decode=True).decode() == "<p>Hello <b>world</b></p>"
+
+
+def test_mail_send_without_html(server):
+    """`html: null` suppresses the HTML part entirely, producing a bare text/plain message."""
+    call("mail.send", message(html=None), job=True)
+
+    msg = server.get_messages()[0].message
+    assert not msg.is_multipart()
+    assert msg.get_content_type() == "text/plain"
+    assert msg.get_payload(decode=True).decode() == "test body"
+
+
+def test_mail_send_requires_text_or_html(server):
+    with pytest.raises(ClientException, match="Text is required when HTML is not set"):
+        call("mail.send", {"subject": "test subject", "to": [TO], "queue": False}, job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_non_ascii_fromname(server):
+    call("mail.send", message(), {"fromname": "Тест"}, job=True)
+
+    mail = server.get_messages()[0]
+    assert mail.mail_from == FROM_EMAIL
+    decoded = str(email.header.make_header(email.header.decode_header(mail.message["From"])))
+    assert decoded == f"Тест <{FROM_EMAIL}>"
+
+
+def test_mail_send_without_fromname(server):
+    call("mail.send", message(), {"fromname": ""}, job=True)
+
+    assert server.get_messages()[0].message["From"] == FROM_EMAIL
+
+
+def test_mail_send_non_ascii_fromemail_without_fromname(server):
+    """A non-ASCII `fromemail` cannot be used as an envelope sender, and fails rather than
+    silently putting the RFC 2047 encoded header into MAIL FROM."""
+    with pytest.raises(ClientException, match="ascii"):
+        call("mail.send", message(), {"fromname": "", "fromemail": "тест@localhost"}, job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_extra_headers(server):
+    """`extra_headers` replaces existing headers and adds new ones, but never overrides Content-Type."""
+    call("mail.send", message(extra_headers={
+        "Content-Type": "text/plain",
+        "Subject": "replaced subject",
+        "X-New": "new value",
+    }), job=True)
+
+    msg = server.get_messages()[0].message
+    assert msg["Subject"] == "replaced subject"
+    assert msg["X-New"] == "new value"
+    assert len(msg.get_all("Content-Type")) == 1
+    assert msg.get_content_type() == "multipart/mixed"
+
+
+ATTACHMENTS = [{
+    "headers": [
+        {"name": "Content-Transfer-Encoding", "value": "base64"},
+        {"name": "Content-Type", "value": "application/octet-stream", "params": {"name": "test.txt"}},
+    ],
+    "content": base64.b64encode(b"attachment contents\n").decode(),
+}]
+
+
+def send_with_attachments(payload, body):
+    """Call `mail.send` with `body` as the attachments upload, and wait for the job."""
+    with session() as s:
+        r = s.post(
+            f"{url()}/_upload",
+            files={
+                "data": (None, io.StringIO(json.dumps({"method": "mail.send", "params": [payload]}))),
+                "file": (None, io.BytesIO(body)),
+            },
+        )
+        r.raise_for_status()
+        job_id = r.json()["job_id"]
+
+    call("core.job_wait", job_id, job=True)
+
+
+def test_mail_send_attachments(server):
+    send_with_attachments(message(attachments=True), json.dumps(ATTACHMENTS).encode())
+
+    parts = list(server.get_messages()[0].message.walk())
+    assert [part.get_content_type() for part in parts] == [
+        "multipart/mixed", "multipart/alternative", "text/plain", "text/html",
+        "application/octet-stream",
+    ]
+    assert parts[4]["Content-Type"] == 'application/octet-stream; name="test.txt"'
+    assert parts[4].get_payload(decode=True) == b"attachment contents\n"
+
+
+def test_mail_send_attachments_without_html(server):
+    send_with_attachments(message(attachments=True, html=None), json.dumps(ATTACHMENTS).encode())
+
+    parts = list(server.get_messages()[0].message.walk())
+    assert [part.get_content_type() for part in parts] == ["multipart/mixed", "application/octet-stream"]
+    assert parts[1].get_payload(decode=True) == b"attachment contents\n"
+
+
+def test_mail_send_empty_attachments(server):
+    """An empty upload is treated as no attachments at all."""
+    send_with_attachments(message(attachments=True), b"")
+
+    parts = list(server.get_messages()[0].message.walk())
+    assert [part.get_content_type() for part in parts] == [
+        "multipart/mixed", "multipart/alternative", "text/plain", "text/html",
+    ]
+
+
+def test_mail_send_attachment_without_headers(server):
+    """`headers` is optional: an attachment can be a bare payload."""
+    send_with_attachments(message(attachments=True), json.dumps([{"content": "dGVzdAo="}]).encode())
+
+    parts = list(server.get_messages()[0].message.walk())
+    assert [part.get_content_type() for part in parts] == [
+        "multipart/mixed", "multipart/alternative", "text/plain", "text/html", "text/plain",
+    ]
+    assert parts[4].get_payload() == "dGVzdAo="
+
+
+def test_mail_send_attachment_without_content(server):
+    """Attachments are uploaded as free-form JSON, so a missing key must not escape as a traceback."""
+    with pytest.raises(ClientException, match="Invalid attachment at index 0"):
+        send_with_attachments(message(attachments=True), json.dumps([{"headers": []}]).encode())
+
+
+def test_mail_send_attachments_not_an_array(server):
+    with pytest.raises(ClientException, match="Attachments must be an array"):
+        send_with_attachments(message(attachments=True), json.dumps({"content": "dGVzdAo="}).encode())
+
+
+def test_mail_send_attachments_invalid_json(server):
+    with pytest.raises(ClientException, match="Attachments are not valid JSON"):
+        send_with_attachments(message(attachments=True), b"{not json")
+
+
+def test_local_administrator_email(administrator_email):
+    assert call("mail.local_administrators_emails") == [administrator_email]
+    assert call("mail.local_administrator_email") == administrator_email
+
+
+def test_local_administrator_email_unset():
+    with no_administrator_emails():
+        assert call("mail.local_administrators_emails") == []
+        assert call("mail.local_administrator_email") is None
+
+
+def test_mail_send_defaults_to_local_administrators(server, administrator_email):
+    call("mail.send", {"subject": "test subject", "text": "test body", "queue": False}, job=True)
+
+    mail = server.get_messages()[0]
+    assert mail.rcpt_to == [administrator_email]
+    assert mail.message["To"] == administrator_email
+
+
+def test_mail_send_without_recipients(server):
+    with no_administrator_emails():
+        with pytest.raises(ClientException, match="None of the local administrators has an e-mail address configured"):
+            call("mail.send", {"subject": "test subject", "text": "test body", "queue": False}, job=True)
+
+
+def test_mail_send_without_outgoingserver(server):
+    with pytest.raises(ClientException, match="You must provide an outgoing mailserver and mail server port"):
+        call("mail.send", message(), {"outgoingserver": ""}, job=True)
+
+
+def test_mail_send_with_smtp_authentication(server):
+    call("mail.send", message(), {"smtp": True, "user": AUTH_USER, "pass": AUTH_PASSWORD}, job=True)
+
+    assert len(server.get_messages()) == 1
+
+
+def test_mail_send_with_invalid_smtp_credentials(server):
+    with pytest.raises(ClientException, match=r"Authentication error \(535\)"):
+        call("mail.send", message(), {"smtp": True, "user": AUTH_USER, "pass": "wrong password"}, job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_ssl(server):
+    """The fake server speaks plain text, so an SSL connection to it fails during the handshake."""
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(timeout=10), {"security": "SSL"}, job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_starttls(server):
+    """The fake server does not advertise STARTTLS, so `security: TLS` fails to negotiate."""
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(timeout=10), {"security": "TLS"}, job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_sender_refused_redacts_sender(server):
+    """NAS-137666: email addresses are PII and must not appear in the error."""
+    with pytest.raises(ClientException) as ve:
+        call("mail.send", message(), {"fromemail": f"{REFUSE_SENDER}@localhost"}, job=True)
+
+    assert "[sender redacted]" in ve.value.error
+    assert REFUSE_SENDER not in ve.value.error
+
+
+def test_mail_send_recipients_refused_redacts_recipients(server):
+    """NAS-137666: email addresses are PII and must not appear in the error."""
+    with pytest.raises(ClientException) as ve:
+        call("mail.send", message(to=[f"{REFUSE_RECIPIENT}@example.com"]), job=True)
+
+    assert "[recipient info redacted]" in ve.value.error
+    assert REFUSE_RECIPIENT not in ve.value.error
+
+
+def test_mail_send_network_activity_disabled(server):
+    with mock("network.general.can_perform_activity", return_value=False):
+        with pytest.raises(ClientException, match="is disabled"):
+            call("mail.send", message(), job=True)
+
+    assert server.get_messages() == []
+
+
+def test_mail_send_queue_is_retried(server):
+    """A message that fails to send with `queue: true` is retried by `mail.send_mail_queue`."""
+    call("mail.update", base_config(server, port=1))
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(subject="queued subject", queue=True), job=True)
+    assert server.get_messages() == []
+
+    call("mail.update", base_config(server))
+    call("mail.send_mail_queue")
+
+    messages = server.get_messages()
+    assert len(messages) == 1
+    assert messages[0].message["Subject"].endswith("queued subject")
+    # The `From` address is refreshed from the current configuration before each retry.
+    assert messages[0].message["From"] == f"{FROM_NAME} <{FROM_EMAIL}>"
+
+
+def test_mail_send_queue_gives_up_after_max_attempts(server):
+    call("mail.update", base_config(server, port=1))
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(queue=True), job=True)
+
+    # `MailQueue.MAX_ATTEMPTS` failed retries drop the message from the queue.
+    for _ in range(3):
+        call("mail.send_mail_queue")
+
+    call("mail.update", base_config(server))
+    call("mail.send_mail_queue")
+    assert server.get_messages() == []
+
+
+def test_mail_send_queue_dropped_when_network_activity_disabled(server):
+    call("mail.update", base_config(server, port=1))
+    with pytest.raises(ClientException, match="Failed to send email"):
+        call("mail.send", message(queue=True), job=True)
+
+    call("mail.update", base_config(server))
+    with mock("network.general.can_perform_activity", return_value=False):
+        call("mail.send_mail_queue")
+
+    call("mail.send_mail_queue")
+    assert server.get_messages() == []

--- a/tests/api2/test_mail.py
+++ b/tests/api2/test_mail.py
@@ -385,6 +385,18 @@ def test_mail_send_attachment_without_content(server):
         send_with_attachments(message(attachments=True), json.dumps([{"headers": []}]).encode())
 
 
+@pytest.mark.parametrize("content", [1, None, ["dGVzdAo="], {"data": "dGVzdAo="}])
+def test_mail_send_attachment_content_not_a_string(server, content):
+    """A non-string payload would otherwise only fail when the message is flattened for sending."""
+    with pytest.raises(ClientException, match="Invalid attachment at index 0: content must be a string"):
+        send_with_attachments(message(attachments=True), json.dumps([{"content": content}]).encode())
+
+
+def test_mail_send_attachment_not_an_object(server):
+    with pytest.raises(ClientException, match="Invalid attachment at index 0"):
+        send_with_attachments(message(attachments=True), json.dumps(["dGVzdAo="]).encode())
+
+
 def test_mail_send_attachments_not_an_array(server):
     with pytest.raises(ClientException, match="Attachments must be an array"):
         send_with_attachments(message(attachments=True), json.dumps({"content": "dGVzdAo="}).encode())
@@ -455,7 +467,7 @@ def test_mail_send_starttls(server):
 
 
 def test_mail_send_sender_refused_redacts_sender(server):
-    """NAS-137666: email addresses are PII and must not appear in the error."""
+    """Email addresses are PII and must not appear in the error."""
     with pytest.raises(ClientException) as ve:
         call("mail.send", message(), {"fromemail": f"{REFUSE_SENDER}@localhost"}, job=True)
 
@@ -464,7 +476,7 @@ def test_mail_send_sender_refused_redacts_sender(server):
 
 
 def test_mail_send_recipients_refused_redacts_recipients(server):
-    """NAS-137666: email addresses are PII and must not appear in the error."""
+    """Email addresses are PII and must not appear in the error."""
     with pytest.raises(ClientException) as ve:
         call("mail.send", message(to=[f"{REFUSE_RECIPIENT}@example.com"]), job=True)
 


### PR DESCRIPTION
* Full tests coverage for `mail` plugin (besides GMail and Outlook which need manual testing)
* `interval` and `channel` functionality removed (it is not used)
* Fix SMTP auth crash when `pass` is `None`
* Fix invalid condition for "an outlook token that is about to expire"
* Fix `send_mail_queue` blocking adding new messages to queue when `mail.send` fails (this was hanging `mail.send` for a long time unnecessarily)
* Fix mail.send omits Cc recipients from the SMTP envelope, so Cc addresses never receive the email (https://ixsystems.atlassian.net/browse/NAS-141845)