### PR TITLE
NAS-142001 / 26.0.0-RC.1 / Stop discarding options passed to pool.dataset.create

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/pool.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool.py
@@ -147,9 +147,6 @@ class PoolCreateEncryptionOptions(BaseModel):
             " brute force attacks but increase unlock time."
         ),
     )
-    algorithm: Literal[
-        "AES-128-CCM", "AES-192-CCM", "AES-256-CCM", "AES-128-GCM", "AES-192-GCM", "AES-256-GCM"
-    ] = Field(default="AES-256-GCM", description="Encryption algorithm to use for dataset encryption.")
     passphrase: Secret[Annotated[str, Field(min_length=8)] | None] = Field(
         default=None,
         description="Must be specified if encryption for root dataset is desired with a passphrase as a key.",

--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -24,7 +24,6 @@ __all__ = [
     "PoolDatasetChangeKeyArgs", "PoolDatasetChangeKeyResult", "PoolDatasetInheritParentEncryptionPropertiesArgs",
     "PoolDatasetInheritParentEncryptionPropertiesResult", "PoolDatasetChecksumChoicesArgs",
     "PoolDatasetChecksumChoicesResult", "PoolDatasetCompressionChoicesArgs", "PoolDatasetCompressionChoicesResult",
-    "PoolDatasetEncryptionAlgorithmChoicesArgs", "PoolDatasetEncryptionAlgorithmChoicesResult",
     "PoolDatasetRecommendedZvolBlocksizeArgs", "PoolDatasetRecommendedZvolBlocksizeResult", "PoolDatasetProcessesArgs",
     "PoolDatasetProcessesResult", "PoolDatasetGetQuotaArgs", "PoolDatasetGetQuotaResult", "PoolDatasetSetQuotaArgs",
     "PoolDatasetSetQuotaResult", "PoolDatasetRecordsizeChoicesArgs", "PoolDatasetRecordsizeChoicesResult",
@@ -700,20 +699,6 @@ class PoolDatasetDetailsArgs(BaseModel):
 
 class PoolDatasetDetailsResult(BaseModel):
     result: list[dict] = Field(description="Array of detailed dataset information objects.")
-
-
-class PoolDatasetEncryptionAlgorithmChoicesArgs(BaseModel):
-    pass
-
-
-@single_argument_result
-class PoolDatasetEncryptionAlgorithmChoicesResult(BaseModel):
-    AES_128_CCM: Literal["AES-128-CCM"] = Field(alias="AES-128-CCM")
-    AES_192_CCM: Literal["AES-192-CCM"] = Field(alias="AES-192-CCM")
-    AES_256_CCM: Literal["AES-256-CCM"] = Field(alias="AES-256-CCM")
-    AES_128_GCM: Literal["AES-128-GCM"] = Field(alias="AES-128-GCM")
-    AES_192_GCM: Literal["AES-192-GCM"] = Field(alias="AES-192-GCM")
-    AES_256_GCM: Literal["AES-256-GCM"] = Field(alias="AES-256-GCM")
 
 
 class PoolDatasetEncryptionSummaryArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -24,7 +24,7 @@ from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.filter_list import filter_list
 
-from .dataset_query_utils import generic_query
+from .dataset_query_utils import generic_query, user_property_names_to_be_renamed
 from .utils import (
     CreateImplArgs,
     CreateImplArgsDataclass,
@@ -32,10 +32,12 @@ from .utils import (
     get_dataset_parents,
     POOL_DS_CREATE_PROPERTIES,
     POOL_DS_UPDATE_PROPERTIES,
+    RE_ZFS_USER_PROP,
     UpdateImplArgs,
     UpdateImplArgsDataclass,
     validate_dedup_license,
     ZFSKeyFormat,
+    ZFS_USER_PROP_MAX_LEN,
     ZFS_VOLUME_BLOCK_SIZE_CHOICES
 )
 
@@ -338,7 +340,24 @@ class PoolDatasetService(CRUDService):
                     'This field must be from zero to 16M'
                 )
 
-        if mode == 'UPDATE':
+        if mode == 'CREATE':
+            managed_user_props = user_property_names_to_be_renamed()
+            seen_user_props = set()
+            for index, prop in enumerate(data.get('user_properties', [])):
+                prop_schema = f'{schema}.user_properties.{index}.key'
+                if (key := prop['key']) in managed_user_props:
+                    verrors.add(
+                        prop_schema,
+                        f'{key!r} is managed by TrueNAS, '
+                        f'use the {managed_user_props[key]!r} field to set it.'
+                    )
+                elif len(key) > ZFS_USER_PROP_MAX_LEN or not RE_ZFS_USER_PROP.fullmatch(key):
+                    verrors.add(prop_schema, f'{key!r} is not a valid ZFS user property name.')
+                elif key in seen_user_props:
+                    verrors.add(prop_schema, f'{key!r} is specified more than once.')
+                else:
+                    seen_user_props.add(key)
+        elif mode == 'UPDATE':
             if data.get('user_properties_update') and not data.get('user_properties'):
                 for index, prop in enumerate(data['user_properties_update']):
                     prop_schema = f'{schema}.user_properties_update.{index}'

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -712,6 +712,9 @@ class PoolDatasetService(CRUDService):
             else:
                 zprops[i.real_name] = transformed
 
+        for up in data['user_properties']:
+            uprops[up['key']] = up['value']
+
         await self.middleware.call(
             'pool.dataset.create_impl',
             CreateImplArgs(

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -404,12 +404,8 @@ class PoolDatasetService(CRUDService):
             kwargs["crypto"] = tls.lzh.resource_cryptography_config(
                 keyformat=args.encrypt["keyformat"],
                 key=args.encrypt["key"],
+                pbkdf2iters=args.encrypt.get("pbkdf2iters"),
             )
-            if pb := args.encrypt.get("pbkdf2iters"):
-                if "properties" in kwargs:
-                    kwargs["properties"]["pbkdf2iters"] = str(pb)
-                else:
-                    kwargs["properties"] = {"pbkdf2iters": str(pb)}
 
         if args.create_ancestors:
             # If we need to create ancestors, we need to handle this differently

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
@@ -9,7 +9,7 @@ from middlewared.service import CallError, job, private, Service, ValidationErro
 from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.utils import secrets
 
-from .utils import DATASET_DATABASE_MODEL_NAME, ZFSKeyFormat
+from .utils import DATASET_DATABASE_MODEL_NAME, ZFS_ENCRYPTION_ALGORITHM, ZFSKeyFormat
 
 
 class PoolDatasetService(Service):
@@ -109,7 +109,7 @@ class PoolDatasetService(Service):
             opts = {
                 'keyformat': (ZFSKeyFormat.PASSPHRASE if passphrase_key_format else ZFSKeyFormat.HEX).value.lower(),
                 'keylocation': 'prompt',
-                'encryption': encryption_dict['algorithm'].lower(),
+                'encryption': ZFS_ENCRYPTION_ALGORITHM,
                 'key': key,
                 **({'pbkdf2iters': encryption_dict['pbkdf2iters']} if passphrase_key_format else {}),
             }

--- a/src/middlewared/middlewared/plugins/pool_/dataset_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_info.py
@@ -1,13 +1,12 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
     PoolDatasetChecksumChoicesArgs, PoolDatasetChecksumChoicesResult, PoolDatasetCompressionChoicesArgs,
-    PoolDatasetCompressionChoicesResult, PoolDatasetEncryptionAlgorithmChoicesArgs,
-    PoolDatasetEncryptionAlgorithmChoicesResult, PoolDatasetRecommendedZvolBlocksizeArgs,
+    PoolDatasetCompressionChoicesResult, PoolDatasetRecommendedZvolBlocksizeArgs,
     PoolDatasetRecommendedZvolBlocksizeResult
 )
 from middlewared.service import Service
 
-from .utils import ZFS_CHECKSUM_CHOICES, ZFS_COMPRESSION_ALGORITHM_CHOICES, ZFS_ENCRYPTION_ALGORITHM_CHOICES
+from .utils import ZFS_CHECKSUM_CHOICES, ZFS_COMPRESSION_ALGORITHM_CHOICES
 
 
 class PoolDatasetService(Service):
@@ -28,17 +27,6 @@ class PoolDatasetService(Service):
         Retrieve compression algorithm supported by ZFS.
         """
         return {v: v for v in ZFS_COMPRESSION_ALGORITHM_CHOICES}
-
-    @api_method(
-        PoolDatasetEncryptionAlgorithmChoicesArgs,
-        PoolDatasetEncryptionAlgorithmChoicesResult,
-        roles=['DATASET_READ']
-    )
-    async def encryption_algorithm_choices(self):
-        """
-        Retrieve encryption algorithms supported for ZFS dataset encryption.
-        """
-        return {v: v for v in ZFS_ENCRYPTION_ALGORITHM_CHOICES}
 
     @api_method(
         PoolDatasetRecommendedZvolBlocksizeArgs,

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -21,6 +21,8 @@ DATASET_DATABASE_MODEL_NAME = 'storage.encrypteddataset'
 RE_DRAID_DATA_DISKS = re.compile(r':\d*d')
 RE_DRAID_SPARE_DISKS = re.compile(r':\d*s')
 RE_DRAID_NAME = re.compile(r'draid\d:\d+d:\d+c:\d+s-\d+')
+RE_ZFS_USER_PROP = re.compile(r'[a-z0-9:._-]+')
+ZFS_USER_PROP_MAX_LEN = 255
 ZFS_CHECKSUM_CHOICES = ['ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN', 'EDONR', 'BLAKE3']
 ZFS_COMPRESSION_ALGORITHM_CHOICES = [
     'ON', 'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-FAST', 'ZLE', 'LZJB',

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -27,9 +27,7 @@ ZFS_COMPRESSION_ALGORITHM_CHOICES = [
 ] + [f'ZSTD-{i}' for i in range(1, 20)] + [
     f'ZSTD-FAST-{i}' for i in itertools.chain(range(1, 11), range(20, 110, 10), range(500, 1500, 500))
 ]
-ZFS_ENCRYPTION_ALGORITHM_CHOICES = [
-    'AES-128-CCM', 'AES-192-CCM', 'AES-256-CCM', 'AES-128-GCM', 'AES-192-GCM', 'AES-256-GCM'
-]
+ZFS_ENCRYPTION_ALGORITHM = 'aes-256-gcm'
 ZFS_VOLUME_BLOCK_SIZE_CHOICES = {
     '512': 512,
     '512B': 512,

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -49,7 +49,6 @@ def test_service_restart_on_unlock_dataset(request):
     with dataset('testsvcunlock', data={
         'encryption': True,
         'encryption_options': {
-            'algorithm': 'AES-256-GCM',
             'pbkdf2iters': 1300000,
             'passphrase': PASSPHRASE,
         },

--- a/tests/api2/test_pool_dataset_encryption.py
+++ b/tests/api2/test_pool_dataset_encryption.py
@@ -110,6 +110,16 @@ class TestNormalPool:
             ds = call('pool.dataset.get_instance', dataset)
             assert ds['key_format']['value'] == 'HEX'
 
+    def test_encrypted_root_uses_requested_pbkdf2iters(self):
+        payload = {
+            'name': dataset,
+            'encryption': True,
+            'inherit_encryption': False,
+            'encryption_options': {'passphrase': passphrase, 'pbkdf2iters': 2000000},
+        }
+        with create_dataset(payload) as ds:
+            assert ds['pbkdf2iters']['value'] == '2000000', ds
+
     def test_encryption_algorithm_cannot_be_specified(self):
         payload = {
             'name': dataset,

--- a/tests/api2/test_pool_dataset_encryption.py
+++ b/tests/api2/test_pool_dataset_encryption.py
@@ -57,14 +57,13 @@ def passphrase_pool():
         'name': encrypted_pool_name,
         'encryption': True,
         'encryption_options': {
-            'algorithm': 'AES-128-CCM',
             'passphrase': pool_passphrase,
         },
     }):
         check_log_for(pool_passphrase)
         ds = call('pool.dataset.get_instance', encrypted_pool_name)
         assert ds['key_format']['value'] == 'PASSPHRASE', ds
-        assert ds['encryption_algorithm']['value'] == 'AES-128-CCM', ds
+        assert ds['encryption_algorithm']['value'] == 'AES-256-GCM', ds
         yield
 
 
@@ -74,14 +73,13 @@ def key_pool():
         'name': encrypted_pool_name,
         'encryption': True,
         'encryption_options': {
-            'algorithm': 'AES-128-CCM',
             'key': pool_token_hex,
         },
     }):
         check_log_for(pool_token_hex)
         ds = call('pool.dataset.get_instance', encrypted_pool_name)
         assert ds['key_format']['value'] == 'HEX', ds
-        assert ds['encryption_algorithm']['value'] == 'AES-128-CCM', ds
+        assert ds['encryption_algorithm']['value'] == 'AES-256-GCM', ds
         yield
 
 
@@ -94,7 +92,6 @@ class TestNormalPool:
             'encryption_options': {
                 'generate_key': False,
                 'pbkdf2iters': 1300000,
-                'algorithm': 'AES-128-CCM',
                 'passphrase': passphrase,
             },
             'encryption': True,
@@ -102,6 +99,7 @@ class TestNormalPool:
         }
         with create_dataset(payload) as ds:
             assert ds['key_format']['value'] == 'PASSPHRASE'
+            assert ds['encryption_algorithm']['value'] == 'AES-256-GCM', ds
             check_log_for(passphrase)
 
             # Add a comment
@@ -111,6 +109,16 @@ class TestNormalPool:
             call('pool.dataset.change_key', dataset, {'key': dataset_token_hex}, job=True)
             ds = call('pool.dataset.get_instance', dataset)
             assert ds['key_format']['value'] == 'HEX'
+
+    def test_encryption_algorithm_cannot_be_specified(self):
+        payload = {
+            'name': dataset,
+            'encryption': True,
+            'inherit_encryption': False,
+            'encryption_options': {'generate_key': True, 'algorithm': 'AES-128-GCM'},
+        }
+        with pytest.raises(ValidationErrors, match='Extra inputs are not permitted'):
+            call('pool.dataset.create', payload)
 
     @pytest.mark.parametrize('payload', [
         {'encryption': False},
@@ -222,7 +230,6 @@ class TestPassphraseEncryptedPool:
             'encryption_options': {
                 'generate_key': False,
                 'pbkdf2iters': 1300000,
-                'algorithm': 'AES-128-CCM',
                 'passphrase': passphrase,
             },
             'encryption': True,

--- a/tests/api2/test_pool_dataset_unlock.py
+++ b/tests/api2/test_pool_dataset_unlock.py
@@ -19,7 +19,6 @@ def passphrase_encryption():
         'encryption_options': {
             'generate_key': False,
             'pbkdf2iters': 1300000,
-            'algorithm': 'AES-128-CCM',
             'passphrase': 'passphrase',
         },
         'encryption': True,

--- a/tests/api2/test_pool_dataset_user_props.py
+++ b/tests/api2/test_pool_dataset_user_props.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
 
@@ -17,6 +18,26 @@ def test_pool_dataset_create_applies_user_props():
         )
         for prop in user_props:
             assert result['user_properties'].get(prop['key'], {}).get('value') == prop['value'], result
+
+
+@pytest.mark.parametrize('user_props, error', [
+    (
+        [{'key': 'org.freenas:description', 'value': 'overwritten'}],
+        "'org.freenas:description' is managed by TrueNAS, use the 'comments' field to set it",
+    ),
+    (
+        [{'key': 'org.truenas.test:invalid name', 'value': 'one'}],
+        'is not a valid ZFS user property name',
+    ),
+    (
+        [{'key': 'org.truenas.test:dupe', 'value': 'one'}, {'key': 'org.truenas.test:dupe', 'value': 'two'}],
+        'is specified more than once',
+    ),
+])
+def test_pool_dataset_create_rejects_bad_user_props(user_props, error):
+    with pytest.raises(ValidationErrors, match=error):
+        with dataset('bad_user_props', data={'user_properties': user_props}):
+            pass
 
 
 @pytest.mark.parametrize('user_props', [True, False])

--- a/tests/api2/test_pool_dataset_user_props.py
+++ b/tests/api2/test_pool_dataset_user_props.py
@@ -4,6 +4,21 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
 
 
+def test_pool_dataset_create_applies_user_props():
+    user_props = [
+        {'key': 'org.truenas.test:first', 'value': 'one'},
+        {'key': 'org.truenas.test:second', 'value': 'two'},
+    ]
+    with dataset('create_user_props', data={'user_properties': user_props}) as ds:
+        result = call(
+            'pool.dataset.query',
+            [['id', '=', ds]],
+            {'get': True, 'extra': {'properties': [], 'retrieve_user_props': True}}
+        )
+        for prop in user_props:
+            assert result['user_properties'].get(prop['key'], {}).get('value') == prop['value'], result
+
+
 @pytest.mark.parametrize('user_props', [True, False])
 def test_pool_dataset_query_user_props_true_false(user_props):
     with dataset("query_test") as ds:

--- a/tests/api2/test_sharing_service_encrypted_dataset_info.py
+++ b/tests/api2/test_sharing_service_encrypted_dataset_info.py
@@ -9,7 +9,6 @@ PASSPHRASE = 'testing123'
 ENCRYPTION_PARAMETERS = {
     'encryption': True,
     'encryption_options': {
-        'algorithm': 'AES-256-GCM',
         'pbkdf2iters': 1300000,
         'passphrase': PASSPHRASE,
     },

--- a/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
+++ b/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
@@ -132,7 +132,6 @@ def encrypted_zvol():
             'encryption': True,
             'inherit_encryption': False,
             'encryption_options': {
-                'algorithm': 'AES-128-CCM',
                 'passphrase': NVMET_ENCRYPTED_PASSPHRASE,
             },
         },


### PR DESCRIPTION
`pool.dataset.create` accepted three options and then threw them away: `encryption_options.algorithm`, `encryption_options.pbkdf2iters`, and `user_properties`.

Per review, the encryption suite is no longer selectable at all — new encrypted datasets, zvols and pool roots are always AES-256-GCM. `encryption_options.algorithm` is removed from the create API along with `pool.dataset.encryption_algorithm_choices`. Callers that still send it get a validation error; requests on older API versions have it dropped by the version adapter and get AES-256-GCM. Existing datasets are unaffected: `encryption` is a ONETIME property, and reading or unlocking a dataset created with another suite is unchanged.

The iteration count was passed through `properties`, where the crypto nvlist — which always carries the default — overwrote it, so a request for 5000000 iterations silently produced 1300000. It now goes through the crypto configuration alongside the key format and key.

`user_properties` was never applied on create. The only code that reads it is guarded by `mode == 'UPDATE'`, so `pool.dataset.update` worked and `pool.dataset.create` quietly dropped whatever it was given.

All three regressed in [NAS-137473](https://ixsystems.atlassian.net/browse/NAS-137473) ([#17160](https://github.com/truenas/middleware/pull/17160)), which moved `pool.dataset.create` off py-libzfs. 25.10 is unaffected, and `pool.create` never was, since the pool root still goes through `zfs.pool.create`.

This needs a companion WebUI change before it can leave draft: the pool manager wizard, the dataset form encryption section, and the zvol form each render an algorithm dropdown fed by `pool.dataset.encryption_algorithm_choices` and send the selection in `encryption_options`.
