### PR TITLE
NAS-141875 / 26.0.0-BETA.3 / Fix IPA SMB machine account setup and self-heal old joins (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/ipa_ctl.py
+++ b/src/freenas/usr/local/libexec/ipa_ctl.py
@@ -272,7 +272,7 @@ def get_keytab(
             cmd.append('-P')
             res = subprocess.run(
                 cmd, check=False,
-                input=b'{password}\n{password}',
+                input=f'{password}\n{password}'.encode(),
                 capture_output=True
             )
         else:

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
@@ -137,3 +137,21 @@ class IPAHealthMixin:
                     IPAHealthCheckFailReason.SSSD_STOPPED,
                     self._faulted_reason
                 )
+
+        # Systems joined by a build that wrote the SMB machine-account credential
+        # incorrectly are left with secrets.tdb, the SMB keytab and the KDC out of sync.
+        # The connection service regenerates the credential in place using the host
+        # credential (no administrator credential is required); only fault -- raising an
+        # alert -- if that regeneration fails.
+        try:
+            self.middleware.call_sync('directoryservices.connection.ipa_smb_heal_machine_account')
+        except Exception as e:
+            self._faulted_reason = (
+                'Failed to regenerate the IPA SMB machine account credentials. SMB '
+                'authentication against the IPA domain may not work until this is '
+                f'resolved: {e}'
+            )
+            raise IPAHealthError(
+                IPAHealthCheckFailReason.IPA_SMB_CREDS,
+                self._faulted_reason
+            )

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -227,25 +227,34 @@ class IPAJoinMixin:
         return True
 
     @kerberos_ticket
-    def _ipa_set_spn(self):
-        """ internal method to create service entries on remote IPA server """
+    def _ipa_set_spn(self, principals=None):
+        """ internal method to create service entries on remote IPA server
+
+        `principals` optionally restricts the operation to a subset of service principals
+        (it defaults to both SMB and NFS). A failure to create a principal is fatal so that
+        a partially-configured join is rolled back by the caller rather than silently
+        reported as success; the sole tolerated case is an IPA domain that does not support
+        SMB, which is skipped.
+        """
+        if principals is None:
+            principals = (
+                (IpaOperation.SET_SMB_PRINCIPAL, ipa_constants.IpaConfigName.IPA_SMB_KEYTAB),
+                (IpaOperation.SET_NFS_PRINCIPAL, ipa_constants.IpaConfigName.IPA_NFS_KEYTAB)
+            )
+
         output = []
-        for op, spn_type in (
-            (IpaOperation.SET_SMB_PRINCIPAL, ipa_constants.IpaConfigName.IPA_SMB_KEYTAB),
-            (IpaOperation.SET_NFS_PRINCIPAL, ipa_constants.IpaConfigName.IPA_NFS_KEYTAB)
-        ):
+        for op, spn_type in principals:
             setspn = subprocess.run(
                 [IPACTL, '-a', op.name], check=False, capture_output=True, timeout=IPACTL_OP_TIMEOUT
             )
 
             try:
                 resp = _parse_ipa_response(setspn)
-                output.append(resp | {'keytab_type': spn_type})
             except FileNotFoundError:
                 self.logger.debug('IPA domain does not provide support for SMB protocol')
                 continue
-            except Exception:
-                self.logger.error('%s: failed to create keytab', op.name, exc_info=True)
+
+            output.append(resp | {'keytab_type': spn_type})
 
         return output
 
@@ -273,10 +282,18 @@ class IPAJoinMixin:
                 self.middleware.call_sync('kerberos.keytab.delete', kt[0]['id'])
 
     @kerberos_ticket
-    def _ipa_setup_services(self, job: Job):
-        job.set_progress(description='Configuring kerberos principals')
+    def _ipa_setup_services(self, job: Job | None = None):
+        if job:
+            job.set_progress(description='Configuring kerberos principals')
+
+        # ipactl's SET_SMB_PRINCIPAL registers the machine account under the NetBIOS name
+        # it reads back from the on-disk smb.conf. Regenerate smb.conf first so that name
+        # reflects the current (possibly renamed) datastore value instead of a stale one.
+        self.middleware.call_sync('etc.generate', 'smb')
+
         resp = self._ipa_set_spn()
         domain_info = None
+        password = None
 
         for entry in resp:
             self._ipa_insert_keytab(entry['keytab_type'], entry['keytab'])
@@ -285,44 +302,95 @@ class IPAJoinMixin:
                 password = entry['password']
 
         if domain_info:
+            self._ipa_configure_smb(job, domain_info, password)
+
+    def _ipa_configure_smb(self, job: Job | None, domain_info: dict, password: str) -> None:
+        if job:
             job.set_progress(description='Configuring SMB server for IPA')
-            self.middleware.call_sync('datastore.update', 'services.cifs', 1, {
-                'cifs_srv_workgroup': domain_info['netbios_name']
-            })
 
-            # insert the domain info into our datastore config so that it's
-            # available for smb.conf generation
-            self.middleware.call_sync('datastore.update', 'directoryservices', 1, {
-                'ipa_smb_domain': {
-                    'name': domain_info['netbios_name'],
-                    'idmap_backend': 'SSS',
-                    'range_low': domain_info['range_id_min'],
-                    'range_high': domain_info['range_id_max'],
-                    'domain_sid': domain_info['domain_sid'],
-                    'domain_name': domain_info['domain_name']
-                }
-            })
+        self.middleware.call_sync('datastore.update', 'services.cifs', 1, {
+            'cifs_srv_workgroup': domain_info['netbios_name']
+        })
 
-            # regenerate our SMB config to apply our new domain
-            self.middleware.call_sync('etc.generate', 'smb')
+        # insert the domain info into our datastore config so that it's
+        # available for smb.conf generation
+        self.middleware.call_sync('datastore.update', 'directoryservices', 1, {
+            'ipa_smb_domain': {
+                'name': domain_info['netbios_name'],
+                'idmap_backend': 'SSS',
+                'range_low': domain_info['range_id_min'],
+                'range_high': domain_info['range_id_max'],
+                'domain_sid': domain_info['domain_sid'],
+                'domain_name': domain_info['domain_name']
+            }
+        })
 
-            # write our domain sid to the secrets.tdb
-            setsid = subprocess.run([
-                'net', 'setdomainsid', domain_info['domain_sid']
-            ], capture_output=True, check=False)
+        # regenerate our SMB config to apply our new domain
+        self.middleware.call_sync('etc.generate', 'smb')
 
-            if setsid.returncode:
-                raise CallError(f'Failed to set domain SID: {setsid.stderr.decode()}')
+        # write our domain sid to the secrets.tdb
+        setsid = subprocess.run([
+            'net', 'setdomainsid', domain_info['domain_sid']
+        ], capture_output=True, check=False)
 
-            # We must write the password encoded in the SMB keytab
-            # to secrets.tdb at this point.
-            self.middleware.call_sync(
-                'directoryservices.secrets.set_ipa_secret',
-                domain_info['netbios_name'],
-                base64.b64encode(password.encode())
-            )
+        if setsid.returncode:
+            raise CallError(f'Failed to set domain SID: {setsid.stderr.decode()}')
 
-            self.middleware.call_sync('directoryservices.secrets.backup')
+        # Write the raw machine-account password (the value the SMB keytab was derived
+        # from) to secrets.tdb so that the keytab and secrets.tdb stay in sync.
+        self.middleware.call_sync(
+            'directoryservices.secrets.set_ipa_secret',
+            domain_info['netbios_name'],
+            password.encode()
+        )
+
+        self.middleware.call_sync('directoryservices.secrets.backup')
+
+    def ipa_smb_heal_machine_account(self) -> None:
+        """ Regenerate the IPA SMB machine-account credential in place if it predates the
+        current credential format (for example a system joined by a build that wrote it
+        incorrectly). A no-op when the credential is already current or the IPA domain has
+        no SMB support. This uses the host credential only -- no administrator credential
+        is required. Invoked from the IPA health check, which raises an alert if it fails.
+        """
+        if self._ipa_smb_creds_need_resync():
+            self.ipa_smb_recover_machine_account()
+
+    def _ipa_smb_creds_need_resync(self) -> bool:
+        """ Whether the IPA SMB machine-account credential predates the current credential
+        format and should be regenerated (for example a system joined by a build that wrote
+        it incorrectly). Returns False for IPA domains without SMB support. """
+        config = self.middleware.call_sync('directoryservices.config')
+        smb_domain = (config.get('configuration') or {}).get('smb_domain')
+        if not smb_domain:
+            return False
+
+        version = self.middleware.call_sync(
+            'directoryservices.secrets.ipa_cred_version', smb_domain['name']
+        )
+        return version < ipa_constants.IPA_SMB_CRED_VERSION
+
+    def ipa_smb_recover_machine_account(self) -> None:
+        """ Regenerate the SMB machine-account credential (KDC password, SMB keytab and
+        secrets.tdb) for an already-joined IPA domain, unconditionally. This is the explicit
+        recovery action: it uses the host credential only, so it needs no administrator
+        credential, and it heals a machine account left inconsistent by a build that wrote
+        the credential incorrectly. NFS is left untouched so its keytab is not needlessly
+        rotated. """
+        self.logger.info('IPA domain: regenerating SMB machine account credentials')
+
+        # smb.conf must reflect the current NetBIOS name before the SMB principal is
+        # recreated against it (see _ipa_setup_services).
+        self.middleware.call_sync('etc.generate', 'smb')
+
+        resp = self._ipa_set_spn(principals=(
+            (IpaOperation.SET_SMB_PRINCIPAL, ipa_constants.IpaConfigName.IPA_SMB_KEYTAB),
+        ))
+
+        for entry in resp:
+            self._ipa_insert_keytab(entry['keytab_type'], entry['keytab'])
+            if entry['keytab_type'] is ipa_constants.IpaConfigName.IPA_SMB_KEYTAB:
+                self._ipa_configure_smb(None, entry['domain_info'][0], entry['password'])
 
     @kerberos_ticket
     def ipa_get_smb_domain_info(self) -> dict | None:

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -8,6 +8,7 @@ from base64 import b64encode, b64decode
 from middlewared.plugins.smb_.constants import SMBPath
 from middlewared.service import Service
 from middlewared.service_exception import CallError, MatchNotFound
+from middlewared.utils.directoryservices.ipa_constants import IPA_SMB_CRED_VERSION
 from middlewared.utils.filter_list import filter_list
 from middlewared.utils.sid import raw_sid_to_str
 from middlewared.utils.tdb import (
@@ -22,6 +23,10 @@ SECRETS_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
 SECRETS_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.BYTES, True)
 SECRETS_TDB_CONFIG = (SECRETS_FILE, SECRETS_TDB_OPTIONS)
 SECRETS_CTDB_CONFIG = ('secrets.tdb', SECRETS_CTDB_OPTIONS)
+
+# TrueNAS-private secrets.tdb key (namespaced away from samba's SECRETS/* keys) recording
+# the version of the IPA SMB machine-account credential last written for a domain.
+IPA_SMB_CRED_VERSION_KEY = 'TRUENAS/IPA_SMB_CRED_VERSION'
 
 
 # c.f. source3/include/secrets.h
@@ -153,8 +158,11 @@ class DomainSecrets(Service):
 
         return struct.unpack("<L", bytes_passwd_chng)[0]
 
-    def set_ipa_secret(self, domain, secret):
-        # The stored secret in secrets.tdb and our kerberos keytab for SMB must be kept in-sync
+    def set_ipa_secret(self, domain: str, secret: bytes):
+        # The stored secret in secrets.tdb and our kerberos keytab for SMB must be kept
+        # in-sync. `secret` is the raw machine-account password bytes (the same value used
+        # to derive the SMB keytab); it is piped verbatim to `net changesecretpw` and must
+        # not be base64- or otherwise encoded, or SMB machine authentication will fail.
         cluster = self.middleware.call_sync("smb.config")["stateful_failover"]
         store_secrets_entry(
             f'{Secrets.MACHINE_PASSWORD.value}/{domain.upper()}', b64encode(b"2\x00").decode(), cluster
@@ -170,10 +178,32 @@ class DomainSecrets(Service):
             capture_output=True, check=False, input=secret
         )
         if setsecret.returncode != 0:
-            raise CallError(f'Failed to set machine account secret: {setsecret.stdout.decode()}')
+            raise CallError(f'Failed to set machine account secret: {setsecret.stderr.decode()}')
 
-        # Ensure we back this info up into our sqlite database as well
-        self.backup()
+        # Record the credential-format version so that systems joined by a build that wrote
+        # this secret incorrectly can be detected and healed after an upgrade.
+        store_secrets_entry(
+            f'{IPA_SMB_CRED_VERSION_KEY}/{domain.upper()}',
+            b64encode(str(IPA_SMB_CRED_VERSION).encode()).decode(), cluster
+        )
+
+    def ipa_cred_version(self, domain):
+        """
+        Return the IPA SMB machine-account credential-format version recorded in
+        secrets.tdb for `domain`, or 0 when no marker is present (which indicates the
+        credential was written by a build predating version tracking and should be
+        regenerated).
+        """
+        cluster = self.middleware.call_sync("smb.config")["stateful_failover"]
+        try:
+            encoded = fetch_secrets_entry(f'{IPA_SMB_CRED_VERSION_KEY}/{domain.upper()}', cluster)
+        except MatchNotFound:
+            return 0
+
+        try:
+            return int(b64decode(encoded).decode())
+        except (ValueError, TypeError):
+            return 0
 
     def set_ldap_idmap_secret(self, domain, user_dn, secret):
         """

--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -25,6 +25,7 @@ class IPAHealthCheckFailReason(enum.IntEnum):
     NTP_EXCESSIVE_SLEW = enum.auto()
     LDAP_BIND_FAILED = enum.auto()
     SSSD_STOPPED = enum.auto()
+    IPA_SMB_CREDS = enum.auto()
 
 
 class ADHealthCheckFailReason(enum.IntEnum):

--- a/src/middlewared/middlewared/utils/directoryservices/ipa_constants.py
+++ b/src/middlewared/middlewared/utils/directoryservices/ipa_constants.py
@@ -38,3 +38,10 @@ class IPASmbDomain:
     domain_name: str
     range_id_min: int
     range_id_max: int
+
+
+# Bump this when a change to how the IPA SMB machine-account credential is written
+# (secrets.tdb / keytab / KDC) requires already-joined systems to regenerate it after
+# an upgrade. A credential with no version marker in secrets.tdb is treated as version 0
+# (it predates version tracking) and is regenerated on the next health check.
+IPA_SMB_CRED_VERSION = 1

--- a/tests/directory_services/test_ipa_join.py
+++ b/tests/directory_services/test_ipa_join.py
@@ -124,3 +124,50 @@ def test_ipa_config_recover(do_freeipa_connection):
     call('directoryservices.health.recover')
     st = call('directoryservices.status')
     assert st['status'] == 'HEALTHY'
+
+
+def test_smb_machine_cred_version_stamped(do_freeipa_connection):
+    """ A completed IPA join must stamp the SMB machine-account credential with a non-zero
+    format version. A missing marker (version 0) is exactly what flags a credential written
+    by an affected build for regeneration, so a fresh, correct join must never look
+    un-stamped. """
+    smb_domain = do_freeipa_connection['config']['configuration']['smb_domain']
+    assert smb_domain, 'IPA domain with SMB support should expose smb_domain config'
+
+    version = call('directoryservices.secrets.ipa_cred_version', smb_domain['name'])
+    assert version > 0, f'SMB machine-account credential was not version-stamped (got {version})'
+
+
+def test_smb_machine_cred_health_check_is_clean(do_freeipa_connection):
+    """ The IPA health check now regenerates the SMB machine-account credential in place
+    when it predates the current format. On an already-current system it must be a no-op:
+    the check passes, the domain stays healthy and the credential stays stamped. """
+    call('directoryservices.health.check')
+
+    st = call('directoryservices.status')
+    assert st['status'] == 'HEALTHY'
+
+    smb_domain = do_freeipa_connection['config']['configuration']['smb_domain']
+    assert call('directoryservices.secrets.ipa_cred_version', smb_domain['name']) > 0
+
+
+def test_ipa_smb_spn_recovery(do_freeipa_connection):
+    """ Explicitly regenerate the IPA SMB machine account -- the recovery action that heals
+    systems joined by an affected build -- and confirm the result is functional. It runs on
+    the host credential alone (no administrator credential); afterwards the SMB keytab is
+    present, the credential is re-stamped, the domain is healthy, and the regenerated
+    machine account authenticates a secure channel to the IPA domain. """
+    smb_domain = do_freeipa_connection['config']['configuration']['smb_domain']
+    assert smb_domain, 'IPA domain with SMB support should expose smb_domain config'
+
+    call('directoryservices.connection.ipa_smb_recover_machine_account')
+
+    call('kerberos.keytab.query', [['name', '=', 'IPA_SMB_KEYTAB']], {'get': True})
+    assert call('directoryservices.secrets.ipa_cred_version', smb_domain['name']) > 0
+
+    call('directoryservices.health.check')
+    assert call('directoryservices.status')['status'] == 'HEALTHY'
+
+    # Secure channel using the regenerated machine-account secret in secrets.tdb.
+    # ssh(check=True) fails the test if wbinfo returns non-zero.
+    ssh('wbinfo -t')

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import struct
+import subprocess
 from base64 import b64encode
 
 import pytest
@@ -19,7 +20,23 @@ from unittest.mock import AsyncMock, MagicMock
 
 from middlewared.plugins.directoryservices_ import secrets as secrets_mod
 from middlewared.plugins.directoryservices_.secrets import DomainSecrets
+from middlewared.service_exception import CallError
 from middlewared.utils.tdb import get_tdb_handle
+
+
+@pytest.fixture
+def secrets_tdb(secrets_service, tmp_path, monkeypatch):
+    """
+    Point the secrets service at a real, empty secrets.tdb in a temp dir and run in
+    non-clustered mode. The tdb is opened O_RDWR without O_CREAT, so it must exist first.
+    """
+    tdb_path = str(tmp_path / 'secrets.tdb')
+    tdb.Tdb(tdb_path, 0, tdb.DEFAULT, os.O_CREAT | os.O_RDWR, 0o600).close()
+    monkeypatch.setattr(
+        secrets_mod, 'SECRETS_TDB_CONFIG', (tdb_path, secrets_mod.SECRETS_TDB_OPTIONS)
+    )
+    secrets_service.middleware.call_sync = MagicMock(return_value={'stateful_failover': False})
+    return secrets_service
 
 
 @pytest.fixture
@@ -163,3 +180,55 @@ def test__get_db_secrets_valid_json_merges_id(secrets_service):
     secrets_service.middleware.call.side_effect = fake_call
 
     assert asyncio.run(secrets_service.get_db_secrets()) == {"id": 7} | blob
+
+
+def test__set_ipa_secret_pipes_raw_password_and_stamps_version(secrets_tdb, monkeypatch):
+    """
+    The IPA <> SMB auth bug: the machine-account password handed to `net changesecretpw`
+    must be the raw bytes that the SMB keytab was derived from -- base64/otherwise encoding
+    it desynchronises secrets.tdb from the keytab and breaks SMB machine authentication.
+    set_ipa_secret must also stamp the credential-format version so systems joined by the
+    broken build can be detected and healed after an upgrade.
+    """
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured['cmd'] = cmd
+        captured['input'] = kwargs.get('input')
+        return subprocess.CompletedProcess(cmd, 0, stdout=b'', stderr=b'')
+
+    monkeypatch.setattr(secrets_mod.subprocess, 'run', fake_run)
+
+    # Deliberately include characters outside the base64 alphabet to catch any re-encoding.
+    raw_password = b'S0me-R@w_Machine!:;<=>()[]~Pass'
+    secrets_tdb.set_ipa_secret('MYDOMAIN', raw_password)
+
+    assert captured['cmd'][:2] == ['net', 'changesecretpw']
+    assert captured['input'] == raw_password, 'password must be piped to net changesecretpw verbatim'
+
+    # A successful write records the current credential-format version for the domain.
+    assert secrets_tdb.ipa_cred_version('MYDOMAIN') == secrets_mod.IPA_SMB_CRED_VERSION
+
+
+def test__set_ipa_secret_error_reports_stderr(secrets_tdb, monkeypatch):
+    """
+    On failure the raised error must surface `net changesecretpw`'s diagnostics, which it
+    writes to stderr -- reporting stdout (empty on the failure path) left the error blank.
+    """
+    def fake_run(cmd, *args, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout=b'', stderr=b'net: unable to write machine account password'
+        )
+
+    monkeypatch.setattr(secrets_mod.subprocess, 'run', fake_run)
+
+    with pytest.raises(CallError, match='unable to write machine account password'):
+        secrets_tdb.set_ipa_secret('MYDOMAIN', b'whatever')
+
+
+def test__ipa_cred_version_absent_reads_as_zero(secrets_tdb):
+    """
+    A domain with no recorded credential version -- i.e. one joined before version tracking
+    existed -- must read as 0 so the health check knows to regenerate its SMB credential.
+    """
+    assert secrets_tdb.ipa_cred_version('OLDDOMAIN') == 0


### PR DESCRIPTION
Set the SMB machine-account password from the generated value when retrieving the keytab and write that same value to secrets.tdb as raw bytes, so the keytab and secrets.tdb agree. Report changesecretpw stderr on failure and drop the unawaited backup() call.

Regenerate smb.conf before creating the SMB service principal so the machine account uses the current NetBIOS name, and make principal creation failures fatal so partial joins roll back.

Stamp a credential version in secrets.tdb; the IPA health check regenerates the SMB machine account in place, via the host credential, for systems joined by an earlier build that wrote it wrong. Expose the same regeneration as an explicit recovery action.

Add unit and integration tests.

Original PR: https://github.com/truenas/middleware/pull/19357
