### PR TITLE
NAS-141823 / 26.0.0-RC.1 / Allow running disabled replication tasks (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -314,9 +314,6 @@ class ReplicationService(CRUDService):
         if really_run:
             task = await self.get_instance(id_)
 
-            if not task["enabled"]:
-                raise CallError("Task is not enabled")
-
             if task["state"]["state"] == "RUNNING":
                 raise CallError("Task is already running")
 

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -662,7 +662,7 @@ class ZettareplService(Service):
             )
 
         replication_tasks = {}
-        for replication_task in await self.middleware.call("replication.query", [["enabled", "=", True]]):
+        for replication_task in await self.middleware.call("replication.query"):
             try:
                 replication_tasks[f"task_{replication_task['id']}"] = await self._replication_task_definition(
                     pools, replication_task
@@ -770,8 +770,8 @@ class ZettareplService(Service):
                 f"task_{periodic_snapshot_task['id']}"
                 for periodic_snapshot_task in replication_task["periodic_snapshot_tasks"]
             ],
-            "auto": replication_task["auto"],
-            "only-matching-schedule": replication_task["only_matching_schedule"],
+            "auto": replication_task["auto"] and replication_task["enabled"],
+            "only-matching-schedule": replication_task["only_matching_schedule"] and replication_task["enabled"],
             "allow-from-scratch": replication_task["allow_from_scratch"],
             "only-from-scratch": replication_task.get("only_from_scratch", False),
             "readonly": replication_task["readonly"].lower(),
@@ -800,7 +800,7 @@ class ZettareplService(Service):
             definition["also-include-naming-schema"] = replication_task["also_include_naming_schema"]
         if replication_task["name_regex"]:
             definition["name-regex"] = replication_task["name_regex"]
-        if replication_task["schedule"] is not None:
+        if replication_task["schedule"] is not None and replication_task["enabled"]:
             definition["schedule"] = zettarepl_schedule(replication_task["schedule"])
         if replication_task["restrict_schedule"] is not None:
             definition["restrict-schedule"] = zettarepl_schedule(replication_task["restrict_schedule"])

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -498,7 +498,7 @@ def test_create_disabled_periodic_snapshot_task_binding():
 
 
 def test_run_disabled_task():
-    """Running a disabled replication task raises an error."""
+    """Running a disabled replication task works."""
     with dataset("src") as src:
         with dataset("dst") as dst:
             with replication_task({
@@ -509,12 +509,16 @@ def test_run_disabled_task():
                 "target_dataset": dst,
                 "recursive": False,
                 "also_include_naming_schema": ["%Y-%m-%d-%H-%M-%S"],
-                "auto": False,
+                "auto": True,
+                "schedule": {},
                 "retention_policy": "NONE",
                 "enabled": False,
             }) as task:
-                with pytest.raises(ClientException, match="Task is not enabled"):
-                    call("replication.run", task["id"], job=True)
+                call("pool.snapshot.create", {"dataset": src, "name": "2026-01-01-00-00-00"})
+
+                call("replication.run", task["id"], job=True)
+
+                assert call("pool.snapshot.query", [["dataset", "=", dst]])
 
 
 def test_update_ssh_credentials_task(ssh_credentials):


### PR DESCRIPTION
Previously, disabled replication tasks were excluded from zettarepl configuration. Now we include them, but we don't let them run automatically.

Original PR: https://github.com/truenas/middleware/pull/19419
