### PR TITLE
NAS-141892 / 27.0.0-BETA.1 / Remove unnecessary `restore_mail_config` fixture

### DIFF
--- a/tests/api2/test_mail.py
+++ b/tests/api2/test_mail.py
@@ -49,17 +49,8 @@ def message(**overrides):
     return {"subject": "test subject", "text": "test body", "to": [TO], "queue": False, **overrides}
 
 
-@pytest.fixture(scope="module", autouse=True)
-def restore_mail_config():
-    original = call("mail.config")
-    try:
-        yield
-    finally:
-        call("mail.update", {k: v for k, v in original.items() if k != "id"})
-
-
 @pytest.fixture(scope="module")
-def smtp_server(restore_mail_config):
+def smtp_server():
     with fake_smtp_server() as server:
         yield server
 


### PR DESCRIPTION
This is the default mail configuration, so there's neither a need nor a way to restore it. If another test needs a specific mail configuration, it should set it explicitly in its own fixture.