### PR TITLE
NAS-141876 / 27.0.0-BETA.1 / Fix recursive role assignment

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -62,7 +62,7 @@ ROLES = {
 
     # Interact with privilege framework
     'PRIVILEGE_READ': Role(),
-    'PRIVILEGE_WRITE': Role(includes=['PRIVILEGE_WRITE']),
+    'PRIVILEGE_WRITE': Role(includes=['PRIVILEGE_READ']),
 
     'REPORTING_READ': Role(),
     'REPORTING_WRITE': Role(includes=['REPORTING_READ']),


### PR DESCRIPTION
This commit fixes a typo for the PRIVILEGE_WRITE role that if granted in isolation to a group could cause a
recursion error to surface to API consumer.