### PR TITLE
NAS-141948 / 27.0.0-BETA.1 / Use systemd watchdog for middlewared main loop

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -24,6 +24,10 @@ RestartPreventExitStatus=SIGTERM
 # We don't want systemd to kill the middlewared process automatically on service stop, instead we rely on middlewared
 # to properly ensure that it shuts down cleanly on stop when SIGTERM is sent.
 SendSIGKILL=no
+# Watchdog notifications are sent by the main asyncio loop. If it hangs, the middleware should be restarted.
+WatchdogSec=600
+# We have to kill it because SIGTERM is handled by the asyncio loop, which is hung.
+WatchdogSignal=SIGKILL
 OOMScoreAdjust=-1000
 
 [Install]

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -797,8 +797,12 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
 
         if self._systemd_notifier:
             self._systemd_notifier.notify('READY=1')
-            self._systemd_notifier.close()
-            self._systemd_notifier = None
+            self.loop.create_task(self.__watchdog(), name="watchdog")
+
+    async def __watchdog(self):
+        while True:
+            self._systemd_notifier.notify("WATCHDOG=1")
+            await asyncio.sleep(60)
 
     def plugin_route_add(self, plugin_name, route, method):
         self.app.router.add_route('*', f'/_plugins/{plugin_name}/{route}', method)

--- a/src/middlewared/middlewared/utils/systemd.py
+++ b/src/middlewared/middlewared/utils/systemd.py
@@ -39,12 +39,3 @@ class SystemdNotifier:
             self._socket.send(msg.encode("latin-1"))
         except Exception:
             logger.exception("Failed to send message %r", msg)
-
-    def close(self) -> None:
-        if self._socket is not None:
-            try:
-                self._socket.close()
-            except Exception:
-                logger.exception("Error closing systemd socket")
-            finally:
-                self._socket = None


### PR DESCRIPTION
After https://github.com/truenas/middleware/pull/19404 is merged, a dead event-loop shouldn't be a problem anymore. Nevertheless, let's use systemd watchdog feature to SIGKILL the middleware if the event loop dies.

Not backporting this to 26 just to be safe in case of unexpected side effects.