### PR TITLE
NAS-141951 / 27.0.0-BETA.1 / fix SMART alerts on drives that crash

### DIFF
--- a/src/middlewared/middlewared/alert/source/smart.py
+++ b/src/middlewared/middlewared/alert/source/smart.py
@@ -112,7 +112,12 @@ class SMARTAlertSource(ThreadedAlertSource):
         if ata_tests := log.get("table", []):
             # NAS-140419: smartctl writes table[] newest-first (see ataPrintSmartSelfTestlog
             # in smartmontools/ataprint.cpp), so [0] is the most recent test.
-            test_failed = not ata_tests[0]["status"]["passed"]
+            # NAS-141951: smartctl omits "passed" entirely when the test result is
+            # unknown -- status nibble 0x1 (aborted by host), 0x2 (interrupted by
+            # host reset) or 0x3 (fatal/unknown error); see "aborted -> unknown" in
+            # ataPrintSmartSelfTestEntry (smartmontools 7.4 ataprint.cpp:2654-2657).
+            # Only an explicit false means the drive recorded a failed self-test.
+            test_failed = ata_tests[0]["status"].get("passed") is False
 
         return SmartInfo(
             uncorrected_errors=ue,

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_smart.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_smart.py
@@ -18,6 +18,16 @@ def _selftest_entry(passed):
     }
 
 
+def _selftest_entry_no_verdict(status_value, status_string):
+    # NAS-141951: smartctl omits "passed" when the result is unknown (status
+    # nibble 0x1-0x3, "aborted -> unknown" in ataprint.cpp).
+    return {
+        "type": {"value": 2, "string": "Extended offline"},
+        "status": {"value": status_value, "string": status_string},
+        "lifetime_hours": 46601,
+    }
+
+
 def _ata_data(self_test_log=None, attributes=None):
     """Build a minimal `smartctl -x -jc` ATA payload."""
     data = {
@@ -73,6 +83,33 @@ def _ata_data(self_test_log=None, attributes=None):
         # Regression guard: a (non-smartctl) top-level "table" must be ignored, not
         # read as the self-test log.
         pytest.param({"table": [_selftest_entry(False)]}, False, id="bogus-toplevel-table"),
+        # NAS-141951: entries without a "passed" verdict must not KeyError and must
+        # not alert -- the result is unknown, not a failure.
+        pytest.param(
+            {"extended": {"count": 1, "table": [_selftest_entry_no_verdict(0x10, "Aborted by host")]}},
+            False,
+            id="extended-newest-aborted-no-verdict",
+        ),
+        pytest.param(
+            {"extended": {"count": 1, "table": [_selftest_entry_no_verdict(0x20, "Interrupted (host reset)")]}},
+            False,
+            id="extended-newest-interrupted-no-verdict",
+        ),
+        pytest.param(
+            {"standard": {"table": [_selftest_entry_no_verdict(0x30, "Fatal or unknown error")]}},
+            False,
+            id="standard-newest-fatal-no-verdict",
+        ),
+        # An aborted newest test must not mask an older explicit failure either --
+        # only index 0 is consulted.
+        pytest.param(
+            {"extended": {
+                "count": 2,
+                "table": [_selftest_entry_no_verdict(0x10, "Aborted by host"), _selftest_entry(False)],
+            }},
+            False,
+            id="extended-aborted-then-older-failed",
+        ),
     ],
 )
 def test_parse_ata_self_test_failure(self_test_log, expected_testfail):


### PR DESCRIPTION
Fix a KeyError crash when the `passed` key doesn't exist in the smartctl output in json form. We're installed on a range of hardware that misbehaves. Furthermore, the lack of deterministic shapes in responses with the json flag in smartctl is alarming.