### PR TITLE
NAS-141883 / 26.0.0-RC.1 / Fix KMIP in-memory cache being wiped after every push

### DIFF
--- a/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
+++ b/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
@@ -91,7 +91,8 @@ class KMIPService(Service, KMIPServerMixin):
                     update_data = {'encryption_key': None, 'kmip_uid': uid}
                 if update_data:
                     self.middleware.call_sync('datastore.update', 'storage.encrypteddataset', ds['id'], update_data)
-        self.zfs_keys = {k: v for k, v in self.zfs_keys.items() if k in existing_datasets}
+        existing_dataset_names = {ds['name'] for ds in existing_datasets}
+        self.zfs_keys = {k: v for k, v in self.zfs_keys.items() if k in existing_dataset_names}
         return failed
 
     @private
@@ -122,7 +123,8 @@ class KMIPService(Service, KMIPServerMixin):
                 self.zfs_keys.pop(ds['name'], None)
                 if connection_successful:
                     self.middleware.call_sync('kmip.delete_kmip_secret_data', ds['kmip_uid'])
-        self.zfs_keys = {k: v for k, v in self.zfs_keys.items() if k in existing_datasets}
+        existing_dataset_names = {ds['name'] for ds in existing_datasets}
+        self.zfs_keys = {k: v for k, v in self.zfs_keys.items() if k in existing_dataset_names}
         return failed
 
     @private


### PR DESCRIPTION
zfs_keys.py:102 (and the same in pull) — {k: v for k, v in store.zfs_keys.items() if k in existing_datasets} compares dataset names against a list of dicts, so it always evaluates false and wipes the in-memory cache after every push. That's why kmip_sync_pending stays true after a successful push, which is what forces several tests to use force_clear.