### PR TITLE
NAS-141666 / 27.0.0-BETA.1 / Relocate migrated container origins out of legacy .ix-virt (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -49,7 +49,7 @@ IdmapConfiguration = Annotated[
 
 
 class ContainerStatus(BaseModel):
-    state: Literal["RUNNING", "STOPPED"] = Field(description="Container state.")
+    state: Literal["RUNNING", "STOPPED", "SUSPENDED"] = Field(description="Container state.")
     pid: int | None = Field(
         description=(
             "Container host PID (if running). Informational only do not rely on this value to identify the container's "
@@ -168,8 +168,20 @@ class ContainerUpdateResult(BaseModel):
     result: ContainerEntry = Field(description="Updated container.")
 
 
+class ContainerDeleteOptions(BaseModel):
+    force: bool = Field(
+        default=False,
+        description=(
+            "Force deletion of a container that is not stopped (running or suspended) by stopping it first."
+        ),
+    )
+
+
 class ContainerDeleteArgs(BaseModel):
     id: int = Field(description="Container ID.")
+    options: ContainerDeleteOptions = Field(
+        default=ContainerDeleteOptions(), description="Container deletion options."
+    )
 
 
 class ContainerDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/container.py
+++ b/src/middlewared/middlewared/api/v27_0_0/container.py
@@ -17,7 +17,7 @@ __all__ = [
     "ContainerEntry", "ContainerStatus",
     "ContainerCreateArgs", "ContainerCreateResult", "ContainerCreate",
     "ContainerUpdateArgs", "ContainerUpdateResult", "ContainerUpdate",
-    "ContainerDeleteArgs", "ContainerDeleteResult",
+    "ContainerDeleteArgs", "ContainerDeleteResult", "ContainerDeleteOptions",
     "ContainerPoolChoicesArgs", "ContainerPoolChoicesResult",
     "ContainerStartArgs", "ContainerStartResult",
     "ContainerStopArgs", "ContainerStopResult", "ContainerStopOptions",
@@ -48,7 +48,7 @@ IdmapConfiguration = Annotated[
 
 
 class ContainerStatus(BaseModel):
-    state: Literal["RUNNING", "STOPPED"] = Field(description="Container state.")
+    state: Literal["RUNNING", "STOPPED", "SUSPENDED"] = Field(description="Container state.")
     pid: int | None = Field(
         description=(
             "Container host PID (if running). Informational only do not rely on this value to identify the container's "
@@ -166,8 +166,20 @@ class ContainerUpdateResult(BaseModel):
     result: ContainerEntry = Field(description="Updated container.")
 
 
+class ContainerDeleteOptions(BaseModel):
+    force: bool = Field(
+        default=False,
+        description=(
+            "Force deletion of a container that is not stopped (running or suspended) by stopping it first."
+        ),
+    )
+
+
 class ContainerDeleteArgs(BaseModel):
     id: int = Field(description="Container ID.")
+    options: ContainerDeleteOptions = Field(
+        default=ContainerDeleteOptions(), description="Container deletion options."
+    )
 
 
 class ContainerDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
+++ b/src/middlewared/middlewared/migration/0020_repair_incus_clone_origins.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import typing
+
+from middlewared.api.current import ZFSResourceQuery
+
+if typing.TYPE_CHECKING:
+    from middlewared.main import Middleware
+
+
+async def migrate(middleware: Middleware) -> None:
+    """Repair what an incus->container migration run on an older build left behind.
+
+    Two things need fixing on those systems:
+
+    Containers under ``.truenas_containers`` whose ``origin`` snapshot still lives
+    inside ``.ix-virt``. Deleting ``.ix-virt`` would cascade into them and destroy
+    them, so each such origin image is moved into the native images tree.
+
+    The legacy parents' mountpoint. That migration gave ``.ix-virt`` and its
+    ``containers`` child an inherited mountpoint and never put it back, so the whole
+    legacy tree - children included, since they inherit it - stays mounted under
+    ``/mnt/<pool>/.ix-virt`` on every boot with nothing managing it.
+
+    Fresh upgraders have no ``container.container`` rows yet when this runs (the
+    incus migration fires later, on ``system.ready``), so this is a no-op for them -
+    they are handled inside the migration itself. Best-effort throughout: a row that
+    cannot be repaired is logged and skipped rather than failing the migration.
+    """
+    if await middleware.call("system.is_ha_capable"):
+        # Gated on the hardware rather than the HA license, so this never runs on a
+        # controller that can be paired. A licensed system has nothing to repair in any
+        # case: the incus migration hangs off `system.ready`, which HA ignores, so it
+        # never ran there, and its pools are not imported yet when migrations do.
+        return
+
+    containers = await middleware.call("datastore.query", "container.container")
+    for container in containers:
+        dataset = container["dataset"]
+        try:
+            status = await middleware.call2(middleware.services.container.relocate_container_origin, dataset)
+        except Exception:
+            middleware.logger.error(
+                "Failed to relocate origin image for container %r (dataset %r)",
+                container["name"],
+                dataset,
+                exc_info=True,
+            )
+            continue
+
+        if status == "RELOCATED":
+            middleware.logger.info(
+                "Relocated origin image for container %r out of .ix-virt",
+                container["name"],
+            )
+        elif status != "ALREADY_SATISFIED":
+            middleware.logger.warning(
+                "Could not relocate origin image for container %r (dataset %r): %s",
+                container["name"],
+                dataset,
+                status,
+            )
+
+    for pool in sorted({container["dataset"].split("/")[0] for container in containers}):
+        # Skipped when the pool is not imported or the legacy tree is already gone,
+        # so this does not log a failure for every dataset it cannot reach.
+        if not await middleware.call2(
+            middleware.services.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[f"{pool}/.ix-virt"], properties=None),
+        ):
+            continue
+
+        await middleware.call2(middleware.services.container.restore_legacy_parent_mountpoints, pool)

--- a/src/middlewared/middlewared/plugins/container/__init__.py
+++ b/src/middlewared/middlewared/plugins/container/__init__.py
@@ -9,6 +9,7 @@ from middlewared.api.current import (
     ContainerCreateArgs,
     ContainerCreateResult,
     ContainerDeleteArgs,
+    ContainerDeleteOptions,
     ContainerDeleteResult,
     ContainerEntry,
     ContainerMigrateArgs,
@@ -40,7 +41,7 @@ from .info import pool_choices
 from .lifecycle import handle_shutdown, start_on_boot
 from .lifecycle import start as start_container
 from .lifecycle import stop as stop_container
-from .migrate import maybe_migrate_legacy
+from .migrate import maybe_migrate_legacy, relocate_container_origin, restore_legacy_parent_mountpoints
 from .migrate import migrate as migrate_containers
 from .nsenter import nsenter
 
@@ -102,11 +103,16 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
         audit_callback=True,
         check_annotations=True,
     )
-    def do_delete(self, audit_callback: AuditCallback, id_: int) -> None:
+    @job(lock=lambda args: f'container_delete:{args[0]}')
+    def do_delete(
+        self, job: Job, audit_callback: AuditCallback, id_: int, options: ContainerDeleteOptions,
+    ) -> None:
         """
         Delete a Container.
+
+        The container must be stopped, unless ``force`` is set - which tears it down first.
         """
-        return self._svc_part.do_delete(id_, audit_callback=audit_callback)
+        return self._svc_part.do_delete(id_, options, audit_callback=audit_callback)
 
     @api_method(ContainerStartArgs, ContainerStartResult, roles=['CONTAINER_WRITE'], check_annotations=True)
     def start(self, id_: int) -> None:
@@ -137,8 +143,23 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
         return await self._svc_part.create_with_dataset(data)
 
     @private
-    def delete_container_from_db_and_libvirt(self, container: ContainerEntry) -> None:
-        self._svc_part.delete_container_from_db_and_libvirt(container)
+    def delete_container_from_libvirt(self, container: ContainerEntry) -> None:
+        self._svc_part.delete_container_from_libvirt(container)
+
+    @private
+    def delete_container_from_db(self, container: ContainerEntry) -> None:
+        self._svc_part.delete_container_from_db(container)
+
+    @private
+    async def migrate_and_start_on_boot(self) -> None:
+        """Bring containers up on boot, migrating any legacy incus ones first.
+
+        Shared by the ``system.ready`` path and the failover path so the ordering
+        lives in one place: HA systems ignore ``system.ready`` and would otherwise
+        start containers without ever migrating them.
+        """
+        await self.call2(self.s.container.maybe_migrate_legacy)
+        await self.call2(self.s.container.start_on_boot)
 
     @private
     def start_on_boot(self) -> None:
@@ -156,10 +177,13 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
     async def maybe_migrate_legacy(self) -> None:
         return await maybe_migrate_legacy(self.context)
 
+    @private
+    def relocate_container_origin(self, container_ds: str) -> str:
+        return relocate_container_origin(self.context, container_ds)
 
-async def __migrate_and_start(middleware: Middleware) -> None:
-    await middleware.call2(middleware.services.container.maybe_migrate_legacy)
-    await middleware.call2(middleware.services.container.start_on_boot)
+    @private
+    def restore_legacy_parent_mountpoints(self, pool: str) -> None:
+        restore_legacy_parent_mountpoints(self.context, pool)
 
 
 async def __event_system_ready(middleware: Middleware, event_type: str, args: Any) -> None:
@@ -169,7 +193,7 @@ async def __event_system_ready(middleware: Middleware, event_type: str, args: An
     if await middleware.call('failover.licensed'):
         return
 
-    middleware.create_task(__migrate_and_start(middleware))
+    middleware.create_task(middleware.call2(middleware.services.container.migrate_and_start_on_boot))
 
 
 async def __event_system_shutdown(middleware: Middleware, event_type: str, args: Any) -> None:

--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -125,10 +125,9 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate[dict[str, Any]]):
     async def delete(self, attachments: list[dict[str, Any]]) -> None:
         for attachment in attachments:
             try:
-                await self.middleware.call2(
-                    self.s.container.delete_container_from_db_and_libvirt,
-                    await self.middleware.call2(self.s.container.get_instance, attachment['id']),
-                )
+                container = await self.middleware.call2(self.s.container.get_instance, attachment['id'])
+                await self.middleware.call2(self.s.container.delete_container_from_libvirt, container)
+                await self.middleware.call2(self.s.container.delete_container_from_db, container)
             except Exception:
                 self.logger.warning('Unable to delete %r container', attachment['id'])
 

--- a/src/middlewared/middlewared/plugins/container/crud.py
+++ b/src/middlewared/middlewared/plugins/container/crud.py
@@ -15,14 +15,17 @@ from middlewared.api.base import BaseModel, Excluded, excluded_field
 from middlewared.api.current import (
     ContainerCreate,
     ContainerCreateResult,
+    ContainerDeleteOptions,
     ContainerEntry,
     ContainerUpdate,
     QueryOptions,
+    ZFSResourceQuery,
     ZFSResourceSnapshotDestroyQuery,
 )
 from middlewared.pylibvirt import gather_pylibvirt_domains_states, get_pylibvirt_domain_state
 from middlewared.service import CallError, CRUDServicePart, ValidationErrors
 import middlewared.sqlalchemy as sa
+from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
 from .bridge import container_bridge_name
 from .dataset import ensure_datasets
@@ -253,7 +256,7 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
 
         name_changed = old.name != new.name
         if name_changed:
-            if old.status.state == 'RUNNING':
+            if old.status.state in ACTIVE_STATES:
                 raise CallError('Container must be stopped before renaming.')
 
             old_dataset = old.dataset
@@ -268,21 +271,48 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
 
         return entry
 
-    def do_delete(self, id_: int, *, audit_callback: AuditCallback) -> None:
+    def do_delete(self, id_: int, options: ContainerDeleteOptions, *, audit_callback: AuditCallback) -> None:
         container = self.get_instance__sync(id_)
         audit_callback(container.name)
 
-        self.delete_container_from_db_and_libvirt(container)
-        self.call_sync2(self.s.zfs.resource.destroy_impl, container.dataset)
+        if container.status.state in ACTIVE_STATES and not options.force:
+            raise CallError(
+                f'Container {container.name!r} is {container.status.state.lower()}. Stop it first, '
+                f'or pass force=True to stop and delete it.',
+                errno.EBUSY,
+            )
+
+        # Deleting the domain destroys it if it is active and gives its post-stop
+        # actions time to finish before undefining it, so the container's runtime
+        # mounts - the idmapped root under /run/truenas_containers/ among them - are
+        # gone before ZFS is touched. Stopping it instead returns while those are
+        # still being torn down and the destroy then fails on a busy dataset.
+        self.delete_container_from_libvirt(container)
+
+        # Destroy the dataset first and only remove the DB records once it is actually
+        # gone, so a failed destroy never orphans the dataset with no container row
+        # pointing at it. A dataset that is already missing - a victim of a legacy
+        # .ix-virt deletion, say - is not an error; fall through and clean up the
+        # now-dangling records.
+        if self.call_sync2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[container.dataset], properties=None),
+        ):
+            failed = self.call_sync2(self.s.zfs.resource.destroy_impl, container.dataset)[0]
+            if failed is not None:
+                raise CallError(f'Failed to delete container {container.name!r} dataset: {failed}')
+
+        self.delete_container_from_db(container)
         self.middleware.call_sync('etc.generate', 'libvirt_guests')
 
-    def delete_container_from_db_and_libvirt(self, container: ContainerEntry) -> None:
+    def delete_container_from_libvirt(self, container: ContainerEntry) -> None:
         pylibvirt_container_obj = pylibvirt_container(self, container)
         try:
             self.middleware.libvirt_domains_manager.containers.delete(pylibvirt_container_obj)
         except DomainDoesNotExistError:
             pass
 
+    def delete_container_from_db(self, container: ContainerEntry) -> None:
         for device in container.devices:
             self.middleware.call_sync('datastore.delete', 'container.device', device.id)
 

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -13,6 +13,7 @@ import middlewared.sqlalchemy as sa
 
 from .crud import ContainerCreateWithDataset
 from .dataset import ensure_datasets
+from .info import license_active
 from .utils import container_dataset
 
 if typing.TYPE_CHECKING:
@@ -44,6 +45,30 @@ async def maybe_migrate_legacy(context: ServiceContext) -> None:
         return
 
     legacy_config = legacy_config[0]
+    if await context.middleware.call('system.is_ha_capable'):
+        # Legacy containers were never migrated on a controller that can be paired, so
+        # there is no established path here and no reason to take the risk of inventing
+        # one during a failover event. The pool is cleared so this is not reconsidered
+        # on every boot; nothing on disk is touched, the legacy datasets stay as they
+        # are under `.ix-virt` if some user somehow was still using it.
+        context.logger.warning(
+            'Legacy virt pool was found set but this system is HA capable; migration skipped.'
+        )
+        await context.middleware.call(
+            'datastore.update', 'virt.global', legacy_config['id'], {'pool': None},
+        )
+        return
+
+    if not await license_active(context):
+        # Returning before virt_global.pool is cleared leaves the legacy
+        # configuration intact, so the migration runs on a later boot once
+        # the license is in place. Nothing on disk is touched meanwhile.
+        context.logger.warning(
+            'Legacy incus containers found but this system is not licensed to use containers; '
+            'migration deferred.'
+        )
+        return
+
     context.logger.info('Legacy incus container configuration found, starting migration')
     try:
         migration_job = await context.call2(context.s.container.migrate)
@@ -87,12 +112,25 @@ async def migrate(context: ServiceContext, job: Job) -> None:
     if not legacy_configuration or legacy_configuration[0]['pool'] is None:
         raise CallError('Legacy containers configuration pool is not set.')
 
+    # Every migrated container has to pass container.validate, which fails
+    # without a license. Bailing out here leaves the legacy datasets untouched
+    # instead of moving them somewhere no container row can point at.
+    if not await license_active(context):
+        raise CallError('System is not licensed to use containers.')
+
     pool = legacy_configuration[0]['pool']
 
     storage_pools = {pool} | set(filter(bool, (legacy_configuration[0]['storage_pools'] or '').split()))
     existing_containers = [container.name for container in await context.call2(context.s.container.query)]
     for storage_pool in storage_pools:
-        await context.to_thread(migrate_specific_pool, context, job, storage_pool, existing_containers)
+        # One unusable pool must not stop the pools that come after it.
+        try:
+            await context.to_thread(migrate_specific_pool, context, job, storage_pool, existing_containers)
+        except Exception as e:
+            context.logger.error('Unable to migrate containers on pool %r', storage_pool, exc_info=True)
+            await job.logs_fd_write(
+                f'Unable to migrate containers on pool {storage_pool!r}: {e!r}.\n'.encode()
+            )
 
 
 async def migrate_devices(
@@ -232,8 +270,16 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
             continue
 
         dst_dataset = os.path.join(container_dataset(pool), f'containers/{name}')
+        needs_mount_revert = False
+        renamed = False
+        container_instance = None
         try:
             if not processed_parents_mountpoints:
+                # Armed before the properties are touched, for the same reason the
+                # per-container revert is: this flag also decides whether the parents
+                # get restored at the end, and the first of the two can be applied
+                # before the second one fails.
+                processed_parents_mountpoints = True
                 for ds in (f'{pool}/.ix-virt', f'{pool}/.ix-virt/containers'):
                     context.middleware.call_sync(
                         'pool.dataset.update_impl',
@@ -243,8 +289,10 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
                             iprops={'mountpoint'}
                         )
                     )
-                processed_parents_mountpoints = True
 
+            # Armed before the properties are touched: a partial apply has to be
+            # reverted too, and update_impl can fail between the two of them.
+            needs_mount_revert = True
             context.middleware.call_sync(
                 'pool.dataset.update_impl',
                 UpdateImplArgs(
@@ -264,6 +312,20 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
                 )
                 continue
 
+            # Relocate the origin image out of .ix-virt before renaming the container
+            # into .truenas_containers, so a later deletion of .ix-virt cannot cascade
+            # into the migrated container. This runs only once the dataset is known to
+            # be a real container: an image kept alive solely by a leftover clone that
+            # is not one stays inside .ix-virt and is reclaimed along with it.
+            if relocate_container_origin(context, dataset['name']) in ('FAILED', 'ABSENT'):
+                # Skip it. Migrating a container whose origin is still inside .ix-virt
+                # would produce something that looks healthy right up until .ix-virt is
+                # deleted and takes it with it; leaving it untouched keeps it whole.
+                job.logs_fd.write((
+                    f'Skipping container {name!r}: could not relocate its base image out of .ix-virt.\n'
+                ).encode())
+                continue
+
             config = manifest['container']['config']
 
             # Move rootfs contents to parent dataset for compatibility with current implementation
@@ -279,6 +341,10 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
             os.rmdir(rootfs_path)
 
             context.call_sync2(context.s.zfs.resource.rename, dataset['name'], dst_dataset)
+            # From here on the dataset lives in its native location, where the mount
+            # properties set above are the correct ones to keep.
+            needs_mount_revert = False
+            renamed = True
 
             container_instance = context.call_sync2(
                 context.s.container.create_with_dataset, ContainerCreateWithDataset(
@@ -289,9 +355,191 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
                     cpuset=config.get('limits.cpu', None),
                 )
             )
+            existing_containers.append(name)
             context.run_coroutine(migrate_devices(context, job, manifest['container'], container_instance))
         except Exception as e:
+            if renamed and container_instance is None:
+                # The dataset was moved but no container row was created. Left there it
+                # is invisible: the migration only ever looks under .ix-virt, and the
+                # native tree is hidden from dataset queries. Move it back so it stays
+                # something the user can see and act on.
+                try:
+                    context.call_sync2(context.s.zfs.resource.rename, dst_dataset, dataset['name'])
+                except Exception:
+                    context.logger.error(
+                        '%s: failed to move back after an incomplete migration', dst_dataset,
+                        exc_info=True,
+                    )
+                else:
+                    needs_mount_revert = True
+
             context.logger.error('Unable to migrate container %r', name, exc_info=True)
             job.logs_fd.write(f'Unable to migrate container {name!r}: {e!r}.\n'.encode())
         else:
             job.logs_fd.write(f'Successfully migrated container {name!r}.\n'.encode())
+        finally:
+            if needs_mount_revert:
+                revert_incus_mount_properties(context, job, dataset['name'])
+
+    if processed_parents_mountpoints:
+        restore_legacy_parent_mountpoints(context, pool)
+
+
+def revert_incus_mount_properties(context: ServiceContext, job: Job, container_ds: str) -> None:
+    """Restore the mount properties incus set on a container dataset that stays put.
+
+    Inspecting a legacy container means mounting it, which means replacing the
+    ``canmount=noauto``/``mountpoint=legacy`` pair incus relies on with a real
+    mountpoint. A container that is not migrated must not keep that: it would be
+    left mounted under ``/mnt/<pool>/.ix-virt`` and remounted on every boot, with
+    nothing left on the system that manages it.
+    """
+    assert job.logs_fd is not None
+    try:
+        context.call_sync2(context.s.zfs.resource.unmount, container_ds)
+    except Exception:
+        context.logger.warning(
+            '%s: failed to unmount after skipping migration', container_ds, exc_info=True,
+        )
+        job.logs_fd.write(f'Failed to unmount {container_ds!r} after skipping it.\n'.encode())
+
+    try:
+        context.middleware.call_sync(
+            'pool.dataset.update_impl',
+            UpdateImplArgs(
+                name=container_ds,
+                zprops={'canmount': 'noauto', 'mountpoint': 'legacy'},
+            ),
+        )
+    except Exception:
+        context.logger.warning(
+            '%s: failed to restore mount properties after skipping migration',
+            container_ds, exc_info=True,
+        )
+        job.logs_fd.write(
+            f'Failed to restore mount properties on {container_ds!r} after skipping it.\n'.encode()
+        )
+
+
+def restore_legacy_parent_mountpoints(context: ServiceContext, pool: str) -> None:
+    """Put the legacy parent datasets back the way incus had them.
+
+    Migrating a container needs its parents mounted, so they are given an inherited
+    mountpoint. Leaving them that way keeps the whole legacy tree mounted under
+    ``/mnt/<pool>/.ix-virt`` for good, even on a run where nothing was migrated.
+    Children first, so the parent is not unmounted out from under one of them.
+    """
+    for ds in (f'{pool}/.ix-virt/containers', f'{pool}/.ix-virt'):
+        try:
+            context.middleware.call_sync(
+                'pool.dataset.update_impl',
+                UpdateImplArgs(name=ds, zprops={'mountpoint': 'legacy'}),
+            )
+        except Exception:
+            context.logger.warning('%s: failed to restore mountpoint after migration', ds, exc_info=True)
+
+
+def relocate_container_origin(context: ServiceContext, container_ds: str) -> str:
+    """Relocate a migrated container's origin image out of legacy ``.ix-virt``.
+
+    A migrated container is a ZFS clone whose ``origin`` snapshot may still
+    live inside ``<pool>/.ix-virt``. A recursive destroy of ``.ix-virt``
+    cascades into dependent clones regardless of where they live, so such a
+    container is destroyed if the user later deletes ``.ix-virt``. This moves
+    the origin image dataset into the native ``<pool>/.truenas_containers/images``
+    tree so the container no longer depends on anything under ``.ix-virt``.
+
+    Best-effort. Returns one of:
+      - ``RELOCATED``: the origin image was moved.
+      - ``ALREADY_SATISFIED``: not a clone, or the origin already lives
+        outside ``.ix-virt`` (a fan-out sibling or earlier run moved it);
+        the caller may proceed.
+      - ``FAILED``: could not relocate; the container still depends on
+        something inside ``.ix-virt``, or it is a clone of another
+        container rather than of an image.
+      - ``ABSENT``: the container dataset (or its pool) is not present.
+    """
+    try:
+        resources = context.call_sync2(
+            context.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[container_ds], properties=['origin']),
+        )
+    except Exception:
+        context.logger.error('%s: failed to read origin', container_ds, exc_info=True)
+        return 'FAILED'
+
+    if not resources:
+        return 'ABSENT'
+
+    origin = resources[0]['properties']['origin']['value']
+    if origin in (None, '', 'none'):
+        return 'ALREADY_SATISFIED'
+
+    origin_dataset = origin.split('@')[0]
+    pool = origin_dataset.split('/')[0]
+    ix_virt = f'{pool}/.ix-virt/'
+    if any(
+        origin_dataset.startswith(f'{prefix}containers/')
+        for prefix in (ix_virt, f'{container_dataset(pool)}/')
+    ):
+        # A container cloned from another container would arrive in the native tree
+        # still linked to that sibling, and the two stay entangled: neither can be
+        # removed without dealing with the snapshot the other hangs off. The sibling
+        # may already have migrated, hence the native path.
+        context.logger.warning(
+            '%s: origin %r is another container; skipping relocation',
+            container_ds, origin_dataset,
+        )
+        return 'FAILED'
+
+    if not origin_dataset.startswith(ix_virt):
+        # Already relocated (fan-out sibling / prior run) or never in .ix-virt.
+        return 'ALREADY_SATISFIED'
+
+    if not (
+        origin_dataset.startswith(f'{ix_virt}images/')
+        or origin_dataset.startswith(f'{ix_virt}deleted/images/')
+    ):
+        # Via the supported API a container origin is always an image
+        # snapshot. Anything else under .ix-virt is only reachable through
+        # the raw incus CLI, which we make no promises about.
+        context.logger.warning(
+            '%s: origin %r is under .ix-virt but is not an image dataset; skipping relocation',
+            container_ds, origin_dataset,
+        )
+        return 'FAILED'
+
+    context.run_coroutine(ensure_datasets(context, pool))
+
+    fingerprint = origin_dataset.rsplit('/', 1)[1]
+    target = os.path.join(container_dataset(pool), f'images/{fingerprint}')
+
+    # EEXIST-tolerance: the same fingerprint can, in crash/manual states,
+    # exist under both images/ and deleted/images/. Same fingerprint means
+    # identical content, so an extra copy is only redundant disk - pick a
+    # free name rather than failing.
+    final_target = target
+    attempt = 0
+    while context.call_sync2(
+        context.s.zfs.resource.query_impl,
+        ZFSResourceQuery(paths=[final_target], properties=None),
+    ):
+        attempt += 1
+        final_target = f'{target}-migrated-{attempt}'
+
+    # canmount is set before the rename so the atomic rename is the last step:
+    # either the image is still wholly in .ix-virt, or it is fully relocated.
+    try:
+        context.middleware.call_sync(
+            'pool.dataset.update_impl',
+            UpdateImplArgs(name=origin_dataset, zprops={'canmount': 'noauto'}),
+        )
+        context.call_sync2(context.s.zfs.resource.rename, origin_dataset, final_target)
+    except Exception:
+        context.logger.error(
+            '%s: failed to relocate origin image %r out of .ix-virt',
+            container_ds, origin_dataset, exc_info=True,
+        )
+        return 'FAILED'
+
+    return 'RELOCATED'

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -1173,7 +1173,7 @@ class FailoverEventsService(Service):
 
     def start_containers(self):
         logger.info('Starting Containers which are set to start on boot')
-        self.middleware.create_task(self.middleware.call('container.start_on_boot'))
+        self.middleware.create_task(self.middleware.call('container.migrate_and_start_on_boot'))
 
     def stop_containers(self):
         logger.info('Trying to gracefully stop Containers')

--- a/src/middlewared/middlewared/test/integration/assets/container.py
+++ b/src/middlewared/middlewared/test/integration/assets/container.py
@@ -87,9 +87,11 @@ def container(image, options=None, start=False, startup_script=None, name="test"
 
         yield container
     finally:
-        if call("container.get_instance", container["id"])["status"]["state"] == "RUNNING":
-            call("container.stop", container["id"], {"force": True}, job=True)
-        call("container.delete", container["id"])
+        # A test may legitimately delete the container itself.
+        if call("container.query", [["id", "=", container["id"]]]):
+            if call("container.get_instance", container["id"])["status"]["state"] != "STOPPED":
+                call("container.stop", container["id"], {"force": True}, job=True)
+            call("container.delete", container["id"], job=True)
 
         #  Id   Name   State
         # --------------------

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -8,7 +8,7 @@ import time
 import pytest
 import websocket
 
-from truenas_api_client import ValidationErrors
+from truenas_api_client import ClientException, ValidationErrors
 from middlewared.test.integration.assets.account import (
     group as account_group,
     user as account_user,
@@ -16,6 +16,7 @@ from middlewared.test.integration.assets.account import (
 from middlewared.test.integration.assets.container import (
     ALPINE_IMAGE_NAME,
     UBUNTU_IMAGE_NAME,
+    VIRSH,
     configure_bridge,
     container,
     filesystem_device,
@@ -146,6 +147,46 @@ def test_container_rename(ubuntu_container):
         {"paths": [expected_dataset], "properties": ["mountpoint"]},
     )
     assert result, f"ZFS dataset {expected_dataset!r} does not exist after rename"
+
+
+def test_container_delete_running_refused(started_ubuntu_container):
+    with pytest.raises(ClientException) as exc_info:
+        call("container.delete", started_ubuntu_container["id"], job=True)
+
+    assert "Stop it first" in str(exc_info.value)
+
+    container = call("container.get_instance", started_ubuntu_container["id"])
+    assert container["status"]["state"] == "RUNNING"
+    assert call(
+        "zfs.resource.query", {"paths": [container["dataset"]], "properties": None}
+    )
+
+
+def test_container_delete_running_force(started_ubuntu_container):
+    container = started_ubuntu_container
+
+    call("container.delete", container["id"], {"force": True}, job=True)
+
+    assert not call("container.query", [["id", "=", container["id"]]])
+    assert not call(
+        "zfs.resource.query", {"paths": [container["dataset"]], "properties": None}
+    )
+    assert container["uuid"] not in ssh(f"{VIRSH} list --all")
+
+
+def test_container_delete_with_snapshot_refused(ubuntu_container):
+    # Taken over ssh so the test does not depend on how the snapshot API treats
+    # datasets under .truenas_containers.
+    snapshot = f"{ubuntu_container['dataset']}@test"
+    ssh(f"zfs snapshot {snapshot}")
+    try:
+        with pytest.raises(ClientException) as exc_info:
+            call("container.delete", ubuntu_container["id"], job=True)
+
+        assert "has snapshots" in str(exc_info.value)
+        assert call("container.query", [["id", "=", ubuntu_container["id"]]])
+    finally:
+        ssh(f"zfs destroy {snapshot}")
 
 
 def test_container_stop_force_after_timeout(ubuntu_container):


### PR DESCRIPTION
## Problem

Incus containers are ZFS clones of an image snapshot. The incus->container auto-migration relocated each container from `<pool>/.ix-virt/containers/<name>` to `<pool>/.truenas_containers/containers/<name>` with a bare `zfs rename` and did nothing else. A `zfs rename` does not change a clone's `origin`, so a migrated container stayed a clone of a snapshot still living inside `.ix-virt`. `.ix-virt` was visible in the UI and not delete-guarded, so deleting it recursively destroyed those origin snapshots and cascaded into the dependent migrated clones — silently destroying migrated containers.

This is also the release that made `.ix-virt` deletable in the first place, so the window between "your containers migrated fine" and "you reclaimed the old dataset and lost them" is exactly this upgrade.

## Solution

Relocate each container's origin image dataset out of `.ix-virt` before renaming the container, so no migrated container depends on anything under `.ix-virt`. Once relocated the image stays put for good, exactly like a natively pulled one — reclaiming either is the job of the `container.image.*` management API landing separately in this release, not of this fix.

- **Shared relocation helper** — `container.relocate_container_origin` reads a container's live `origin`; if it points at an image under `.ix-virt/images` or `.ix-virt/deleted/images`, it sets `canmount=noauto` on that image dataset and then renames it into the native `.truenas_containers/images/` tree. The rename goes last so it is the single atomic commit point: the image is either wholly still in `.ix-virt` or wholly relocated, never half-way, and the helper's return value describes reality. All fan-out clones auto-repoint on the rename; an origin already outside `.ix-virt` is left alone; a relocation failure leaves the container wholly inside `.ix-virt` (best-effort, skip). A container whose origin is another container rather than an image is refused outright — relocating it would carry a dependency into the native tree where deleting either one destroys the other. The same fingerprint arriving twice (it can exist under both `images/` and `deleted/images/`) lands as `<fp>-migrated-N` rather than failing.
- **Migration path** — the incus->container migration calls the helper immediately before renaming each container, and skips any container whose base image cannot be relocated.
- **Repair migration** — new `0020_repair_incus_clone_origins` runs the same relocation over existing `container.container` rows for systems that already ran the old migration, and puts those systems' legacy mountpoints back as well.
- **The legacy tree is left as it was found** — inspecting a legacy container means mounting it, which means replacing the `canmount`/`mountpoint` pair it was stored with. That is now undone: a container that is skipped rather than migrated gets its properties restored, and the legacy parents get their `mountpoint` back at the end of the run. Without this the whole `.ix-virt` tree stays mounted under `/mnt` and is remounted on every boot, with nothing left on the system that manages it.
- **HA is left out of it** — legacy containers were never migrated on an HA system, because the migration hangs off `system.ready`, which HA deliberately ignores. Rather than inventing that path here and running it for the first time during a failover event, both the migration and the repair migration now bail out on `system.is_ha_capable()` — gated on the hardware, not the failover license, so a controller that *can* be paired is never migrated behind the user's back. The migration clears `virt.global.pool` on the way out so this is not reconsidered on every boot; nothing on disk is touched, and the legacy datasets stay where they are under `.ix-virt`. The repair migration has nothing to do there in any case: the old migration never ran, and pools are not imported yet when migrations do. Migration and start-on-boot do still get folded into one `container.migrate_and_start_on_boot` entry point that the failover path calls too, so the ordering lives in one place instead of two.
- **Licensing** — a system that is not licensed for containers no longer migrates, because every migrated container has to pass `container.validate`, which fails without a license. The legacy configuration is left intact rather than cleared, so the migration runs on a later boot once the license is in place; nothing on disk is touched meanwhile.
- **Failures are contained** — one unusable pool no longer stops the pools after it. A container whose dataset was renamed but whose database row could not be created is moved back where it came from, rather than being left in a tree that nothing enumerates and nothing can delete. Containers created during the run are recorded as they are created, so a same-named container on a second pool is skipped instead of colliding with the one already migrated.
- **Delete guard** — `.truenas_containers` is added to `INTERNAL_PATHS` so neither it nor anything under it — the relocated images included — can be destroyed through `pool.dataset.delete` or `zfs.resource.destroy`; the plugin's own snapshot/clone/destroy calls that touch it now pass `bypass=True`. Same-pool container creation clones the image snapshot through `zfs.resource.snapshot.clone_impl` directly and mounts the result itself, since `pool.snapshot.clone` has no bypass passthrough to offer.
- **Safer deletion** — `do_delete` now tears the libvirt domain down first (it holds the dataset), destroys the dataset next, and only removes the database rows once the dataset is confirmed gone, so a failed destroy never orphans the dataset with no row pointing at it; an already-missing dataset is tolerated so a container whose data was lost to the old cascade can still be removed cleanly. The destroy is recursive, matching the apps stack, so a container that has snapshots is deletable — which also means anything cloned from those snapshots goes with it. `delete_container_from_db_and_libvirt` splits into the two halves this ordering needs, and the pool-dataset attachment delegate calls both.
- **Active-instance guards** — deleting or renaming a container that is not stopped (running or suspended) is refused; delete additionally accepts `force=True`, which stops it first, mirroring the VM delete flow. The container status model now includes the `SUSPENDED` state it can actually report.
- **Delete locking** — delete becomes a job so it can stop the container and wait on the destroy, and its lock is keyed per container id: a constant lock string would hit `@job`'s default `lock_queue_size` of 5 and, past five queued deletes, silently fold a new request into a queued delete of a *different* container and hand that job back to the caller, who would then see SUCCESS for a container nobody deleted.


Original PR: https://github.com/truenas/middleware/pull/19351
