### PR TITLE
NAS-141882 / 26.0.0-RC.1 / Fix `clear_sync_pending_zfs_keys`

### DIFF
--- a/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
+++ b/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
@@ -154,7 +154,7 @@ class KMIPService(Service, KMIPServerMixin):
             'datastore.query', 'storage.encrypteddataset', [['kmip_uid', '!=', None]]
         ):
             if ds['encryption_key']:
-                await self.middleware.call('datastore.update', 'storage.encrypteddataset', {'kmip_uid': None})
+                await self.middleware.call('datastore.update', 'storage.encrypteddataset', ds['id'], {'kmip_uid': None})
             else:
                 to_remove.append(ds['id'])
         await self.middleware.call('datastore.delete', 'storage.encrypteddataset', [['id', 'in', to_remove]])


### PR DESCRIPTION
The bug — zfs_keys.py:164: clear_sync_pending_zfs_keys called datastore.update('storage.encrypteddataset', {'kmip_uid': None}), passing the update data dict into the id_or_filters position and leaving the required data argument unfilled. Any dataset that still held a local encryption_key triggered TypeError: DatastoreService.update() missing 1 required positional argument: 'data', which aborted the whole function — so the sibling datastore.delete on line 167 never ran and orphan rows were left behind.