### PR TITLE
NAS-141897 / 27.0.0-BETA.1 / Remove unreachable `validate_homedir_mountinfo` call

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -520,9 +520,6 @@ class UserService(CRUDService):
                     f'{p.parent}: parent path of specified home directory does not exist.'
                 )
 
-            if not verrors:
-                self.validate_homedir_mountinfo(verrors, schema, p.parent)
-
         elif self.validate_homedir_mountinfo(verrors, schema, p):
             attrs = self.middleware.call_sync('filesystem.stat', data['home']).attributes
             if 'IMMUTABLE' in attrs:


### PR DESCRIPTION
Code above adds errors, so `verrors` is never empty