### PR TITLE
NAS-141901 / 27.0.0-BETA.1 / Add attachment-delegate regression tests for type-safe snapshot tasks (by creatorcary)

### DIFF
--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -8,6 +8,7 @@ sys.path.append(os.getcwd())
 
 from middlewared.test.integration.assets.nfs import nfs_share
 from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.snapshot_task import snapshot_task
 from middlewared.test.integration.utils import call, client
 
 
@@ -33,3 +34,27 @@ def test_attachment_with_child_path(request):
                 attachments = call('pool.dataset.attachments_with_path', child_path, True)
                 assert len(attachments) == 1, attachments
                 assert attachments[0]['type'] == 'NFS Share', attachments
+
+
+def test_attachment_name_for_snapshot_task():
+    """A periodic snapshot task is reported by `attachments_with_path`.
+
+    Unlike share delegates (which return dicts), `pool.snapshottask` returns type-safe models, so this
+    exercises the `getattr` (non-dict) branch of the base delegate's `get_attachment_name`.
+    """
+    with dataset(PARENT_DATASET) as parent_dataset:
+        parent_path = f'/mnt/{parent_dataset}'
+        with snapshot_task({
+            "dataset": parent_dataset,
+            "recursive": False,
+            "lifetime_value": 1,
+            "lifetime_unit": "WEEK",
+            "naming_schema": "auto-%Y%m%d.%H%M%S-1w",
+            "schedule": {},
+            "enabled": True,
+        }):
+            attachments = call('pool.dataset.attachments_with_path', parent_path)
+            snapshot_tasks = [a for a in attachments if a['type'] == 'Snapshot Task']
+            assert snapshot_tasks == [{'type': 'Snapshot Task', 'service': None, 'attachments': [parent_dataset]}], (
+                attachments
+            )

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -557,34 +557,52 @@ def test_attachment_delegate_delete():
     assert call("replication.query", [["id", "=", task["id"]]]) == []
 
 
-def test_attachment_delegate_toggle():
-    """Exporting/importing a pool disables/re-enables its replication tasks via the delegate."""
-    pool_name = "test_replication_toggle"
-    with another_pool({"name": pool_name}) as new_pool:
-        src = f"{pool_name}/src"
-        call("pool.dataset.create", {"name": src})
+ATTACHMENT_TOGGLE_POOL = "test_attachment_toggle"
+ATTACHMENT_TOGGLE_SRC = f"{ATTACHMENT_TOGGLE_POOL}/src"
 
-        task = call("replication.create", {
-            "name": "test_attachment_toggle",
-            "direction": "PUSH",
-            "transport": "LOCAL",
-            "source_datasets": [src],
-            "target_dataset": "data",
-            "recursive": False,
-            "name_regex": ".+",
-            "auto": False,
-            "retention_policy": "NONE",
-        })
+
+@pytest.mark.parametrize("namespace,data", (
+    pytest.param("replication", {
+        "name": "test_attachment_toggle",
+        "direction": "PUSH",
+        "transport": "LOCAL",
+        "source_datasets": [ATTACHMENT_TOGGLE_SRC],
+        "target_dataset": "data",
+        "recursive": False,
+        "name_regex": ".+",
+        "auto": False,
+        "retention_policy": "NONE",
+    }, id="replication"),
+    pytest.param("pool.snapshottask", {
+        "dataset": ATTACHMENT_TOGGLE_SRC,
+        "recursive": False,
+        "lifetime_value": 1,
+        "lifetime_unit": "WEEK",
+        "naming_schema": "auto-%Y%m%d.%H%M%S-1w",
+        "schedule": {},
+        "enabled": True,
+    }, id="snapshot_task"),
+))
+def test_attachment_delegate_toggle(namespace, data):
+    """Non-cascade export then re-import disables and re-enables a pool's attachments via the delegate.
+
+    The `snapshot_task` case guards the type-safe `pool.snapshottask` conversion: that delegate returns
+    model objects, so the export `enable_on_import` bookkeeping and the re-import re-enable step must not
+    subscript attachments like dicts.
+    """
+    with another_pool({"name": ATTACHMENT_TOGGLE_POOL}) as new_pool:
+        call("pool.dataset.create", {"name": ATTACHMENT_TOGGLE_SRC})
+        task = call(f"{namespace}.create", data)
         try:
             # Export without cascade disables the attachment via `toggle(attachments, False)`.
             call("pool.export", new_pool["id"], job=True)
-            assert call("replication.get_instance", task["id"])["enabled"] is False
+            assert call(f"{namespace}.get_instance", task["id"])["enabled"] is False
 
             # Re-import re-enables the attachment via `toggle(attachments, True)`.
-            call("pool.import_pool", {"guid": new_pool["guid"], "name": pool_name}, job=True)
-            assert call("replication.get_instance", task["id"])["enabled"] is True
+            call("pool.import_pool", {"guid": new_pool["guid"], "name": ATTACHMENT_TOGGLE_POOL}, job=True)
+            assert call(f"{namespace}.get_instance", task["id"])["enabled"] is True
         finally:
-            call("replication.delete", task["id"])
+            call(f"{namespace}.delete", task["id"])
 
 
 def test_query_check_dataset_encryption_keys():


### PR DESCRIPTION
Adds integration coverage for the attachment-delegate paths that break when a delegate returns type-safe models instead of dicts — the fragility behind the recent `pool.export` crash. `pool.snapshottask` is the only delegate returning models ([NAS-139294](https://ixsystems.atlassian.net/browse/NAS-139294)), and no existing test exercised it through these paths.

- `test_attachment_delegate_toggle` is parametrized over a replication task (dict delegate) and a periodic snapshot task (model delegate). The snapshot-task case covers the non-cascade `pool.export` disable / `enable_on_import` bookkeeping and the re-import re-enable step.
- `test_attachment_name_for_snapshot_task` lists a snapshot task via `pool.dataset.attachments_with_path`, exercising the `getattr` (non-dict) branch of the base delegate's `get_attachment_name`.

Verified on a 26/INCREMENTAL VM: all three cases pass on current code, and both regression guards fail with `'PeriodicSnapshotTaskQueryResultItem' object is not subscriptable` when their respective fix is reverted.


Original PR: https://github.com/truenas/middleware/pull/19378
