### PR TITLE
NAS-141910 / 27.0.0-BETA.1 / add job flag to json schema

### DIFF
--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -84,6 +84,7 @@ class APIDumpMethod(BaseModel):
     doc: str | None
     schemas: dict[str, Any]
     removed_in: str | None
+    job: bool = False
     input_pipes: bool = False
     output_pipes: bool = False
     check_pipes: bool = True
@@ -180,6 +181,7 @@ class APIDumper:
             doc=doc,
             schemas=schemas,
             removed_in=getattr(method.methodobj, "_removed_in", None),
+            job=bool(job),
             input_pipes=input_pipes,
             output_pipes=output_pipes,
             check_pipes=check_pipes

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_api_dumper_job_flag.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_api_dumper_job_flag.py
@@ -1,0 +1,78 @@
+import pytest
+
+from middlewared.api.base import BaseModel
+from middlewared.api.base.server.doc import APIDumper
+from middlewared.service import job
+
+
+class JobFlagTestArgs(BaseModel):
+    name: str
+
+
+class JobFlagTestResult(BaseModel):
+    result: bool
+
+
+class FakeMethod:
+    def __init__(self, methodobj, name="test.method"):
+        self.name = name
+        self.methodobj = methodobj
+
+    async def accepts_model(self):
+        return JobFlagTestArgs
+
+    async def returns_model(self):
+        return JobFlagTestResult
+
+
+class FakeRoleManager:
+    def atomic_roles_for_method(self, name):
+        return {"READONLY_ADMIN"}
+
+
+def make_dumper():
+    return APIDumper("v1.0", "v1.0 (current)", api=None, role_manager=FakeRoleManager())
+
+
+@pytest.mark.asyncio
+async def test_non_job_method():
+    async def plain_method(self, data):
+        """Do something."""
+
+    dump = await make_dumper()._dump_method(FakeMethod(plain_method))
+
+    assert dump.job is False
+    assert dump.input_pipes is False
+    assert dump.output_pipes is False
+    assert dump.check_pipes is True
+    assert "This method is a job." not in dump.doc
+
+
+@pytest.mark.asyncio
+async def test_job_method():
+    @job()
+    async def job_method(self, job_, data):
+        """Do something."""
+
+    dump = await make_dumper()._dump_method(FakeMethod(job_method))
+
+    assert dump.job is True
+    assert dump.input_pipes is False
+    assert dump.output_pipes is False
+    assert dump.check_pipes is True
+    # The doc text is still appended for the docs builder.
+    assert dump.doc.endswith("This method is a job.")
+
+
+@pytest.mark.asyncio
+async def test_job_method_with_pipes():
+    @job(pipes=["input", "output"], check_pipes=False)
+    async def pipes_method(self, job_, data):
+        """Do something."""
+
+    dump = await make_dumper()._dump_method(FakeMethod(pipes_method))
+
+    assert dump.job is True
+    assert dump.input_pipes is True
+    assert dump.output_pipes is True
+    assert dump.check_pipes is False


### PR DESCRIPTION
Same idea as adding `--keep-refs`. The team working on MCP doesn't have an easy way to determine if an endpoint is a job and so they're having to parse the text in the api description. This adds a `job` boolean so it becomes much easier to programmatically determine if the API endpoint is a job. Output looks something like
```
{
  "name": "pool.scrub.run",
  "roles": ["..."],
  "doc": "...\n\nThis method is a job.",
  "schemas": { "accepts": { ... }, "returns": { ... } },
  "removed_in": null,
  "job": true,
  "input_pipes": false,
  "output_pipes": false,
  "check_pipes": true
}
```