### PR TITLE
NAS-141988 / 26.0.0-BETA.3 / Move remote disk retaste call in failover event (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -612,26 +612,13 @@ class FailoverEventsService(Service):
         maybe_unlocked = False
         try:
             maybe_unlocked = self.run_call('disk.sed_unlock_all', True)
+            if maybe_unlocked:
+                logger.info('Done unlocking all SED disks (if any)')
         except Exception as e:
             # failing here doesn't mean the zpool won't import
             # we could have failed on only 1 disk so log an
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
-
-        if maybe_unlocked:
-            logger.info('Done unlocking all SED disks (if any)')
-            try:
-                if self.run_call("failover.remote_connected"):
-                    logger.info("Retasting disks on standby node")
-                    self.run_call(
-                        "failover.call_remote",
-                        "disk.retaste",
-                        [],
-                        {"raise_connect_error": False, "timeout": 5},
-                    )
-                    logger.info("Done scheduling retasting disks on standby node")
-            except Exception:
-                logger.exception('Unexpected failure scheduling retasting disks on standby node')
 
         # setup the zpool cachefile  TODO: see comment below about cachefile usage
         # self.run_call('failover.zpool.cachefile.setup', 'MASTER')
@@ -806,6 +793,20 @@ class FailoverEventsService(Service):
             logger.info('Done allowing network traffic.')
 
         logger.info('Critical portion of failover is now complete')
+
+        if maybe_unlocked:
+            try:
+                if self.run_call("failover.remote_connected"):
+                    logger.info("Retasting disks on standby node")
+                    self.run_call(
+                        "failover.call_remote",
+                        "disk.retaste",
+                        [],
+                        {"raise_connect_error": False, "timeout": 5},
+                    )
+                    logger.info("Done scheduling retasting disks on standby node")
+            except Exception:
+                logger.exception('Unexpected failure scheduling retasting disks on standby node')
 
         # regenerate cron
         logger.info('Regenerating cron')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -797,16 +797,20 @@ class FailoverEventsService(Service):
         if maybe_unlocked:
             try:
                 if self.run_call("failover.remote_connected"):
-                    logger.info("Retasting disks on standby node")
+                    logger.info("Scheudling disks retaste on standby node")
                     self.run_call(
                         "failover.call_remote",
                         "disk.retaste",
                         [],
-                        {"raise_connect_error": False, "timeout": 5},
+                        {
+                            "raise_connect_error": False,
+                            "timeout": 2,
+                            "job": "RETURN"  # return immediately, no need to wate
+                        },
                     )
-                    logger.info("Done scheduling retasting disks on standby node")
+                    logger.info("Done scheduling disks retaste on standby node")
             except Exception:
-                logger.exception('Unexpected failure scheduling retasting disks on standby node')
+                logger.exception('Unexpected failure scheduling disks retaste on standby node')
 
         # regenerate cron
         logger.info('Regenerating cron')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -805,7 +805,7 @@ class FailoverEventsService(Service):
                         {
                             "raise_connect_error": False,
                             "timeout": 2,
-                            "job": "RETURN"  # return immediately, no need to wate
+                            "job": "RETURN"  # return immediately, no need to wait
                         },
                     )
                     logger.info("Done scheduling disks retaste on standby node")


### PR DESCRIPTION
There is no reason that this remote call should be ran before we import the zpool. This is sending a request to the remote controller on an HA system and who knows what state it's in at the time we make the request. The point is that it should never delay or block the importing of the zpool on the master event.

This does 3 things:
1. move the remote call to outside the "critical" failover section to prevent unnecessary delays in restoring services in a failover event
2. fix the logging messages to be persistent
3. add the `job: "RETURN"` argument to `failover.call_remote` so we do not wait for this to complete at all. We just fire and forget

Original PR: https://github.com/truenas/middleware/pull/19426


Original PR: https://github.com/truenas/middleware/pull/19427
