### PR TITLE
NAS-142015 / 27.0.0-BETA.1 / Apply the VM system clock setting to the generated domain

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import typing
 
-from truenas_pylibvirt import VmBootloader, VmCpuMode
+from truenas_pylibvirt import Time, VmBootloader, VmCpuMode
 
 from middlewared.api.current import QueryOptions, VMEntry, VMStartOptions, VMStopOptions
 from middlewared.service import CallError, ServiceContext
@@ -116,6 +116,7 @@ def pylibvirt_vm(
     data.update({
         'bootloader': VmBootloader(data['bootloader']),
         'cpu_mode': VmCpuMode(data['cpu_mode']),
+        'time': Time(data['time']),
         'nvram_path': os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(data['id'], data['name'])),
         'tpm_path': os.path.join(SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name(data['id'], data['name'])),
         'devices': devices,

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_clock_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_clock_xml.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any
+from xml.etree import ElementTree
+
+import pytest
+
+from middlewared.api.current import VMEntry
+from middlewared.plugins.vm.lifecycle import pylibvirt_vm
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service.context import ServiceContext
+
+
+def make_vm_entry(**overrides: Any) -> VMEntry:
+    defaults: dict[str, Any] = dict(
+        id=1,
+        name="testvm",
+        uuid="2f9a4a5f-0f7f-4d1e-9c3a-7c9f3b5d2e11",
+        memory=1024,
+        devices=[],
+        display_available=False,
+        status={"state": "STOPPED", "pid": None, "domain_state": None},
+    )
+    return VMEntry(**(defaults | overrides))
+
+
+def clock_xml(vm: VMEntry) -> str:
+    context = ServiceContext(Middleware(), logging.getLogger("test"))
+    # `xml_generator` takes a container-only context, and `VmDomain.run()` yields nothing, so
+    # production passes `None` here for VMs too.
+    generator = pylibvirt_vm(context, vm).xml_generator(None)
+    return ElementTree.tostring(generator._clock_xml()).decode().strip()
+
+
+@pytest.mark.parametrize(
+    "time,hyperv_enlightenments,expected_xml",
+    [
+        ("LOCAL", False, '<clock offset="localtime" />'),
+        ("LOCAL", True, '<clock offset="localtime"><timer name="hypervclock" present="yes" /></clock>'),
+        ("UTC", False, '<clock offset="utc" />'),
+        ("UTC", True, '<clock offset="utc"><timer name="hypervclock" present="yes" /></clock>'),
+    ],
+)
+def test_clock_xml(time, hyperv_enlightenments, expected_xml):
+    vm = make_vm_entry(time=time, hyperv_enlightenments=hyperv_enlightenments)
+
+    assert clock_xml(vm) == expected_xml


### PR DESCRIPTION
## Problem
`pylibvirt_vm()` builds the domain configuration by unpacking `VMEntry.model_dump()` into a plain dataclass, converting `bootloader` and `cpu_mode` into their enums but not `time`. The API model types `time` as a string literal, so the configuration held `'LOCAL'`/`'UTC'` instead of a `Time` member, and the clock offset is decided by comparing that field against `Time.LOCAL`. That comparison was always false, so every VM was defined with `<clock offset="utc">` regardless of what the user picked, and Windows guests — which expect a localtime RTC — ran off by the host's UTC offset. Containers were unaffected because their equivalent helper already does the conversion.

## Solution
Convert `time` alongside the other two enums. Every caller reaches this through `VMEntry`, whose `Literal['LOCAL', 'UTC']` guarantees a valid value, so the conversion cannot raise. Added a unit test covering both offsets with and without Hyper-V enlightenments, which restores coverage that was dropped when XML generation moved out to truenas_pylibvirt.