### PR TITLE
NAS-141916 / 26.0.0-BETA.3 / work-around a firmware crash on a NVMe SED capable drive that (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -497,6 +497,15 @@ class PoolService(CRUDService):
 
         verrors.check()
 
+        disks, vdevs = await self._process_topology('pool_create', data, None, data['all_sed'])
+
+        # WARNING: Fenced MUST NOT start (or reload) until SED provisioning inside
+        # self._process_topology() has completed. Its persistent reservation
+        # register/acquire burst racing the TCG Security Send/Receive session
+        # corrupts controller state on some SED drive firmware (observed on
+        # TCG Ruby 1.0 NVMe). SED setup writes no user data, so fencing is
+        # only required before disks are written to (resize, format, zpool
+        # create), all of which happen below.
         is_ha = await self.middleware.call('failover.licensed')
         if is_ha and (rc := await self.middleware.call('failover.fenced.start')):
             if rc == FencedExitCodes.ALREADY_RUNNING.value[0]:
@@ -509,8 +518,6 @@ class PoolService(CRUDService):
                 for i in filter(lambda x: x.value[0] == rc, FencedExitCodes):
                     err = i.value[1]
                 raise CallError(err)
-
-        disks, vdevs = await self._process_topology('pool_create', data, None, data['all_sed'])
 
         if osize := (await self.middleware.call('system.advanced.config'))['overprovision']:
             if log_disks := {disk: osize


### PR DESCRIPTION
we sell. The gist is of the problem is that we were running TCG initialization commands to the disks in parallel with certain NVMe register/acquire commands. Because the new SED library is considerably faster (just issuing commands via kernel interface) this exposed the crash (i.e. its a race). The OEM is being notified but in the meantime we'll work around the issue by initializing the SED drives first, and then reload/start fenced.

Original PR: https://github.com/truenas/middleware/pull/19388
