### PR TITLE
NAS-141898 / 27.0.0-BETA.1 / Remove unnecessary uid/gid range checks

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -59,9 +59,7 @@ from middlewared.plugins.account_.constants import (
     ADMIN_GID,
     ADMIN_UID,
     ALLOWED_BUILTIN_GIDS,
-    CONTAINER_ROOT_UID,
     DEFAULT_HOME_PATH,
-    IDMAP_COUNT,
     MIN_AUTO_XID,
     NO_LOGIN_SHELL,
     SKEL_PATH,
@@ -1553,14 +1551,6 @@ class UserService(CRUDService):
                 )
 
             combined_uid = combined.get('uid')
-            if combined_uid is not None and CONTAINER_ROOT_UID <= combined_uid < CONTAINER_ROOT_UID + IDMAP_COUNT:
-                verrors.add(
-                    f'{schema}.userns_idmap',
-                    f'User UID {combined_uid} falls within the host-side range reserved for '
-                    f'container userns mappings [{CONTAINER_ROOT_UID}, {CONTAINER_ROOT_UID + IDMAP_COUNT}); '
-                    'a user namespace idmap cannot be configured for it.'
-                )
-
             await self.validate_userns_idmap_conflict(
                 verrors, schema, data['userns_idmap'], combined_uid,
                 exclude_id=old['id'] if old else None,
@@ -2549,18 +2539,6 @@ class GroupService(CRUDService):
                 )
 
         effective_gid = entry['gid'] if entry else data.get('gid')
-        if (
-            data.get('userns_idmap')
-            and effective_gid is not None
-            and CONTAINER_ROOT_UID <= effective_gid < CONTAINER_ROOT_UID + IDMAP_COUNT
-        ):
-            verrors.add(
-                f'{schema}.userns_idmap',
-                f'Group GID {effective_gid} falls within the host-side range reserved for '
-                f'container userns mappings [{CONTAINER_ROOT_UID}, {CONTAINER_ROOT_UID + IDMAP_COUNT}); '
-                'a user namespace idmap cannot be configured for it.'
-            )
-
         await self.validate_userns_idmap_conflict(
             verrors, schema, data.get('userns_idmap'), effective_gid, exclude_id=pk,
         )


### PR DESCRIPTION
LocalUID/LocalGID max (90000000) is below the container range (2147000001), so such an id can't be submitted.