### PR TITLE
NAS-141973 / 27.0.0-BETA.1 / fix invalid maximum advertisement VRRP timeout value (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-07-27_19-21_normalize_failover_timeout.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-07-27_19-21_normalize_failover_timeout.py
@@ -1,0 +1,28 @@
+"""Normalize failover timeout to at most 120 seconds
+
+Values above 120 produce a VRRPv3 advertisement interval larger than the
+protocol maximum of 40.95 seconds (RFC 5798 section 5.2.7), which keepalived
+rejects, breaking failover entirely.
+
+Revision ID: 1dc145b1f6fa
+Revises: b3f0a9c41d7e
+Create Date: 2026-07-27 19:21:01.865610+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1dc145b1f6fa'
+down_revision = 'b3f0a9c41d7e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE system_failover SET timeout = 120 WHERE timeout > 120")
+    op.execute("UPDATE system_failover SET timeout = 0 WHERE timeout < 0")
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-07-27_19-21_normalize_failover_timeout.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-07-27_19-21_normalize_failover_timeout.py
@@ -9,12 +9,13 @@ Revises: b3f0a9c41d7e
 Create Date: 2026-07-27 19:21:01.865610+00:00
 
 """
+
 from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = '1dc145b1f6fa'
-down_revision = 'b3f0a9c41d7e'
+revision = "1dc145b1f6fa"
+down_revision = "b3f0a9c41d7e"
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-07-27_20-20_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-07-27_20-20_merge.py
@@ -1,0 +1,21 @@
+"""Merge migration for normalizing failover timeout (revision 1dc145b1f6fa)
+
+Revision ID: 74ee5c16e7ff
+Revises: f6576b92199e, 1dc145b1f6fa
+Create Date: 2026-07-27 20:20:00.000000+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "74ee5c16e7ff"
+down_revision = ("f6576b92199e", "1dc145b1f6fa")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v26_0_0/failover.py
+++ b/src/middlewared/middlewared/api/v26_0_0/failover.py
@@ -44,6 +44,20 @@ class FailoverSyncToPeer(BaseModel):
 
 class FailoverUpdate(FailoverEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
+    timeout: int = Field(
+        ge=0,
+        le=120,
+        description=(
+            "The time to WAIT (in seconds) until a failover occurs when a network event occurs on an interface that is "
+            "marked critical for failover AND HA is enabled and working appropriately. The default time to wait is 2 "
+            "seconds.\n"
+            "\n"
+            "Maximum is 120 seconds. This value is used to derive the VRRPv3 advertisement interval, which cannot "
+            "exceed 40.95 seconds (RFC 5798 section 5.2.7).\n"
+            "\n"
+            "**NOTE: This setting does NOT effect the `disabled` or `master` parameters.**"
+        ),
+    )
 
 
 class FailoverUpgrade(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/failover.py
+++ b/src/middlewared/middlewared/api/v27_0_0/failover.py
@@ -44,6 +44,20 @@ class FailoverSyncToPeer(BaseModel):
 
 class FailoverUpdate(FailoverEntry, metaclass=ForUpdateMetaclass):
     id: Excluded = excluded_field()
+    timeout: int = Field(
+        ge=0,
+        le=120,
+        description=(
+            "The time to WAIT (in seconds) until a failover occurs when a network event occurs on an interface that is "
+            "marked critical for failover AND HA is enabled and working appropriately. The default time to wait is 2 "
+            "seconds.\n"
+            "\n"
+            "Maximum is 120 seconds. This value is used to derive the VRRPv3 advertisement interval, which cannot "
+            "exceed 40.95 seconds (RFC 5798 section 5.2.7).\n"
+            "\n"
+            "**NOTE: This setting does NOT effect the `disabled` or `master` parameters.**"
+        ),
+    )
 
 
 class FailoverUpgrade(BaseModel):

--- a/src/middlewared/middlewared/etc_files/keepalived.conf.mako
+++ b/src/middlewared/middlewared/etc_files/keepalived.conf.mako
@@ -21,6 +21,16 @@
         # I round to the 100th decimal place since VRRP version 3
         # uses centisecond intervals by default
         advert_int = round(((128 * config['timeout']) / 385), 2)
+        if advert_int > 40.95:
+            # VRRPv3 carries the advertisement interval in a 12-bit
+            # centisecond field, so keepalived rejects anything above
+            # 40.95 seconds and fails to apply the config entirely
+            middleware.logger.warning(
+                'failover.timeout: %r produces a VRRP advertisement interval of %.2f seconds'
+                ' which exceeds the VRRPv3 maximum, clamping to 40.95 seconds',
+                config['timeout'], advert_int,
+            )
+            advert_int = 40.95
 
     info = middleware.call_sync('interface.query')
     info = [i for i in info if len(i['failover_virtual_aliases'])]

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -168,3 +168,16 @@ def test_004_remove_critical_failover_group(request):
             errno.EINVAL,
         )
     ]
+
+
+@pytest.mark.skipif(not ha, reason="Test valid on HA systems only")
+def test_005_failover_timeout_out_of_range(request):
+    # timeout values above 120 seconds produce a VRRP advertisement interval
+    # beyond the VRRPv3 maximum of 40.95 seconds, which keepalived rejects,
+    # breaking failover entirely (SEE-577)
+    before = call("failover.config")["timeout"]
+    with pytest.raises(ValidationErrors, match="Input should be less than or equal to 120"):
+        call("failover.update", {"timeout": 3600})
+    with pytest.raises(ValidationErrors, match="Input should be greater than or equal to 0"):
+        call("failover.update", {"timeout": -1})
+    assert call("failover.config")["timeout"] == before


### PR DESCRIPTION
A fun one. Exposed by a real customer escalation. They had put 3600 as a value into our API. We accepted it with no validation. The underlying daemon we use (keepalived) does not allow values this high, especially since we use VRRPv3. The gist is simple, the exceedingly high value that we didn't validate was written to the keepalived.conf file and the service failed to start without any real indication to the support team or customer ultimately preventing failover from occurring.

Let's go ahead and fix this situation by adding a migration to clamp any values > 120 seconds to 120 seconds. Do note that the advertisement timeout is in centiseconds per the RFC but we expose the value to the customer as seconds.

Original PR: https://github.com/truenas/middleware/pull/19406
