### PR TITLE
NAS-141908 / 27.0.0-BETA.1 / add --keep-refs to --dump-api

### DIFF
--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -98,11 +98,23 @@ class APIDumpEvent(BaseModel):
 
 
 class APIDumper:
-    def __init__(self, version: str, version_title: str, api: API, role_manager: RoleManager):
+    """Dumps an API version's methods and events as JSON schemas.
+
+    By default, schemas are post-processed for the documentation builder: every `$ref` is
+    replaced with an inline copy of its definition and the `$defs` tables are dropped. With
+    `keep_refs=True`, each method/event schema is instead emitted as pydantic's native
+    output — a standalone JSON Schema document that retains the `$defs` table, named model
+    definitions, and resolvable discriminator mappings — for consumers that need model
+    identities (e.g. client code generators).
+    """
+
+    def __init__(self, version: str, version_title: str, api: API, role_manager: RoleManager, *,
+                 keep_refs: bool = False):
         self.version = version
         self.version_title = version_title
         self.api = api
         self.role_manager = role_manager
+        self.keep_refs = keep_refs
 
     async def dump(self) -> APIDump:
         return APIDump(
@@ -180,9 +192,15 @@ class APIDumper:
             return None
 
         accepts_json_schema = model_json_schema(accepts_model)
-        accepts_json_schema = replace_refs(accepts_json_schema)
-
         returns_json_schema = model_json_schema(returns_model, mode="serialization")
+
+        if self.keep_refs:
+            return {
+                "accepts": accepts_json_schema,
+                "returns": returns_json_schema,
+            }
+
+        accepts_json_schema = replace_refs(accepts_json_schema)
         returns_json_schema = replace_refs(returns_json_schema)
 
         return {
@@ -228,6 +246,9 @@ class APIDumper:
         )
 
     def _dump_event_schemas(self, event: Event) -> dict[str, Any]:
+        if self.keep_refs:
+            return {name: model_json_schema(model) for name, model in event.event["models"].items()}
+
         properties = {}
         for name, model in event.event["models"].items():
             schema = model_json_schema(model)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1836,10 +1836,9 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
             if api.version == current_api.version:
                 version_title += " (current)"
 
-            result["versions"].append(
-                (await APIDumper(version, version_title, api, self.role_manager,
-                                 keep_refs=keep_refs).dump()).model_dump()
-            )
+            dumper = APIDumper(version, version_title, api, self.role_manager, keep_refs=keep_refs)
+            dumped_api = await dumper.dump()
+            result["versions"].append(dumped_api.model_dump())
 
         # Use async-safe json.dump to prevent blocking on file I/O
         await asyncio.to_thread(json.dump, result, stream)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1824,7 +1824,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
 
             last = current
 
-    async def dump_api(self, stream: typing.TextIO):
+    async def dump_api(self, stream: typing.TextIO, keep_refs: bool = False):
         self.__plugins_load()
 
         apis = self._load_apis()
@@ -1837,7 +1837,8 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
                 version_title += " (current)"
 
             result["versions"].append(
-                (await APIDumper(version, version_title, api, self.role_manager).dump()).model_dump()
+                (await APIDumper(version, version_title, api, self.role_manager,
+                                 keep_refs=keep_refs).dump()).model_dump()
             )
 
         # Use async-safe json.dump to prevent blocking on file I/O
@@ -2061,6 +2062,11 @@ def main():
     # This generates a complete JSON representation of all API versions, methods, and models
     # that is consumed by the middlewared_docs package builder to generate API documentation.
     parser.add_argument('--dump-api', action='store_true', help=argparse.SUPPRESS)
+    # Hidden modifier for --dump-api: emit each method/event schema as pydantic's native output,
+    # retaining the `$defs` table with named model definitions and resolvable discriminator mappings
+    # instead of inlining every definition at its use site. Consumed by client code generators that
+    # need model identities; the documentation builder uses the default (inlined) output.
+    parser.add_argument('--keep-refs', action='store_true', help=argparse.SUPPRESS)
     # Hidden argument for dumping all methods metadata to JSON
     # This generates the complete output of CoreService.get_methods() without any filtering.
     parser.add_argument('--dump-methods', action='store_true', help=argparse.SUPPRESS)
@@ -2090,6 +2096,9 @@ def main():
         # If --test wasn't specified but there are unknown args, it's an error
         if test_command:
             parser.error(f"unrecognized arguments: {' '.join(test_command)}")
+
+    if args.keep_refs and not args.dump_api:
+        parser.error('--keep-refs requires --dump-api')
 
     os.makedirs(MIDDLEWARE_RUN_DIR, exist_ok=True)
     pidpath = os.path.join(MIDDLEWARE_RUN_DIR, 'middlewared.pid')
@@ -2123,7 +2132,7 @@ def main():
     )
 
     if args.dump_api:
-        asyncio.get_event_loop().run_until_complete(middleware.dump_api(sys.stdout))
+        asyncio.get_event_loop().run_until_complete(middleware.dump_api(sys.stdout, keep_refs=args.keep_refs))
         return
 
     if args.dump_methods:

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_api_dumper_keep_refs.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_api_dumper_keep_refs.py
@@ -1,0 +1,143 @@
+import typing
+
+from pydantic import Field
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.server.doc import APIDumper
+
+
+class KeepRefsSharedOptions(BaseModel):
+    verbose: bool = False
+
+
+class KeepRefsPasswordLogin(BaseModel):
+    mechanism: typing.Literal["PASSWORD_PLAIN"]
+    username: str
+    options: KeepRefsSharedOptions = Field(default_factory=KeepRefsSharedOptions)
+
+
+class KeepRefsTokenLogin(BaseModel):
+    mechanism: typing.Literal["TOKEN_PLAIN"]
+    token: str
+
+
+class KeepRefsTestArgs(BaseModel):
+    login_data: typing.Annotated[KeepRefsPasswordLogin | KeepRefsTokenLogin, Field(discriminator="mechanism")]
+    options: KeepRefsSharedOptions = Field(default_factory=KeepRefsSharedOptions)
+
+
+class KeepRefsTestResult(BaseModel):
+    result: KeepRefsSharedOptions
+
+
+class FakeMethod:
+    def __init__(self, accepts, returns):
+        self._accepts = accepts
+        self._returns = returns
+
+    async def accepts_model(self):
+        return self._accepts
+
+    async def returns_model(self):
+        return self._returns
+
+
+class FakeEvent:
+    def __init__(self, models):
+        self.name = "test.event"
+        self.event = {"models": models, "description": "Test event", "private": False}
+
+
+def make_dumper(keep_refs):
+    return APIDumper("v1.0", "v1.0 (current)", api=None, role_manager=None, keep_refs=keep_refs)
+
+
+def collect_refs(schema, refs=None):
+    """Collect every `$ref` target and `discriminator.mapping` target in the document."""
+    if refs is None:
+        refs = []
+    if isinstance(schema, dict):
+        for k, v in schema.items():
+            if k == "$ref":
+                refs.append(v)
+            elif k == "discriminator" and isinstance(v, dict):
+                refs.extend(v.get("mapping", {}).values())
+            collect_refs(v, refs)
+    elif isinstance(schema, list):
+        for v in schema:
+            collect_refs(v, refs)
+    return refs
+
+
+def assert_refs_resolve(document):
+    defs = document.get("$defs", {})
+    refs = collect_refs(document)
+    assert refs, "expected the document to contain references"
+    for ref in refs:
+        assert ref.startswith("#/$defs/"), ref
+        assert ref.removeprefix("#/$defs/") in defs, f"{ref} does not resolve"
+
+
+@pytest.mark.asyncio
+async def test_keep_refs_method_schemas():
+    schemas = await make_dumper(keep_refs=True)._dump_method_schemas(FakeMethod(KeepRefsTestArgs, KeepRefsTestResult))
+
+    assert set(schemas) == {"accepts", "returns"}
+
+    accepts = schemas["accepts"]
+    # Model identities are preserved: the document is titled after the model and named
+    # definitions are kept in the `$defs` table instead of being inlined anonymously.
+    assert accepts["title"] == "KeepRefsTestArgs"
+    for name in ("KeepRefsSharedOptions", "KeepRefsPasswordLogin", "KeepRefsTokenLogin"):
+        assert name in accepts["$defs"]
+
+    # Every `$ref` and every `discriminator.mapping` target resolves within the document.
+    assert_refs_resolve(accepts)
+    mapping = accepts["properties"]["login_data"]["discriminator"]["mapping"]
+    assert mapping == {
+        "PASSWORD_PLAIN": "#/$defs/KeepRefsPasswordLogin",
+        "TOKEN_PLAIN": "#/$defs/KeepRefsTokenLogin",
+    }
+
+    # Positional call parameters are derivable from the properties order.
+    assert list(accepts["properties"]) == list(KeepRefsTestArgs.schema_model_fields())
+
+    assert_refs_resolve(schemas["returns"])
+
+
+@pytest.mark.asyncio
+async def test_default_method_schemas_are_inlined():
+    schemas = await make_dumper(keep_refs=False)._dump_method_schemas(FakeMethod(KeepRefsTestArgs, KeepRefsTestResult))
+
+    assert set(schemas["properties"]) == {"Call parameters", "Return value"}
+    assert "$defs" not in schemas
+
+    def assert_no_refs(schema):
+        if isinstance(schema, dict):
+            assert "$ref" not in schema
+            for v in schema.values():
+                assert_no_refs(v)
+        elif isinstance(schema, list):
+            for v in schema:
+                assert_no_refs(v)
+
+    assert_no_refs(schemas["properties"]["Call parameters"]["prefixItems"])
+    assert_no_refs(schemas["properties"]["Return value"].get("properties"))
+
+
+def test_keep_refs_event_schemas():
+    schemas = make_dumper(keep_refs=True)._dump_event_schemas(FakeEvent({"ADDED": KeepRefsPasswordLogin}))
+
+    assert set(schemas) == {"ADDED"}
+    assert schemas["ADDED"]["title"] == "KeepRefsPasswordLogin"
+    assert "KeepRefsSharedOptions" in schemas["ADDED"]["$defs"]
+    assert_refs_resolve(schemas["ADDED"])
+
+
+def test_default_event_schemas_are_inlined():
+    schemas = make_dumper(keep_refs=False)._dump_event_schemas(FakeEvent({"ADDED": KeepRefsPasswordLogin}))
+
+    assert set(schemas["properties"]) == {"ADDED"}
+    assert "$defs" not in schemas["properties"]["ADDED"]
+    assert "$ref" not in str(schemas["properties"]["ADDED"].get("properties", {}))


### PR DESCRIPTION
This is needed for the MCP feature since they're using the dump-api command to generate typescript interfaces from our json schemas. Should be no change in functionality, just an extra argument.