### PR TITLE
NAS-141860 / 27.0.0-BETA.1 / Stop pydantic serializer warnings for HttpsOnlyURL fields

### DIFF
--- a/src/middlewared/middlewared/api/base/types/urls.py
+++ b/src/middlewared/middlewared/api/base/types/urls.py
@@ -1,12 +1,16 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import AfterValidator, HttpUrl
+from pydantic import AfterValidator, HttpUrl, PlainSerializer
 
 from middlewared.api.base.validators import https_only_check
 
 __all__ = ["HttpsOnlyURL", "HttpVerb"]
 
 
-HttpsOnlyURL = Annotated[HttpUrl, AfterValidator(https_only_check)]
+# `AfterValidator` keeps the field as an `HttpUrl` so the annotation matches the
+# stored value; `PlainSerializer(str)` ensures `model_dump()` emits a plain
+# string in both `python` and `json` modes so downstream consumers (WebSocket
+# JSON encoding, `urllib.parse.urljoin`) don't see a `Url` object.
+HttpsOnlyURL = Annotated[HttpUrl, AfterValidator(https_only_check), PlainSerializer(str, return_type=str)]
 
 HttpVerb: TypeAlias = Literal["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]

--- a/src/middlewared/middlewared/api/base/validators/base.py
+++ b/src/middlewared/middlewared/api/base/validators/base.py
@@ -34,10 +34,10 @@ def time_validator(value: str) -> str:
     return ':'.join(digits.rjust(2, '0') for digits in (hours, minutes))
 
 
-def https_only_check(url: HttpUrl) -> str:
+def https_only_check(url: HttpUrl) -> HttpUrl:
     if url.scheme != 'https':
         raise ValueError('URL scheme must be https')
-    return str(url)
+    return url
 
 
 def email_validator(value: str) -> str:


### PR DESCRIPTION
This commit fixes an issue where every serialization of an HttpsOnlyURL field logged a PydanticSerializationUnexpectedValue warning. The AfterValidator returned a str while the annotation stayed HttpUrl, so the serializer expected a Url but got a str. We now keep the value as an HttpUrl and attach a PlainSerializer(str) so model_dump still emits a plain string in both python and json modes without the warning.