### PR TITLE
NAS-141966 / 26.0.0-RC.1 / Remove frames from JSON-RPC error responses (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -19,7 +19,6 @@ from middlewared.service_exception import (
     CallException, CallError, MatchNotFound, ValidationError, ValidationErrors, adapt_exception, get_errname
 )
 from middlewared.utils.auth import AUID_UNSET, AUID_FAULTED
-from middlewared.utils.debug import get_frame_details
 from middlewared.utils.lang import undefined
 from middlewared.utils.limits import MsgSizeError, MsgSizeLimit, parse_message
 from middlewared.utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
@@ -114,21 +113,10 @@ class RpcWebSocketApp(App):
         return result
 
     def truenas_error_traceback(self, exc_info: ExcInfo) -> dict:
-        etype, value, tb = exc_info
-
-        frames = []
-        cur_tb = tb
-        while cur_tb:
-            tb_frame = cur_tb.tb_frame
-            cur_tb = cur_tb.tb_next
-
-            cur_frame = get_frame_details(tb_frame, self.middleware.logger)
-            if cur_frame:
-                frames.append(cur_frame)
+        etype, value = exc_info[0], exc_info[1]
 
         return {
             "class": etype.__name__,
-            "frames": frames,
             "formatted": "".join(traceback.format_exception(*exc_info)),
             "repr": repr(value),
         }

--- a/src/middlewared/middlewared/apps/websocket_app.py
+++ b/src/middlewared/middlewared/apps/websocket_app.py
@@ -22,7 +22,6 @@ from middlewared.service_exception import (
     ValidationErrors,
     get_errname,
 )
-from middlewared.utils.debug import get_frame_details
 from middlewared.utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
 from middlewared.utils.origin import ConnectionOrigin
 from middlewared.utils.threading import run_coro_threadsafe
@@ -62,19 +61,9 @@ class WebSocketApplication(RpcWebSocketApp):
         run_coro_threadsafe(self.response.send_str(json.dumps(data)), loop=self.loop)
 
     def _tb_error(self, exc_info: OptExcInfo) -> dict:
-        klass, exc, trace = exc_info
-        frames = []
-        cur_tb = trace
-        while cur_tb:
-            tb_frame = cur_tb.tb_frame
-            cur_tb = cur_tb.tb_next
-            cur_frame = get_frame_details(tb_frame, self.logger)
-            if cur_frame:
-                frames.append(cur_frame)
-
+        klass = exc_info[0]
         return {
             "class": klass.__name__,
-            "frames": frames,
             "formatted": "".join(format_exception(*exc_info)),
             "repr": repr(exc_info[1]),
         }

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_error_traceback_redaction.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_error_traceback_redaction.py
@@ -1,0 +1,70 @@
+"""Regression test for locals disclosure via JSON-RPC error tracebacks."""
+
+import errno
+import json
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from middlewared.api.base.server.ws_handler.rpc import RpcWebSocketApp
+from middlewared.apps.websocket_app import WebSocketApplication
+
+SECRET_API_KEY = "1-THISVALUEMUSTNEVERAPPEARINANERRORRESPONSE"
+
+
+def _exc_info_carrying_secret():
+    """Raise an exception from frames whose locals hold ``SECRET_API_KEY``."""
+
+    def login_with_api_key(api_key):
+        raise ValueError("boom")
+
+    def dispatch(params):
+        return login_with_api_key(params[0])
+
+    try:
+        dispatch([SECRET_API_KEY])
+    except ValueError:
+        return sys.exc_info()
+
+
+@pytest.fixture
+def rpc_app():
+    # truenas_error_traceback / format_truenas_error do not need a fully constructed
+    # app; bypass __init__ and supply only what format_truenas_error may touch.
+    app = object.__new__(RpcWebSocketApp)
+    app.middleware = Mock()
+    app.py_exceptions = False
+    return app
+
+
+def test_truenas_error_traceback_omits_frames(rpc_app):
+    trace = rpc_app.truenas_error_traceback(_exc_info_carrying_secret())
+
+    assert "frames" not in trace
+    # The fields that remain are the ones clients actually consume / that are safe.
+    assert trace["class"] == "ValueError"
+    assert isinstance(trace["formatted"], str) and trace["formatted"]
+
+
+def test_truenas_error_traceback_does_not_leak(rpc_app):
+    trace = rpc_app.truenas_error_traceback(_exc_info_carrying_secret())
+
+    assert SECRET_API_KEY not in json.dumps(trace)
+
+
+def test_format_truenas_error_payload_does_not_leak(rpc_app):
+    # The full error `data` payload that gets sent to the client.
+    payload = rpc_app.format_truenas_error(errno.EBUSY, "Rate Limit Exceeded", _exc_info_carrying_secret(), None)
+
+    assert "frames" not in payload["trace"]
+    assert SECRET_API_KEY not in json.dumps(payload)
+
+
+def test_legacy_websocket_tb_error_does_not_leak():
+    app = object.__new__(WebSocketApplication)
+
+    trace = app._tb_error(_exc_info_carrying_secret())
+
+    assert "frames" not in trace
+    assert SECRET_API_KEY not in json.dumps(trace)


### PR DESCRIPTION
The client-facing error trace included every stack frame's locals (via get_frame_details, which reprs each local). This can result in API calls echoing back parameters from the call to the same API client in the error response. Generally, this information is not consumed by the truenas API client, jobs framework, or other internal call sites.

Original PR: https://github.com/truenas/middleware/pull/19403
