### PR TITLE
NAS-141948 / 26.0.0-RC.1 / Properly handle exceptions in main loop (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1766,15 +1766,18 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin, CallMixin):
 
             os._exit(exit_code)
 
+        exitcode = 0
         try:
             self.loop.run_forever()
-        except RuntimeError as e:
-            if e.args[0] != "Event loop is closed":
-                raise
+        except BaseException as e:
+            if not (isinstance(e, RuntimeError) and e.args[0] == "Event loop is closed"):
+                sys.stderr.write("Unhandled exception in event loop:\n")
+                traceback.print_exc(file=sys.stderr)
+                exitcode = 1
 
         # Use os._exit rather than sys.exit to avoid Python-level cleanup (atexit handlers, thread joins, etc.)
         # that could block in this abnormal shutdown path.
-        os._exit(0)
+        os._exit(exitcode)
 
     async def __initialize(self):
         self._systemd_notifier = SystemdNotifier()


### PR DESCRIPTION
An unhandled exception in event loop terminates `main()` prematurely:
```
Jul 27 12:03:48 truenas middlewared[34613]: Traceback (most recent call last):
Jul 27 12:03:48 truenas middlewared[34613]:   File "/usr/bin/middlewared", line 8, in <module>
Jul 27 12:03:48 truenas middlewared[34613]:     sys.exit(main())
Jul 27 12:03:48 truenas middlewared[34613]:              ~~~~^^
Jul 27 12:03:48 truenas middlewared[34613]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 2171, in main
Jul 27 12:03:48 truenas middlewared[34613]:     middleware.run(single_task)
Jul 27 12:03:48 truenas middlewared[34613]:     ~~~~~~~~~~~~~~^^^^^^^^^^^^^
Jul 27 12:03:48 truenas middlewared[34613]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1907, in run
Jul 27 12:03:48 truenas middlewared[34613]:     self.loop.run_forever()
Jul 27 12:03:48 truenas middlewared[34613]:     ~~~~~~~~~~~~~~~~~~~~~^^
Jul 27 12:03:48 truenas middlewared[34613]:   File "/usr/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
Jul 27 12:03:48 truenas middlewared[34613]:     self._run_once()
Jul 27 12:03:48 truenas middlewared[34613]:     ~~~~~~~~~~~~~~^^
Jul 27 12:03:48 truenas middlewared[34613]:   File "/usr/lib/python3.13/asyncio/base_events.py", line 2015, in _run_once
Jul 27 12:03:48 truenas middlewared[34613]:     handle = heapq.heappop(self._scheduled)
Jul 27 12:03:48 truenas middlewared[34613]: RuntimeError: list changed size during iteration
```
Then the normal python shutdown procedure starts, and `atexit` handlers start trying to call methods on a terminated loop, blocking the middleware indefinitely
```
Jul 27 12:03:50 truenas middlewared[34613]: Exception in thread zr_proc_join:
Jul 27 12:03:51 truenas middlewared[34613]: Traceback (most recent call last):
Jul 27 12:03:51 truenas middlewared[34613]:   File "/usr/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
Jul 27 12:03:51 truenas middlewared[34613]:     self.run()
Jul 27 12:03:51 truenas middlewared[34613]:     ~~~~~~~~^^
Jul 27 12:03:51 truenas middlewared[34613]:   File "/usr/lib/python3.13/threading.py", line 994, in run
Jul 27 12:03:51 truenas middlewared[34613]:     self._target(*self._args, **self._kwargs)
Jul 27 12:03:51 truenas middlewared[34613]:     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 27 12:03:51 truenas middlewared[34613]:   File "/usr/lib/python3/dist-packages/middlewared/plugins/zettarepl.py", line 401, in _join
Jul 27 12:03:51 truenas middlewared[34613]:     for k, v in self.middleware.call_sync("zettarepl.get_state").get("tasks", {}).items():
Jul 27 12:03:51 truenas middlewared[34613]:                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
Jul 27 12:03:51 truenas middlewared[34613]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1433, in call_sync
Jul 27 12:03:51 truenas middlewared[34613]:     return self.run_coroutine(self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args))
Jul 27 12:03:51 truenas middlewared[34613]:            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 27 12:03:51 truenas middlewared[34613]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1571, in run_coroutine
Jul 27 12:03:51 truenas middlewared[34613]:     raise RuntimeError('Middleware is terminating')
Jul 27 12:03:51 truenas middlewared[34613]: RuntimeError: Middleware is terminating
```

Now, we handle all exceptions and always reach `os._exit` which skips all `atexit` handlers.

Original PR: https://github.com/truenas/middleware/pull/19404
