### PR TITLE
NAS-141984 / 26.0.0-RC.1 / Fix small bugs in NFS code

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/debug.py
+++ b/src/middlewared/middlewared/plugins/nfs_/debug.py
@@ -132,7 +132,8 @@ class NFSService(Service):
                 with open(f"/proc/sys/sunrpc/{svc}", "r") as f:
                     val = int(f.readline().strip(), 16)
 
-                for dbgflg in self.dbgcls[svc_name]:
+                dbgcls = self.dbgcls[svc_name]
+                for dbgflg in dbgcls:
                     if dbgflg.name == 'NONE':
                         continue
 
@@ -145,10 +146,10 @@ class NFSService(Service):
                     flags.append(dbgflg.name)
 
                 if not flags:
-                    flags = [dbgflg.NONE.name]
+                    flags = [dbgcls.NONE.name]
 
-                if dbgflg.ALL.name in flags:
-                    flags = [dbgflg.ALL.name]
+                if dbgcls.ALL.name in flags:
+                    flags = [dbgcls.ALL.name]
 
                 output[svc_name] = flags
 

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -40,7 +40,7 @@ class NFSService(Service):
         return entries
 
     @private
-    def clear_nfs3_rmtab(self, ip_to_clear=["all"]):
+    def clear_nfs3_rmtab(self, ip_to_clear=None):
         """
         Clear some or all NFSv3 client entries in rmtab.
         rmtab can become clogged with stale entries, this provides a
@@ -48,6 +48,9 @@ class NFSService(Service):
         Optional input: list of ip to remove, e.g. ip_to_clear=["a.b.c.d"]
         DEFAULT: Clear all entries
         """
+        if ip_to_clear is None:
+            ip_to_clear = ["all"]
+
         rmtab = os.path.join(NFSServicePathInfo.STATEDIR.path(), "rmtab")
         with suppress(FileNotFoundError):
             # Handle default:  clear all

--- a/src/middlewared/middlewared/plugins/nfs_/validators.py
+++ b/src/middlewared/middlewared/plugins/nfs_/validators.py
@@ -44,9 +44,9 @@ def sanitize_networks(
     elif found_all_networks:
         verrors.add(
             f"{schema_name}.networks",
-            f"Do not use {v} to represent all-networks.  "
+            f"Do not use {found_all_networks} to represent all-networks.  "
             f"No entry is required to configure 'allow everybody'.  "
-            f"Please remove {v}."
+            f"Please remove {found_all_networks}."
         )
     elif convert:
         # Perform the courtesy conversion to CIDR format
@@ -83,9 +83,9 @@ def sanitize_hosts(schema_name: str, hosts: list, verrors: ValidationErrors):
     if found_all_hosts:
         verrors.add(
             f"{schema_name}.hosts",
-            f"Do not use {v} to represent all-hosts.  "
+            f"Do not use {found_all_hosts} to represent all-hosts.  "
             f"No entry is required to configure 'allow everybody'.  "
-            f"Please remove {v} or replace with '*'."
+            f"Please remove {found_all_hosts} or replace with '*'."
         )
 
 


### PR DESCRIPTION
`sanitize_networks` and `sanitize_hosts` reported incorrect error messages when wildcard host/network was not the last on the list.

`clear_nfs3_rmtab` accepted mutable value as default argument. This didn't affect anything currently, but can potentially result in memory leaks and weird behavior if code is modified.

`dbgflg` was a leaked loop variable that worked by accident

Backported from https://github.com/truenas/middleware/pull/19417