### PR TITLE
NAS-141967 / 26.0.0-BETA.3 / Fix termination of clustered secrets key names (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -113,15 +113,6 @@ def keys_are_null_terminated(name: str, data_type: TDBDataType) -> bool:
     Whether the on-disk keys of the TDB/CTDB database identified by `name` carry a
     trailing NUL terminator.
 
-    This MUST match how the database's owner encodes its keys, and it MUST be identical
-    for a given database whether that database is accessed as a local tdb file
-    (``TDBHandle``) or through ctdb (``CTDBHandle``) -- otherwise the two access paths
-    write mismatched keys into the same database. That exact drift broke SMB stateful
-    failover: ``secrets.tdb`` keys were written NUL-terminated into ctdb, but samba's
-    ``secrets_fetch()``/``secrets_store()`` key on ``string_tdb_data()`` (``strlen``, no
-    terminator), so winbindd could not fetch the domain SID and aborted with
-    "Could not fetch our SID - did we join?".
-
     ``secrets.tdb`` is the odd one out: unlike most samba databases (which key via
     ``string_term_tdb_data()`` == ``strlen + 1``) its keys have no terminator.
     """

--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -108,6 +108,36 @@ class TDBOps:
     vacuum: Callable[..., Any]
 
 
+def keys_are_null_terminated(name: str, data_type: TDBDataType) -> bool:
+    """
+    Whether the on-disk keys of the TDB/CTDB database identified by `name` carry a
+    trailing NUL terminator.
+
+    This MUST match how the database's owner encodes its keys, and it MUST be identical
+    for a given database whether that database is accessed as a local tdb file
+    (``TDBHandle``) or through ctdb (``CTDBHandle``) -- otherwise the two access paths
+    write mismatched keys into the same database. That exact drift broke SMB stateful
+    failover: ``secrets.tdb`` keys were written NUL-terminated into ctdb, but samba's
+    ``secrets_fetch()``/``secrets_store()`` key on ``string_tdb_data()`` (``strlen``, no
+    terminator), so winbindd could not fetch the domain SID and aborted with
+    "Could not fetch our SID - did we join?".
+
+    ``secrets.tdb`` is the odd one out: unlike most samba databases (which key via
+    ``string_term_tdb_data()`` == ``strlen + 1``) its keys have no terminator.
+    """
+    match os.path.basename(name):
+        case 'gencache.tdb':
+            return True
+        case 'secrets.tdb':
+            return False
+        case 'group_mapping.tdb' | 'group_mapping_rejects.tdb' | 'passdb.tdb':
+            return True
+        case _:
+            # Most samba tdb files use NULL-terminated string keys; middleware-owned
+            # databases that store JSON/STRING values do not.
+            return data_type is TDBDataType.BYTES
+
+
 class TDBHandle:
     hdl: Any = None
     name: str | None = None
@@ -329,7 +359,6 @@ class TDBHandle:
             case 'gencache.tdb':
                 # See gencache_init() in source3/lib/gencache.c in Samba
                 tdb_flags = tdb.INCOMPATIBLE_HASH | tdb.NOSYNC | MUTEX_LOCKING
-                self.keys_null_terminated = True
                 open_flags = os.O_CREAT | os.O_RDWR
                 open_mode = 0o644
             case 'secrets.tdb':
@@ -338,16 +367,16 @@ class TDBHandle:
                 open_mode = 0o600
             case 'group_mapping.tdb' | 'group_mapping_rejects.tdb' | 'passdb.tdb':
                 tdb_flags = tdb.DEFAULT
-                open_flags = os.O_RDWR
-                self.keys_null_terminated = True
                 open_flags = os.O_CREAT | os.O_RDWR
                 open_mode = 0o600
             case _:
                 tdb_flags = tdb.DEFAULT
-                # Typically tdb files will have NULL-terminated keys
-                self.keys_null_terminated = options.data_type is TDBDataType.BYTES
                 open_flags = os.O_CREAT | os.O_RDWR
                 open_mode = 0o600
+
+        # Key NUL-termination is a property of the database itself, so it must be derived
+        # identically here and in CTDBHandle (see keys_are_null_terminated).
+        self.keys_null_terminated = keys_are_null_terminated(name, self.data_type)
 
         match self.path_type:
             case TDBPathType.CUSTOM:
@@ -473,7 +502,10 @@ class CTDBHandle(TDBHandle):
         self.data_type = TDBDataType(options.data_type)
         self.path_type = TDBPathType(options.backend)
         self.options = options
-        self.keys_null_terminated = True
+        # Must agree with the local-file TDBHandle for the same database (see
+        # keys_are_null_terminated). Hardcoding True here silently NUL-terminated
+        # secrets.tdb keys in ctdb and broke SMB stateful failover.
+        self.keys_null_terminated = keys_are_null_terminated(name, self.data_type)
 
         # lazy-initialize CTDB client
         try:

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -308,11 +308,6 @@ def test__ipa_cred_version_absent_reads_as_zero(secrets_tdb):
 
 
 @pytest.mark.parametrize('name,data_type,expected', [
-    # secrets.tdb is the odd one out: samba keys it via string_tdb_data() (strlen, no
-    # terminator), so its keys MUST NOT be null-terminated. The value returned here is
-    # consumed identically by the local TDBHandle and the clustered CTDBHandle; when the
-    # two disagreed (CTDBHandle hardcoded True) winbindd could not fetch the domain SID
-    # and SMB stateful failover broke ("Could not fetch our SID - did we join?").
     ('secrets.tdb', TDBDataType.BYTES, False),
     ('/var/lib/truenas-samba/private/secrets.tdb', TDBDataType.BYTES, False),
     # Most samba databases key via string_term_tdb_data() (strlen + 1).

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 from middlewared.plugins.directoryservices_ import secrets as secrets_mod
 from middlewared.plugins.directoryservices_.secrets import DomainSecrets
 from middlewared.service_exception import CallError
-from middlewared.utils.tdb import get_tdb_handle
+from middlewared.utils.tdb import TDBDataType, get_tdb_handle, keys_are_null_terminated
 
 
 @pytest.fixture
@@ -305,3 +305,49 @@ def test__ipa_cred_version_absent_reads_as_zero(secrets_tdb):
     existed -- must read as 0 so the health check knows to regenerate its SMB credential.
     """
     assert secrets_tdb.ipa_cred_version('OLDDOMAIN') == 0
+
+
+@pytest.mark.parametrize('name,data_type,expected', [
+    # secrets.tdb is the odd one out: samba keys it via string_tdb_data() (strlen, no
+    # terminator), so its keys MUST NOT be null-terminated. The value returned here is
+    # consumed identically by the local TDBHandle and the clustered CTDBHandle; when the
+    # two disagreed (CTDBHandle hardcoded True) winbindd could not fetch the domain SID
+    # and SMB stateful failover broke ("Could not fetch our SID - did we join?").
+    ('secrets.tdb', TDBDataType.BYTES, False),
+    ('/var/lib/truenas-samba/private/secrets.tdb', TDBDataType.BYTES, False),
+    # Most samba databases key via string_term_tdb_data() (strlen + 1).
+    ('gencache.tdb', TDBDataType.BYTES, True),
+    ('group_mapping.tdb', TDBDataType.BYTES, True),
+    ('group_mapping_rejects.tdb', TDBDataType.BYTES, True),
+    ('passdb.tdb', TDBDataType.BYTES, True),
+    ('share_info.tdb', TDBDataType.BYTES, True),       # default: BYTES -> terminated
+    ('winbindd_cache.tdb', TDBDataType.BYTES, True),   # default: BYTES -> terminated
+    ('middleware_cache', TDBDataType.JSON, False),     # middleware-owned JSON -> not
+])
+def test__keys_are_null_terminated_conventions(name, data_type, expected):
+    """
+    Lock the per-database key convention that both TDB access paths share. A regression
+    that flips secrets.tdb back to null-terminated re-breaks winbindd on stateful failover.
+    """
+    assert keys_are_null_terminated(name, data_type) is expected
+
+
+def test__secrets_tdb_keys_are_not_null_terminated_on_disk(tmp_path):
+    """
+    End-to-end proof that a key written through the secrets.tdb handle lands on disk
+    without a trailing NUL -- the exact byte layout samba's secrets_fetch() expects. If
+    the handle null-terminates the key, secrets_fetch_domain_sid() misses and winbindd
+    aborts. Inspecting the raw underlying tdb keys (bypassing the wrapper, which would
+    hide the terminator) surfaces a regression as a failure here.
+    """
+    tdb_path = str(tmp_path / 'secrets.tdb')
+    # secrets.tdb opens O_RDWR without O_CREAT, so the db must already exist.
+    tdb.Tdb(tdb_path, 0, tdb.DEFAULT, os.O_CREAT | os.O_RDWR, 0o600).close()
+
+    key = 'SECRETS/SID/ACME'
+    with get_tdb_handle(tdb_path, secrets_mod.SECRETS_TDB_OPTIONS) as hdl:
+        hdl.store(key, b64encode(b'\x01\x04rawsidbytes').decode())
+        raw_keys = list(hdl.hdl.keys())  # underlying tdb.Tdb -> raw key bytes
+
+    assert key.encode() in raw_keys, f'expected un-terminated key on disk; got {raw_keys}'
+    assert key.encode() + b'\x00' not in raw_keys, 'secrets key must not be NUL-terminated'


### PR DESCRIPTION
This commit fixes an issue where the clustered secrets file entries were being migrated with a terminated an extra null for their name. The termination behavior depends on the particular tdb file in question in samba / winbind.

Original PR: https://github.com/truenas/middleware/pull/19422
