### PR TITLE
NAS-141358 / 27.0.0-BETA.1 / Dedupe ix-vendor restarts on ipaddress.change

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/netlink_events.py
+++ b/src/middlewared/middlewared/plugins/device_/netlink_events.py
@@ -9,6 +9,12 @@ from middlewared.plugins.service.services.dbus_router import system_dbus
 from middlewared.utils.threading import start_daemon_thread
 
 IX_VEND_LOCK = asyncio.Lock()
+IX_VEND_DEBOUNCE_SECONDS = 5
+
+# Last-seen address set per interface index, used to suppress vendor service
+# restarts for events that do not change any address.
+_iface_ip_snapshot = {}
+_pending_vendor_restart = None
 
 # Netlink constants
 AF_NETLINK = 16
@@ -419,17 +425,39 @@ def netlink_events(middleware):
 
 
 async def _systemctl_restart_ixvendor(middleware):
-    if IX_VEND_LOCK.locked():
-        # A restart is already in progress; skip to avoid piling up
-        return
-
+    # The lock serializes restarts; a restart scheduled while another is in
+    # progress waits its turn instead of being dropped, so the vendor service
+    # always ends up restarted with the latest address state.
     async with IX_VEND_LOCK:
         if await middleware.call2(middleware.services.system.vendor.is_vendored):
             await system_dbus.call_unit_action_and_wait("ix-vendor.service", "Restart")
 
 
 async def _restart_vendor_service(middleware, event_type, args):
-    middleware.create_task(_systemctl_restart_ixvendor(middleware))
+    global _pending_vendor_restart
+
+    fields = args["fields"]
+    current_ips = frozenset(fields["available_ips"])
+    if _iface_ip_snapshot.get(fields["index"]) == current_ips:
+        # The kernel re-emits RTM_NEWADDR every time an address lifetime is
+        # refreshed by a router advertisement, so these events routinely fire
+        # (as often as every few seconds behind routers with aggressive RA
+        # timers) without any address actually changing. Only restart the
+        # vendor service when the interface's address set differs from what
+        # we last saw.
+        return
+
+    _iface_ip_snapshot[fields["index"]] = current_ips
+
+    # A single network change (DHCP renewal, docker start/stop, interface
+    # bounce) fires several events in quick succession; coalesce them so a
+    # single restart runs once the burst settles.
+    if _pending_vendor_restart is not None:
+        _pending_vendor_restart.cancel()
+    _pending_vendor_restart = asyncio.get_event_loop().call_later(
+        IX_VEND_DEBOUNCE_SECONDS,
+        lambda: middleware.create_task(_systemctl_restart_ixvendor(middleware)),
+    )
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
@@ -1,0 +1,140 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from middlewared.plugins.device_ import netlink_events
+
+
+def make_event(
+    index: int = 2,
+    ips: tuple[str, ...] = ("10.0.0.5", "fe80::be24:11ff:fea2:a630"),
+    iface: str = "enp1s0",
+    event: str = "add",
+    family: str = "inet6",
+    ip: str | None = None,
+) -> dict[str, Any]:
+    """Build an ipaddress.change event payload as emitted by process_netlink_data.
+
+    `ip` is the address the netlink message was about (for a remove event it is
+    no longer part of `available_ips`); defaults to the first available address.
+    """
+    return {
+        "fields": {
+            "iface": iface,
+            "ip": ip if ip is not None else f"{ips[0]}/64",
+            "event": event,
+            "family": family,
+            "scope": 0,
+            "index": index,
+            "broadcast": None,
+            "available_ips": list(ips),
+        }
+    }
+
+
+@pytest.fixture
+def restart_env(monkeypatch):
+    """Reset module state, zero the debounce delay, and stub the restart implementation."""
+    monkeypatch.setattr(netlink_events, "_iface_ip_snapshot", {})
+    monkeypatch.setattr(netlink_events, "_pending_vendor_restart", None)
+    monkeypatch.setattr(netlink_events, "IX_VEND_DEBOUNCE_SECONDS", 0)
+    restart_mock = AsyncMock()
+    monkeypatch.setattr(netlink_events, "_systemctl_restart_ixvendor", restart_mock)
+    middleware = MagicMock()
+    middleware.create_task = lambda coro: asyncio.ensure_future(coro)
+    return middleware, restart_mock
+
+
+async def settle():
+    """Let zero-delay call_later timers fire and their tasks run."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+class TestVendorRestartDedupe:
+    @pytest.mark.asyncio
+    async def test_lifetime_refresh_is_deduped(self, restart_env):
+        """RTM_NEWADDR re-emitted for an RA lifetime refresh (unchanged address set) must not restart."""
+        middleware, restart_mock = restart_env
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event())
+        for _ in range(5):
+            await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event())
+        await settle()
+        assert restart_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_address_set_restarts(self, restart_env):
+        middleware, restart_mock = restart_env
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(ips=("10.0.0.5",)))
+        await settle()
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(ips=("10.0.0.5", "2001:db8::1")))
+        await settle()
+        assert restart_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_interfaces_tracked_independently(self, restart_env):
+        middleware, restart_mock = restart_env
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(index=2, ips=("10.0.0.5",)))
+        await settle()
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(index=3, ips=("172.16.0.1",)))
+        await settle()
+        assert restart_mock.await_count == 2
+        # Repeats on either interface are deduped
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(index=2, ips=("10.0.0.5",)))
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(index=3, ips=("172.16.0.1",)))
+        await settle()
+        assert restart_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_burst_is_coalesced_into_one_restart(self, restart_env):
+        """Several distinct changes inside the debounce window yield a single restart."""
+        middleware, restart_mock = restart_env
+        for ips in (("10.0.0.5",), ("10.0.0.5", "2001:db8::1"), ("2001:db8::1",)):
+            await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(ips=ips))
+        await settle()
+        assert restart_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_address_set_change_restarts(self, restart_env):
+        """Losing the last address on an interface is a real change."""
+        middleware, restart_mock = restart_env
+        await netlink_events._restart_vendor_service(middleware, "CHANGED", make_event(ips=("10.0.0.5",)))
+        await settle()
+        await netlink_events._restart_vendor_service(
+            middleware, "CHANGED", make_event(ips=(), event="remove", ip="10.0.0.5/24")
+        )
+        await settle()
+        assert restart_mock.await_count == 2
+
+
+class TestVendorRestartSerialization:
+    @pytest.mark.asyncio
+    async def test_restart_during_restart_waits_instead_of_dropping(self, monkeypatch):
+        """A restart scheduled while another is running must still execute afterwards."""
+        monkeypatch.setattr(netlink_events, "IX_VEND_LOCK", asyncio.Lock())
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def dbus_action(unit, action):
+            if dbus_mock.call_unit_action_and_wait.await_count == 1:
+                first_started.set()
+                await release_first.wait()
+
+        dbus_mock = MagicMock()
+        dbus_mock.call_unit_action_and_wait = AsyncMock(side_effect=dbus_action)
+        monkeypatch.setattr(netlink_events, "system_dbus", dbus_mock)
+
+        middleware = MagicMock()
+        middleware.call2 = AsyncMock(return_value=True)
+
+        task1 = asyncio.ensure_future(netlink_events._systemctl_restart_ixvendor(middleware))
+        await first_started.wait()
+        task2 = asyncio.ensure_future(netlink_events._systemctl_restart_ixvendor(middleware))
+        await asyncio.sleep(0)
+        assert dbus_mock.call_unit_action_and_wait.await_count == 1
+
+        release_first.set()
+        await asyncio.gather(task1, task2)
+        assert dbus_mock.call_unit_action_and_wait.await_count == 2


### PR DESCRIPTION
The kernel re-emits RTM_NEWADDR whenever an address's valid/preferred lifetime is refreshed by a router advertisement, so behind routers with aggressive RA timers (300s lifetimes, RAs every 5–10s — see NAS-141358) every refresh fired an `ipaddress.change` event and restarted ix-vendor.service, burning ~3s of CPU per cycle continuously on vendored systems.

Fix, mirroring the debounce pattern already used by truenas_connect's `update_ips`:

- Track the last-seen `available_ips` set per interface index and skip the restart when an event carries an unchanged set (RA lifetime refreshes, DAD-completion re-announcements).
- Coalesce genuine change bursts (DHCP renewal, docker start/stop) with a 5s debounce.
- Let a restart scheduled while one is in progress wait on IX_VEND_LOCK instead of being dropped, so the vendor service always ends up restarted with the latest address state.

Event emission is untouched — other `ipaddress.change` subscribers (truenas_connect) still receive every event.

Unit tests included. Validated on 25.10.4 hardware: repeatedly refreshing a SLAAC address's lifetimes (simulating the RA storm with `ip addr change ... valid_lft 300 preferred_lft 300`) produced 8 ix-vendor restarts in ~35s before this change and 0 after; a real address add/remove still restarts exactly once.

A 25.10 backport is straightforward (same handler; that train's `run(["systemctl", ...])` restart body needs `import asyncio` and the lock added) and would cover the affected HexOS user base from the ticket.
