### PR TITLE
NAS-142002 / 25.10.6 / Use TrueNAS vm APIs when /etc/tn-test/config.json present (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/hostkvm.py
+++ b/src/middlewared/middlewared/test/integration/assets/hostkvm.py
@@ -1,8 +1,10 @@
+import json
 import os
 import re
 import shlex
 
 from middlewared.test.integration.utils import call, run_on_runner, RunOnRunnerException, ssh
+from middlewared.test.integration.utils.client import client as tn_client
 
 try:
     from config import KVM_HOST, KVM_PASSWORD, KVM_USERNAME
@@ -10,9 +12,35 @@ try:
 except ImportError:
     have_kvm_host_cfg = False
 
+TN_TEST_CONFIG_PATH = '/etc/tn-test/config.json'
+
 TM_NODE_RE = re.compile('^tm[0-9]{3}$')
 HA_NODE_RE = re.compile('^ha[0-9]{3}_c[1|2]$')
 WHOLE_HA_NODE_RE = re.compile('^ha[0-9]{3}$')
+
+
+def _tn_test_config():
+    """
+    Return the parsed /etc/tn-test/config.json if present, else None.
+    Its presence indicates the test runner is talking to guest VMs hosted
+    on a TrueNAS box (via the TrueNAS vm APIs) rather than a Debian/KVM host.
+    """
+    try:
+        with open(TN_TEST_CONFIG_PATH) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+
+def _tn_client(cfg):
+    return tn_client(host_ip=cfg['tn_host'], auth=(cfg['tn_username'], cfg['tn_password']))
+
+
+def _tn_vm_id(c, vmname):
+    vms = c.call('vm.query', [['name', '=', vmname]])
+    if not vms:
+        raise RuntimeError(f'{vmname}: VM not found on TrueNAS host')
+    return vms[0]['id']
 
 
 def get_kvm_domain():
@@ -54,6 +82,13 @@ def poweroff_vm(vmname, graceful=True):
     Issue a virsh destroy <domain>.  This is similar to pulling the power
     cable.  The VM can be restarted later.
     """
+    if cfg := _tn_test_config():
+        # virsh destroy [--graceful] is a hard poweroff of qemu; the guest
+        # never sees ACPI.  vm.poweroff matches that; vm.stop would do a
+        # clean ACPI shutdown and wait shutdown_timeout, which is the wrong
+        # semantics for tests that expect an abrupt power event.
+        with _tn_client(cfg) as c:
+            return c.call('vm.poweroff', _tn_vm_id(c, vmname))
     command = ['destroy', vmname]
     if graceful:
         command.append('--graceful')
@@ -61,14 +96,26 @@ def poweroff_vm(vmname, graceful=True):
 
 
 def reset_vm(vmname):
+    if cfg := _tn_test_config():
+        with _tn_client(cfg) as c:
+            return c.call('vm.reset', _tn_vm_id(c, vmname))
     return _virsh(['reset', vmname])
 
 
 def shutdown_vm(vmname, mode='acpi'):
+    if cfg := _tn_test_config():
+        # The virsh --mode selector (acpi/agent/signal/...) has no direct
+        # equivalent in the TrueNAS vm API; vm.stop performs an ACPI shutdown.
+        with _tn_client(cfg) as c:
+            return c.call('vm.stop', _tn_vm_id(c, vmname), {}, job=True)
     return _virsh(['shutdown', vmname, '--mode', mode])
 
 
 def start_vm(vmname, force_boot=False):
+    if cfg := _tn_test_config():
+        # No --force-boot equivalent in the TrueNAS vm API; force_boot is ignored.
+        with _tn_client(cfg) as c:
+            return c.call('vm.start', _tn_vm_id(c, vmname))
     command = ['start', vmname]
     if force_boot:
         command.append('--force-boot')


### PR DESCRIPTION
Falls back to virsh otherwise, preserving behavior on the Debian/KVM rig.

This change is required so that CI tests can manipulate VM state (i.e. thru the VM **host**) on the new CI rig.

Original PR: https://github.com/truenas/middleware/pull/19443
