### PR TITLE
NAS-141823 / 27.0.0-BETA.1 / Allow running disabled replication tasks

### DIFF
--- a/src/middlewared/middlewared/plugins/replication/methods.py
+++ b/src/middlewared/middlewared/plugins/replication/methods.py
@@ -39,9 +39,6 @@ async def run_task(context: ServiceContext, job: Job, id_: int, really_run: bool
     if really_run:
         task = await context.call2(context.s.replication.get_instance, id_)
 
-        if not task.enabled:
-            raise CallError("Task is not enabled")
-
         if task.state["state"] == "RUNNING":
             raise CallError("Task is already running")
 

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -705,7 +705,7 @@ class ZettareplService(Service):
             )
 
         replication_tasks = {}
-        for replication_task in await self.call2(self.s.replication.query, [["enabled", "=", True]]):
+        for replication_task in await self.call2(self.s.replication.query):
             # `_replication_task_definition` builds a zettarepl-library task definition and is shared with one-time
             # tasks (`self.onetime_replication_tasks`), which are plain dicts of a different shape. Dump the model to
             # a dict here so both paths feed it the same representation.
@@ -817,8 +817,8 @@ class ZettareplService(Service):
                 f"task_{periodic_snapshot_task['id']}"
                 for periodic_snapshot_task in replication_task["periodic_snapshot_tasks"]
             ],
-            "auto": replication_task["auto"],
-            "only-matching-schedule": replication_task["only_matching_schedule"],
+            "auto": replication_task["auto"] and replication_task["enabled"],
+            "only-matching-schedule": replication_task["only_matching_schedule"] and replication_task["enabled"],
             "allow-from-scratch": replication_task["allow_from_scratch"],
             "only-from-scratch": replication_task.get("only_from_scratch", False),
             "readonly": replication_task["readonly"].lower(),
@@ -847,7 +847,7 @@ class ZettareplService(Service):
             definition["also-include-naming-schema"] = replication_task["also_include_naming_schema"]
         if replication_task["name_regex"]:
             definition["name-regex"] = replication_task["name_regex"]
-        if replication_task["schedule"] is not None:
+        if replication_task["schedule"] is not None and replication_task["enabled"]:
             definition["schedule"] = zettarepl_schedule(replication_task["schedule"])
         if replication_task["restrict_schedule"] is not None:
             definition["restrict-schedule"] = zettarepl_schedule(replication_task["restrict_schedule"])

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -498,7 +498,7 @@ def test_create_disabled_periodic_snapshot_task_binding():
 
 
 def test_run_disabled_task():
-    """Running a disabled replication task raises an error."""
+    """Running a disabled replication task works."""
     with dataset("src") as src:
         with dataset("dst") as dst:
             with replication_task({
@@ -509,12 +509,16 @@ def test_run_disabled_task():
                 "target_dataset": dst,
                 "recursive": False,
                 "also_include_naming_schema": ["%Y-%m-%d-%H-%M-%S"],
-                "auto": False,
+                "auto": True,
+                "schedule": {},
                 "retention_policy": "NONE",
                 "enabled": False,
             }) as task:
-                with pytest.raises(ClientException, match="Task is not enabled"):
-                    call("replication.run", task["id"], job=True)
+                call("pool.snapshot.create", {"dataset": src, "name": "2026-01-01-00-00-00"})
+
+                call("replication.run", task["id"], job=True)
+
+                assert call("pool.snapshot.query", [["dataset", "=", dst]])
 
 
 def test_update_ssh_credentials_task(ssh_credentials):


### PR DESCRIPTION
Previously, disabled replication tasks were excluded from zettarepl configuration. Now we include them, but we don't let them run automatically.