### PR TITLE
NAS-141994 / 26.0.0-BETA.3 / Export ServiceOptions from the v26_0_0 API module (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/service.py
+++ b/src/middlewared/middlewared/api/v26_0_0/service.py
@@ -8,7 +8,8 @@ from middlewared.api.base import BaseModel
 __all__ = [
     "ServiceEntry", "ServiceStartedArgs", "ServiceStartedResult",
     "ServiceStartedOrEnabledArgs", "ServiceStartedOrEnabledResult",
-    "ServiceUpdateArgs", "ServiceUpdateResult", "ServiceControlArgs", "ServiceControlResult",
+    "ServiceUpdateArgs", "ServiceUpdateResult",
+    "ServiceOptions", "ServiceControlArgs", "ServiceControlResult",
 ]
 
 


### PR DESCRIPTION
## Problem
`plugins/smb_/sid.py` imports `ServiceOptions` from `middlewared.api.current`, but `api/v26_0_0/service.py` defines the class without listing it in `__all__`. Since `v26_0_0/__init__.py` pulls the module in with `from .service import *`, the name never gets rebound and the import raises `ImportError` at plugin load. `load_modules` doesn't guard `importlib.import_module`, so this is fatal — middlewared won't start. It only shows up on 26 because master's `api/current.py` points at `v27_0_0`, whose `__all__` does export the name.

## Solution
Added `ServiceOptions` to `v26_0_0/service.py`'s `__all__`, matching v27. An AST sweep of every name imported from `middlewared.api.current` across the tree confirms this was the only one missing from v26's exports, so nothing else is queued behind it. `ServiceUpdate` is also unexported relative to v27, but nothing imports it through `api.current`, so I left it alone.

Original PR: https://github.com/truenas/middleware/pull/19437
