### PR TITLE
NAS-141936 / 27.0.0-BETA.1 / Fix invalid `sssd.conf` configuration when directory service `auxiliary_parameters` are invalid

### DIFF
--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -37,7 +37,7 @@
                 aux.append(param)
             else:
                 try:
-                    min_uid = param.split()[1]
+                    min_uid = int(param.split()[1])
                 except Exception:
                     pass
 


### PR DESCRIPTION
Invalid non-integer from `nss_min_uid` will silently be passed as `min_id`