### PR TITLE
NAS-141876 / 26.0.0-BETA.3 / Fix recursive role assignment (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -61,7 +61,7 @@ ROLES = {
 
     # Interact with privilege framework
     'PRIVILEGE_READ': Role(),
-    'PRIVILEGE_WRITE': Role(includes=['PRIVILEGE_WRITE']),
+    'PRIVILEGE_WRITE': Role(includes=['PRIVILEGE_READ']),
 
     'REPORTING_READ': Role(),
     'REPORTING_WRITE': Role(includes=['REPORTING_READ']),


### PR DESCRIPTION
This commit fixes a typo for the PRIVILEGE_WRITE role that if granted in isolation to a group could cause a
recursion error to surface to API consumer.

Original PR: https://github.com/truenas/middleware/pull/19358
