### PR TITLE
NAS-141888 / 27.0.0-BETA.1 / Fix passdb reinit

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -30,7 +30,7 @@ class SMBService(Service):
             return query_passdb_entries(filters or [], options or {}, clustered)
         except PassdbMustReinit as err:
             self.logger.warning(err.errmsg)
-            self.synchronize_passdb().wait_sync(raise_error=True)
+            self.middleware.call_sync('smb.synchronize_passdb').wait_sync(raise_error=True)
             return query_passdb_entries(filters or [], options or {}, clustered)
 
     @private

--- a/tests/api2/test_smb_passdb_reinit.py
+++ b/tests/api2/test_smb_passdb_reinit.py
@@ -1,0 +1,48 @@
+import shlex
+
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import call, ssh
+
+# See middlewared.plugins.smb_.util_passdb: PASSDB_DIR = /var/run/samba-cache/private
+PASSDB_PATH = "/var/run/samba-cache/private/passdb.tdb"
+USERNAME = "covpdbreinit"
+
+
+def _delete_passdb_user_key(username):
+    """Drop the ``USER_<name>`` entry from passdb.tdb, leaving its ``RID_<rid>``
+    entry behind.
+
+    On the next read the dangling RID entry makes ``query_passdb_entries`` raise
+    ``PassdbMustReinit``, which is exactly what drives ``passdb_list`` through its
+    resync path. Keys are stored as null-terminated C strings, hence ``bytes([0])``.
+    """
+    py = (
+        "import tdb, os; "
+        f't = tdb.Tdb("{PASSDB_PATH}", 0, tdb.DEFAULT, os.O_RDWR); '
+        f't.delete(b"USER_{username}" + bytes([0])); '
+        "t.close()"
+    )
+    ssh(f"python3 -c {shlex.quote(py)}")
+
+
+def test_passdb_list_recovers_from_reinit():
+    call("smb.synchronize_passdb", job=True)
+
+    with user(
+        {
+            "username": USERNAME,
+            "full_name": "cov passdb reinit",
+            "group_create": True,
+            "smb": True,
+            "password": "PassdbPass1!",
+        }
+    ):
+        assert any(e["username"] == USERNAME for e in call("smb.passdb_list"))
+
+        # Corrupt the passdb so the next read is forced down the reinit path.
+        _delete_passdb_user_key(USERNAME)
+
+        entries = call("smb.passdb_list")
+        assert any(e["username"] == USERNAME for e in entries)


### PR DESCRIPTION
The ``PassdbMustReinit`` handler used to call ``self.synchronize_passdb()``
directly instead of through the middleware, so the ``@job`` method never
received its injected ``passdb_job`` argument and raised
``TypeError: synchronize_passdb() missing 1 required positional argument``
on every SMB user operation whenever the passdb had drifted from the account
table.