### PR TITLE
NAS-141946 / 27.0.0-BETA.1 / Fix AD member-server breakage on HA failover and upgrade

### DIFF
--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -60,13 +60,8 @@ class AuthService(Service):
         privileges = await self.middleware.call('privilege.privileges_for_groups', groups_key, groups)
         if not privileges:
             if not user['local']:
-                # A directory services user can authenticate (valid credentials) yet match no
-                # privilege for two reasons: the normal case where the account simply has no
-                # TrueNAS role, and the failure case where its NSS group list was truncated by
-                # a degraded provider (e.g. winbindd returning a partial getgrouplist). We
-                # can't tell them apart here, so log the evaluated group list as a factual
-                # breadcrumb -- an operator correlates it with directory services health status
-                # rather than this line asserting degradation on every routine no-role login.
+                # Directory services issues can be particularly difficult to pin down and
+                # so catching additional logging here is useful.
                 self.logger.info(
                     '%s: authenticated directory services user matched no privilege granting API '
                     'access; evaluated group list: %s.',

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -59,6 +59,19 @@ class AuthService(Service):
         groups = set(user['grouplist'])
         privileges = await self.middleware.call('privilege.privileges_for_groups', groups_key, groups)
         if not privileges:
+            if not user['local']:
+                # A directory services user can authenticate (valid credentials) yet match no
+                # privilege for two reasons: the normal case where the account simply has no
+                # TrueNAS role, and the failure case where its NSS group list was truncated by
+                # a degraded provider (e.g. winbindd returning a partial getgrouplist). We
+                # can't tell them apart here, so log the evaluated group list as a factual
+                # breadcrumb -- an operator correlates it with directory services health status
+                # rather than this line asserting degradation on every routine no-role login.
+                self.logger.info(
+                    '%s: authenticated directory services user matched no privilege granting API '
+                    'access; evaluated group list: %s.',
+                    user['pw_name'], sorted(groups)
+                )
             return None
 
         return {

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
@@ -210,6 +210,14 @@ class ADHealthMixin:
             case ADHealthCheckFailReason.WINBIND_STOPPED:
                 # pick up winbind restart below
                 pass
+            case ADHealthCheckFailReason.WINBIND_STALE_LOCAL_SID:
+                # Reconcile the on-disk SID before the restart below. A bare restart only
+                # heals the case where secrets.tdb already holds the configured SID and only
+                # winbindd's in-memory copy is stale; if secrets.tdb itself is stale, winbindd
+                # would re-read the stale value and the check would fault again every cycle.
+                # smb.set_system_sid rewrites secrets.tdb from the configured SID (a no-op
+                # when it already matches), so the restart below always converges.
+                self.middleware.call_sync('smb.set_system_sid')
             case _:
                 # not recoverable
                 raise error from None
@@ -234,7 +242,8 @@ class ADHealthMixin:
         except Exception:
             domain_info = None
 
-        workgroup = self.middleware.call_sync('smb.config')['workgroup']
+        smb_config = self.middleware.call_sync('smb.config')
+        workgroup = smb_config['workgroup']
 
         if domain_info:
             if domain_info['server_time_offset'] > MAX_SERVER_TIME_OFFSET:
@@ -305,6 +314,41 @@ class ADHealthMixin:
                 ADHealthCheckFailReason.AD_WBCLIENT_FAILURE,
                 faulted_reason
             )
+
+        # winbindd captures the local SAM domain SID from secrets.tdb when it starts.
+        # If the SID changes under a running winbindd (for example via `net setlocalsid`
+        # during an HA failover), its domain list no longer matches what the SAMR/passdb
+        # layer accepts and group token expansion fails with NT_STATUS_NO_SUCH_DOMAIN.
+        # Restarting winbindd rebuilds the domain list.
+        db_sid = self.middleware.call_sync('datastore.config', 'services.cifs')['cifs_SID']
+        if not db_sid:
+            # No configured server SID to compare against. Deliberately avoid
+            # smb.local_server_sid() here: with no stored SID it synthesizes (and on the
+            # active controller persists) a random SID, which would both corrupt the stored
+            # value from a health check and guarantee a spurious mismatch against winbindd.
+            # A directory-services-enabled server always has this set, so treat its absence
+            # as a skip, not a fault.
+            self.logger.warning(
+                'Local server SID is not set in configuration; skipping stale local SID check.'
+            )
+        else:
+            try:
+                wb_local_sid = ctx.domain_info(smb_config['netbiosname'])['sid']
+            except Exception:
+                # Unable to determine winbindd's view of the local SAM domain. This is
+                # ambiguous (for example a transient winbind hiccup) so we don't force a
+                # restart on it -- log and let the remaining checks proceed.
+                self.logger.warning(
+                    'Failed to retrieve local SAM domain information from winbindd', exc_info=True
+                )
+            else:
+                if wb_local_sid != db_sid:
+                    raise ADHealthError(
+                        ADHealthCheckFailReason.WINBIND_STALE_LOCAL_SID,
+                        f'winbindd reports local SAM domain SID [{wb_local_sid}] but the configured '
+                        f'server SID is [{db_sid}]. This indicates the local server SID was changed '
+                        'while winbindd was running.'
+                    )
 
         # If needed we can replace `ping_dc()` with `check_trust()`
         # for now we're defaulting to lower-cost test unless it gives

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
@@ -263,9 +263,11 @@ class ADJoinMixin:
                 'by an Active Directory administrator: %s', netads.stderr.decode()
             )
 
-        # Above step nukes our secrets file so we can forcibly overwrite our secrets backup
+        # Above step nukes our secrets file so we can forcibly overwrite our secrets backup.
+        # allow_missing_machine_secret is required because the machine account password is
+        # intentionally gone at this point -- we want to clear the stored backup, not keep it.
         try:
-            self.middleware.call_sync('directoryservices.secrets.backup')
+            self.middleware.call_sync('directoryservices.secrets.backup', True)
         except Exception:
             self.logger.debug('Failed to remove stale secrets', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/connection.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/connection.py
@@ -97,10 +97,12 @@ class DomainConnection(
             case DSType.IPA:
                 if not clustered:
                     self.middleware.call_sync('directoryservices.secrets.restore')
+                    self._reconcile_standby_local_sid()
                 activate_fn = self._ipa_activate
             case DSType.AD:
                 if not clustered:
                     self.middleware.call_sync('directoryservices.secrets.restore')
+                    self._reconcile_standby_local_sid()
                 activate_fn = self._ad_activate
             case DSType.LDAP:
                 activate_fn = self._ldap_activate
@@ -118,6 +120,40 @@ class DomainConnection(
             self.middleware.call_sync('directoryservices.health.recover')
         except Exception:
             self.logger.warning('Failed to become healthy on standby controller', exc_info=True)
+
+    def _reconcile_standby_local_sid(self) -> None:
+        """
+        Ensure the standby's restored secrets.tdb carries the authoritative local server
+        SID before winbindd starts.
+
+        ``directoryservices.secrets.restore`` replays the ``SECRETS/SID/{netbios}`` value
+        that was current when the backup was taken, which can lag the database value. If
+        left unreconciled, winbindd starts with a stale local SAM domain SID. That state
+        cannot self-heal via a winbindd restart on the standby (the wrong SID is persisted
+        in secrets.tdb, so a restart just re-reads it), so it is rewritten here, before
+        winbindd starts, to keep the standby correct ahead of any failover.
+
+        This is best effort: a failure to reconcile is logged and swallowed rather than
+        aborting standby activation. The activation and health-recovery steps that follow
+        this call are wrapped for the same reason, and the periodic health check provides a
+        further backstop once this controller is promoted.
+        """
+        try:
+            if not self.middleware.call_sync('datastore.config', 'services.cifs')['cifs_SID']:
+                # Without a stored SID, smb.local_server_sid() would synthesize a fresh random
+                # SID on every call on the standby (it only persists on the active controller),
+                # so reconciling here would stamp a bogus SID. A directory-services-enabled
+                # server always has this set, so treat its absence as a skip, not an error.
+                self.logger.warning(
+                    'Local server SID is not set in configuration; skipping standby SID reconciliation.'
+                )
+                return
+
+            self.middleware.call_sync('smb.set_system_sid')
+        except Exception:
+            self.logger.warning(
+                'Failed to reconcile local server SID on standby controller', exc_info=True
+            )
 
     def activate(self) -> int:
         """ Generate etc files and start services, then start cache fill job and return job id """

--- a/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/secrets.py
@@ -271,7 +271,7 @@ class DomainSecrets(Service):
             return {'id': db['id']}
         return {'id': db['id']} | secrets
 
-    async def backup(self):
+    async def backup(self, allow_missing_machine_secret=False):
         """
         store backup of secrets.tdb contents (keyed on current netbios name) in
         freenas-v1.db file. Only the current netbiosname's entry is retained --
@@ -280,6 +280,12 @@ class DomainSecrets(Service):
         of historical hostnames indefinitely. In HA the netbiosname is shared
         (it's the virtual SMB hostname, not per-controller) so pruning never
         loses the standby's backup.
+
+        ``allow_missing_machine_secret`` permits overwriting the stored backup with a
+        secrets.tdb dump that contains no machine account password. This is only
+        expected when deliberately clearing the backup (for example after leaving a
+        domain). By default such an overwrite is refused so a machine-secret-less dump
+        cannot destroy an otherwise-good backup.
         """
         failover_status = await self.middleware.call('failover.status')
         if failover_status not in ('SINGLE', 'MASTER'):
@@ -293,6 +299,17 @@ class DomainSecrets(Service):
 
         if not (secrets := (await self.middleware.call('directoryservices.secrets.dump'))):
             self.logger.warning("Unable to parse secrets")
+            return
+
+        if not allow_missing_machine_secret and not any(
+            key.startswith(f'{Secrets.MACHINE_PASSWORD.value}/') for key in secrets
+        ):
+            self.logger.warning(
+                "Refusing to overwrite the stored directory services secrets backup: the "
+                "current secrets.tdb contains no machine account password. This can occur "
+                "transiently during startup before the machine account secret has been "
+                "restored from the database backup."
+            )
             return
 
         fresh = {f"{netbios_name.upper()}$": secrets}

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -592,7 +592,31 @@ class KerberosKeytabService(CRUDService):
         if not ds_config['enable'] or ds_config['service_type'] != 'ACTIVEDIRECTORY':
             return
 
+        workgroup = (await self.middleware.call('smb.config'))['workgroup']
+        if not await self.middleware.call('directoryservices.secrets.has_domain', workgroup):
+            # The live secrets.tdb has no machine account password entry yet. This is not a
+            # password rotation -- it happens transiently during startup when smb.set_system_sid
+            # has created secrets.tdb (writing only the local server SID) but the machine account
+            # secret has not yet been restored from the database backup. Backing up now would dump
+            # a machine-secret-less secrets.tdb over the good backup and destroy it. Skip until the
+            # secret is present. Keyed on the machine account password rather than its last-change
+            # timestamp: a corrupt timestamp with the password intact must not be mistaken for this
+            # startup state (which would otherwise skip keytab refreshes forever).
+            return
+
         ts = await self.middleware.call('directoryservices.get_last_password_change')
+        if ts['secrets'] is None:
+            # The machine account password is present but its last-change timestamp is unreadable
+            # (a corrupt secrets.tdb entry). We can't compare timestamps to decide whether the
+            # keytab needs refreshing, and backing up now could propagate the corruption over a
+            # good backup, so log and skip this cycle. A genuine password change rewrites the
+            # timestamp to a valid value, healing this on a later run.
+            self.logger.warning(
+                'Machine account password last-change timestamp is unreadable although the machine '
+                'account password is present; skipping keytab and secrets update this cycle.'
+            )
+            return
+
         if ts['dbconfig'] == ts['secrets']:
             return
 

--- a/src/middlewared/middlewared/plugins/smb_/sid.py
+++ b/src/middlewared/middlewared/plugins/smb_/sid.py
@@ -1,7 +1,8 @@
 import subprocess
 
+from middlewared.api.current import ServiceOptions
 from middlewared.service import Service, private
-from middlewared.service_exception import CallError
+from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils.sid import random_sid
 
 from .constants import SMBCmd
@@ -27,6 +28,26 @@ class SMBService(Service):
     @private
     def set_system_sid(self):
         server_sid = self.local_server_sid()
+        netbiosname = self.middleware.call_sync('smb.config')['netbiosname']
+
+        sid_read_failed = False
+        try:
+            current_sid = self.middleware.call_sync('directoryservices.secrets.domain_sid', netbiosname)
+        except (FileNotFoundError, MatchNotFound):
+            # secrets.tdb does not exist yet or holds no SID for our netbios name
+            current_sid = None
+        except Exception:
+            # An unexpected read failure is not the same as a genuinely-absent SID: we
+            # cannot prove the SID was unchanged, so record that the read failed and let
+            # the restart decision below err on the side of restarting winbindd.
+            self.logger.warning(
+                '%s: failed to read current local server SID from secrets', netbiosname, exc_info=True
+            )
+            current_sid = None
+            sid_read_failed = True
+
+        if current_sid == server_sid:
+            return
 
         setsid = subprocess.run([
             SMBCmd.NET.value, '-d', '0',
@@ -35,3 +56,23 @@ class SMBService(Service):
 
         if setsid.returncode != 0:
             raise CallError(f'setlocalsid failed: {setsid.stderr.decode()}')
+
+        if (current_sid is None and not sid_read_failed) or not self.call_sync2(self.s.service.started, 'idmap'):
+            # Skip the restart when we know there was no prior SID (a fresh secrets.tdb has
+            # nothing stale for winbindd to rebuild) or when winbindd isn't running. When the
+            # read failed instead, current_sid is None but sid_read_failed is True, so we fall
+            # through and restart -- leaving winbindd on a possibly-stale SID is the worse risk.
+            return
+
+        # winbindd captures the local SAM domain SID from secrets.tdb when it starts.
+        # Changing the SID under a running winbindd leaves its domain list referencing
+        # a SID that the SAMR/passdb layer no longer accepts, and group token expansion
+        # fails with NT_STATUS_NO_SUCH_DOMAIN until winbindd is restarted.
+        self.logger.warning(
+            '%s: local server SID changed from %s to %s while winbindd was running. Restarting '
+            'winbindd to rebuild its view of the local SAM domain.',
+            netbiosname, current_sid, server_sid
+        )
+        self.call_sync2(
+            self.s.service.control, 'RESTART', 'idmap', ServiceOptions(silent=False, ha_propagate=False)
+        ).wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -37,6 +37,7 @@ class ADHealthCheckFailReason(enum.IntEnum):
     AD_WBCLIENT_FAILURE = enum.auto()
     NTP_EXCESSIVE_SLEW = enum.auto()
     WINBIND_STOPPED = enum.auto()
+    WINBIND_STALE_LOCAL_SID = enum.auto()
 
 
 class LDAPHealthCheckFailReason(enum.IntEnum):

--- a/tests/directory_services/test_zzz_truenas_ha.py
+++ b/tests/directory_services/test_zzz_truenas_ha.py
@@ -1,7 +1,12 @@
 import pytest
 
-from middlewared.test.integration.assets.directory_service import directoryservice
-from middlewared.test.integration.utils import call, ssh, truenas_server
+from middlewared.test.integration.assets.directory_service import (
+    directoryservice,
+    AD_DOM2_LIMITED_USER,
+    AD_DOM2_LIMITED_USER_PASSWORD,
+)
+from middlewared.test.integration.assets.privilege import privilege
+from middlewared.test.integration.utils import call, client, ssh, truenas_server
 from middlewared.test.integration.utils.failover import do_failover, ha_enabled
 
 
@@ -67,3 +72,57 @@ def test_failover(service_type):
 
     check_ds_status(call('directoryservices.status'), None)
     check_ds_status(call('failover.call_remote', 'directoryservices.status'), None)
+
+
+@pytest.mark.skipif(not ha_enabled, reason='HA only test')
+def test_ad_user_privilege_auth_survives_failover():
+    """
+    An AD user granted API access through a group privilege must still authenticate to the
+    API after a failover.
+
+    ``test_failover`` above only asserts ``directoryservices.status`` is HEALTHY, which does
+    not exercise group-membership resolution on the newly-active controller. Asserting a real
+    login -- and that the group-derived privilege is retained -- is what covers that.
+    """
+    with directoryservice('ACTIVEDIRECTORY') as ds:
+        domain_name = ds['config']['configuration']['domain']
+        short_name = ds['domain_info']['domain_controller']['pre-win2k_domain']
+
+        # RID 513 is the constant RID for the "Domain Users" group. The limited AD user is a
+        # member of it and has no other path to API access, so the granted READONLY_ADMIN
+        # role depends entirely on that group membership resolving on the active controller.
+        domain_sid = call('idmap.domain_info', short_name)['sid']
+        limited_user = f'{AD_DOM2_LIMITED_USER}@{domain_name}'
+
+        with privilege({
+            'name': 'AD failover privilege',
+            'local_groups': [],
+            'ds_groups': [f'{domain_sid}-513'],
+            'roles': ['READONLY_ADMIN'],
+            'web_shell': False,
+        }):
+            # Baseline: the user authenticates and receives the group-derived role before
+            # failover, so a post-failover failure is unambiguously a failover regression.
+            with client(auth=(limited_user, AD_DOM2_LIMITED_USER_PASSWORD)) as c:
+                methods = c.call('core.get_methods')
+                assert 'system.info' in methods
+                assert 'pool.create' not in methods
+
+            do_failover()
+
+            # DS health alone does not prove group resolution works; the login below does.
+            check_ds_status(call('directoryservices.status'), 'HEALTHY')
+
+            # The same AD user must still authenticate on the new active controller and retain
+            # the group-derived privilege. A stale local SAM SID would truncate the group list,
+            # dropping the privileged group -- denying the login (this context manager would
+            # raise) or stripping the role.
+            with client(auth=(limited_user, AD_DOM2_LIMITED_USER_PASSWORD)) as c:
+                me = c.call('auth.me')
+                assert 'DIRECTORY_SERVICE' in me['account_attributes']
+                methods = c.call('core.get_methods')
+                assert 'system.info' in methods, (
+                    'AD user lost its group-derived privilege after failover; local SAM SID '
+                    'or group membership resolution did not survive promotion'
+                )
+                assert 'pool.create' not in methods

--- a/tests/directory_services/test_zzz_truenas_ha.py
+++ b/tests/directory_services/test_zzz_truenas_ha.py
@@ -13,6 +13,22 @@ from middlewared.test.integration.utils.failover import do_failover, ha_enabled
 SAF_PATH = '/root/.KDC_SERVER_AFFINITY'
 
 
+@pytest.fixture(scope='function')
+def enable_ds_auth():
+    """ Directory services users may only authenticate to the API when the ds_auth
+    system.general setting is on (with it off, the generated PAM stacks for API login
+    exclude the directory services modules entirely). Every test in this file is
+    HA-only and HA systems are always enterprise-licensed, so the setting can be
+    toggled directly. Changing it regenerates PAM on both controllers, which also
+    covers logins performed after a failover. """
+    call('system.general.update', {'ds_auth': True})
+
+    try:
+        yield
+    finally:
+        call('system.general.update', {'ds_auth': False})
+
+
 def check_ds_status(status_dict, expected):
     msg = status_dict['status_msg']
     status = status_dict['status']
@@ -75,7 +91,7 @@ def test_failover(service_type):
 
 
 @pytest.mark.skipif(not ha_enabled, reason='HA only test')
-def test_ad_user_privilege_auth_survives_failover():
+def test_ad_user_privilege_auth_survives_failover(enable_ds_auth):
     """
     An AD user granted API access through a group privilege must still authenticate to the
     API after a failover.

--- a/tests/unit/test_activedirectory_health.py
+++ b/tests/unit/test_activedirectory_health.py
@@ -36,6 +36,10 @@ SAF_PINNED_IP = "10.0.0.42"
 SAF_PINNED_HOST = "dc-joined.ad.example.com"
 
 SMB_CONFIG = {"workgroup": "AD", "netbiosname": "TRUENAS"}
+
+# winbindd's view of the local SAM domain SID and the configured server SID. These
+# agree on a healthy system; the stale-SID health check fires when they diverge.
+LOCAL_SAM_SID = "S-1-5-21-1111111111-2222222222-3333333333"
 DS_CONFIG = {
     "kerberos_realm": "AD.EXAMPLE.COM",
     "configuration": {"domain": "AD.EXAMPLE.COM"},
@@ -82,6 +86,11 @@ def harness(saf_cache_file):
                 return {"name": "AD_MACHINE_ACCOUNT"}
             case "service.started":
                 return True
+            case "datastore.config":
+                # services.cifs row -- the configured local server SID. Read directly
+                # (rather than via smb.local_server_sid) so the health check never
+                # synthesizes/persists a random SID as a side effect.
+                return {"cifs_SID": LOCAL_SAM_SID}
             case _:
                 raise AssertionError(f"unexpected middleware call: {name}")
 
@@ -133,14 +142,16 @@ def _wbclient_with_failing_ping(
     """
     instance = MagicMock()
     instance.ping_dc.side_effect = _make_wbc_error(wbc_error_code, ntstatus, message)
+    instance.domain_info.return_value = {"sid": LOCAL_SAM_SID}
     cls = MagicMock(return_value=instance)
     return cls
 
 
-def _wbclient_healthy():
-    """WBClient mock whose ping_dc() succeeds."""
+def _wbclient_healthy(local_sam_sid=LOCAL_SAM_SID):
+    """WBClient mock whose ping_dc() succeeds and whose local SAM SID matches the db by default."""
     instance = MagicMock()
     instance.ping_dc.return_value = None
+    instance.domain_info.return_value = {"sid": local_sam_sid}
     cls = MagicMock(return_value=instance)
     return cls
 
@@ -175,6 +186,149 @@ def test__health_check_ad_does_not_run_password_test_when_ping_dc_succeeds(harne
         "on every periodic check writes a temporary krb5.conf and regenerates the "
         "system one, which is unnecessary churn."
     )
+
+
+# ---- Stale local SAM SID detection --------------------------------------------------------
+
+
+def test__health_check_ad_detects_stale_local_sid(harness):
+    """
+    If winbindd's view of the local SAM domain SID diverges from the configured server SID
+    (as when `net setlocalsid` runs under a live winbindd), the health check must fault with
+    WINBIND_STALE_LOCAL_SID so recovery routes to a winbindd restart.
+    """
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password") as test_pw,
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=_wbclient_healthy(local_sam_sid="S-1-5-21-9999999999-8888888888-7777777777"),
+        ),
+    ):
+        with pytest.raises(ADHealthError) as excinfo:
+            harness._health_check_ad()
+
+    assert excinfo.value.reason is ADHealthCheckFailReason.WINBIND_STALE_LOCAL_SID
+    assert LOCAL_SAM_SID in excinfo.value.errmsg
+    # The mismatch is detected before ping_dc, so no password refinement should run.
+    assert not test_pw.called
+
+
+def test__health_check_ad_domain_info_failure_does_not_fault(harness):
+    """
+    A failure to read winbindd's local SAM domain info is ambiguous (possibly a transient
+    winbind hiccup) and must NOT by itself fault the health check into a winbindd restart
+    -- otherwise a benign query blip becomes a 10-minute restart loop. The remaining
+    checks (here, a healthy ping_dc) should still run and pass.
+    """
+    instance = MagicMock()
+    instance.ping_dc.return_value = None
+    instance.domain_info.side_effect = wbclient.WBCError(
+        wbclient.WBC_ERR_DOMAIN_NOT_FOUND, "domain not found", "tests/synthetic"
+    )
+    wbclient_mock = MagicMock(return_value=instance)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password"),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=wbclient_mock,
+        ),
+    ):
+        # No raise: ambiguous domain_info failure is logged, not faulted.
+        harness._health_check_ad()
+
+    # And the check must have continued past the swallowed domain_info failure rather than
+    # returning early -- otherwise "does not fault" could pass for the wrong reason. ping_dc
+    # is the next step, so its having run proves the flow proceeded.
+    assert instance.ping_dc.called, (
+        "health check should continue to ping_dc after a logged domain_info failure"
+    )
+
+
+def test__health_check_ad_missing_server_sid_skips_stale_check(harness):
+    """
+    When no server SID is stored in configuration, the stale-SID check must be skipped
+    rather than calling smb.local_server_sid() -- which would synthesize (and, on the active
+    controller, persist) a random SID, corrupting the stored value from a read-only health
+    check and guaranteeing a spurious WINBIND_STALE_LOCAL_SID fault. winbindd's domain_info
+    must not even be consulted, and the remaining checks (here, a healthy ping_dc) still run.
+    """
+    orig = harness.middleware.call_sync.side_effect
+
+    def call_sync(name, *args, **kwargs):
+        if name == "datastore.config":
+            return {"cifs_SID": ""}
+        return orig(name, *args, **kwargs)
+
+    harness.middleware.call_sync.side_effect = call_sync
+
+    instance = MagicMock()
+    instance.ping_dc.return_value = None
+    # A SID that WOULD mismatch if it were ever consulted -- proving the check is skipped.
+    instance.domain_info.return_value = {"sid": "S-1-5-21-9999999999-8888888888-7777777777"}
+    wbclient_mock = MagicMock(return_value=instance)
+
+    with (
+        patch.object(_ADHealthHarness, "_test_machine_account_password"),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.get_domain_info",
+            return_value=LIBADS_DOMAIN_INFO,
+        ),
+        patch(
+            "middlewared.plugins.directoryservices_.activedirectory_health_mixin.WBClient",
+            new=wbclient_mock,
+        ),
+    ):
+        # No raise: an absent server SID is a skip, not a fault.
+        harness._health_check_ad()
+
+    assert not instance.domain_info.called, (
+        "with no configured server SID the stale-SID check must be skipped without "
+        "consulting winbindd's domain_info"
+    )
+    assert instance.ping_dc.called, "health check should proceed to ping_dc"
+
+
+def test__recover_ad_stale_local_sid_reconciles_and_restarts_winbind(harness):
+    """
+    Recovery for WINBIND_STALE_LOCAL_SID must reconcile the on-disk SID (smb.set_system_sid)
+    AND restart winbindd. A bare restart cannot fix a SID that is stale in secrets.tdb itself
+    -- winbindd would just re-read it and the check would fault again every cycle -- so the
+    reconcile is required for the fault to converge.
+    """
+    restart_job = MagicMock()
+    harness.call_sync2 = Mock(return_value=restart_job)
+
+    calls = []
+
+    def call_sync(name, *args, **kwargs):
+        calls.append(name)
+        if name == "smb.set_system_sid":
+            return None
+        raise AssertionError(f"unexpected middleware call: {name}")
+
+    harness.middleware.call_sync.side_effect = call_sync
+
+    harness._recover_ad(
+        ADHealthError(ADHealthCheckFailReason.WINBIND_STALE_LOCAL_SID, "stale local sid")
+    )
+
+    assert "smb.set_system_sid" in calls, (
+        "recovery must reconcile the on-disk SID via smb.set_system_sid so the restart converges"
+    )
+    control_call = harness.call_sync2.call_args
+    assert control_call.args[0] is harness.s.service.control
+    assert control_call.args[1] == "RESTART"
+    assert control_call.args[2] == "idmap"
+    restart_job.wait_sync.assert_called_once_with(raise_error=True)
 
 
 # ---- Refinement path: password test runs after ping_dc fails ------------------------------
@@ -500,6 +654,7 @@ def test__health_check_ad_unexpected_non_wbcerror_does_not_crash(harness):
     """
     instance = MagicMock()
     instance.ping_dc.side_effect = RuntimeError("libwbclient.so broken")
+    instance.domain_info.return_value = {"sid": LOCAL_SAM_SID}
     wbclient_mock = MagicMock(return_value=instance)
 
     with (

--- a/tests/unit/test_directoryservices_connection.py
+++ b/tests/unit/test_directoryservices_connection.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for DomainConnection standby local-SID reconciliation.
+
+secrets.restore replays the local server SID that was current when the backup was taken,
+which can lag the database value. _reconcile_standby_local_sid rewrites it from the
+authoritative configuration before winbindd starts so the standby never comes up with a
+stale local SAM domain SID (which cannot self-heal via a winbindd restart and only surfaces
+after the standby is promoted).
+"""
+
+import logging
+
+from unittest.mock import MagicMock
+
+from middlewared.plugins.directoryservices_.connection import DomainConnection
+
+
+def _connection_service():
+    svc = object.__new__(DomainConnection)
+    svc.middleware = MagicMock()
+    svc.logger = logging.getLogger("test_directoryservices_connection")
+    return svc
+
+
+def test__reconcile_standby_local_sid_rewrites_when_sid_configured():
+    """
+    With a configured server SID, the standby must call smb.set_system_sid so the restored
+    secrets.tdb is reconciled to the authoritative value before winbindd starts.
+    """
+    svc = _connection_service()
+
+    def call_sync(method, *args, **kwargs):
+        if method == "datastore.config":
+            assert args[0] == "services.cifs"
+            return {"cifs_SID": "S-1-5-21-1111111111-2222222222-3333333333"}
+        if method == "smb.set_system_sid":
+            return None
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    svc.middleware.call_sync.side_effect = call_sync
+
+    svc._reconcile_standby_local_sid()
+
+    assert any(
+        c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list
+    ), "reconcile must invoke smb.set_system_sid when a server SID is configured"
+
+
+def test__reconcile_standby_local_sid_skips_when_sid_absent():
+    """
+    Without a stored SID, smb.local_server_sid() would synthesize a fresh random SID per
+    call on the standby, so reconcile must skip rather than stamp a bogus SID onto the
+    standby's secrets.tdb.
+    """
+    svc = _connection_service()
+
+    def call_sync(method, *args, **kwargs):
+        if method == "datastore.config":
+            return {"cifs_SID": ""}
+        if method == "smb.set_system_sid":
+            raise AssertionError("smb.set_system_sid must not be called when no SID is configured")
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    svc.middleware.call_sync.side_effect = call_sync
+
+    # Should return without raising and without calling smb.set_system_sid.
+    svc._reconcile_standby_local_sid()
+
+
+def test__reconcile_standby_local_sid_swallows_failures():
+    """
+    The reconcile is a best-effort pre-failover optimization. If smb.set_system_sid raises
+    (e.g. `net setlocalsid` exits non-zero, or the winbindd restart job fails), the exception
+    must NOT propagate -- otherwise it aborts activate_standby before the activation and
+    health-recovery steps that follow it, leaving directory services inactive on the standby.
+    """
+    from middlewared.service_exception import CallError
+
+    svc = _connection_service()
+
+    def call_sync(method, *args, **kwargs):
+        if method == "datastore.config":
+            return {"cifs_SID": "S-1-5-21-1111111111-2222222222-3333333333"}
+        if method == "smb.set_system_sid":
+            raise CallError("setlocalsid failed: boom")
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    svc.middleware.call_sync.side_effect = call_sync
+
+    # Must not raise: the failure is logged and swallowed.
+    svc._reconcile_standby_local_sid()
+
+    assert any(
+        c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list
+    ), "reconcile should have attempted smb.set_system_sid before swallowing the failure"

--- a/tests/unit/test_directoryservices_connection.py
+++ b/tests/unit/test_directoryservices_connection.py
@@ -41,9 +41,9 @@ def test__reconcile_standby_local_sid_rewrites_when_sid_configured():
 
     svc._reconcile_standby_local_sid()
 
-    assert any(
-        c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list
-    ), "reconcile must invoke smb.set_system_sid when a server SID is configured"
+    assert any(c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list), (
+        "reconcile must invoke smb.set_system_sid when a server SID is configured"
+    )
 
 
 def test__reconcile_standby_local_sid_skips_when_sid_absent():
@@ -90,6 +90,6 @@ def test__reconcile_standby_local_sid_swallows_failures():
     # Must not raise: the failure is logged and swallowed.
     svc._reconcile_standby_local_sid()
 
-    assert any(
-        c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list
-    ), "reconcile should have attempted smb.set_system_sid before swallowing the failure"
+    assert any(c.args[0] == "smb.set_system_sid" for c in svc.middleware.call_sync.call_args_list), (
+        "reconcile should have attempted smb.set_system_sid before swallowing the failure"
+    )

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -125,6 +125,79 @@ def test__backup_skips_when_failover_status_is_backup(secrets_service):
     asyncio.run(secrets_service.backup())
 
 
+def test__backup_refuses_overwrite_when_machine_secret_absent(secrets_service):
+    """
+    A secrets.tdb dump that lacks a machine account password must NOT overwrite the stored
+    backup -- otherwise a transiently incomplete secrets.tdb (local SID written, machine
+    secret not yet restored) could replace a good backup with a machine-secret-less one.
+    """
+    fresh_dump = {
+        # Local SID only -- no SECRETS/MACHINE_PASSWORD/* entry.
+        "SECRETS/SID/NEWHOST": "c2lkYnl0ZXM=",
+    }
+    called = {"datastore_update": False}
+
+    async def fake_call(method, *args, **kwargs):
+        if method == "failover.status":
+            return "SINGLE"
+        if method == "smb.config":
+            return {"netbiosname": "NEWHOST"}
+        if method == "directoryservices.secrets.dump":
+            return fresh_dump
+        if method == "datastore.update":
+            called["datastore_update"] = True
+            return None
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    async def fake_get_db_secrets():
+        return {"id": 1, "NEWHOST$": {"SECRETS/MACHINE_PASSWORD/NEWDOMAIN": "Z29vZA=="}}
+
+    secrets_service.get_db_secrets = fake_get_db_secrets
+    secrets_service.middleware.call.side_effect = fake_call
+
+    asyncio.run(secrets_service.backup())
+
+    assert called["datastore_update"] is False, (
+        "backup() must not overwrite the stored secrets when the current secrets.tdb has no "
+        "machine account password -- doing so destroys the good backup."
+    )
+
+
+def test__backup_allows_missing_machine_secret_when_explicit(secrets_service):
+    """
+    The domain-leave path deliberately backs up a nuked secrets.tdb to clear the stored
+    secret. allow_missing_machine_secret=True must permit that overwrite.
+    """
+    fresh_dump = {"SECRETS/SID/NEWHOST": "c2lkYnl0ZXM="}
+    captured = {}
+
+    async def fake_call(method, *args, **kwargs):
+        if method == "failover.status":
+            return "SINGLE"
+        if method == "smb.config":
+            return {"netbiosname": "NEWHOST"}
+        if method == "directoryservices.secrets.dump":
+            return fresh_dump
+        if method == "datastore.update":
+            captured["args"] = args
+            return None
+        raise AssertionError(f"unexpected middleware call: {method}")
+
+    async def fake_get_db_secrets():
+        return {"id": 1, "NEWHOST$": {"SECRETS/MACHINE_PASSWORD/NEWDOMAIN": "Z29vZA=="}}
+
+    secrets_service.get_db_secrets = fake_get_db_secrets
+    secrets_service.middleware.call.side_effect = fake_call
+
+    asyncio.run(secrets_service.backup(allow_missing_machine_secret=True))
+
+    saved = json.loads(captured["args"][2]["secrets"])
+    assert saved == {"NEWHOST$": fresh_dump}, (
+        "With allow_missing_machine_secret=True the clearing backup must proceed and store "
+        "the (machine-secret-less) dump."
+    )
+
+
 def test__last_password_change_real_tdb_roundtrip(secrets_service, tmp_path, monkeypatch):
     """
     Regression for the stray ']' in the secrets.tdb key, exercised end-to-end against a real

--- a/tests/unit/test_kerberos_check_updated_keytab.py
+++ b/tests/unit/test_kerberos_check_updated_keytab.py
@@ -1,0 +1,126 @@
+"""
+Unit tests for KerberosService.check_updated_keytab's decision to refresh the machine-account
+keytab / secrets backup.
+
+The skip guard must key on whether the machine account password is present (has_domain), NOT on
+the last-password-change timestamp. Keying on the timestamp conflates two distinct states: the
+startup window where secrets.tdb holds only the local server SID (password absent -- skip so we
+don't clobber the good backup) and a corrupt/unreadable timestamp with the password intact
+(which must not skip keytab refreshes forever).
+"""
+
+import asyncio
+import logging
+
+from unittest.mock import AsyncMock, MagicMock
+
+from middlewared.plugins.kerberos import KerberosService
+
+
+WORKGROUP = "AD"
+
+
+def _kerberos_service(*, has_domain, last_change, capture_warnings=False):
+    """
+    Build a KerberosService whose middleware answers the calls check_updated_keytab makes.
+    ``has_domain`` is the bool returned by directoryservices.secrets.has_domain; ``last_change``
+    is the dict returned by directoryservices.get_last_password_change. Backup and keytab-store
+    calls are recorded on svc.performed.
+    """
+    svc = object.__new__(KerberosService)
+    svc.middleware = MagicMock()
+    svc.middleware.call = AsyncMock()
+    svc.logger = MagicMock() if capture_warnings else logging.getLogger("test_kerberos_keytab")
+    svc.performed = []
+
+    async def call(method, *args, **kwargs):
+        match method:
+            case "system.ready":
+                return True
+            case "failover.is_single_master_node":
+                return True
+            case "directoryservices.config":
+                return {"enable": True, "service_type": "ACTIVEDIRECTORY"}
+            case "smb.config":
+                return {"workgroup": WORKGROUP}
+            case "directoryservices.secrets.has_domain":
+                assert args[0] == WORKGROUP
+                return has_domain
+            case "directoryservices.get_last_password_change":
+                return last_change
+            case "directoryservices.secrets.backup":
+                svc.performed.append("backup")
+                return None
+            case "kerberos.keytab.store_ad_keytab":
+                svc.performed.append("store_ad_keytab")
+                return None
+            case _:
+                raise AssertionError(f"unexpected middleware call: {method}")
+
+    svc.middleware.call.side_effect = call
+    return svc
+
+
+def _called(svc, method):
+    return any(c.args[0] == method for c in svc.middleware.call.call_args_list)
+
+
+def test_skips_when_machine_password_absent():
+    """
+    Startup window: secrets.tdb holds only the local server SID (no machine account password).
+    has_domain is False -> skip before get_last_password_change, so nothing is backed up over
+    the good DB backup.
+    """
+    svc = _kerberos_service(has_domain=False, last_change=None)
+
+    asyncio.run(svc.check_updated_keytab())
+
+    assert svc.performed == [], "no backup or keytab store when the machine password is absent"
+    # get_last_password_change must not even be consulted once has_domain is False.
+    assert not _called(svc, "directoryservices.get_last_password_change")
+
+
+def test_skips_but_warns_when_timestamp_corrupt_with_password_present():
+    """
+    When the machine password is present but its last-change timestamp is unreadable
+    (secrets=None from a corrupt entry), check_updated_keytab must skip WITHOUT backing up
+    (don't propagate corruption over the good backup) and must log a warning rather than
+    silently skipping keytab refreshes forever.
+    """
+    svc = _kerberos_service(
+        has_domain=True,
+        last_change={"dbconfig": 1718800000, "secrets": None},
+        capture_warnings=True,
+    )
+
+    asyncio.run(svc.check_updated_keytab())
+
+    assert svc.performed == [], "corrupt timestamp must not trigger a backup/keytab rewrite"
+    assert svc.logger.warning.called, (
+        "an unreadable timestamp with the password present must be logged, not silently skipped"
+    )
+
+
+def test_skips_when_timestamps_match():
+    """Password present, timestamps equal -> nothing changed, no backup/keytab work."""
+    svc = _kerberos_service(
+        has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718800000}
+    )
+
+    asyncio.run(svc.check_updated_keytab())
+
+    assert svc.performed == []
+
+
+def test_backs_up_and_stores_keytab_on_password_change():
+    """
+    Password present and the secrets timestamp differs from the stored one -> a real rotation
+    -> back up secrets and refresh the keytab.
+    """
+    svc = _kerberos_service(
+        has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718900000}
+    )
+
+    asyncio.run(svc.check_updated_keytab())
+
+    assert svc.performed == ["backup", "store_ad_keytab"]

--- a/tests/unit/test_kerberos_check_updated_keytab.py
+++ b/tests/unit/test_kerberos_check_updated_keytab.py
@@ -103,9 +103,7 @@ def test_skips_but_warns_when_timestamp_corrupt_with_password_present():
 
 def test_skips_when_timestamps_match():
     """Password present, timestamps equal -> nothing changed, no backup/keytab work."""
-    svc = _kerberos_service(
-        has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718800000}
-    )
+    svc = _kerberos_service(has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718800000})
 
     asyncio.run(svc.check_updated_keytab())
 
@@ -117,9 +115,7 @@ def test_backs_up_and_stores_keytab_on_password_change():
     Password present and the secrets timestamp differs from the stored one -> a real rotation
     -> back up secrets and refresh the keytab.
     """
-    svc = _kerberos_service(
-        has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718900000}
-    )
+    svc = _kerberos_service(has_domain=True, last_change={"dbconfig": 1718800000, "secrets": 1718900000})
 
     asyncio.run(svc.check_updated_keytab())
 

--- a/tests/unit/test_smb_set_system_sid.py
+++ b/tests/unit/test_smb_set_system_sid.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for SMBService.set_system_sid winbindd-restart decision.
+
+set_system_sid writes the configured local server SID with ``net setlocalsid`` and, when it
+changes the SID under a running winbindd, restarts winbindd so its view of the local SAM
+domain is rebuilt (otherwise group-token expansion fails with NT_STATUS_NO_SUCH_DOMAIN). The
+subtlety these tests lock in: a failure to *read* the current SID must not be mistaken for a
+genuinely-absent prior SID -- in the read-failure case we cannot prove the SID was unchanged,
+so winbindd must still be restarted.
+"""
+
+import logging
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from middlewared.plugins.smb_ import sid as sid_module
+from middlewared.plugins.smb_.sid import SMBService
+from middlewared.service_exception import MatchNotFound
+
+
+NETBIOS = "TRUENAS"
+SERVER_SID = "S-1-5-21-1111111111-2222222222-3333333333"
+OLD_SID = "S-1-5-21-9999999999-8888888888-7777777777"
+
+
+def _smb_service(current_sid, *, idmap_started=True, sid_exc=None):
+    """
+    Build an SMBService instance wired with mocks. ``current_sid`` is what
+    directoryservices.secrets.domain_sid returns; ``sid_exc``, if set, is raised by that
+    call instead (to exercise the absent / read-failure branches). The stored cifs_SID is
+    always SERVER_SID, so local_server_sid() returns SERVER_SID without needing failover.
+    """
+    svc = object.__new__(SMBService)
+    svc.middleware = MagicMock()
+    svc.s = MagicMock()
+    svc.logger = logging.getLogger("test_smb_set_system_sid")
+
+    def call_sync(name, *args, **kwargs):
+        if name == "datastore.config":
+            return {"cifs_SID": SERVER_SID}
+        if name == "smb.config":
+            return {"netbiosname": NETBIOS}
+        if name == "directoryservices.secrets.domain_sid":
+            if sid_exc is not None:
+                raise sid_exc
+            return current_sid
+        raise AssertionError(f"unexpected middleware call: {name}")
+
+    svc.middleware.call_sync.side_effect = call_sync
+
+    restart_job = MagicMock()
+
+    def call_sync2(method, *args, **kwargs):
+        if method is svc.s.service.started:
+            return idmap_started
+        if method is svc.s.service.control:
+            return restart_job
+        raise AssertionError(f"unexpected call_sync2 target: {method}")
+
+    svc.call_sync2 = Mock(side_effect=call_sync2)
+    svc._restart_job = restart_job
+    return svc
+
+
+def _restarted(svc):
+    """True if a winbindd (idmap) RESTART was issued."""
+    return any(
+        c.args[0] is svc.s.service.control and c.args[1] == "RESTART" and c.args[2] == "idmap"
+        for c in svc.call_sync2.call_args_list
+    )
+
+
+@pytest.fixture
+def net_setlocalsid_ok():
+    with patch.object(sid_module.subprocess, "run") as run:
+        run.return_value = MagicMock(returncode=0, stderr=b"")
+        yield run
+
+
+def test_read_failure_restarts_winbindd(net_setlocalsid_ok):
+    """
+    A transient/unexpected failure to read the current SID must not be treated as
+    'no prior SID'. We can't prove the SID is unchanged and we just ran setlocalsid, so
+    winbindd must be restarted -- otherwise it is left on a possibly-stale local SAM SID,
+    reintroducing the NT_STATUS_NO_SUCH_DOMAIN denial this whole method exists to prevent.
+    """
+    svc = _smb_service(current_sid=None, idmap_started=True, sid_exc=RuntimeError("tdb locked"))
+
+    svc.set_system_sid()
+
+    assert net_setlocalsid_ok.called
+    assert _restarted(svc), "read failure with winbindd running must trigger a restart"
+    svc._restart_job.wait_sync.assert_called_once_with(raise_error=True)
+
+
+def test_absent_prior_sid_does_not_restart(net_setlocalsid_ok):
+    """
+    A genuinely absent prior SID (fresh secrets.tdb -- MatchNotFound) means winbindd has
+    nothing stale to rebuild, so setlocalsid runs but no restart is issued.
+    """
+    svc = _smb_service(current_sid=None, idmap_started=True, sid_exc=MatchNotFound())
+
+    svc.set_system_sid()
+
+    assert net_setlocalsid_ok.called
+    assert not _restarted(svc), "absent prior SID must not trigger a winbindd restart"
+
+
+def test_missing_secrets_file_does_not_restart(net_setlocalsid_ok):
+    """A missing secrets.tdb (FileNotFoundError) is likewise a genuine absence, not a change."""
+    svc = _smb_service(current_sid=None, idmap_started=True, sid_exc=FileNotFoundError())
+
+    svc.set_system_sid()
+
+    assert net_setlocalsid_ok.called
+    assert not _restarted(svc)
+
+
+def test_changed_sid_restarts_winbindd(net_setlocalsid_ok):
+    """A real change of the local SID under a running winbindd triggers a restart."""
+    svc = _smb_service(current_sid=OLD_SID, idmap_started=True)
+
+    svc.set_system_sid()
+
+    assert net_setlocalsid_ok.called
+    assert _restarted(svc)
+    svc._restart_job.wait_sync.assert_called_once_with(raise_error=True)
+
+
+def test_unchanged_sid_is_a_noop(net_setlocalsid_ok):
+    """When the stored SID already matches, neither setlocalsid nor a restart runs."""
+    svc = _smb_service(current_sid=SERVER_SID, idmap_started=True)
+
+    svc.set_system_sid()
+
+    assert not net_setlocalsid_ok.called
+    assert not _restarted(svc)
+
+
+def test_read_failure_no_restart_when_winbindd_stopped(net_setlocalsid_ok):
+    """
+    Even on a read failure, if winbindd isn't running there is no live view to rebuild, so
+    no restart is attempted (the SID is written for the next start to pick up).
+    """
+    svc = _smb_service(current_sid=None, idmap_started=False, sid_exc=RuntimeError("tdb locked"))
+
+    svc.set_system_sid()
+
+    assert net_setlocalsid_ok.called
+    assert not _restarted(svc)


### PR DESCRIPTION
Fix two AD member server issues:

1. After initial AD setup on TrueNAS HA, winbindd can end up running with a stale cached domain SID that no longer matches what the rpc SAMR service accepts. This leads to local-alias expansion in group tokens failing with `NT_STATUS_NO_SUCH_DOMAIN` and failure to generate full group list when doing privilege checks. It self-resolves after a second failover event.

2. On upgrade the new boot environment has an empty secrets.tdb. Machine account restore can race with a periodic keytab check, and if it loses (keytab check comes first), the periodic keytab check can backup the incomplete secrets.tdb over the good database copy, destroying the stored machine account secret.

Changes:

a. smb.set_system_sid: skip setting local sid when the sid is unchanged and restart winbindd only when the SID changes while it is running.
b. in directoryservices.connection.activate_standby, reconcile the local SID to the configured value before winbindd starts (AD and IPA). Recover by rewriting the SID and restarting winbindd.
c. auth.authenticate_user: log the evaluated group list when directory services authenticates user but no privilege is matched. This is potentially somewhat spammy, but if we don't do it then we lose information about what is going wrong with authz.
d. kerberos.check_updated_keytab: skip when machine account password is absent. Warn and skip if timestamp is unreadable.
e. directoryservices.secrets.backup: by default refuse to overwrite the stored backup with a dump that does not contain a machine account password.
f. Add more unit tests.

Detection for mismatch between winbindd running configuration and local server sid is accomplished by using libwbclient.