### PR TITLE
NAS-141918 / 27.0.0-BETA.1 / Simplify cloud_sync SyncRWLock internals

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync/lock.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/lock.py
@@ -16,8 +16,7 @@ class SyncRWLock:
     """Synchronous read-write lock implementation."""
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._read_ready = threading.Condition(self._lock)
+        self._read_ready = threading.Condition()
         self._readers = 0
         self._writers = 0
         self._fs_manager: FsLockManager | None = None
@@ -26,14 +25,14 @@ class SyncRWLock:
     @contextmanager
     def reader_lock(self) -> Iterator[None]:
         """Context manager for acquiring read lock."""
-        with self._lock:
+        with self._read_ready:
             while self._writers > 0:
                 self._read_ready.wait()
             self._readers += 1
         try:
             yield
         finally:
-            with self._lock:
+            with self._read_ready:
                 self._readers -= 1
                 if self._readers == 0:
                     self._read_ready.notify_all()
@@ -43,14 +42,14 @@ class SyncRWLock:
     @contextmanager
     def writer_lock(self) -> Iterator[None]:
         """Context manager for acquiring write lock."""
-        with self._lock:
+        with self._read_ready:
             while self._writers > 0 or self._readers > 0:
                 self._read_ready.wait()
             self._writers += 1
         try:
             yield
         finally:
-            with self._lock:
+            with self._read_ready:
                 self._writers -= 1
                 self._read_ready.notify_all()
                 if self._fs_manager and self._readers == 0:
@@ -72,13 +71,6 @@ class FsLockManager:
         self.sync_locks[path]._fs_manager = self
         self.sync_locks[path]._fs_path = path
         return self._choose_sync_lock(self.sync_locks[path], direction)
-
-    def _choose_lock(self, lock: SyncRWLock, direction: FsLockDirection) -> Any:
-        if direction == FsLockDirection.READ:
-            return lock.reader_lock
-        if direction == FsLockDirection.WRITE:
-            return lock.writer_lock
-        raise ValueError(direction)
 
     def _choose_sync_lock(self, lock: SyncRWLock, direction: FsLockDirection) -> Any:
         if direction == FsLockDirection.READ:

--- a/src/middlewared/middlewared/plugins/cloud_sync/lock.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/lock.py
@@ -12,8 +12,8 @@ class FsLockDirection(enum.Enum):
     WRITE = 1
 
 
-class SyncRWLock:
-    """Synchronous read-write lock implementation."""
+class RWLock:
+    """Read-write lock implementation."""
 
     def __init__(self) -> None:
         self._read_ready = threading.Condition()
@@ -58,21 +58,21 @@ class SyncRWLock:
 
 class FsLockManager:
     def __init__(self) -> None:
-        self.sync_locks: dict[str, SyncRWLock] = {}
+        self.locks: dict[str, RWLock] = {}
 
     def lock(self, path: str, direction: FsLockDirection) -> Any:
-        """Return a synchronous lock context manager."""
+        """Return a lock context manager."""
         path = os.path.normpath(path)
-        for k in self.sync_locks:
+        for k in self.locks:
             if os.path.commonpath([k, path]) in [k, path]:
-                return self._choose_sync_lock(self.sync_locks[k], direction)
+                return self._choose_lock(self.locks[k], direction)
 
-        self.sync_locks[path] = SyncRWLock()
-        self.sync_locks[path]._fs_manager = self
-        self.sync_locks[path]._fs_path = path
-        return self._choose_sync_lock(self.sync_locks[path], direction)
+        self.locks[path] = RWLock()
+        self.locks[path]._fs_manager = self
+        self.locks[path]._fs_path = path
+        return self._choose_lock(self.locks[path], direction)
 
-    def _choose_sync_lock(self, lock: SyncRWLock, direction: FsLockDirection) -> Any:
+    def _choose_lock(self, lock: RWLock, direction: FsLockDirection) -> Any:
         if direction == FsLockDirection.READ:
             return lock.reader_lock()
         if direction == FsLockDirection.WRITE:
@@ -81,7 +81,7 @@ class FsLockManager:
 
     def _remove_lock(self, path: str | None) -> None:
         if path is not None:
-            self.sync_locks.pop(path, None)
+            self.locks.pop(path, None)
 
 
 # Process-wide singletons shared by every cloud sync job (mirrors the class attributes the


### PR DESCRIPTION
I noticed some changes to this code in a previous PR that has since been merged and realized we're being inefficient when it comes to the locking primitives. SyncRWLock kept a separate threading.Lock and wrapped it in a Condition, but a Condition can own its lock directly. The extra attribute is gone and every critical section now enters the Condition itself. Behavior is identical since the lock is never acquired reentrantly.

Also removes FsLockManager._choose_lock, dead code superseded by _choose_sync_lock.

No public API changes. The only consumers use the manager's lock() context managers, which are unchanged.