### PR TITLE
NAS-141885 / 27.0.0-BETA.1 / Depend on websockify explicitly for SPICE display

### DIFF
--- a/src/middlewared/debian/control
+++ b/src/middlewared/debian/control
@@ -185,6 +185,7 @@ Depends: alembic,
          syslog-ng-mod-sql,
          tcpdump,
          truenas-files,
+         websockify,
          wireguard-tools,
          ${misc:Depends},
          ${python3:Depends}


### PR DESCRIPTION
## Problem
VMs with a SPICE display device shell out to the `websockify` binary at runtime (truenas_pylibvirt's display device runs `websockify --web /usr/share/spice-html5/ ...` to proxy the console to the web UI). We never declared that dependency though — websockify only got installed as a transitive `Recommends:` of `spice-html5`. Once truenas_build disabled `install_recommends` by default, the `truenas` package started installing with `--no-install-recommends`, so websockify silently stopped being pulled in and SPICE consoles broke.

## Solution
Add `websockify` to middlewared's `Depends`. It's a genuine hard runtime dependency of the SPICE path, so declaring it explicitly makes it come in regardless of the build's recommends setting and keeps us correct even if spice-html5's packaging changes.