### PR TITLE
NAS-141749 / 27.0.0-BETA.1 /  Report apps whose metadata is unusable so they can be deleted

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/app.py
+++ b/src/middlewared/middlewared/api/v27_0_0/app.py
@@ -81,8 +81,19 @@ class AppActiveWorkloads(BaseModel):
 class AppEntry(BaseModel):
     name: NonEmptyString = Field(description="The display name of the application.")
     id: NonEmptyString = Field(description="Unique identifier for the application instance.")
-    state: Literal['CRASHED', 'DEPLOYING', 'RUNNING', 'STOPPED', 'STOPPING'] = Field(
-        description="Current operational state of the application.",
+    state: Literal['CRASHED', 'DEPLOYING', 'ERROR', 'RUNNING', 'STOPPED', 'STOPPING'] = Field(
+        description=(
+            "Current operational state of the application. `ERROR` means the application's on-disk data could "
+            "not be read, in which case the only operation it supports is deletion."
+        ),
+    )
+    error_reason: Literal['METADATA_MISSING', 'METADATA_UNREADABLE', 'METADATA_INCOMPLETE'] | None = Field(
+        default=None,
+        description=(
+            "Why the application is in the `ERROR` state, or `null` if it is not. `METADATA_MISSING` means its "
+            "metadata file is absent, `METADATA_UNREADABLE` that the file could not be read or parsed, and "
+            "`METADATA_INCOMPLETE` that it was read but does not describe the application."
+        ),
     )
     upgrade_available: bool = Field(description="Whether a newer version of the application is available for upgrade.")
     latest_version: NonEmptyString | None = Field(
@@ -96,8 +107,14 @@ class AppEntry(BaseModel):
     )
     custom_app: bool = Field(description="Whether this is a custom application (`true`) or from a catalog (`false`).")
     migrated: bool = Field(description="Whether this application has been migrated from kubernetes.")
-    human_version: NonEmptyString = Field(description="Human-readable version string for display purposes.")
-    version: NonEmptyString = Field(description="Technical version identifier of the currently installed application.")
+    human_version: NonEmptyString | None = Field(
+        description="Human-readable version string for display purposes. `null` if the state is `ERROR`.",
+    )
+    version: NonEmptyString | None = Field(
+        description=(
+            "Technical version identifier of the currently installed application. `null` if the state is `ERROR`."
+        ),
+    )
     metadata: dict = Field(
         description="Application metadata including description, category, and other catalog information.",
     )
@@ -119,6 +136,19 @@ class AppEntry(BaseModel):
         default=None,
         description="Current configuration values for the application. `null` if configuration is not requested.",
     )
+
+    @classmethod
+    def to_previous(cls, value):
+        # Neither the `ERROR` state nor a null version existed before this version, so an app whose
+        # metadata cannot be read is reported to older clients the way any other broken app is
+        if value.get("state") == "ERROR":
+            value["state"] = "CRASHED"
+
+        for key in ("version", "human_version"):
+            if value.get(key) is None and key in value:
+                value[key] = "unknown"
+
+        return value
 
 
 class AppCreate(BaseModel):

--- a/src/middlewared/middlewared/api/v27_0_0/app.py
+++ b/src/middlewared/middlewared/api/v27_0_0/app.py
@@ -92,7 +92,8 @@ class AppEntry(BaseModel):
         description=(
             "Why the application is in the `ERROR` state, or `null` if it is not. `METADATA_MISSING` means its "
             "metadata file is absent, `METADATA_UNREADABLE` that the file could not be read or parsed, and "
-            "`METADATA_INCOMPLETE` that it was read but does not describe the application."
+            "`METADATA_INCOMPLETE` that it was read but does not describe the application - a key it cannot "
+            "be rendered without is absent, or one it holds cannot be interpreted."
         ),
     )
     upgrade_available: bool = Field(description="Whether a newer version of the application is available for upgrade.")

--- a/src/middlewared/middlewared/plugins/apps/app_scale.py
+++ b/src/middlewared/middlewared/plugins/apps/app_scale.py
@@ -6,16 +6,16 @@ from middlewared.api.current import AppEntry, AppUpdate, QueryOptions
 from middlewared.service import ServiceContext
 
 from .compose_utils import compose_action
-from .crud import get_instance, update_internal
+from .crud import get_usable_instance, update_internal
 from .ix_apps.query import get_default_workload_values
-from .utils import get_app_stop_cache_key
+from .utils import app_version, get_app_stop_cache_key
 
 if TYPE_CHECKING:
     from middlewared.job import Job
 
 
 def stop_app(context: ServiceContext, job: Job, app_name: str) -> None:
-    app = get_instance(context, app_name)
+    app = get_usable_instance(context, app_name)
     cache_key = get_app_stop_cache_key(app_name)
     try:
         context.middleware.call_sync('cache.put', cache_key, True)
@@ -27,7 +27,7 @@ def stop_app(context: ServiceContext, job: Job, app_name: str) -> None:
         )
         job.set_progress(20, f'Stopping {app_name!r} app')
         compose_action(
-            app_name, app.version, 'down', remove_orphans=True, remove_images=False, remove_volumes=False,
+            app_name, app_version(app), 'down', remove_orphans=True, remove_images=False, remove_volumes=False,
         )
         job.set_progress(100, f'Stopped {app_name!r} app')
     finally:
@@ -41,12 +41,12 @@ def stop_app(context: ServiceContext, job: Job, app_name: str) -> None:
 
 
 def start_app(context: ServiceContext, job: Job, app_name: str) -> None:
-    app = get_instance(context, app_name)
+    app = get_usable_instance(context, app_name)
     job.set_progress(20, f'Starting {app_name!r} app')
-    compose_action(app_name, app.version, 'up', force_recreate=True, remove_orphans=True)
+    compose_action(app_name, app_version(app), 'up', force_recreate=True, remove_orphans=True)
     job.set_progress(100, f'Started {app_name!r} app')
 
 
 def redeploy_app(context: ServiceContext, job: Job, app_name: str) -> AppEntry:
-    app = get_instance(context, app_name, QueryOptions(extra={'retrieve_config': True}))
+    app = get_usable_instance(context, app_name, QueryOptions(extra={'retrieve_config': True}))
     return update_internal(context, job, app, AppUpdate(), 'Redeployment')

--- a/src/middlewared/middlewared/plugins/apps/available_apps_info.py
+++ b/src/middlewared/middlewared/plugins/apps/available_apps_info.py
@@ -73,8 +73,9 @@ def _available_raw(context: ServiceContext) -> list[dict[str, Any]]:
 
     results = []
     installed_apps = [
-        (app.metadata['name'], app.metadata['train'])
+        (app_metadata['name'], app_metadata['train'])
         for app in context.call_sync2(context.s.app.query)
+        if (app_metadata := app.metadata) and {'name', 'train'} <= app_metadata.keys()
     ]
 
     catalog = context.call_sync2(context.s.catalog.config)

--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -21,17 +21,28 @@ logger = logging.getLogger('app_lifecycle')
 
 
 def compose_action(
-    app_name: str, app_version: str, action: typing.Literal['up', 'down', 'pull'], *,
+    app_name: str, app_version: str | None, action: typing.Literal['up', 'down', 'pull'], *,
     force_recreate: bool = False, remove_orphans: bool = False, remove_images: bool = False,
     remove_volumes: bool = False, pull_images: bool = False,
     progress_callback: ProgressCallback | None = None,
     job: Job | None = None,
+    allow_missing_compose_files: bool = False,
 ) -> None:
-    compose_files = list(itertools.chain(
-        *[('-f', item) for item in get_rendered_templates_of_app(app_name, app_version)]
-    ))
-    if not compose_files:
+    compose_files = []
+    if app_version is not None:
+        try:
+            compose_files = list(itertools.chain(
+                *[('-f', item) for item in get_rendered_templates_of_app(app_name, app_version)]
+            ))
+        except FileNotFoundError:
+            if not allow_missing_compose_files:
+                raise
+
+    if not compose_files and not allow_missing_compose_files:
         raise CallError(f'No compose files found for app {app_name!r}')
+
+    # Without any compose file, docker resolves the project from the labels it stamped on the
+    # containers, networks and volumes it created, which is all we have to go on for a broken app
 
     args = ['-p', f'{PROJECT_PREFIX}{app_name}', action]
 

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -84,6 +84,9 @@ def query_apps(
     for app_entry in apps:
         if app_entry['custom_app']:
             version_details = get_version_details()
+        elif not app_entry.get('version'):
+            # We cannot locate the app's version directory, so there is no schema to report
+            continue
         else:
             version_details = context.call_sync2(
                 context.s.catalog.app_version_details,

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -37,22 +37,39 @@ if TYPE_CHECKING:
     from middlewared.job import Job
 
 
+# Methods which lay an app's directory down before its metadata is written into it
+APP_INSTALL_METHODS: frozenset[str] = frozenset(('app.create', 'app.convert_to_custom'))
+
+
 def apps_being_installed(context: ServiceContext) -> set[str]:
     """
     Names of apps with an installation in flight, read from the in-memory job queue.
 
     An app's directory is created shortly before its metadata is written to it, so without this an
     install in progress is indistinguishable on disk from an app whose metadata has gone missing.
+    Converting an app to a custom one deletes and recreates it in place, opening the same window on
+    an app which was working a moment ago.
     """
     installing = set()
     for job in context.middleware.jobs.all().values():
-        if job.method_name != 'app.create' or job.state not in (State.WAITING, State.RUNNING) or not job.args:
+        if (
+            job.method_name not in APP_INSTALL_METHODS
+            or job.state not in (State.WAITING, State.RUNNING)
+            or not job.args
+        ):
             continue
 
-        # Depending on how the job was queued, its payload is either the raw dict from the caller
-        # or an already validated model
+        # Conversion is handed the app name itself, while an install is handed either the raw dict
+        # from the caller or an already validated model, depending on how the job was queued
         payload = job.args[0]
-        app_name = payload.get('app_name') if isinstance(payload, dict) else getattr(payload, 'app_name', None)
+        app_name: str | None
+        if isinstance(payload, str):
+            app_name = payload
+        elif isinstance(payload, dict):
+            app_name = payload.get('app_name')
+        else:
+            app_name = getattr(payload, 'app_name', None)
+
         if app_name:
             installing.add(app_name)
 
@@ -142,7 +159,9 @@ def query_apps(
         'host_ip': host_ip,
         'retrieve_config': retrieve_config,
         'image_update_cache': context.call_sync2(context.s.app.image.get_update_cache, True),
-        'installing': apps_being_installed(context),
+        # Walking the job queue is only worth it for an app we would otherwise report as broken, so
+        # this is handed over as something to call rather than as an answer
+        'installing': lambda: apps_being_installed(context),
     }
     if len(filters) == 1 and filters[0][0] in ('id', 'name') and filters[0][1] == '=':
         kwargs['specific_app'] = filters[0][2]

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-import logging
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from catalog_reader.custom_app import get_version_details
@@ -36,8 +35,6 @@ if TYPE_CHECKING:
     from middlewared.api.base.server.app import App
     from middlewared.api.current import QueryOptionsCount, QueryOptionsGet
     from middlewared.job import Job
-
-logger = logging.getLogger('app_lifecycle')
 
 
 def apps_being_installed(context: ServiceContext) -> set[str]:
@@ -83,10 +80,6 @@ def to_app_entry(row: dict[str, Any], retrieve_config: bool) -> AppEntry:
             # There is no entry we could report an app we cannot even name as. A row of this shape
             # only comes of a query which selected neither `name` nor `id`.
             raise
-
-        # Worth a warning of its own: the app's on-disk data is the likely cause, but a change to
-        # the API model would land here for every app on the box while blaming the user's files
-        logger.warning('%s: reported as broken, the entry built for it is not one we can describe', app_name)
 
     # Its real workloads keep the ports and volumes the app is still holding on to visible to
     # conflict checks, where we can describe them

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import os
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from catalog_reader.custom_app import get_version_details
@@ -118,9 +119,21 @@ def to_app_entries(
     if isinstance(result, int):
         return result
     if isinstance(result, dict):
+        # One entry was asked for, so there is nothing to leave out - the caller has to be given it
+        # or told why not
         return to_app_entry(result, retrieve_config)
 
-    return [to_app_entry(row, retrieve_config) for row in result]
+    entries = []
+    for row in result:
+        try:
+            entries.append(to_app_entry(row, retrieve_config))
+        except ValidationError:
+            # An app `to_app_entry` could not even name, which only a `select` that took away both
+            # `name` and `id` produces. Leaving the row out keeps the rest of the query usable,
+            # where letting the error escape returns nothing at all for every app on the box
+            continue
+
+    return entries
 
 
 @overload
@@ -217,7 +230,13 @@ def get_app_config(context: ServiceContext, app_name: str) -> dict[str, Any]:
 def create_app(context: ServiceContext, job: Job, data: AppCreate) -> AppEntry:
     context.call_sync2(context.s.docker.validate_state)
 
-    if query_apps(context, [['id', '=', data.app_name]], QueryOptions()):
+    if query_apps(context, [['id', '=', data.app_name]], QueryOptions()) or os.path.exists(
+        get_installed_app_path(data.app_name)
+    ):
+        # The query alone is not enough: this runs inside the `app.create` job for this very name,
+        # so an app with no metadata and no containers is hidden from it as an install in flight -
+        # which is exactly what a directory an earlier install abandoned before writing any metadata
+        # looks like. Whatever is on disk, the name is taken until it is deleted
         raise CallError(f'Application with name {data.app_name} already exists', errno=errno.EEXIST)
 
     if data.custom_app:

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -13,6 +13,7 @@ from middlewared.api.current import (
     CatalogAppVersionDetails,
     QueryOptions,
 )
+from middlewared.job import State
 from middlewared.service import CallError, InstanceNotFound, ServiceContext, ValidationErrors
 from middlewared.utils.filter_list import filter_list
 
@@ -26,13 +27,35 @@ from .ix_apps.query import list_apps
 from .ix_apps.setup import setup_install_app_dir
 from .resources import delete_internal_resources, get_app_volume_ds, remove_failed_resources
 from .schema_normalization import normalize_and_validate_values
-from .utils import band_progress, to_entries
+from .utils import app_version, assert_app_usable, band_progress, to_entries
 from .version_utils import get_latest_version_from_app_versions
 
 if TYPE_CHECKING:
     from middlewared.api.base.server.app import App
     from middlewared.api.current import QueryOptionsCount, QueryOptionsGet
     from middlewared.job import Job
+
+
+def apps_being_installed(context: ServiceContext) -> set[str]:
+    """
+    Names of apps with an installation in flight, read from the in-memory job queue.
+
+    An app's directory is created shortly before its metadata is written to it, so without this an
+    install in progress is indistinguishable on disk from an app whose metadata has gone missing.
+    """
+    installing = set()
+    for job in context.middleware.jobs.all().values():
+        if job.method_name != 'app.create' or job.state not in (State.WAITING, State.RUNNING) or not job.args:
+            continue
+
+        # Depending on how the job was queued, its payload is either the raw dict from the caller
+        # or an already validated model
+        payload = job.args[0]
+        app_name = payload.get('app_name') if isinstance(payload, dict) else getattr(payload, 'app_name', None)
+        if app_name:
+            installing.add(app_name)
+
+    return installing
 
 
 @overload
@@ -70,6 +93,7 @@ def query_apps(
         'host_ip': host_ip,
         'retrieve_config': extra.get('retrieve_config', False),
         'image_update_cache': context.call_sync2(context.s.app.image.get_update_cache, True),
+        'installing': apps_being_installed(context),
     }
     if len(filters) == 1 and filters[0][0] in ('id', 'name') and filters[0][1] == '=':
         kwargs['specific_app'] = filters[0][2]
@@ -107,9 +131,19 @@ def get_instance(context: ServiceContext, app_name: str, options: QueryOptions |
     return results[0]
 
 
+def get_usable_instance(context: ServiceContext, app_name: str, options: QueryOptions | None = None) -> AppEntry:
+    """
+    Like ``get_instance`` but refuses apps we cannot manage. Deletion is the only operation that
+    should be using ``get_instance`` directly.
+    """
+    app = get_instance(context, app_name, options)
+    assert_app_usable(app)
+    return app
+
+
 def get_app_config(context: ServiceContext, app_name: str) -> dict[str, Any]:
-    app = get_instance(context, app_name)
-    return get_current_app_config(app_name, app.version)
+    app = get_usable_instance(context, app_name)
+    return get_current_app_config(app_name, app_version(app))
 
 
 def create_app(context: ServiceContext, job: Job, data: AppCreate) -> AppEntry:
@@ -235,7 +269,7 @@ def create_internal(
 
 
 def update_app(context: ServiceContext, job: Job, app_name: str, data: AppUpdate) -> AppEntry:
-    app = get_instance(context, app_name, QueryOptions(extra={'retrieve_config': True}))
+    app = get_usable_instance(context, app_name, QueryOptions(extra={'retrieve_config': True}))
     app = update_internal(context, job, app, data, trigger_compose=app.state != 'STOPPED')
     context.call_sync2(context.s.app.metadata_generate).wait_sync(raise_error=True)
     return app
@@ -246,16 +280,17 @@ def update_internal(
     data: AppUpdate, progress_keyword: str = 'Update', trigger_compose: bool = True,
 ) -> AppEntry:
     app_name = app.id
+    version = app_version(app)
     if app.custom_app:
         if progress_keyword == 'Update':
             new_values = validate_payload(data.model_dump(expose_secrets=True), 'app_update')
         else:
-            new_values = get_current_app_config(app_name, app.version)
+            new_values = get_current_app_config(app_name, version)
     else:
-        config = get_current_app_config(app_name, app.version)
+        config = get_current_app_config(app_name, version)
         config.update(data.values.get_secret_value())
         app_version_details = context.call_sync2(
-            context.s.catalog.app_version_details, get_installed_app_version_path(app_name, app.version)
+            context.s.catalog.app_version_details, get_installed_app_version_path(app_name, version)
         )
 
         new_values = context.run_coroutine(normalize_and_validate_values(
@@ -265,10 +300,10 @@ def update_internal(
 
     job.set_progress(25, 'Initial Validation completed')
 
-    update_app_config(app_name, app.version, new_values, custom_app=app.custom_app)
+    update_app_config(app_name, version, new_values, custom_app=app.custom_app)
     if app.custom_app is False:
         # TODO: Eventually we would want this to be executed for custom apps as well
-        update_app_metadata_for_portals(app_name, app.version)
+        update_app_metadata_for_portals(app_name, version)
     job.set_progress(60, 'Configuration updated')
     context.middleware.send_event(
         'app.query', 'CHANGED', id=app_name, fields=get_instance(context, app_name).model_dump()
@@ -276,7 +311,7 @@ def update_internal(
     if trigger_compose:
         job.set_progress(70, 'Updating docker resources')
         compose_action(
-            app_name, app.version, 'up', force_recreate=True, remove_orphans=True,
+            app_name, version, 'up', force_recreate=True, remove_orphans=True,
             progress_callback=band_progress(job, 70, 99), job=job,
         )
 
@@ -286,7 +321,9 @@ def update_internal(
 
 def delete_app(context: ServiceContext, job: Job, app_name: str, options: AppDelete) -> Literal[True]:
     app_config = get_instance(context, app_name)
-    if options.force_remove_custom_app and not app_config.custom_app:
+    if options.force_remove_custom_app and not app_config.custom_app and app_config.state != 'ERROR':
+        # A broken app always reports itself as not being a custom app because we cannot tell either
+        # way, so the flag must not stand in the way of removing it
         raise CallError('`force_remove_custom_app` flag is only valid for a custom app', errno=errno.EINVAL)
 
     return delete_internal_resources(context, app_name, app_config, options, job)

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import errno
-from typing import TYPE_CHECKING, Any, Literal, overload
+import logging
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from catalog_reader.custom_app import get_version_details
+from pydantic import ValidationError
 
 from middlewared.api.current import (
     AppCreate,
@@ -23,17 +25,19 @@ from .custom_app_utils import validate_payload
 from .ix_apps.lifecycle import add_context_to_values, get_current_app_config, update_app_config
 from .ix_apps.metadata import get_collective_metadata, update_app_metadata, update_app_metadata_for_portals
 from .ix_apps.path import get_installed_app_path, get_installed_app_version_path
-from .ix_apps.query import list_apps
+from .ix_apps.query import error_app_data, get_default_workload_values, list_apps
 from .ix_apps.setup import setup_install_app_dir
 from .resources import delete_internal_resources, get_app_volume_ds, remove_failed_resources
 from .schema_normalization import normalize_and_validate_values
-from .utils import app_version, assert_app_usable, band_progress, to_entries
+from .utils import app_version, assert_app_usable, band_progress
 from .version_utils import get_latest_version_from_app_versions
 
 if TYPE_CHECKING:
     from middlewared.api.base.server.app import App
     from middlewared.api.current import QueryOptionsCount, QueryOptionsGet
     from middlewared.job import Job
+
+logger = logging.getLogger('app_lifecycle')
 
 
 def apps_being_installed(context: ServiceContext) -> set[str]:
@@ -58,6 +62,57 @@ def apps_being_installed(context: ServiceContext) -> set[str]:
     return installing
 
 
+def to_app_entry(row: dict[str, Any], retrieve_config: bool) -> AppEntry:
+    """
+    One row of ``list_apps`` as an entry, or the error entry when the API model cannot describe it.
+
+    A row carries data we do not produce ourselves - every key of the app's metadata file, and the
+    workloads docker reports - so a metadata file which was hand edited, or written by a release we
+    know nothing about, can hold a key we do not expect or a value of a type we cannot use.
+    Reporting such an app the way one with unusable metadata is reported leaves it deletable, where
+    letting the validation error escape would take app.query down for every app on the box.
+    """
+    constructor = cast('type[AppEntry]', getattr(AppEntry, '__query_result_item__', AppEntry))
+    try:
+        # Validated rather than splatted: yaml mapping keys need not be strings, and `**row` would
+        # raise TypeError before the model ever got the chance to reject the key
+        return constructor.model_validate(row)
+    except ValidationError:
+        app_name = row.get('name') or row.get('id')
+        if not isinstance(app_name, str) or not app_name:
+            # There is no entry we could report an app we cannot even name as. A row of this shape
+            # only comes of a query which selected neither `name` nor `id`.
+            raise
+
+        # Worth a warning of its own: the app's on-disk data is the likely cause, but a change to
+        # the API model would land here for every app on the box while blaming the user's files
+        logger.warning('%s: reported as broken, the entry built for it is not one we can describe', app_name)
+
+    # Its real workloads keep the ports and volumes the app is still holding on to visible to
+    # conflict checks, where we can describe them
+    try:
+        return constructor.model_validate(error_app_data(
+            app_name, 'METADATA_INCOMPLETE', row.get('active_workloads') or {}, retrieve_config,
+        ))
+    except ValidationError:
+        # The workloads are themselves what cannot be described. Everything else in the error entry
+        # is a constant, so reporting no workloads at all always leaves a deletable app.
+        return constructor.model_validate(error_app_data(
+            app_name, 'METADATA_INCOMPLETE', get_default_workload_values(), retrieve_config,
+        ))
+
+
+def to_app_entries(
+    result: list[dict[str, Any]] | dict[str, Any] | int, retrieve_config: bool,
+) -> list[AppEntry] | AppEntry | int:
+    if isinstance(result, int):
+        return result
+    if isinstance(result, dict):
+        return to_app_entry(result, retrieve_config)
+
+    return [to_app_entry(row, retrieve_config) for row in result]
+
+
 @overload
 def query_apps(  # type: ignore[overload-overlap]
     context: ServiceContext, filters: list[Any], options: QueryOptionsCount, app: App | None = None,
@@ -79,10 +134,11 @@ def query_apps(
 def query_apps(
     context: ServiceContext, filters: list[Any], options: QueryOptions, app: App | None = None,
 ) -> list[AppEntry] | AppEntry | int:
-    if not context.call_sync2(context.s.docker.validate_state, False):
-        return to_entries(filter_list([], filters, options.model_dump()), AppEntry)
-
     extra = options.extra
+    retrieve_config = extra.get('retrieve_config', False)
+    if not context.call_sync2(context.s.docker.validate_state, False):
+        return to_app_entries(filter_list([], filters, options.model_dump()), retrieve_config)
+
     host_ip = extra.get('host_ip')
     if app is not None and not host_ip:
         if app.origin.is_tcp_ip_family:
@@ -91,7 +147,7 @@ def query_apps(
     retrieve_app_schema = extra.get('include_app_schema', False)
     kwargs = {
         'host_ip': host_ip,
-        'retrieve_config': extra.get('retrieve_config', False),
+        'retrieve_config': retrieve_config,
         'image_update_cache': context.call_sync2(context.s.app.image.get_update_cache, True),
         'installing': apps_being_installed(context),
     }
@@ -102,7 +158,7 @@ def query_apps(
 
     apps = list_apps(available_apps_mapping, **kwargs)
     if not retrieve_app_schema:
-        return to_entries(filter_list(apps, filters, options.model_dump()), AppEntry)
+        return to_app_entries(filter_list(apps, filters, options.model_dump()), retrieve_config)
 
     questions_context = context.call_sync2(context.s.catalog.get_normalized_questions_context)
     for app_entry in apps:
@@ -120,7 +176,7 @@ def query_apps(
 
         app_entry['version_details'] = version_details
 
-    return to_entries(filter_list(apps, filters, options.model_dump()), AppEntry)
+    return to_app_entries(filter_list(apps, filters, options.model_dump()), retrieve_config)
 
 
 def get_instance(context: ServiceContext, app_name: str, options: QueryOptions | None = None) -> AppEntry:
@@ -182,7 +238,12 @@ def create_app(context: ServiceContext, job: Job, data: AppCreate) -> AppEntry:
         catalog_app = data.catalog_app
         train = data.train
         for installed_app in get_collective_metadata().values():
-            installed_app_metadata = installed_app.get('metadata') or {}
+            # An entry of the collective metadata is whatever yaml parsed it as, so one broken app
+            # must not stand in the way of installing an unrelated one
+            if not isinstance(installed_app, dict) or not isinstance(installed_app.get('metadata'), dict):
+                continue
+
+            installed_app_metadata = installed_app['metadata']
             if installed_app_metadata.get('name') == catalog_app and installed_app_metadata.get('train') == train:
                 verrors.add(
                     'app_create.catalog_app',

--- a/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_ops.py
@@ -13,6 +13,7 @@ from .ix_apps.lifecycle import get_rendered_template_config_of_app, update_app_c
 from .ix_apps.metadata import update_app_metadata
 from .ix_apps.setup import setup_install_app_dir
 from .resources import delete_internal_resources, remove_failed_resources
+from .utils import app_version, assert_app_usable
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -20,10 +21,11 @@ if TYPE_CHECKING:
 
 def convert_to_custom_app(context: ServiceContext, job: Job, app_name: str) -> AppEntry:
     app = context.call_sync2(context.s.app.get_instance, app_name)
+    assert_app_usable(app)
     if app.custom_app is True:
         raise CallError(f'{app_name!r} is already a custom app')
 
-    rendered_config = get_rendered_template_config_of_app(app_name, app.version)
+    rendered_config = get_rendered_template_config_of_app(app_name, app_version(app))
     if not rendered_config:
         raise CallError(f'No rendered config found for {app_name!r}')
 

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -16,7 +16,8 @@ def _load_app_yaml(yaml_path: str) -> dict[str, typing.Any]:
     try:
         with open(yaml_path, 'r') as f:
             return safe_yaml_load(f, dict)
-    except (FileNotFoundError, yaml.YAMLError, ValueError):
+    except (OSError, yaml.YAMLError, ValueError):
+        # OSError covers a missing file as well as one we cannot read at all, i.e. EACCES/EIO/EISDIR
         return {}
 
 

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -14,6 +14,11 @@ from .utils import AppErrorReason, dump_yaml
 # treated as fatal (portals -> {}, notes -> None, migrated -> False), so metadata written by an
 # older release is never misreported as broken - a false ERROR would block a working app.
 APP_METADATA_REQUIRED_KEYS: frozenset[str] = frozenset(('metadata', 'custom_app', 'version', 'human_version'))
+# Defaulted here rather than left to the API model: a query result makes every field optional so
+# that a caller can select a subset of them, so an app which does not carry these validates and then
+# reports them as undefined instead of as the values an entry promises. `portals` is defaulted where
+# it is normalized instead.
+APP_METADATA_DEFAULTS: dict[str, typing.Any] = {'migrated': False, 'notes': None}
 # Keys of the nested catalog metadata that upgrade detection indexes
 APP_CATALOG_METADATA_REQUIRED_KEYS: frozenset[str] = frozenset(('name', 'train', 'version'))
 
@@ -98,13 +103,16 @@ def get_app_metadata_checked(app_name: str) -> tuple[dict[str, typing.Any], AppE
 
 
 def resolve_app_metadata(
-    app_name: str, collective_metadata: dict[str, typing.Any], has_resources: bool, installing: set[str],
+    app_name: str, collective_metadata: dict[str, typing.Any], has_resources: bool,
+    installing: typing.Callable[[], set[str]],
 ) -> tuple[dict[str, typing.Any], AppErrorReason | None, bool]:
     """
     Resolve one app's metadata along with the reason it is unusable, if any.
 
     The returned boolean is ``False`` when the app should be ignored entirely. Costs no I/O for
-    apps present in ``collective_metadata``, which is every app on a healthy system.
+    apps present in ``collective_metadata``, which is every app on a healthy system. ``installing``
+    is called only for an app we would otherwise report as broken, since answering it means walking
+    the whole job queue.
     """
     if (app_metadata := collective_metadata.get(app_name)) is not None:
         return app_metadata, app_metadata_error(app_metadata), True
@@ -116,7 +124,7 @@ def resolve_app_metadata(
         # that is itself missing or corrupt cannot flip every app on the system into ERROR.
         return app_metadata, None, False
 
-    if error_reason == 'METADATA_MISSING' and not has_resources and app_name in installing:
+    if error_reason == 'METADATA_MISSING' and not has_resources and app_name in installing():
         # The app directory is created a moment before its metadata is written, so an install in
         # flight is indistinguishable from an abandoned directory by looking at the filesystem alone
         return app_metadata, None, False

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -8,7 +8,14 @@ from middlewared.utils.yaml import safe_yaml_load
 
 from .path import get_collective_config_path, get_collective_metadata_path, get_installed_app_metadata_path
 from .portals import get_portals_and_app_notes
-from .utils import dump_yaml
+from .utils import AppErrorReason, dump_yaml
+
+# Keys we cannot render an app without. Anything outside this set is defaulted instead of being
+# treated as fatal (portals -> {}, notes -> None, migrated -> False), so metadata written by an
+# older release is never misreported as broken - a false ERROR would block a working app.
+APP_METADATA_REQUIRED_KEYS: frozenset[str] = frozenset(('metadata', 'custom_app', 'version', 'human_version'))
+# Keys of the nested catalog metadata that upgrade detection indexes
+APP_CATALOG_METADATA_REQUIRED_KEYS: frozenset[str] = frozenset(('name', 'train', 'version'))
 
 
 def _load_app_yaml(yaml_path: str) -> dict[str, typing.Any]:
@@ -23,6 +30,66 @@ def _load_app_yaml(yaml_path: str) -> dict[str, typing.Any]:
 
 def get_app_metadata(app_name: str) -> dict[str, typing.Any]:
     return _load_app_yaml(get_installed_app_metadata_path(app_name))
+
+
+def app_metadata_error(app_metadata: dict[str, typing.Any]) -> AppErrorReason | None:
+    """
+    Report why ``app_metadata`` cannot be used, if it cannot. Performs no I/O.
+    """
+    if not app_metadata:
+        return 'METADATA_MISSING'
+
+    if not APP_METADATA_REQUIRED_KEYS.issubset(app_metadata):
+        return 'METADATA_INCOMPLETE'
+
+    catalog_metadata = app_metadata['metadata']
+    if not isinstance(catalog_metadata, dict) or not APP_CATALOG_METADATA_REQUIRED_KEYS.issubset(catalog_metadata):
+        return 'METADATA_INCOMPLETE'
+
+    return None
+
+
+def get_app_metadata_checked(app_name: str) -> tuple[dict[str, typing.Any], AppErrorReason | None]:
+    """
+    Like ``get_app_metadata`` but reports why the app's metadata is unusable, if it is.
+    """
+    try:
+        with open(get_installed_app_metadata_path(app_name), 'r') as f:
+            app_metadata: dict[str, typing.Any] = safe_yaml_load(f, dict)
+    except FileNotFoundError:
+        return {}, 'METADATA_MISSING'
+    except (OSError, yaml.YAMLError, ValueError):
+        # We cannot read it at all (EACCES/EIO/EISDIR), it is not valid YAML, or it is not a mapping
+        return {}, 'METADATA_UNREADABLE'
+
+    return app_metadata, app_metadata_error(app_metadata)
+
+
+def resolve_app_metadata(
+    app_name: str, collective_metadata: dict[str, typing.Any], has_resources: bool, installing: set[str],
+) -> tuple[dict[str, typing.Any], AppErrorReason | None, bool]:
+    """
+    Resolve one app's metadata along with the reason it is unusable, if any.
+
+    The returned boolean is ``False`` when the app should be ignored entirely. Costs no I/O for
+    apps present in ``collective_metadata``, which is every app on a healthy system.
+    """
+    if (app_metadata := collective_metadata.get(app_name)) is not None:
+        return app_metadata, app_metadata_error(app_metadata), True
+
+    app_metadata, error_reason = get_app_metadata_checked(app_name)
+    if error_reason is None:
+        # The app's own metadata is intact, it just has not made it into the collective metadata
+        # yet (or no longer is, mid-delete). Ignoring it here also means a collective metadata file
+        # that is itself missing or corrupt cannot flip every app on the system into ERROR.
+        return app_metadata, None, False
+
+    if error_reason == 'METADATA_MISSING' and not has_resources and app_name in installing:
+        # The app directory is created a moment before its metadata is written, so an install in
+        # flight is indistinguishable from an abandoned directory by looking at the filesystem alone
+        return app_metadata, None, False
+
+    return app_metadata, error_reason, True
 
 
 def update_app_metadata(

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -32,18 +32,50 @@ def get_app_metadata(app_name: str) -> dict[str, typing.Any]:
     return _load_app_yaml(get_installed_app_metadata_path(app_name))
 
 
-def app_metadata_error(app_metadata: dict[str, typing.Any]) -> AppErrorReason | None:
+def _is_non_empty_str(value: typing.Any) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def app_metadata_error(app_metadata: typing.Any) -> AppErrorReason | None:
     """
     Report why ``app_metadata`` cannot be used, if it cannot. Performs no I/O.
+
+    Only a key which is *present* holding something unusable is rejected - an absent optional key is
+    left to be defaulted, since reporting a working app as broken takes away every operation but
+    deletion.
     """
     if not app_metadata:
         return 'METADATA_MISSING'
 
-    if not APP_METADATA_REQUIRED_KEYS.issubset(app_metadata):
+    if not isinstance(app_metadata, dict) or not APP_METADATA_REQUIRED_KEYS.issubset(app_metadata):
+        # An app's entry in the collective metadata file is whatever yaml parsed it as, so it need
+        # not be a mapping at all - and a non-mapping cannot even be tested for the keys we need
+        return 'METADATA_INCOMPLETE'
+
+    if (
+        # The version doubles as the name of the app's installed directory, and both of these are
+        # reported to API consumers as non-empty strings
+        not _is_non_empty_str(app_metadata['version'])
+        or not _is_non_empty_str(app_metadata['human_version'])
+        or not isinstance(app_metadata['custom_app'], bool)
+    ):
+        return 'METADATA_INCOMPLETE'
+
+    if 'migrated' in app_metadata and not isinstance(app_metadata['migrated'], bool):
+        return 'METADATA_INCOMPLETE'
+
+    if 'portals' in app_metadata and not isinstance(app_metadata['portals'], dict):
+        return 'METADATA_INCOMPLETE'
+
+    if 'notes' in app_metadata and app_metadata['notes'] is not None and not isinstance(app_metadata['notes'], str):
         return 'METADATA_INCOMPLETE'
 
     catalog_metadata = app_metadata['metadata']
     if not isinstance(catalog_metadata, dict) or not APP_CATALOG_METADATA_REQUIRED_KEYS.issubset(catalog_metadata):
+        return 'METADATA_INCOMPLETE'
+
+    if any(not _is_non_empty_str(catalog_metadata[key]) for key in APP_CATALOG_METADATA_REQUIRED_KEYS):
+        # The train and the app name are used as catalog lookup keys and the version is parsed as one
         return 'METADATA_INCOMPLETE'
 
     return None

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -10,9 +10,9 @@ from middlewared.plugins.catalog.utils import IX_APP_NAME
 
 from .docker.query import list_resources_by_project
 from .lifecycle import get_current_app_config
-from .metadata import get_collective_config, get_collective_metadata
+from .metadata import get_collective_config, get_collective_metadata, resolve_app_metadata
 from .path import get_app_parent_config_path
-from .utils import PROJECT_PREFIX, AppState, ContainerState, get_app_name_from_project_name
+from .utils import PROJECT_PREFIX, AppErrorReason, AppState, ContainerState, get_app_name_from_project_name
 
 COMPOSE_SERVICE_KEY: str = 'com.docker.compose.service'
 KNOWN_NORMAL_EXIT_CODES: tuple[int, ...] = (
@@ -97,14 +97,46 @@ def normalize_portal_uris(portals: dict[str, str], host_ip: str | None) -> dict[
     return {name: normalize_portal_uri(uri, host_ip) for name, uri in portals.items()}
 
 
+def error_app_data(
+    app_name: str, error_reason: AppErrorReason, workloads: dict[str, Any], retrieve_config: bool,
+) -> dict[str, Any]:
+    """
+    Entry for an app whose on-disk metadata is unusable. Everything we would normally read out of
+    that metadata is reported as unknown rather than guessed at.
+    """
+    return {
+        'name': app_name,
+        'id': app_name,
+        'active_workloads': workloads,
+        'state': AppState.ERROR.value,
+        'error_reason': error_reason,
+        'upgrade_available': False,
+        'latest_version': None,
+        'latest_app_version': None,
+        'image_updates_available': False,
+        'action_required': False,
+        'custom_app': False,
+        'migrated': False,
+        'human_version': None,
+        'version': None,
+        'metadata': {},
+        'portals': {},
+        'notes': None,
+        'version_details': None,
+        'config': {} if retrieve_config else None,
+    }
+
+
 def list_apps(
     train_to_apps_version_mapping: dict[str, dict[str, dict[str, str | None]]],
     specific_app: str | None = None,
     host_ip: str | None = None,
     retrieve_config: bool = False,
     image_update_cache: dict[str, Any] | None = None,
+    installing: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     apps = []
+    installing = installing or set()
     image_update_cache = image_update_cache or {}
     app_names = set()
     metadata = get_collective_metadata()
@@ -115,11 +147,17 @@ def list_apps(
     ).items():
         app_name = get_app_name_from_project_name(app_name)
         app_names.add(app_name)
-        if app_name not in metadata:
-            # The app is malformed or something is seriously wrong with it
+        app_metadata, error_reason, present = resolve_app_metadata(app_name, metadata, True, installing)
+        if not present:
             continue
 
         workloads = translate_resources_to_desired_workflow(app_resources)
+        if error_reason is not None:
+            # Report the app's real workloads so that the ports and volumes it is still holding on to
+            # remain visible to conflict checks, even though we know nothing else about it
+            apps.append(error_app_data(app_name, error_reason, workloads, retrieve_config))
+            continue
+
         # When we stop docker service and start it again - the containers can be in exited
         # state which means we need to account for this.
         state = AppState.STOPPED
@@ -139,7 +177,6 @@ def list_apps(
 
         state_value: str = state.value
 
-        app_metadata = metadata[app_name]
         active_workloads = get_default_workload_values() if state_value == 'STOPPED' else workloads
         image_updates_available = any(
             image_update_cache.get(normalize_reference(k)['complete_tag']) for k in active_workloads['images']
@@ -157,6 +194,7 @@ def list_apps(
             'action_required': False,
             'latest_app_version': latest_app_version,
             'image_updates_available': image_updates_available,
+            'error_reason': None,
             'version_details': None,
             **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
         }
@@ -180,11 +218,16 @@ def list_apps(
                 lambda e: e.is_dir() and ((specific_app and e.name == specific_app) or e.name not in app_names), scan
             ):
                 app_names.add(entry.name)
-                if entry.name not in metadata:
-                    # The app is malformed or something is seriously wrong with it
+                app_metadata, error_reason, present = resolve_app_metadata(entry.name, metadata, False, installing)
+                if not present:
                     continue
 
-                app_metadata = metadata[entry.name]
+                if error_reason is not None:
+                    apps.append(error_app_data(
+                        entry.name, error_reason, get_default_workload_values(), retrieve_config,
+                    ))
+                    continue
+
                 upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(
                     train_to_apps_version_mapping, app_metadata
                 )
@@ -198,6 +241,7 @@ def list_apps(
                     'action_required': False,
                     'latest_app_version': latest_app_version,
                     'image_updates_available': False,
+                    'error_reason': None,
                     'version_details': None,
                     **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
                 }

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -101,7 +101,10 @@ def get_config_of_app(
     if not retrieve_config:
         return {'config': None}
 
-    if config := collective_config.get(app_data['name']):
+    # An entry of the collective config file is whatever yaml parsed it as, so it need not be a
+    # mapping at all - falling through to the app's own file is what stops a value the API model
+    # cannot describe from turning a healthy app into a broken one
+    if isinstance(config := collective_config.get(app_data['name']), dict) and config:
         return {'config': config}
 
     # app_metadata_error has already rejected an app whose version is not a usable path
@@ -176,10 +179,17 @@ def list_apps(
     metadata = get_collective_metadata()
     collective_config = get_collective_config() if retrieve_config else {}
     # This will only give us apps which are running or in deploying state
-    for app_name, app_resources in list_resources_by_project(
+    for project_name, app_resources in list_resources_by_project(
         project_name=f'{PROJECT_PREFIX}{specific_app}' if specific_app else None,
     ).items():
-        app_name = get_app_name_from_project_name(app_name)
+        app_name = get_app_name_from_project_name(project_name)
+        if not project_name.startswith(PROJECT_PREFIX) or not app_name:
+            # Docker reports every compose project on the box, including ones the user deployed
+            # themselves, and taking the prefix off a name which does not carry one invents an app
+            # no operation can act on - `webserver` reads as an app named `server`, and a project
+            # named exactly `ix-` as one with no name at all
+            continue
+
         app_names.add(app_name)
         app_metadata, error_reason, present = resolve_app_metadata(app_name, metadata, True, installing)
         if not present:

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from dataclasses import dataclass
+import functools
 import os
-from typing import Any
+from typing import Any, Callable
 
 from packaging.version import InvalidVersion, Version
 
@@ -10,7 +11,7 @@ from middlewared.plugins.catalog.utils import IX_APP_NAME
 
 from .docker.query import list_resources_by_project
 from .lifecycle import get_current_app_config
-from .metadata import get_collective_config, get_collective_metadata, resolve_app_metadata
+from .metadata import APP_METADATA_DEFAULTS, get_collective_config, get_collective_metadata, resolve_app_metadata
 from .path import get_app_parent_config_path
 from .utils import PROJECT_PREFIX, AppErrorReason, AppState, ContainerState, get_app_name_from_project_name
 
@@ -164,10 +165,12 @@ def list_apps(
     host_ip: str | None = None,
     retrieve_config: bool = False,
     image_update_cache: dict[str, Any] | None = None,
-    installing: set[str] | None = None,
+    installing: Callable[[], set[str]] | None = None,
 ) -> list[dict[str, Any]]:
     apps = []
-    installing = installing or set()
+    # Answering this walks the whole job queue, so it is asked at most once per call and only for an
+    # app we would otherwise report as broken
+    installing = functools.cache(installing) if installing else (lambda: set())
     image_update_cache = image_update_cache or {}
     app_names = set()
     metadata = get_collective_metadata()
@@ -217,8 +220,9 @@ def list_apps(
         )
         app_data = {
             # Written into the metadata by an app which asks for it, and defaulted for one which
-            # does not - unlike the keys below, this one is the app's to set
+            # does not - unlike the keys below, these are the app's to set
             'action_required': False,
+            **APP_METADATA_DEFAULTS,
             **app_metadata,
             'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip),
             # Everything we determined ourselves comes last, so that metadata which was hand edited
@@ -270,6 +274,7 @@ def list_apps(
                 # See the app_data of a running app for why the keys are ordered this way
                 app_data = {
                     'action_required': False,
+                    **APP_METADATA_DEFAULTS,
                     **app_metadata,
                     'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip),
                     'name': entry.name,

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import os
 from typing import Any
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from middlewared.plugins.apps_images.utils import normalize_reference
 from middlewared.plugins.catalog.utils import IX_APP_NAME
@@ -35,6 +35,20 @@ class VolumeMount:
         return hash((self.source, self.destination, self.type))
 
 
+def parse_version(version: Any) -> Version | None:
+    """
+    ``version`` as something comparable, or ``None`` when it is not a version at all. Corrupt
+    metadata can hold anything here, and a catalog can name a version we cannot make sense of.
+    """
+    if not isinstance(version, str):
+        return None
+
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
+
+
 def upgrade_available_for_app(
     version_mapping: dict[str, dict[str, dict[str, str | None]]],
     app_metadata: dict[str, Any],
@@ -42,25 +56,25 @@ def upgrade_available_for_app(
 ) -> tuple[bool, str | None, str | None]:
     # TODO: Eventually we would want this to work as well but this will always require middleware changes
     #  depending on what new functionality we want introduced for custom app, so let's take care of this at that point
-    catalog_app_metadata = app_metadata.get('metadata') or {}
+    catalog_app_metadata = app_metadata.get('metadata')
+    if not isinstance(catalog_app_metadata, dict):
+        catalog_app_metadata = {}
+
     catalog_app = catalog_app_metadata.get('name')
     catalog_train = catalog_app_metadata.get('train')
-    if (
-        app_metadata.get('custom_app') is False
-        # Corrupt metadata can hold anything at all here, including values yaml parsed as a
-        # non-string, so these must be validated before they are used as lookup keys
-        and isinstance(catalog_app, str)
-        and isinstance(catalog_train, str)
-        and catalog_app_metadata.get('version')
-        and (
-            latest_version_info := version_mapping.get(catalog_train, {}).get(catalog_app)
-        )
-        and latest_version_info['version']
-    ):
+    installed_version = parse_version(catalog_app_metadata.get('version'))
+    # Corrupt metadata can hold anything at all here, including values yaml parsed as a non-string,
+    # so these must be validated before they are used as lookup keys
+    latest_version_info = (
+        version_mapping.get(catalog_train, {}).get(catalog_app)
+        if isinstance(catalog_app, str) and isinstance(catalog_train, str) else None
+    ) or {}
+    latest_version = parse_version(latest_version_info.get('version'))
+    if app_metadata.get('custom_app') is False and installed_version is not None and latest_version is not None:
         return (
-            Version(catalog_app_metadata['version']) < Version(latest_version_info['version']),
+            installed_version < latest_version,
             latest_version_info['version'],
-            latest_version_info['app_version']
+            latest_version_info.get('app_version'),
         )
     elif (app_metadata.get('custom_app') or catalog_app == IX_APP_NAME) and image_updates_available:
         return True, None, None
@@ -83,18 +97,33 @@ def normalize_portal_uri(portal_uri: str, host_ip: str | None) -> str:
 def get_config_of_app(
     app_data: dict[str, Any], collective_config: dict[str, Any], retrieve_config: bool,
 ) -> dict[str, Any]:
-    if retrieve_config:
-        return {
-            'config': collective_config.get(app_data['name']) or (
-                get_current_app_config(app_data['name'], app_data['version']) if app_data['version'] else {}
-            )
-        }
-    else:
+    if not retrieve_config:
         return {'config': None}
 
+    if config := collective_config.get(app_data['name']):
+        return {'config': config}
 
-def normalize_portal_uris(portals: dict[str, str], host_ip: str | None) -> dict[str, str]:
-    return {name: normalize_portal_uri(uri, host_ip) for name, uri in portals.items()}
+    if not app_data['version']:
+        return {'config': {}}
+
+    try:
+        return {'config': get_current_app_config(app_data['name'], app_data['version'])}
+    except Exception:
+        # Letting this escape would take app.query down for every app on the box. It is not logged
+        # here - app.query runs constantly, and app_metadata_generate already reported the failure
+        # when it could not read the same file.
+        return {'config': {}}
+
+
+def normalize_portal_uris(portals: Any, host_ip: str | None) -> Any:
+    # Corrupt metadata can hold anything at all here, so anything we cannot normalize is returned as
+    # it stands and the model level guard on the row decides whether the app can be described at all
+    if not isinstance(portals, dict):
+        return portals
+
+    return {
+        name: normalize_portal_uri(uri, host_ip) if isinstance(uri, str) else uri for name, uri in portals.items()
+    }
 
 
 def error_app_data(

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -103,6 +103,8 @@ def get_config_of_app(
     if config := collective_config.get(app_data['name']):
         return {'config': config}
 
+    # app_metadata_error has already rejected an app whose version is not a usable path
+    # component, but the path this builds is only safe while that stays true
     if not app_data['version']:
         return {'config': {}}
 
@@ -214,18 +216,23 @@ def list_apps(
             train_to_apps_version_mapping, app_metadata
         )
         app_data = {
+            # Written into the metadata by an app which asks for it, and defaulted for one which
+            # does not - unlike the keys below, this one is the app's to set
+            'action_required': False,
+            **app_metadata,
+            'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip),
+            # Everything we determined ourselves comes last, so that metadata which was hand edited
+            # or written by a release we know nothing about cannot pass itself off as any of it
             'name': app_name,
             'id': app_name,
             'active_workloads': active_workloads,
             'state': state_value,
             'upgrade_available': upgrade_available,
             'latest_version': latest_version,
-            'action_required': False,
             'latest_app_version': latest_app_version,
             'image_updates_available': image_updates_available,
             'error_reason': None,
             'version_details': None,
-            **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
         }
         if (
             app_data.get('custom_app') or (app_metadata.get('metadata') or {}).get('name') == IX_APP_NAME
@@ -260,19 +267,21 @@ def list_apps(
                 upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(
                     train_to_apps_version_mapping, app_metadata
                 )
+                # See the app_data of a running app for why the keys are ordered this way
                 app_data = {
+                    'action_required': False,
+                    **app_metadata,
+                    'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip),
                     'name': entry.name,
                     'id': entry.name,
                     'active_workloads': get_default_workload_values(),
                     'state': AppState.STOPPED.value,
                     'upgrade_available': upgrade_available,
                     'latest_version': latest_version,
-                    'action_required': False,
                     'latest_app_version': latest_app_version,
                     'image_updates_available': False,
                     'error_reason': None,
                     'version_details': None,
-                    **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
                 }
                 apps.append(app_data | get_config_of_app(app_data, collective_config, retrieve_config))
     except FileNotFoundError:

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -42,16 +42,18 @@ def upgrade_available_for_app(
 ) -> tuple[bool, str | None, str | None]:
     # TODO: Eventually we would want this to work as well but this will always require middleware changes
     #  depending on what new functionality we want introduced for custom app, so let's take care of this at that point
-    catalog_app_metadata = app_metadata['metadata']
-    catalog_app = catalog_app_metadata['name']
+    catalog_app_metadata = app_metadata.get('metadata') or {}
+    catalog_app = catalog_app_metadata.get('name')
+    catalog_train = catalog_app_metadata.get('train')
     if (
-        app_metadata['custom_app'] is False
+        app_metadata.get('custom_app') is False
+        # Corrupt metadata can hold anything at all here, including values yaml parsed as a
+        # non-string, so these must be validated before they are used as lookup keys
+        and isinstance(catalog_app, str)
+        and isinstance(catalog_train, str)
+        and catalog_app_metadata.get('version')
         and (
-            latest_version_info := version_mapping.get(
-                catalog_app_metadata['train'], {}
-            ).get(
-                catalog_app_metadata['name']
-            )
+            latest_version_info := version_mapping.get(catalog_train, {}).get(catalog_app)
         )
         and latest_version_info['version']
     ):
@@ -60,7 +62,7 @@ def upgrade_available_for_app(
             latest_version_info['version'],
             latest_version_info['app_version']
         )
-    elif (app_metadata['custom_app'] or catalog_app == IX_APP_NAME) and image_updates_available:
+    elif (app_metadata.get('custom_app') or catalog_app == IX_APP_NAME) and image_updates_available:
         return True, None, None
     else:
         return False, None, None
@@ -156,9 +158,11 @@ def list_apps(
             'latest_app_version': latest_app_version,
             'image_updates_available': image_updates_available,
             'version_details': None,
-            **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
+            **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
         }
-        if (app_data['custom_app'] or app_metadata['metadata']['name'] == IX_APP_NAME) and image_updates_available:
+        if (
+            app_data.get('custom_app') or (app_metadata.get('metadata') or {}).get('name') == IX_APP_NAME
+        ) and image_updates_available:
             # We want to mark custom apps and ix-apps as upgrade available if image updates are available
             # so if user tries to upgrade, we will just be pulling a newer version of the image
             # against the same docker tag
@@ -195,7 +199,7 @@ def list_apps(
                     'latest_app_version': latest_app_version,
                     'image_updates_available': False,
                     'version_details': None,
-                    **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
+                    **app_metadata | {'portals': normalize_portal_uris(app_metadata.get('portals') or {}, host_ip)}
                 }
                 apps.append(app_data | get_config_of_app(app_data, collective_config, retrieve_config))
     except FileNotFoundError:

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
@@ -1,17 +1,26 @@
 import enum
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 import yaml
 
 PROJECT_PREFIX = 'ix-'
 
+# Kept in sync by hand with `AppEntry.error_reason` in middlewared.api.<current version>.app,
+# which cannot import this module (API schemas may not import plugins).
+AppErrorReason: TypeAlias = Literal['METADATA_MISSING', 'METADATA_UNREADABLE', 'METADATA_INCOMPLETE']
+
 
 class AppState(enum.Enum):
     CRASHED = 'CRASHED'
     DEPLOYING = 'DEPLOYING'
+    ERROR = 'ERROR'
     RUNNING = 'RUNNING'
     STOPPED = 'STOPPED'
     STOPPING = 'STOPPING'
+
+
+# States in which an app's on-disk data is unusable, so it can only be deleted
+UNUSABLE_STATES: frozenset[str] = frozenset({AppState.ERROR.value})
 
 
 class ContainerState(enum.Enum):

--- a/src/middlewared/middlewared/plugins/apps/logs.py
+++ b/src/middlewared/middlewared/plugins/apps/logs.py
@@ -56,7 +56,7 @@ class AppContainerLogsFollowTailEventSource(
     def validate_log_args(self, app_name: str, container_id: str) -> None:
         app = self.middleware.call_sync2(self.middleware.services.app.get_instance, app_name)
         if app.state not in (AppState.CRASHED.value, AppState.RUNNING.value, AppState.DEPLOYING.value):
-            raise CallError(f'Unable to retrieve logs of stopped {app_name!r} app')
+            raise CallError(f'Unable to retrieve logs of {app_name!r} app in {app.state!r} state')
 
         if not any(c.id == container_id for c in app.active_workloads.container_details):
             raise CallError(f'Container "{container_id}" not found in app "{app_name}"', errno=errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/metadata.py
@@ -27,16 +27,19 @@ def app_metadata_generate(job: Job, blacklisted_apps: list[str] | None = None) -
                 # The app is malformed or something is seriously wrong with it
                 continue
 
+            # Recorded even when the app is broken. Absence from this file is how an app becomes
+            # invisible to app.query, and an app nobody can see is an app nobody can delete.
+            # Consumers report an unusable entry as an app in the ERROR state instead of indexing
+            # into it blindly.
+            metadata[entry.name] = app_metadata
+
             try:
-                metadata[entry.name] = app_metadata
                 config[entry.name] = get_current_app_config(entry.name, app_metadata['version'])
             except Exception:
-                # A half-written app must not make it into the collective metadata, as consumers of that
-                # file index into it directly. Nor should it fail the whole job - every app lifecycle
-                # operation waits on this and would otherwise break because of one unrelated broken app.
-                metadata.pop(entry.name, None)
+                # This must not fail the whole job - every app lifecycle operation waits on it and
+                # would otherwise break because of one unrelated broken app.
                 logger.warning(
-                    '%s: skipped while generating app metadata, app data is unusable', entry.name, exc_info=True
+                    '%s: app config could not be read while generating app metadata', entry.name, exc_info=True
                 )
 
     with atomic_write(get_collective_metadata_path(), 'w') as f:

--- a/src/middlewared/middlewared/plugins/apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,8 @@ from .ix_apps.utils import dump_yaml
 if TYPE_CHECKING:
     from middlewared.job import Job
 
+logger = logging.getLogger('app_lifecycle')
+
 
 def app_metadata_generate(job: Job, blacklisted_apps: list[str] | None = None) -> None:
     config = {}
@@ -24,8 +27,17 @@ def app_metadata_generate(job: Job, blacklisted_apps: list[str] | None = None) -
                 # The app is malformed or something is seriously wrong with it
                 continue
 
-            metadata[entry.name] = app_metadata
-            config[entry.name] = get_current_app_config(entry.name, app_metadata['version'])
+            try:
+                metadata[entry.name] = app_metadata
+                config[entry.name] = get_current_app_config(entry.name, app_metadata['version'])
+            except Exception:
+                # A half-written app must not make it into the collective metadata, as consumers of that
+                # file index into it directly. Nor should it fail the whole job - every app lifecycle
+                # operation waits on this and would otherwise break because of one unrelated broken app.
+                metadata.pop(entry.name, None)
+                logger.warning(
+                    '%s: skipped while generating app metadata, app data is unusable', entry.name, exc_info=True
+                )
 
     with atomic_write(get_collective_metadata_path(), 'w') as f:
         f.write(dump_yaml(metadata))

--- a/src/middlewared/middlewared/plugins/apps/pull_images.py
+++ b/src/middlewared/middlewared/plugins/apps/pull_images.py
@@ -7,15 +7,15 @@ from middlewared.plugins.apps_images.utils import normalize_reference
 from middlewared.service import ServiceContext
 
 from .compose_utils import compose_action
-from .crud import get_instance
-from .utils import band_progress, child_job_progress
+from .crud import get_usable_instance
+from .utils import app_version, band_progress, child_job_progress
 
 if TYPE_CHECKING:
     from middlewared.job import Job
 
 
 def outdated_docker_images_for_app(context: ServiceContext, app_name: str) -> list[str]:
-    app = get_instance(context, app_name)
+    app = get_usable_instance(context, app_name)
     image_update_cache = context.call_sync2(context.s.app.image.get_update_cache, True)
     images = []
     for image_tag in app.active_workloads.images:
@@ -26,7 +26,7 @@ def outdated_docker_images_for_app(context: ServiceContext, app_name: str) -> li
 
 
 def pull_images_for_app(context: ServiceContext, job: Job, app_name: str, options: AppPullImages) -> None:
-    app = get_instance(context, app_name)
+    app = get_usable_instance(context, app_name)
     return pull_images_internal(context, app_name, app, options, job)
 
 
@@ -38,7 +38,7 @@ def pull_images_internal(
         job.set_progress(20, 'Pulling app images')
         progress_callback = band_progress(job, 20, 75 if options.redeploy else 99)
 
-    compose_action(app_name, app.version, action='pull', progress_callback=progress_callback, job=job)
+    compose_action(app_name, app_version(app), action='pull', progress_callback=progress_callback, job=job)
     if job is not None:
         job.set_progress(80 if options.redeploy else 100, 'Images pulled successfully')
 

--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 import contextlib
+import logging
 import shutil
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -28,16 +29,19 @@ from .compose_utils import compose_action
 from .ix_apps.path import get_app_parent_volume_ds, get_installed_app_path
 from .ix_apps.utils import ContainerState
 from .resources_utils import get_normalized_gpu_choices
-from .utils import IX_APPS_MOUNT_PATH
+from .utils import IX_APPS_MOUNT_PATH, assert_app_usable
 
 if TYPE_CHECKING:
     from middlewared.job import Job
+
+logger = logging.getLogger('app_lifecycle')
 
 
 async def container_ids(
     context: ServiceContext, app_name: str, options: AppContainerIDOptions,
 ) -> AppContainerResponse:
     app = await context.call2(context.s.app.get_instance, app_name)
+    assert_app_usable(app)
     return AppContainerResponse(root={
         c.id: ContainerDetails(
             id=c.id,
@@ -170,16 +174,27 @@ def delete_internal_resources(
 ) -> Literal[True]:
     if job is not None:
         job.set_progress(20, f'Deleting {app_name!r} app')
+
+    app_broken = app_config.state == 'ERROR'
     try:
         compose_action(
             app_name, app_config.version, 'down', remove_orphans=True,
             remove_volumes=True, remove_images=options.remove_images,
+            # A broken app has no version we can trust and therefore no compose file to point at, so
+            # docker has to fall back to finding the project's resources by their labels
+            allow_missing_compose_files=app_broken,
         )
     except Exception:
+        if app_broken:
+            # Refusing here is how a broken app ends up impossible to remove, which is precisely what
+            # being able to report it in the first place is meant to solve
+            logger.warning(
+                '%s: failed to remove docker resources of a broken app, continuing', app_name, exc_info=True
+            )
         # We want to make sure if this fails for a custom app which has no resources deployed, and the explicit
         # boolean flag is set, we allow the deletion of the app as there really isn't anything which compose down
         # is going to accomplish as there are no containers/networks/volumes in place for the app
-        if not (
+        elif not (
             app_config.custom_app and options.force_remove_custom_app and all(
                 not getattr(app_config.active_workloads, k, [])
                 for k in ('container_details', 'volumes', 'networks')
@@ -193,7 +208,9 @@ def delete_internal_resources(
     if job is not None:
         job.set_progress(80, 'Cleaning up resources')
 
-    shutil.rmtree(get_installed_app_path(app_name))
+    # A broken app's directory may itself be part of what is wrong with it, so do not let cleaning it
+    # up be the thing that blocks the removal
+    shutil.rmtree(get_installed_app_path(app_name), ignore_errors=app_broken)
 
     if options.remove_ix_volumes and (apps_volume_ds := get_app_volume_ds(context, app_name)):
         context.call_sync2(context.s.zfs.resource.destroy_impl, apps_volume_ds, recursive=True, bypass=True)

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -12,6 +12,7 @@ from .ix_apps.path import get_installed_app_path, get_installed_app_version_path
 from .ix_apps.rollback import clean_newer_versions, get_rollback_versions
 from .resources import get_app_volume_ds
 from .schema_normalization import normalize_and_validate_values
+from .utils import app_version, assert_app_usable
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -22,10 +23,11 @@ def rollback(context: ServiceContext, job: Job, app_name: str, options: AppRollb
     Rollback `app_name` app to previous version.
     """
     app = context.call_sync2(context.s.app.get_instance, app_name, QueryOptions(extra={'retrieve_config': True}))
+    assert_app_usable(app)
     verrors = ValidationErrors()
     if options.app_version == app.version:
         verrors.add('options.app_version', 'Cannot rollback to same version')
-    elif options.app_version not in get_rollback_versions(app_name, app.version):
+    elif options.app_version not in get_rollback_versions(app_name, app_version(app)):
         verrors.add('options.app_version', 'Specified version is not available for rollback')
 
     if app.state == 'STOPPED':
@@ -87,4 +89,5 @@ def rollback(context: ServiceContext, job: Job, app_name: str, options: AppRollb
 
 def rollback_versions(context: ServiceContext, app_name: str) -> list[str]:
     app = context.call_sync2(context.s.app.get_instance, app_name)
-    return get_rollback_versions(app_name, app.version)
+    assert_app_usable(app)
+    return get_rollback_versions(app_name, app_version(app))

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -40,7 +40,14 @@ from .migration_utils import get_migration_scripts
 from .pull_images import pull_images_internal
 from .resources import get_app_volume_ds, get_hostpaths_datasets
 from .schema_normalization import normalize_and_validate_values
-from .utils import band_progress, child_job_progress, get_upgrade_snap_name, upgrade_summary_info
+from .utils import (
+    app_version,
+    assert_app_usable,
+    band_progress,
+    child_job_progress,
+    get_upgrade_snap_name,
+    upgrade_summary_info,
+)
 from .version_utils import get_latest_version_from_app_versions
 
 if TYPE_CHECKING:
@@ -56,6 +63,7 @@ async def upgrade_summary(
     context: ServiceContext, app_name: str, options: AppUpgradeSummaryOptions
 ) -> AppUpgradeSummary:
     app = await context.call2(context.s.app.get_instance, app_name)
+    assert_app_usable(app)
     if app.upgrade_available is False:
         raise CallError(f'No upgrade available for {app_name!r}')
 
@@ -83,7 +91,7 @@ async def upgrade_summary(
         available_versions_for_upgrade=[
             AppVersionInfo(version=v['version'], human_version=v['human_version'])
             for v in versions_config['versions'].values()
-            if Version(v['version']) > Version(app.version)
+            if Version(v['version']) > Version(app_version(app))
         ],
     )
 
@@ -135,6 +143,7 @@ async def upgrade_app(context: ServiceContext, job: Job, app_name: str, options:
 
 def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppUpgradeOptions) -> AppEntry:
     app = context.call_sync2(context.s.app.get_instance, app_name, QueryOptions(extra={'retrieve_config': True}))
+    assert_app_usable(app)
     if app.state == 'STOPPED':
         raise CallError('In order to upgrade an app, it must not be in stopped state')
 
@@ -199,7 +208,7 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
         job.set_progress(40, f'Configuration updated for {app_name!r}, upgrading app')
 
         if app_volume_ds := get_app_volume_ds(context, app_name):
-            snap_name = f'{app_volume_ds}@{app.version}'
+            snap_name = f'{app_volume_ds}@{app_version(app)}'
             try:
                 context.call_sync2(context.s.zfs.resource.snapshot.destroy_impl, ZFSResourceSnapshotDestroyQuery(
                     path=snap_name,
@@ -211,7 +220,7 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
 
             context.call_sync2(context.s.zfs.resource.snapshot.create_impl, ZFSResourceSnapshotCreateQuery(
                 dataset=app_volume_ds,
-                name=app.version,
+                name=app_version(app),
                 recursive=True,
                 bypass=True,
             ))
@@ -246,7 +255,7 @@ async def get_versions(context: ServiceContext, app: AppEntry, new_version: str)
         raise CallError(f'Unable to locate {new_version!r} version for {metadata["name"]!r} app')
 
     verrors = ValidationErrors()
-    if Version(new_version) <= Version(app.version):
+    if Version(new_version) <= Version(app_version(app)):
         verrors.add('options.app_version', 'Upgrade version must be greater than current version')
 
     verrors.check()
@@ -281,14 +290,14 @@ def take_snapshot_of_hostpath(
 
             continue
 
-        snap_name = f'{dataset}@{get_upgrade_snap_name(app_info.name, app_info.version)}'
+        snap_name = f'{dataset}@{get_upgrade_snap_name(app_info.name, app_version(app_info))}'
         if context.call_sync2(context.s.zfs.resource.snapshot.exists, snap_name):
             logger.debug('Snapshot %r already exists for %r app', snap_name, app_info.name)
             continue
 
         context.call_sync2(context.s.zfs.resource.snapshot.create_impl, ZFSResourceSnapshotCreateQuery(
             dataset=dataset,
-            name=get_upgrade_snap_name(app_info.name, app_info.version),
+            name=get_upgrade_snap_name(app_info.name, app_version(app_info)),
             bypass=True,
         ))
         logger.debug('Created snapshot %r for %r app', snap_name, app_info.name)
@@ -321,7 +330,7 @@ def upgrade_values(app: AppEntry, upgrade_version: dict[str, Any]) -> dict[str, 
 
 
 def get_data_for_upgrade_values(app: AppEntry, upgrade_version: dict[str, Any]) -> tuple[list[str], dict[str, Any]]:
-    current_version = app.version
+    current_version = app_version(app)
     target_version = upgrade_version['version']
     migration_files_path = get_migration_scripts(app.name, current_version, target_version)
     config = get_current_app_config(app.name, current_version)

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -17,8 +17,10 @@ from middlewared.plugins.docker.state_utils import (
 from middlewared.plugins.docker.state_utils import (  # noqa: F401,I250
     DatasetDefaults as DatasetDefaults,
 )
+from middlewared.service_exception import CallError
 
 from .ix_apps.utils import PROJECT_PREFIX as PROJECT_PREFIX  # noqa: F401,I250
+from .ix_apps.utils import UNUSABLE_STATES
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -42,11 +44,31 @@ def to_entries(
     return [constructor(**row) for row in result]
 
 
+def assert_app_usable(app: AppEntry) -> None:
+    """
+    Refuse to manage an app whose on-disk data we cannot make sense of.
+    """
+    if app.state in UNUSABLE_STATES:
+        raise CallError(
+            f'{app.id!r} app cannot be managed because its metadata is unusable ({app.error_reason}). '
+            'The app can only be deleted.'
+        )
+
+
+def app_version(app: AppEntry) -> str:
+    """
+    Version of an app which has already passed ``assert_app_usable``.
+    """
+    assert app.version is not None, f'{app.id}: a usable app always has a version'
+    return app.version
+
+
 def upgrade_summary_info(app: AppEntry) -> AppUpgradeSummary:
+    assert app.human_version is not None, f'{app.id}: a usable app always has a human version'
     return AppUpgradeSummary(
-        latest_version=app.version,
+        latest_version=app_version(app),
         latest_human_version=app.human_version,
-        upgrade_version=app.version,
+        upgrade_version=app_version(app),
         upgrade_human_version=app.human_version,
         changelog='Image updates are available for this app',
         available_versions_for_upgrade=[],

--- a/src/middlewared/middlewared/plugins/docker/config.py
+++ b/src/middlewared/middlewared/plugins/docker/config.py
@@ -88,7 +88,7 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
             if pool_changed:
                 await self.call2(self.s.app.clear_upgrade_alerts_for_all)
                 job.set_progress(15, 'Stopping Apps')
-                apps = await self.call2(self.s.app.query, [['state', '!=', 'STOPPED']])
+                apps = await self.call2(self.s.app.query, [['state', 'nin', ['STOPPED', 'ERROR']]])
                 batch_size = 10
                 for i in range(0, len(apps), batch_size):
                     await (await self.middleware.call(
@@ -148,7 +148,8 @@ class DockerConfigServicePart(ConfigServicePart[DockerEntry]):
                 job.set_progress(95, 'Initiating redeployment of applications to apply new address pools changes')
                 await self.middleware.call(
                     'core.bulk', 'app.redeploy', [
-                        [app.name] for app in await self.call2(self.s.app.query, [['state', '!=', 'STOPPED']])
+                        [app.name]
+                        for app in await self.call2(self.s.app.query, [['state', 'nin', ['STOPPED', 'ERROR']]])
                     ]
                 )
 

--- a/src/middlewared/middlewared/plugins/usage/gather.py
+++ b/src/middlewared/middlewared/plugins/usage/gather.py
@@ -175,7 +175,12 @@ async def gather_applications(service: Service, context: GatherContext) -> dict[
     apps = await service.call2(service.s.app.query)
     output["apps"] = len(apps)
     for app in apps:
-        output["catalog_items"][app.metadata["train"]][app.metadata["name"]][app.version] += 1
+        metadata = app.metadata
+        if not (metadata.get("train") and metadata.get("name") and app.version):
+            # Nothing to attribute this app to, its metadata is unusable
+            continue
+
+        output["catalog_items"][metadata["train"]][metadata["name"]][app.version] += 1
 
     for image in await service.call2(service.s.app.image.query):
         output["docker_images"].update(image.repo_tags)

--- a/src/middlewared/middlewared/pytest/unit/api/handler/version/test_app_entry_downgrade.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/version/test_app_entry_downgrade.py
@@ -1,0 +1,126 @@
+import pytest
+
+from middlewared.api.base.handler.accept import validate_model
+from middlewared.api.base.handler.version import APIVersion, APIVersionsAdapter
+from middlewared.api.v26_0_0.app import AppEntry as AppEntry_v26_0_0
+from middlewared.api.v27_0_0.app import AppEntry as AppEntry_v27_0_0
+from middlewared.service.crud_service import get_instance_result
+from middlewared.service_exception import ValidationErrors
+
+from .utils import TestModelProvider
+
+MODEL_NAME = "AppGetInstanceResult"
+AppGetInstanceResult_v26_0_0 = get_instance_result(AppEntry_v26_0_0)
+AppGetInstanceResult_v27_0_0 = get_instance_result(AppEntry_v27_0_0)
+
+
+def _build_adapter():
+    return APIVersionsAdapter(
+        [
+            APIVersion("v26.0.0", TestModelProvider({MODEL_NAME: AppGetInstanceResult_v26_0_0})),
+            APIVersion("v27.0.0", TestModelProvider({MODEL_NAME: AppGetInstanceResult_v27_0_0})),
+        ]
+    )
+
+
+def app_entry(**overrides):
+    return {
+        "name": "actual-budget",
+        "id": "actual-budget",
+        "state": "RUNNING",
+        "error_reason": None,
+        "upgrade_available": False,
+        "latest_version": None,
+        "latest_app_version": None,
+        "image_updates_available": False,
+        "custom_app": False,
+        "migrated": False,
+        "human_version": "24.10.1_1.1.13",
+        "version": "1.1.13",
+        "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
+        "active_workloads": {
+            "containers": 0,
+            "used_ports": [],
+            "used_host_ips": [],
+            "container_details": [],
+            "volumes": [],
+            "images": [],
+            "networks": [],
+        },
+        "notes": None,
+        "action_required": False,
+        "portals": {},
+    } | overrides
+
+
+def error_app_entry(**overrides):
+    return app_entry(
+        **{
+            "state": "ERROR",
+            "error_reason": "METADATA_UNREADABLE",
+            "version": None,
+            "human_version": None,
+            "metadata": {},
+        }
+        | overrides
+    )
+
+
+async def adapt(value):
+    return await _build_adapter().adapt({"result": value}, MODEL_NAME, "v27.0.0", "v26.0.0")
+
+
+@pytest.mark.asyncio
+async def test_error_state_is_reported_as_crashed():
+    result = (await adapt(error_app_entry()))["result"]
+
+    assert result["state"] == "CRASHED"
+
+
+@pytest.mark.asyncio
+async def test_null_versions_are_filled_in():
+    result = (await adapt(error_app_entry()))["result"]
+
+    assert result["version"] == "unknown"
+    assert result["human_version"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_error_reason_is_dropped():
+    result = (await adapt(error_app_entry()))["result"]
+
+    assert "error_reason" not in result
+
+
+@pytest.mark.asyncio
+async def test_downgraded_error_app_is_valid_for_the_older_version():
+    # Without the substitutions above this raises, and in production it would instead be silently
+    # logged and the newer shape handed to the client anyway
+    adapted = await adapt(error_app_entry())
+
+    validate_model(AppGetInstanceResult_v26_0_0, adapted)
+
+
+@pytest.mark.asyncio
+async def test_healthy_app_is_unchanged():
+    result = (await adapt(app_entry()))["result"]
+
+    assert result["state"] == "RUNNING"
+    assert result["version"] == "1.1.13"
+    assert result["human_version"] == "24.10.1_1.1.13"
+
+
+def test_partial_entry_is_tolerated():
+    # `app.query` supports `select`, and its result items have every field optional, so the
+    # conversion has to cope with only a subset of them being present
+    result = AppEntry_v27_0_0.to_previous({"state": "ERROR"})
+
+    assert result["state"] == "CRASHED"
+    assert "version" not in result
+    assert "human_version" not in result
+
+
+@pytest.mark.asyncio
+async def test_error_state_is_rejected_by_the_older_version_directly():
+    with pytest.raises(ValidationErrors):
+        validate_model(AppGetInstanceResult_v26_0_0, {"result": error_app_entry()})

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
@@ -158,13 +158,13 @@ def test_metadata_in_collective_costs_no_io(app_configs):
     # Nothing is written to `app_configs`, so a filesystem read would fail to find anything
     collective = {"app-a": complete_metadata()}
 
-    assert resolve_app_metadata("app-a", collective, True, set()) == (complete_metadata(), None, True)
+    assert resolve_app_metadata("app-a", collective, True, lambda: set()) == (complete_metadata(), None, True)
 
 
 def test_incomplete_metadata_in_collective_is_reported(app_configs):
     collective = {"app-a": {"version": "1.1.13"}}
 
-    app_metadata, error_reason, present = resolve_app_metadata("app-a", collective, True, set())
+    app_metadata, error_reason, present = resolve_app_metadata("app-a", collective, True, lambda: set())
 
     assert (error_reason, present) == ("METADATA_INCOMPLETE", True)
 
@@ -173,30 +173,65 @@ def test_intact_metadata_outside_collective_is_ignored(app_configs):
     # An install or delete in flight, or a collective metadata file which is itself unreadable
     write_metadata(app_configs, "app-a", yaml.safe_dump(complete_metadata()))
 
-    assert resolve_app_metadata("app-a", {}, False, set()) == (complete_metadata(), None, False)
+    assert resolve_app_metadata("app-a", {}, False, lambda: set()) == (complete_metadata(), None, False)
 
 
 def test_unreadable_metadata_outside_collective_is_reported(app_configs):
     write_metadata(app_configs, "app-a", "{")
 
-    assert resolve_app_metadata("app-a", {}, False, set()) == ({}, "METADATA_UNREADABLE", True)
+    assert resolve_app_metadata("app-a", {}, False, lambda: set()) == ({}, "METADATA_UNREADABLE", True)
 
 
 def test_absent_metadata_is_reported_when_not_installing(app_configs):
     (app_configs / "app-a").mkdir()
 
-    assert resolve_app_metadata("app-a", {}, False, set()) == ({}, "METADATA_MISSING", True)
+    assert resolve_app_metadata("app-a", {}, False, lambda: set()) == ({}, "METADATA_MISSING", True)
 
 
 def test_absent_metadata_is_ignored_while_installing(app_configs):
     # The app directory is created moments before its metadata is written to it
     (app_configs / "app-a").mkdir()
 
-    assert resolve_app_metadata("app-a", {}, False, {"app-a"}) == ({}, None, False)
+    assert resolve_app_metadata("app-a", {}, False, lambda: {"app-a"}) == ({}, None, False)
 
 
 def test_absent_metadata_is_reported_while_installing_if_resources_exist(app_configs):
     # Containers only exist once the metadata has been written, so there is no install window here
     (app_configs / "app-a").mkdir()
 
-    assert resolve_app_metadata("app-a", {}, True, {"app-a"}) == ({}, "METADATA_MISSING", True)
+    assert resolve_app_metadata("app-a", {}, True, lambda: {"app-a"}) == ({}, "METADATA_MISSING", True)
+
+
+def refuse_to_answer():
+    raise AssertionError("the job queue was walked for an app which could not be mid-install")
+
+
+def test_metadata_in_collective_is_not_asked_what_is_installing(app_configs):
+    collective = {"app-a": complete_metadata()}
+
+    assert resolve_app_metadata("app-a", collective, True, refuse_to_answer) == (complete_metadata(), None, True)
+
+
+def test_intact_metadata_outside_collective_is_not_asked_what_is_installing(app_configs):
+    write_metadata(app_configs, "app-a", yaml.safe_dump(complete_metadata()))
+
+    assert resolve_app_metadata("app-a", {}, False, refuse_to_answer) == (complete_metadata(), None, False)
+
+
+def test_unreadable_metadata_is_not_asked_what_is_installing(app_configs):
+    # Only a directory holding no metadata at all can be an install in flight
+    write_metadata(app_configs, "app-a", "{")
+
+    assert resolve_app_metadata("app-a", {}, False, refuse_to_answer) == ({}, "METADATA_UNREADABLE", True)
+
+
+def test_absent_metadata_is_asked_what_is_installing(app_configs):
+    (app_configs / "app-a").mkdir()
+    asked = []
+
+    def installing():
+        asked.append(None)
+        return {"app-a"}
+
+    assert resolve_app_metadata("app-a", {}, False, installing) == ({}, None, False)
+    assert len(asked) == 1

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
@@ -1,0 +1,157 @@
+import os
+
+import pytest
+import yaml
+
+from middlewared.plugins.apps.ix_apps.metadata import (
+    APP_CATALOG_METADATA_REQUIRED_KEYS,
+    APP_METADATA_REQUIRED_KEYS,
+    app_metadata_error,
+    get_app_metadata_checked,
+    resolve_app_metadata,
+)
+
+
+def complete_metadata():
+    return {
+        "custom_app": False,
+        "human_version": "24.10.1_1.1.13",
+        "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
+        "migrated": False,
+        "notes": None,
+        "portals": {},
+        "version": "1.1.13",
+    }
+
+
+def test_complete_metadata_is_usable():
+    assert app_metadata_error(complete_metadata()) is None
+
+
+def test_empty_metadata_is_missing():
+    assert app_metadata_error({}) == "METADATA_MISSING"
+
+
+@pytest.mark.parametrize("key", sorted(APP_METADATA_REQUIRED_KEYS))
+def test_absent_required_key_is_incomplete(key):
+    app_metadata = complete_metadata()
+    app_metadata.pop(key)
+
+    assert app_metadata_error(app_metadata) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("key", sorted(APP_CATALOG_METADATA_REQUIRED_KEYS))
+def test_absent_catalog_metadata_key_is_incomplete(key):
+    app_metadata = complete_metadata()
+    app_metadata["metadata"].pop(key)
+
+    assert app_metadata_error(app_metadata) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("catalog_metadata", [None, "actual-budget", [], 1])
+def test_catalog_metadata_which_is_not_a_mapping_is_incomplete(catalog_metadata):
+    assert app_metadata_error(complete_metadata() | {"metadata": catalog_metadata}) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("key", ["notes", "migrated", "portals", "action_required"])
+def test_defaulted_keys_are_not_required(key):
+    # Metadata written by older releases can be missing these, and reporting a working app as broken
+    # would take away every operation but deletion
+    app_metadata = complete_metadata()
+    app_metadata.pop(key, None)
+
+    assert app_metadata_error(app_metadata) is None
+
+
+@pytest.fixture
+def app_configs(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.metadata.get_installed_app_metadata_path",
+        lambda app_name: os.path.join(tmp_path, app_name, "metadata.yaml"),
+    )
+    return tmp_path
+
+
+def write_metadata(app_configs, app_name, contents):
+    app_dir = app_configs / app_name
+    app_dir.mkdir()
+    (app_dir / "metadata.yaml").write_text(contents)
+
+
+def test_readable_metadata_is_returned(app_configs):
+    write_metadata(app_configs, "app-a", 'version: "1.1.13"\n')
+
+    assert get_app_metadata_checked("app-a") == ({"version": "1.1.13"}, "METADATA_INCOMPLETE")
+
+
+def test_absent_metadata_file_is_missing(app_configs):
+    (app_configs / "app-a").mkdir()
+
+    assert get_app_metadata_checked("app-a") == ({}, "METADATA_MISSING")
+
+
+def test_unparseable_metadata_is_unreadable(app_configs):
+    write_metadata(app_configs, "app-a", "{")
+
+    assert get_app_metadata_checked("app-a") == ({}, "METADATA_UNREADABLE")
+
+
+def test_metadata_which_is_not_a_mapping_is_unreadable(app_configs):
+    write_metadata(app_configs, "app-a", "- a\n- b\n")
+
+    assert get_app_metadata_checked("app-a") == ({}, "METADATA_UNREADABLE")
+
+
+def test_metadata_we_cannot_open_is_unreadable(app_configs):
+    # A directory where the file should be stands in for any of EACCES/EIO/EISDIR
+    (app_configs / "app-a" / "metadata.yaml").mkdir(parents=True)
+
+    assert get_app_metadata_checked("app-a") == ({}, "METADATA_UNREADABLE")
+
+
+def test_metadata_in_collective_costs_no_io(app_configs):
+    # Nothing is written to `app_configs`, so a filesystem read would fail to find anything
+    collective = {"app-a": complete_metadata()}
+
+    assert resolve_app_metadata("app-a", collective, True, set()) == (complete_metadata(), None, True)
+
+
+def test_incomplete_metadata_in_collective_is_reported(app_configs):
+    collective = {"app-a": {"version": "1.1.13"}}
+
+    app_metadata, error_reason, present = resolve_app_metadata("app-a", collective, True, set())
+
+    assert (error_reason, present) == ("METADATA_INCOMPLETE", True)
+
+
+def test_intact_metadata_outside_collective_is_ignored(app_configs):
+    # An install or delete in flight, or a collective metadata file which is itself unreadable
+    write_metadata(app_configs, "app-a", yaml.safe_dump(complete_metadata()))
+
+    assert resolve_app_metadata("app-a", {}, False, set()) == (complete_metadata(), None, False)
+
+
+def test_unreadable_metadata_outside_collective_is_reported(app_configs):
+    write_metadata(app_configs, "app-a", "{")
+
+    assert resolve_app_metadata("app-a", {}, False, set()) == ({}, "METADATA_UNREADABLE", True)
+
+
+def test_absent_metadata_is_reported_when_not_installing(app_configs):
+    (app_configs / "app-a").mkdir()
+
+    assert resolve_app_metadata("app-a", {}, False, set()) == ({}, "METADATA_MISSING", True)
+
+
+def test_absent_metadata_is_ignored_while_installing(app_configs):
+    # The app directory is created moments before its metadata is written to it
+    (app_configs / "app-a").mkdir()
+
+    assert resolve_app_metadata("app-a", {}, False, {"app-a"}) == ({}, None, False)
+
+
+def test_absent_metadata_is_reported_while_installing_if_resources_exist(app_configs):
+    # Containers only exist once the metadata has been written, so there is no install window here
+    (app_configs / "app-a").mkdir()
+
+    assert resolve_app_metadata("app-a", {}, True, {"app-a"}) == ({}, "METADATA_MISSING", True)

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_error.py
@@ -53,6 +53,51 @@ def test_catalog_metadata_which_is_not_a_mapping_is_incomplete(catalog_metadata)
     assert app_metadata_error(complete_metadata() | {"metadata": catalog_metadata}) == "METADATA_INCOMPLETE"
 
 
+@pytest.mark.parametrize("app_metadata", ["actual-budget", 1, 1.13, True, ["actual-budget"]])
+def test_metadata_which_is_not_a_mapping_is_incomplete(app_metadata):
+    # An app's entry in the collective metadata file is whatever yaml parsed it as, and testing a
+    # non-mapping for the keys we need raises rather than answering
+    assert app_metadata_error(app_metadata) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("key", sorted(APP_METADATA_REQUIRED_KEYS - {"metadata", "custom_app"}))
+@pytest.mark.parametrize("value", [None, "", 1.13, True, [], {}])
+def test_version_which_is_not_a_non_empty_string_is_incomplete(key, value):
+    # Both name a directory or are reported to API consumers as a non-empty string, and yaml parses
+    # an unquoted 1.13 as a float
+    assert app_metadata_error(complete_metadata() | {key: value}) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("key", ["custom_app", "migrated"])
+@pytest.mark.parametrize("value", [None, "", "false", 0, 1, []])
+def test_flag_which_is_not_a_bool_is_incomplete(key, value):
+    assert app_metadata_error(complete_metadata() | {key: value}) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("portals", ["http://0.0.0.0:8080", 1, ["http://0.0.0.0:8080"]])
+def test_portals_which_are_not_a_mapping_is_incomplete(portals):
+    assert app_metadata_error(complete_metadata() | {"portals": portals}) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("notes", [1, ["a", "b"], {"a": "b"}])
+def test_notes_which_are_not_a_string_is_incomplete(notes):
+    assert app_metadata_error(complete_metadata() | {"notes": notes}) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("key", sorted(APP_CATALOG_METADATA_REQUIRED_KEYS))
+@pytest.mark.parametrize("value", [None, "", 1.13, True, [], {}])
+def test_catalog_metadata_value_which_is_not_a_non_empty_string_is_incomplete(key, value):
+    app_metadata = complete_metadata()
+    app_metadata["metadata"][key] = value
+
+    assert app_metadata_error(app_metadata) == "METADATA_INCOMPLETE"
+
+
+@pytest.mark.parametrize("notes", [None, "Some notes"])
+def test_notes_a_string_or_null_is_usable(notes):
+    assert app_metadata_error(complete_metadata() | {"notes": notes}) is None
+
+
 @pytest.mark.parametrize("key", ["notes", "migrated", "portals", "action_required"])
 def test_defaulted_keys_are_not_required(key):
     # Metadata written by older releases can be missing these, and reporting a working app as broken

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
@@ -1,0 +1,111 @@
+import contextlib
+import io
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from middlewared.plugins.apps.metadata import app_metadata_generate
+from middlewared.utils.yaml import safe_yaml_load
+
+
+def app_metadata(version="1.1.0"):
+    return {
+        "custom_app": False,
+        "human_version": f"24.10.1_{version}",
+        "metadata": {"name": "actual-budget", "train": "community", "version": version},
+        "migrated": False,
+        "notes": None,
+        "portals": {},
+        "version": version,
+    }
+
+
+class FakeDirEntry:
+    def __init__(self, name):
+        self.name = name
+
+    def is_dir(self):
+        return True
+
+
+@contextlib.contextmanager
+def generate(app_names, metadata_map, config_side_effect):
+    """Run `app_metadata_generate` against fake apps, yielding what it wrote to disk."""
+    written = {}
+
+    @contextlib.contextmanager
+    def fake_atomic_write(path, *args, **kwargs):
+        f = io.StringIO()
+        yield f
+        written[path] = safe_yaml_load(f.getvalue()) or {}
+
+    scandir = MagicMock()
+    scandir.return_value.__enter__.return_value = [FakeDirEntry(name) for name in app_names]
+
+    with (
+        patch("middlewared.plugins.apps.metadata.os.scandir", scandir),
+        patch("middlewared.plugins.apps.metadata.atomic_write", fake_atomic_write),
+        patch("middlewared.plugins.apps.metadata.get_app_metadata", side_effect=lambda name: metadata_map[name]),
+        patch("middlewared.plugins.apps.metadata.get_current_app_config", side_effect=config_side_effect),
+        patch("middlewared.plugins.apps.metadata.get_collective_metadata_path", return_value="metadata.yaml"),
+        patch("middlewared.plugins.apps.metadata.get_collective_config_path", return_value="user_config.yaml"),
+    ):
+        app_metadata_generate(MagicMock())
+
+    yield written["metadata.yaml"], written["user_config.yaml"]
+
+
+def test_healthy_apps_are_collected():
+    metadata_map = {"app-a": app_metadata(), "app-b": app_metadata("2.0.0")}
+    with generate(["app-a", "app-b"], metadata_map, lambda name, version: {"name": name}) as (metadata, config):
+        assert sorted(metadata) == ["app-a", "app-b"]
+        assert sorted(config) == ["app-a", "app-b"]
+
+
+@pytest.mark.parametrize(
+    "broken_metadata,failing_config",
+    [
+        # `version` is absent, so building the app's config raises KeyError
+        ({"custom_app": False, "metadata": {"name": "b", "train": "community"}}, False),
+        # `version` is present but the version directory is gone (mode 3)
+        (app_metadata(), True),
+    ],
+)
+def test_one_broken_app_does_not_stop_the_others(broken_metadata, failing_config):
+    metadata_map = {"app-a": app_metadata(), "app-broken": broken_metadata, "app-b": app_metadata("2.0.0")}
+
+    def get_config(name, version):
+        if name == "app-broken" and failing_config:
+            raise FileNotFoundError(2, "No such file or directory")
+        return {"name": name}
+
+    with generate(["app-a", "app-broken", "app-b"], metadata_map, get_config) as (metadata, config):
+        # The healthy apps still land on disk, and the broken one is left out of BOTH files so that
+        # consumers which index into the collective metadata directly cannot trip over it.
+        assert sorted(metadata) == ["app-a", "app-b"]
+        assert sorted(config) == ["app-a", "app-b"]
+
+
+def test_broken_app_is_logged(caplog):
+    metadata_map = {"app-broken": app_metadata()}
+
+    def get_config(name, version):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    # Bind to the named logger explicitly: `app_lifecycle` has propagation disabled once
+    # middlewared configures logging for real.
+    with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
+        with generate(["app-broken"], metadata_map, get_config) as (metadata, config):
+            assert metadata == {}
+            assert config == {}
+
+    assert "app-broken: skipped while generating app metadata" in caplog.text
+
+
+def test_unreadable_metadata_is_skipped():
+    # `get_app_metadata` collapses an unreadable/unparseable file to an empty dict
+    metadata_map = {"app-a": app_metadata(), "app-broken": {}}
+    with generate(["app-a", "app-broken"], metadata_map, lambda name, version: {"name": name}) as (metadata, config):
+        assert sorted(metadata) == ["app-a"]
+        assert sorted(config) == ["app-a"]

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
@@ -4,6 +4,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from middlewared.plugins.apps.metadata import app_metadata_generate
 from middlewared.utils.yaml import safe_yaml_load
@@ -68,7 +69,7 @@ def test_healthy_apps_are_collected():
     [
         # `version` is absent, so building the app's config raises KeyError
         ({"custom_app": False, "metadata": {"name": "b", "train": "community"}}, False),
-        # `version` is present but the version directory is gone (mode 3)
+        # `version` is present but its config cannot be read (mode 3)
         (app_metadata(), True),
     ],
 )
@@ -81,10 +82,36 @@ def test_one_broken_app_does_not_stop_the_others(broken_metadata, failing_config
         return {"name": name}
 
     with generate(["app-a", "app-broken", "app-b"], metadata_map, get_config) as (metadata, config):
-        # The healthy apps still land on disk, and the broken one is left out of BOTH files so that
-        # consumers which index into the collective metadata directly cannot trip over it.
-        assert sorted(metadata) == ["app-a", "app-b"]
+        # The healthy apps still land on disk, and so does the broken one's metadata - only the
+        # config it has none of is left out.
+        assert sorted(metadata) == ["app-a", "app-b", "app-broken"]
         assert sorted(config) == ["app-a", "app-b"]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileNotFoundError(2, "No such file or directory"),
+        IsADirectoryError(21, "Is a directory"),
+        yaml.YAMLError("could not parse"),
+        ValueError("not a mapping"),
+        KeyError("version"),
+    ],
+)
+def test_app_whose_config_cannot_be_read_keeps_its_metadata(error):
+    """
+    Whatever the app's config died of, its metadata stays in the collective file. Being absent from
+    that file is how an app becomes invisible to `app.query`, and an app nobody can see is an app
+    nobody can delete.
+    """
+    metadata_map = {"app-broken": app_metadata()}
+
+    def get_config(name, version):
+        raise error
+
+    with generate(["app-broken"], metadata_map, get_config) as (metadata, config):
+        assert sorted(metadata) == ["app-broken"]
+        assert config == {}
 
 
 def test_broken_app_is_logged(caplog):
@@ -97,10 +124,10 @@ def test_broken_app_is_logged(caplog):
     # middlewared configures logging for real.
     with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
         with generate(["app-broken"], metadata_map, get_config) as (metadata, config):
-            assert metadata == {}
+            assert sorted(metadata) == ["app-broken"]
             assert config == {}
 
-    assert "app-broken: skipped while generating app metadata" in caplog.text
+    assert "app-broken: app config could not be read" in caplog.text
 
 
 def test_unreadable_metadata_is_skipped():

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
@@ -6,7 +6,8 @@ from pydantic import ValidationError
 import pytest
 
 from middlewared.api.current import AppCreate
-from middlewared.plugins.apps.crud import create_app, to_app_entries, to_app_entry
+from middlewared.job import State
+from middlewared.plugins.apps.crud import apps_being_installed, create_app, to_app_entries, to_app_entry
 from middlewared.plugins.apps.ix_apps.query import get_default_workload_values
 from middlewared.service import ValidationErrors
 
@@ -172,3 +173,56 @@ def test_an_instance_which_is_already_installed_is_still_refused():
             pass
 
     assert "does not allow multiple instances" in str(exc_info.value)
+
+
+def installing_apps(*jobs):
+    """Run `apps_being_installed` against a job queue holding `jobs`."""
+    context = MagicMock()
+    context.middleware.jobs.all.return_value = dict(enumerate(jobs))
+    return apps_being_installed(context)
+
+
+def fake_job(method_name, args, state=State.RUNNING):
+    return types.SimpleNamespace(method_name=method_name, args=args, state=state)
+
+
+@pytest.mark.parametrize("state", [State.WAITING, State.RUNNING])
+def test_an_install_queued_with_a_raw_payload_is_reported(state):
+    job = fake_job("app.create", [{"app_name": "actual-budget"}], state)
+
+    assert installing_apps(job) == {"actual-budget"}
+
+
+def test_an_install_queued_with_a_validated_payload_is_reported():
+    payload = AppCreate(app_name="actual-budget", catalog_app="actual-budget", train="community", version="1.1.13")
+
+    assert installing_apps(fake_job("app.create", [payload])) == {"actual-budget"}
+
+
+def test_a_conversion_is_reported():
+    # Converting an app deletes and recreates it in place, and the job is handed the name itself
+    assert installing_apps(fake_job("app.convert_to_custom", ["actual-budget"])) == {"actual-budget"}
+
+
+@pytest.mark.parametrize("state", [State.SUCCESS, State.FAILED, State.ABORTED])
+def test_a_job_which_is_no_longer_running_is_ignored(state):
+    job = fake_job("app.create", [{"app_name": "actual-budget"}], state)
+
+    assert installing_apps(job) == set()
+
+
+def test_a_job_of_another_method_is_ignored():
+    assert installing_apps(fake_job("app.delete", ["actual-budget"])) == set()
+
+
+@pytest.mark.parametrize("args", [[], [{}], [None]])
+def test_a_job_we_cannot_name_an_app_from_is_ignored(args):
+    assert installing_apps(fake_job("app.create", args)) == set()
+
+
+def test_every_app_in_flight_is_reported():
+    assert installing_apps(
+        fake_job("app.create", [{"app_name": "actual-budget"}]),
+        fake_job("app.convert_to_custom", ["plex"]),
+        fake_job("app.create", [{"app_name": "syncthing"}], State.SUCCESS),
+    ) == {"actual-budget", "plex"}

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 import types
 from unittest.mock import MagicMock, patch
 
@@ -75,23 +74,6 @@ def test_row_with_a_non_string_key_is_reported_as_broken(key):
     entry = to_app_entry(app_row() | {key: "value"}, False)
 
     assert (entry.id, entry.state, entry.error_reason) == ("actual-budget", "ERROR", "METADATA_INCOMPLETE")
-
-
-def test_broken_row_is_logged(caplog):
-    # A change to the API model would land here for every app on the box, and would otherwise do so
-    # silently while blaming the user's on-disk files
-    with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
-        to_app_entry(app_row(version=1.13), False)
-
-    assert "actual-budget: reported as broken" in caplog.text
-
-
-def test_healthy_row_is_not_logged(caplog):
-    # `app.query` runs constantly, so the happy path has to stay quiet
-    with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
-        to_app_entry(app_row(), False)
-
-    assert "actual-budget" not in caplog.text
 
 
 def test_row_we_cannot_even_name_is_not_swallowed():

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import types
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,7 @@ from middlewared.api.current import AppCreate
 from middlewared.job import State
 from middlewared.plugins.apps.crud import apps_being_installed, create_app, to_app_entries, to_app_entry
 from middlewared.plugins.apps.ix_apps.query import get_default_workload_values
-from middlewared.service import ValidationErrors
+from middlewared.service import CallError, ValidationErrors
 
 
 def app_row(**overrides):
@@ -110,6 +111,22 @@ def test_broken_entry_reports_config_as_asked(retrieve_config, expected_config):
     assert entry.config == expected_config
 
 
+def test_an_app_we_cannot_name_does_not_fail_the_rest():
+    # `to_app_entry` has no entry it could report such a row as, and letting it re-raise returned
+    # nothing at all for every app on the box
+    rows = [app_row(), {"version": 1.13}, app_row(id="other", name="other")]
+
+    entries = to_app_entries(rows, False)
+
+    assert [entry.id for entry in entries] == ["actual-budget", "other"]
+
+
+def test_a_single_row_we_cannot_name_is_not_swallowed():
+    # `get: true` is typed as returning an entry, so there is nothing to leave out here
+    with pytest.raises(ValidationError):
+        to_app_entries({"version": 1.13}, False)
+
+
 def test_one_broken_app_does_not_fail_the_rest():
     rows = [
         app_row(),
@@ -148,6 +165,7 @@ def install(collective_metadata):
     context.call_sync2.return_value = APP_DETAILS
     with (
         patch("middlewared.plugins.apps.crud.query_apps", return_value=[]),
+        patch("middlewared.plugins.apps.crud.os.path.exists", return_value=False),
         patch("middlewared.plugins.apps.crud.get_collective_metadata", return_value=collective_metadata),
         patch("middlewared.plugins.apps.crud.create_internal") as create_internal,
     ):
@@ -173,6 +191,47 @@ def test_an_instance_which_is_already_installed_is_still_refused():
             pass
 
     assert "does not allow multiple instances" in str(exc_info.value)
+
+
+@pytest.fixture
+def app_configs(monkeypatch, tmp_path):
+    """Point the on-disk collision check of `create_app` at a directory the test controls."""
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.crud.get_installed_app_path", lambda app_name: str(tmp_path / app_name)
+    )
+    return tmp_path
+
+
+def create(app_name):
+    """Run `create_app` against a box with nothing installed, returning the install."""
+    context = MagicMock()
+    context.call_sync2.return_value = APP_DETAILS
+    with (
+        patch("middlewared.plugins.apps.crud.query_apps", return_value=[]),
+        patch("middlewared.plugins.apps.crud.get_collective_metadata", return_value={}),
+        patch("middlewared.plugins.apps.crud.create_internal") as create_internal,
+    ):
+        create_app(
+            context,
+            MagicMock(),
+            AppCreate(app_name=app_name, catalog_app="actual-budget", train="community", version="1.1.13"),
+        )
+        return create_internal
+
+
+def test_a_name_an_abandoned_directory_holds_is_refused(app_configs):
+    # The query cannot see this app: it runs inside the `app.create` job for the same name, which
+    # hides an app with no metadata and no containers as an install in flight
+    (app_configs / "budget-two").mkdir()
+
+    with pytest.raises(CallError) as exc_info:
+        create("budget-two")
+
+    assert exc_info.value.errno == errno.EEXIST
+
+
+def test_a_name_nothing_on_disk_holds_still_installs(app_configs):
+    assert create("budget-two").call_count == 1
 
 
 def installing_apps(*jobs):

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_apps_crud.py
@@ -1,0 +1,192 @@
+import contextlib
+import logging
+import types
+from unittest.mock import MagicMock, patch
+
+from pydantic import ValidationError
+import pytest
+
+from middlewared.api.current import AppCreate
+from middlewared.plugins.apps.crud import create_app, to_app_entries, to_app_entry
+from middlewared.plugins.apps.ix_apps.query import get_default_workload_values
+from middlewared.service import ValidationErrors
+
+
+def app_row(**overrides):
+    """A query row as `list_apps` builds it for a healthy app."""
+    return {
+        "name": "actual-budget",
+        "id": "actual-budget",
+        "state": "RUNNING",
+        "error_reason": None,
+        "upgrade_available": False,
+        "latest_version": None,
+        "latest_app_version": None,
+        "image_updates_available": False,
+        "custom_app": False,
+        "migrated": False,
+        "human_version": "24.10.1_1.1.13",
+        "version": "1.1.13",
+        "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
+        "active_workloads": get_default_workload_values(),
+        "notes": None,
+        "action_required": False,
+        "portals": {},
+        "version_details": None,
+        "config": None,
+    } | overrides
+
+
+def test_valid_row_is_converted():
+    entry = to_app_entry(app_row(), False)
+
+    assert (entry.id, entry.state, entry.version) == ("actual-budget", "RUNNING", "1.1.13")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # yaml parses an unquoted 1.13 as a float, and 1.1.13 as a string
+        {"version": 1.13},
+        {"version": ""},
+        {"human_version": []},
+        {"custom_app": "maybe"},
+        {"notes": ["a", "b"]},
+        {"portals": "http://0.0.0.0:8080"},
+        {"metadata": "actual-budget"},
+        {"action_required": "yes"},
+        # A key the model knows nothing about, which it reports as an extra input
+        {"some_new_key": "value"},
+    ],
+)
+def test_row_the_model_rejects_is_reported_as_broken(overrides):
+    entry = to_app_entry(app_row(**overrides), False)
+
+    assert entry.state == "ERROR"
+    assert entry.error_reason == "METADATA_INCOMPLETE"
+    assert entry.version is None
+    assert entry.human_version is None
+
+
+@pytest.mark.parametrize("key", [True, 5, None])
+def test_row_with_a_non_string_key_is_reported_as_broken(key):
+    # `on:` parses as the bool True and `5:` as an int, and splatting such a row would raise
+    # TypeError rather than anything a validation handler could catch
+    entry = to_app_entry(app_row() | {key: "value"}, False)
+
+    assert (entry.id, entry.state, entry.error_reason) == ("actual-budget", "ERROR", "METADATA_INCOMPLETE")
+
+
+def test_broken_row_is_logged(caplog):
+    # A change to the API model would land here for every app on the box, and would otherwise do so
+    # silently while blaming the user's on-disk files
+    with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
+        to_app_entry(app_row(version=1.13), False)
+
+    assert "actual-budget: reported as broken" in caplog.text
+
+
+def test_healthy_row_is_not_logged(caplog):
+    # `app.query` runs constantly, so the happy path has to stay quiet
+    with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
+        to_app_entry(app_row(), False)
+
+    assert "actual-budget" not in caplog.text
+
+
+def test_row_we_cannot_even_name_is_not_swallowed():
+    # Only a query which selected neither `name` nor `id` produces a row of this shape, and there is
+    # no entry we could report such an app as
+    with pytest.raises(ValidationError):
+        to_app_entry({"version": 1.13}, False)
+
+
+def test_real_workloads_are_kept_when_they_are_usable():
+    # They are what keeps the ports and volumes a broken app is still holding on to visible
+    workloads = get_default_workload_values() | {"containers": 2, "used_host_ips": ["10.0.0.1"]}
+
+    entry = to_app_entry(app_row(version=1.13, active_workloads=workloads), False)
+
+    assert entry.state == "ERROR"
+    assert entry.active_workloads.containers == 2
+    assert entry.active_workloads.used_host_ips == ["10.0.0.1"]
+
+
+def test_unusable_workloads_are_dropped():
+    entry = to_app_entry(app_row(active_workloads={"containers": "two"}), False)
+
+    assert entry.state == "ERROR"
+    assert entry.active_workloads.containers == 0
+    assert entry.active_workloads.used_ports == []
+
+
+@pytest.mark.parametrize("retrieve_config,expected_config", [(True, {}), (False, None)])
+def test_broken_entry_reports_config_as_asked(retrieve_config, expected_config):
+    entry = to_app_entry(app_row(version=1.13), retrieve_config)
+
+    assert entry.config == expected_config
+
+
+def test_one_broken_app_does_not_fail_the_rest():
+    rows = [
+        app_row(),
+        app_row(id="broken", name="broken", version=1.13),
+        app_row(id="other", name="other"),
+    ]
+
+    entries = to_app_entries(rows, False)
+
+    assert [(entry.id, entry.state) for entry in entries] == [
+        ("actual-budget", "RUNNING"),
+        ("broken", "ERROR"),
+        ("other", "RUNNING"),
+    ]
+
+
+def test_count_is_passed_through():
+    assert to_app_entries(3, False) == 3
+
+
+def test_single_row_is_converted():
+    # `app.query` with `get: true` hands us the row on its own rather than in a list
+    assert to_app_entries(app_row(), False).id == "actual-budget"
+
+
+APP_DETAILS = types.SimpleNamespace(
+    versions={"1.1.13": {"app_metadata": {"annotations": {"disallow_multiple_instances": True}}}},
+)
+INSTALLED_METADATA = {"metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"}}
+
+
+@contextlib.contextmanager
+def install(collective_metadata):
+    """Run `create_app` for an app which does not allow multiple instances, yielding the install."""
+    context = MagicMock()
+    context.call_sync2.return_value = APP_DETAILS
+    with (
+        patch("middlewared.plugins.apps.crud.query_apps", return_value=[]),
+        patch("middlewared.plugins.apps.crud.get_collective_metadata", return_value=collective_metadata),
+        patch("middlewared.plugins.apps.crud.create_internal") as create_internal,
+    ):
+        create_app(
+            context,
+            MagicMock(),
+            AppCreate(app_name="budget-two", catalog_app="actual-budget", train="community", version="1.1.13"),
+        )
+        yield create_internal
+
+
+@pytest.mark.parametrize("installed_app", ["actual-budget", 1, ["actual-budget"], {"metadata": "actual-budget"}])
+def test_broken_app_does_not_block_installing_an_unrelated_one(installed_app):
+    # An entry of the collective metadata is whatever yaml parsed it as, and reading into it blindly
+    # made an install fail because of an app which has nothing to do with it
+    with install({"broken": installed_app}) as create_internal:
+        assert create_internal.call_count == 1
+
+
+def test_an_instance_which_is_already_installed_is_still_refused():
+    with pytest.raises(ValidationErrors) as exc_info:
+        with install({"broken": "actual-budget", "actual-budget": INSTALLED_METADATA}):
+            pass
+
+    assert "does not allow multiple instances" in str(exc_info.value)

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_assert_app_usable.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_assert_app_usable.py
@@ -1,0 +1,34 @@
+import unittest.mock
+
+import pytest
+
+from middlewared.plugins.apps.utils import app_version, assert_app_usable
+from middlewared.service import CallError
+
+
+def app(state, **kwargs):
+    return unittest.mock.Mock(id="actual-budget", state=state, **kwargs)
+
+
+@pytest.mark.parametrize("state", ["CRASHED", "DEPLOYING", "RUNNING", "STOPPED", "STOPPING"])
+def test_usable_states_are_allowed(state):
+    assert_app_usable(app(state))
+
+
+def test_error_state_is_refused():
+    with pytest.raises(CallError) as exc_info:
+        assert_app_usable(app("ERROR", error_reason="METADATA_UNREADABLE"))
+
+    # The reason belongs in the message, it is the only clue as to what to look at on disk
+    assert "METADATA_UNREADABLE" in str(exc_info.value)
+    assert "actual-budget" in str(exc_info.value)
+
+
+def test_app_version_returns_the_version():
+    assert app_version(app("RUNNING", version="1.1.13")) == "1.1.13"
+
+
+def test_app_version_refuses_an_app_without_one():
+    # Reaching this means an operation is missing its `assert_app_usable` call
+    with pytest.raises(AssertionError):
+        app_version(app("ERROR", version=None))

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps.py
@@ -66,14 +66,16 @@ def common_impl(
     mock_list_resources_by_project.return_value = collections.defaultdict(None, workload)
     mock_translate_resources_to_desired_workflow.return_value = workload['ix-actual-budget']
     mock_upgrade_available_for_app.return_value = (False, '1.21.0', '1.0.0')
-    mock_entry1 = unittest.mock.Mock(is_file=lambda: True, name='config1.json')
-    scandir.return_value.__enter__.return_value = [mock_entry1]
+    # These tests are about apps which have docker resources, so there is nothing for the
+    # `app_configs` scan to pick up
+    scandir.return_value.__enter__.return_value = []
 
     result = list_apps(AVAILABLE_MAPPING, **KWARGS)
     assert result is not None
     assert isinstance(result, list)
     assert isinstance(result[0], dict)
     assert result[0]['state'] == desired_state
+    assert result[0]['error_reason'] is None
 
 
 @pytest.mark.parametrize(

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
@@ -265,6 +265,84 @@ def test_config_which_cannot_be_read_does_not_break_the_query(query, monkeypatch
     assert [(app["id"], app["error_reason"], app["config"]) for app in apps] == [("actual-budget", None, {})]
 
 
+@pytest.mark.parametrize("project_name", ["webserver", "portainer", "ix-"])
+def test_a_compose_project_which_is_not_ours_is_not_an_app(query, monkeypatch, project_name):
+    # Docker reports every compose project on the box, and taking the prefix off a name which does
+    # not carry one invents an app the UI then offers to delete - against a name which is not ours
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.metadata.get_app_metadata_checked",
+        lambda app_name: ({}, "METADATA_MISSING"),
+    )
+
+    assert query({}, resources={project_name: RESOURCES["ix-actual-budget"]}) == []
+
+
+def test_a_compose_project_which_is_not_ours_does_not_hide_a_real_app(query):
+    # `webserver` reads as an app named `server`, which filters the real one out of the stopped loop
+    # and lends it containers it does not own
+    apps = query(
+        {"server": COMPLETE_METADATA},
+        resources={"webserver": RESOURCES["ix-actual-budget"]},
+        config_dirs=["server"],
+    )
+
+    assert [(app["id"], app["state"], app["active_workloads"]["containers"]) for app in apps] == [
+        ("server", "STOPPED", 0)
+    ]
+
+
+@pytest.mark.parametrize("collective_config", ["some-config", 1, ["key"], True])
+def test_collective_config_which_is_not_a_mapping_does_not_break_the_app(query, monkeypatch, collective_config):
+    # An entry of the collective config file is whatever yaml parsed it as, and reporting a value
+    # the API model cannot describe turned a healthy running app into a broken one
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.query.get_current_app_config", lambda app_name, version: {"own": True}
+    )
+    apps = query(
+        {"actual-budget": COMPLETE_METADATA},
+        resources=RESOURCES,
+        collective_config={"actual-budget": collective_config},
+        retrieve_config=True,
+    )
+
+    assert [(app["id"], app["state"], app["error_reason"], app["config"]) for app in apps] == [
+        ("actual-budget", "RUNNING", None, {"own": True})
+    ]
+
+
+@pytest.mark.parametrize("collective_config", ["some-config", 1, ["key"], True])
+def test_an_app_whose_collective_config_is_not_a_mapping_still_converts(query, monkeypatch, collective_config):
+    # Where the harm lands: the row reaches the API model, which describes `config` as a mapping
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.query.get_current_app_config", lambda app_name, version: {"own": True}
+    )
+    apps = query(
+        {"actual-budget": COMPLETE_METADATA},
+        resources=RESOURCES,
+        collective_config={"actual-budget": collective_config},
+        retrieve_config=True,
+    )
+
+    entry = to_app_entry(apps[0], True)
+
+    assert (entry.state, entry.error_reason, entry.config) == ("RUNNING", None, {"own": True})
+
+
+def test_a_collective_config_which_is_a_mapping_is_still_used(query, monkeypatch):
+    def unread_config(app_name, version):
+        raise AssertionError("the app's own config file was read instead of the collective one")
+
+    monkeypatch.setattr("middlewared.plugins.apps.ix_apps.query.get_current_app_config", unread_config)
+    apps = query(
+        {"actual-budget": COMPLETE_METADATA},
+        resources=RESOURCES,
+        collective_config={"actual-budget": {"key": "value"}},
+        retrieve_config=True,
+    )
+
+    assert apps[0]["config"] == {"key": "value"}
+
+
 @pytest.mark.parametrize("portals", ["http://0.0.0.0:8080", 1, ["http://0.0.0.0:8080"]])
 def test_portals_which_cannot_be_normalized_are_returned_untouched(portals):
     # `to_app_entry` is what reports such an app as broken, and it can only do so if what it is

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
@@ -3,6 +3,7 @@ import unittest.mock
 import pytest
 
 from middlewared.api.current import AppEntry
+from middlewared.plugins.apps.crud import to_app_entry
 from middlewared.plugins.apps.ix_apps.query import error_app_data, list_apps, normalize_portal_uris
 
 INCOMPLETE_METADATA = {"version": "1.1.13"}
@@ -15,6 +16,7 @@ COMPLETE_METADATA = {
     "portals": {},
     "version": "1.1.13",
 }
+METADATA_WITHOUT_DEFAULTS = {k: v for k, v in COMPLETE_METADATA.items() if k not in ("migrated", "notes")}
 RESOURCES = {
     "ix-actual-budget": {
         "containers": [
@@ -126,7 +128,34 @@ def test_stopped_app_without_metadata_is_ignored_while_installing(query, monkeyp
         lambda app_name: ({}, "METADATA_MISSING"),
     )
 
-    assert query({}, config_dirs=["actual-budget"], installing={"actual-budget"}) == []
+    assert query({}, config_dirs=["actual-budget"], installing=lambda: {"actual-budget"}) == []
+
+
+def test_the_job_queue_is_not_walked_for_a_healthy_system(query):
+    # Answering what is installing walks every job on the box, and app.query runs constantly
+    def installing():
+        raise AssertionError("the job queue was walked for an app which could not be mid-install")
+
+    apps = query({"actual-budget": COMPLETE_METADATA}, resources=RESOURCES, installing=installing)
+
+    assert apps[0]["error_reason"] is None
+
+
+def test_the_job_queue_is_walked_once_for_apps_missing_their_metadata(query, monkeypatch):
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.metadata.get_app_metadata_checked",
+        lambda app_name: ({}, "METADATA_MISSING"),
+    )
+    asked = []
+
+    def installing():
+        asked.append(None)
+        return {"app-a"}
+
+    apps = query({}, config_dirs=["app-a", "app-b", "app-c"], installing=installing)
+
+    assert [app["id"] for app in apps] == ["app-b", "app-c"]
+    assert len(asked) == 1
 
 
 def test_healthy_apps_are_unaffected(query):
@@ -135,6 +164,41 @@ def test_healthy_apps_are_unaffected(query):
     assert apps[0]["state"] == "RUNNING"
     assert apps[0]["error_reason"] is None
     assert apps[0]["version"] == "1.1.13"
+
+
+@pytest.mark.parametrize(
+    "resources,config_dirs,state", [(RESOURCES, (), "RUNNING"), (None, ["actual-budget"], "STOPPED")]
+)
+def test_metadata_without_the_defaulted_keys_is_usable(query, resources, config_dirs, state):
+    # Metadata written by an older release, or hand edited, can be missing these. Checked for a
+    # running app and a stopped one, i.e. both loops in `list_apps`.
+    apps = query({"actual-budget": METADATA_WITHOUT_DEFAULTS}, resources=resources, config_dirs=config_dirs)
+
+    assert apps[0]["state"] == state
+    assert apps[0]["error_reason"] is None
+    assert (apps[0]["migrated"], apps[0]["notes"]) == (False, None)
+
+
+@pytest.mark.parametrize(
+    "resources,config_dirs,state", [(RESOURCES, (), "RUNNING"), (None, ["actual-budget"], "STOPPED")]
+)
+def test_an_app_without_the_defaulted_keys_survives_the_conversion(query, resources, config_dirs, state):
+    # A query result makes every field optional, so a row missing these converts without complaint
+    # and only the entry itself shows whether they were defaulted or left undefined
+    apps = query({"actual-budget": METADATA_WITHOUT_DEFAULTS}, resources=resources, config_dirs=config_dirs)
+
+    entry = to_app_entry(apps[0], False)
+
+    assert (entry.state, entry.error_reason) == (state, None)
+    assert (entry.migrated, entry.notes) == (False, None)
+
+
+def test_metadata_which_carries_the_defaulted_keys_keeps_them(query):
+    metadata = COMPLETE_METADATA | {"migrated": True, "notes": "Some notes"}
+
+    apps = query({"actual-budget": metadata}, resources=RESOURCES)
+
+    assert (apps[0]["migrated"], apps[0]["notes"]) == (True, "Some notes")
 
 
 @pytest.mark.parametrize(

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
@@ -1,0 +1,158 @@
+import unittest.mock
+
+import pytest
+
+from middlewared.api.current import AppEntry
+from middlewared.plugins.apps.ix_apps.query import error_app_data, list_apps
+
+INCOMPLETE_METADATA = {"version": "1.1.13"}
+RESOURCES = {
+    "ix-actual-budget": {
+        "containers": [
+            {
+                "Config": {"Labels": {"com.docker.compose.service": "web"}, "Image": "nginx:latest"},
+                "State": {"Status": "running"},
+                "NetworkSettings": {"Ports": {"80/tcp": [{"HostPort": "8080", "HostIp": "0.0.0.0"}]}},
+                "Mounts": [],
+                "Id": "abc123",
+            }
+        ],
+        "networks": [],
+    }
+}
+
+
+class FakeDirEntry:
+    def __init__(self, name):
+        self.name = name
+
+    def is_dir(self):
+        return True
+
+
+@pytest.fixture
+def query(monkeypatch):
+    """Drive `list_apps` with a given collective metadata, docker resources and app_configs listing."""
+
+    def run(collective_metadata, resources=None, config_dirs=(), installing=None, **kwargs):
+        monkeypatch.setattr(
+            "middlewared.plugins.apps.ix_apps.query.get_collective_metadata", lambda: collective_metadata
+        )
+        monkeypatch.setattr(
+            "middlewared.plugins.apps.ix_apps.query.list_resources_by_project", lambda **kw: resources or {}
+        )
+        scandir = unittest.mock.MagicMock()
+        scandir.return_value.__enter__.return_value = [FakeDirEntry(name) for name in config_dirs]
+        with unittest.mock.patch("os.scandir", scandir):
+            return list_apps({}, installing=installing, **kwargs)
+
+    return run
+
+
+def test_app_with_resources_and_incomplete_metadata_is_reported(query):
+    apps = query({"actual-budget": INCOMPLETE_METADATA}, resources=RESOURCES)
+
+    assert len(apps) == 1
+    assert apps[0]["state"] == "ERROR"
+    assert apps[0]["error_reason"] == "METADATA_INCOMPLETE"
+    assert apps[0]["version"] is None
+    assert apps[0]["human_version"] is None
+
+
+def test_app_with_resources_keeps_its_real_workloads(query):
+    # Otherwise the ports it is still holding become invisible to conflict detection
+    apps = query({"actual-budget": INCOMPLETE_METADATA}, resources=RESOURCES)
+
+    workloads = apps[0]["active_workloads"]
+    assert workloads["containers"] == 1
+    assert workloads["used_ports"][0]["host_ports"][0]["host_port"] == 8080
+    assert workloads["images"] == ["nginx:latest"]
+
+
+def test_app_missing_from_collective_metadata_is_reported(query, monkeypatch):
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.query.resolve_app_metadata",
+        lambda *args: ({}, "METADATA_UNREADABLE", True),
+    )
+    apps = query({}, resources=RESOURCES)
+
+    assert [(app["id"], app["state"], app["error_reason"]) for app in apps] == [
+        ("actual-budget", "ERROR", "METADATA_UNREADABLE")
+    ]
+
+
+def test_app_whose_own_metadata_is_intact_is_ignored(query, monkeypatch):
+    # An install or delete in flight, or a collective metadata file which is itself unreadable
+    monkeypatch.setattr("middlewared.plugins.apps.ix_apps.query.resolve_app_metadata", lambda *args: ({}, None, False))
+
+    assert query({}, resources=RESOURCES) == []
+
+
+def test_stopped_app_with_incomplete_metadata_is_reported(query):
+    apps = query({"actual-budget": INCOMPLETE_METADATA}, config_dirs=["actual-budget"])
+
+    assert len(apps) == 1
+    assert apps[0]["state"] == "ERROR"
+    assert apps[0]["error_reason"] == "METADATA_INCOMPLETE"
+    assert apps[0]["active_workloads"]["containers"] == 0
+    assert apps[0]["active_workloads"]["used_ports"] == []
+
+
+def test_stopped_app_without_metadata_is_reported(query, monkeypatch):
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.metadata.get_app_metadata_checked",
+        lambda app_name: ({}, "METADATA_MISSING"),
+    )
+    apps = query({}, config_dirs=["actual-budget"])
+
+    assert [(app["id"], app["error_reason"]) for app in apps] == [("actual-budget", "METADATA_MISSING")]
+
+
+def test_stopped_app_without_metadata_is_ignored_while_installing(query, monkeypatch):
+    monkeypatch.setattr(
+        "middlewared.plugins.apps.ix_apps.metadata.get_app_metadata_checked",
+        lambda app_name: ({}, "METADATA_MISSING"),
+    )
+
+    assert query({}, config_dirs=["actual-budget"], installing={"actual-budget"}) == []
+
+
+def test_healthy_apps_are_unaffected(query):
+    metadata = {
+        "actual-budget": {
+            "custom_app": False,
+            "human_version": "24.10.1_1.1.13",
+            "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
+            "migrated": False,
+            "notes": None,
+            "portals": {},
+            "version": "1.1.13",
+        }
+    }
+    apps = query(metadata, resources=RESOURCES)
+
+    assert apps[0]["state"] == "RUNNING"
+    assert apps[0]["error_reason"] is None
+    assert apps[0]["version"] == "1.1.13"
+
+
+@pytest.mark.parametrize("retrieve_config,expected_config", [(True, {}), (False, None)])
+def test_error_entry_is_accepted_by_the_api_model(retrieve_config, expected_config):
+    entry = error_app_data(
+        "actual-budget",
+        "METADATA_MISSING",
+        {
+            "containers": 0,
+            "used_ports": [],
+            "used_host_ips": [],
+            "container_details": [],
+            "volumes": [],
+            "images": [],
+            "networks": [],
+        },
+        retrieve_config,
+    )
+
+    assert entry["config"] == expected_config
+    # Constructing this is what `app.query` does with every row it returns
+    AppEntry.__query_result_item__(**entry)

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
@@ -3,9 +3,18 @@ import unittest.mock
 import pytest
 
 from middlewared.api.current import AppEntry
-from middlewared.plugins.apps.ix_apps.query import error_app_data, list_apps
+from middlewared.plugins.apps.ix_apps.query import error_app_data, list_apps, normalize_portal_uris
 
 INCOMPLETE_METADATA = {"version": "1.1.13"}
+COMPLETE_METADATA = {
+    "custom_app": False,
+    "human_version": "24.10.1_1.1.13",
+    "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
+    "migrated": False,
+    "notes": None,
+    "portals": {},
+    "version": "1.1.13",
+}
 RESOURCES = {
     "ix-actual-budget": {
         "containers": [
@@ -34,9 +43,12 @@ class FakeDirEntry:
 def query(monkeypatch):
     """Drive `list_apps` with a given collective metadata, docker resources and app_configs listing."""
 
-    def run(collective_metadata, resources=None, config_dirs=(), installing=None, **kwargs):
+    def run(collective_metadata, resources=None, config_dirs=(), installing=None, collective_config=None, **kwargs):
         monkeypatch.setattr(
             "middlewared.plugins.apps.ix_apps.query.get_collective_metadata", lambda: collective_metadata
+        )
+        monkeypatch.setattr(
+            "middlewared.plugins.apps.ix_apps.query.get_collective_config", lambda: collective_config or {}
         )
         monkeypatch.setattr(
             "middlewared.plugins.apps.ix_apps.query.list_resources_by_project", lambda **kw: resources or {}
@@ -118,22 +130,54 @@ def test_stopped_app_without_metadata_is_ignored_while_installing(query, monkeyp
 
 
 def test_healthy_apps_are_unaffected(query):
-    metadata = {
-        "actual-budget": {
-            "custom_app": False,
-            "human_version": "24.10.1_1.1.13",
-            "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.13"},
-            "migrated": False,
-            "notes": None,
-            "portals": {},
-            "version": "1.1.13",
-        }
-    }
-    apps = query(metadata, resources=RESOURCES)
+    apps = query({"actual-budget": COMPLETE_METADATA}, resources=RESOURCES)
 
     assert apps[0]["state"] == "RUNNING"
     assert apps[0]["error_reason"] is None
     assert apps[0]["version"] == "1.1.13"
+
+
+@pytest.mark.parametrize("app_metadata", ["actual-budget", 1, 1.13, ["actual-budget"]])
+def test_metadata_entry_which_is_not_a_mapping_is_reported(query, app_metadata):
+    # An entry of the collective metadata file is whatever yaml parsed it as, and testing a
+    # non-mapping for the keys we need raises rather than answering
+    apps = query({"actual-budget": app_metadata}, resources=RESOURCES)
+
+    assert [(app["id"], app["state"], app["error_reason"]) for app in apps] == [
+        ("actual-budget", "ERROR", "METADATA_INCOMPLETE")
+    ]
+
+
+@pytest.mark.parametrize("resources,config_dirs", [(RESOURCES, ()), (None, ["actual-budget"])])
+def test_config_which_cannot_be_read_does_not_break_the_query(query, monkeypatch, resources, config_dirs):
+    """
+    An app whose config could not be read now survives into the collective metadata, so the query
+    reaches this file again - and letting the second failure escape would take `app.query` down for
+    every app on the box. Checked for a running app and a stopped one, i.e. both loops in `list_apps`.
+    """
+
+    def unreadable_config(app_name, version):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr("middlewared.plugins.apps.ix_apps.query.get_current_app_config", unreadable_config)
+    apps = query(
+        {"actual-budget": COMPLETE_METADATA}, resources=resources, config_dirs=config_dirs, retrieve_config=True
+    )
+
+    assert [(app["id"], app["error_reason"], app["config"]) for app in apps] == [("actual-budget", None, {})]
+
+
+@pytest.mark.parametrize("portals", ["http://0.0.0.0:8080", 1, ["http://0.0.0.0:8080"]])
+def test_portals_which_cannot_be_normalized_are_returned_untouched(portals):
+    # `to_app_entry` is what reports such an app as broken, and it can only do so if what it is
+    # handed still carries the value the model will reject
+    assert normalize_portal_uris(portals, "10.0.0.1") == portals
+
+
+def test_portal_uris_which_are_not_strings_are_left_alone():
+    portals = {"web": 8080, "ui": "http://0.0.0.0:8081"}
+
+    assert normalize_portal_uris(portals, "10.0.0.1") == {"web": 8080, "ui": "http://10.0.0.1:8081"}
 
 
 @pytest.mark.parametrize("retrieve_config,expected_config", [(True, {}), (False, None)])

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_list_apps_error_state.py
@@ -137,6 +137,40 @@ def test_healthy_apps_are_unaffected(query):
     assert apps[0]["version"] == "1.1.13"
 
 
+@pytest.mark.parametrize(
+    "overrides,key,expected",
+    [
+        ({"name": 1}, "name", "actual-budget"),
+        ({"id": 1}, "id", "actual-budget"),
+        ({"state": "SOMETHING"}, "state", "RUNNING"),
+        ({"error_reason": "METADATA_MISSING"}, "error_reason", None),
+        ({"upgrade_available": "yes"}, "upgrade_available", False),
+        ({"version_details": "none"}, "version_details", None),
+    ],
+)
+def test_metadata_does_not_override_what_we_determined_ourselves(query, overrides, key, expected):
+    # A metadata supplied `id` would leave the app undeletable, since `get_instance` looks it up by
+    # the name it was asked for, and the rest blind the checks which act on the state we reported
+    apps = query({"actual-budget": COMPLETE_METADATA | overrides}, resources=RESOURCES)
+
+    assert apps[0][key] == expected
+
+
+def test_metadata_does_not_override_the_workloads(query):
+    # These are what keeps the ports and volumes the app is holding visible to conflict detection
+    apps = query({"actual-budget": COMPLETE_METADATA | {"active_workloads": "none"}}, resources=RESOURCES)
+
+    assert apps[0]["active_workloads"]["containers"] == 1
+
+
+def test_metadata_the_api_model_cannot_describe_reaches_the_conversion(query):
+    # The row stays everything the metadata file holds, so that `to_app_entry` is the one which
+    # decides an app cannot be described rather than this silently dropping what it would reject
+    apps = query({"actual-budget": COMPLETE_METADATA | {"some_new_key": "value"}}, resources=RESOURCES)
+
+    assert apps[0]["some_new_key"] == "value"
+
+
 @pytest.mark.parametrize("app_metadata", ["actual-budget", 1, 1.13, ["actual-budget"]])
 def test_metadata_entry_which_is_not_a_mapping_is_reported(query, app_metadata):
     # An entry of the collective metadata file is whatever yaml parsed it as, and testing a

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
@@ -1,0 +1,60 @@
+import pytest
+
+from middlewared.plugins.apps.ix_apps.query import upgrade_available_for_app
+
+VERSION_MAPPING = {
+    "community": {
+        "actual-budget": {"version": "1.1.13", "app_version": "24.10.1"},
+    },
+}
+
+
+def complete_metadata():
+    return {
+        "custom_app": False,
+        "human_version": "24.10.1_1.1.0",
+        "metadata": {"name": "actual-budget", "train": "community", "version": "1.1.0"},
+        "migrated": False,
+        "portals": {},
+        "version": "1.1.0",
+    }
+
+
+def test_upgrade_available_for_complete_metadata():
+    upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(
+        VERSION_MAPPING, complete_metadata()
+    )
+    assert upgrade_available is True
+    assert latest_version == "1.1.13"
+    assert latest_app_version == "24.10.1"
+
+
+@pytest.mark.parametrize(
+    "app_metadata",
+    [
+        # Nothing at all
+        {},
+        # Missing the catalog metadata dict entirely
+        {"custom_app": False, "version": "1.1.0"},
+        # Catalog metadata present but missing each key upgrade detection indexes
+        {"custom_app": False, "metadata": {"train": "community", "version": "1.1.0"}},
+        {"custom_app": False, "metadata": {"name": "actual-budget", "version": "1.1.0"}},
+        {"custom_app": False, "metadata": {"name": "actual-budget", "train": "community"}},
+        # Catalog metadata is not even a mapping
+        {"custom_app": False, "metadata": None},
+        # Missing custom_app, which decides which branch we take
+        {"metadata": {"name": "actual-budget", "train": "community", "version": "1.1.0"}},
+    ],
+)
+def test_unusable_metadata_does_not_raise(app_metadata):
+    assert upgrade_available_for_app(VERSION_MAPPING, app_metadata) == (False, None, None)
+
+
+@pytest.mark.parametrize("app_metadata", [{}, {"custom_app": True}, {"custom_app": True, "metadata": None}])
+def test_unusable_metadata_with_image_updates_does_not_raise(app_metadata):
+    upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(
+        VERSION_MAPPING, app_metadata, image_updates_available=True
+    )
+    assert upgrade_available is bool(app_metadata.get("custom_app"))
+    assert latest_version is None
+    assert latest_app_version is None

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
@@ -50,6 +50,36 @@ def test_unusable_metadata_does_not_raise(app_metadata):
     assert upgrade_available_for_app(VERSION_MAPPING, app_metadata) == (False, None, None)
 
 
+@pytest.mark.parametrize("installed_version", ["latest", "", "not a version", "1.1.13/../..", 1.13, None, []])
+def test_installed_version_which_cannot_be_parsed_does_not_raise(installed_version):
+    # `Version` raises `InvalidVersion` on anything it cannot parse, and an app whose versions
+    # cannot be compared simply has no upgrade available
+    app_metadata = complete_metadata()
+    app_metadata["metadata"]["version"] = installed_version
+
+    assert upgrade_available_for_app(VERSION_MAPPING, app_metadata) == (False, None, None)
+
+
+@pytest.mark.parametrize("latest_version", ["latest", "", "not a version", None])
+def test_catalog_version_which_cannot_be_parsed_does_not_raise(latest_version):
+    version_mapping = {"community": {"actual-budget": {"version": latest_version, "app_version": "24.10.1"}}}
+
+    assert upgrade_available_for_app(version_mapping, complete_metadata()) == (False, None, None)
+
+
+def test_catalog_entry_without_a_version_does_not_raise():
+    version_mapping = {"community": {"actual-budget": {"app_version": "24.10.1"}}}
+
+    assert upgrade_available_for_app(version_mapping, complete_metadata()) == (False, None, None)
+
+
+def test_unparseable_installed_version_still_reports_image_updates_for_a_custom_app():
+    app_metadata = complete_metadata() | {"custom_app": True}
+    app_metadata["metadata"]["version"] = "latest"
+
+    assert upgrade_available_for_app(VERSION_MAPPING, app_metadata, image_updates_available=True) == (True, None, None)
+
+
 @pytest.mark.parametrize("app_metadata", [{}, {"custom_app": True}, {"custom_app": True, "metadata": None}])
 def test_unusable_metadata_with_image_updates_does_not_raise(app_metadata):
     upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -388,3 +388,81 @@ def test_drift_repair_ix_apps(docker_pool):
     # runs the drift-repair enforce_mountpoint_perms call.
     call("docker.start_service")
     assert _chokepoint_perms(IX_APPS_CHOKEPOINT) == (0o700, 0, 0)
+
+
+@pytest.mark.parametrize("corrupt,expected_reason", [
+    # Keeps `version`, so the incomplete metadata still lands in the collective metadata file and
+    # the app is classified from it without any extra read
+    (
+        "python3 -c \"import yaml,sys;p=sys.argv[1];d=yaml.safe_load(open(p));d.pop('metadata');"
+        "open(p,'w').write(yaml.safe_dump(d))\" {path}",
+        "METADATA_INCOMPLETE",
+    ),
+    # Unparseable, so the app is dropped from the collective metadata entirely and has to be
+    # classified by reading its own metadata file
+    ("printf '{{' > {path}", "METADATA_UNREADABLE"),
+])
+def test_app_with_unusable_metadata_is_reported_and_deletable(docker_pool, corrupt, expected_reason):
+    """
+    An app we cannot read the metadata of used to be invisible to `app.query`, which left no way to
+    remove it. It must now be reported, refused for everything but deletion, and actually deletable.
+    """
+    app_name = "actual-budget"
+    metadata_path = f"/mnt/.ix-apps/app_configs/{app_name}/metadata.yaml"
+    call(
+        "app.create",
+        {"app_name": app_name, "train": "community", "catalog_app": app_name},
+        job=True,
+    )
+    deleted = False
+    try:
+        ssh(f"cp {metadata_path} /tmp/{app_name}.metadata.bak")
+        ssh(corrupt.format(path=metadata_path))
+        call("app.metadata_generate", job=True)
+
+        app_info = call("app.query", [["id", "=", app_name]], {"get": True})
+        assert app_info["state"] == "ERROR", app_info
+        assert app_info["error_reason"] == expected_reason, app_info
+        assert app_info["version"] is None, app_info
+        assert app_info["human_version"] is None, app_info
+        assert app_info["metadata"] == {}, app_info
+
+        # Its containers are still running, so the ports they hold must stay accounted for
+        used_ports = app_info["active_workloads"]["used_ports"]
+        assert used_ports, app_info
+        assert used_ports[0]["host_ports"][0]["host_port"] in call("app.used_ports")
+
+        # One broken app must not take the rest of the apps subsystem down with it
+        assert call("app.query")
+        assert call("app.available", [["name", "=", app_name]])
+
+        for method, args, is_job in (
+            ("app.start", [app_name], True),
+            ("app.stop", [app_name], True),
+            ("app.redeploy", [app_name], True),
+            ("app.config", [app_name], False),
+            ("app.rollback_versions", [app_name], False),
+            ("app.outdated_docker_images", [app_name], False),
+            ("app.container_console_choices", [app_name], False),
+            ("app.convert_to_custom", [app_name], True),
+        ):
+            with pytest.raises(Exception) as exc_info:
+                call(method, *args, job=is_job)
+            assert "metadata is unusable" in str(exc_info.value), (method, exc_info.value)
+
+        call("app.delete", app_name, {"remove_images": True, "remove_ix_volumes": True}, job=True)
+        deleted = True
+
+        assert call("app.query", [["id", "=", app_name]]) == []
+        assert ssh(f"test -e /mnt/.ix-apps/app_configs/{app_name}; echo $?").strip() == "1"
+        assert call("app.get_app_volume_ds", app_name) is None
+    finally:
+        if not deleted:
+            # Later tests in this module reuse this app name, so it must not be left poisoned
+            ssh(f"cp /tmp/{app_name}.metadata.bak {metadata_path} || true")
+            try:
+                call("app.delete", app_name, {"remove_images": True, "remove_ix_volumes": True}, job=True)
+            except Exception:
+                ssh(f"rm -rf /mnt/.ix-apps/app_configs/{app_name}")
+            call("app.metadata_generate", job=True)
+        ssh(f"rm -f /tmp/{app_name}.metadata.bak")


### PR DESCRIPTION
## Problem

An app whose `metadata.yaml` we cannot read or make sense of was skipped outright by `list_apps`, so it never appeared in `app.query`. That left no way to get rid of it: `app.delete` resolves the app first and failed with `[ENOENT] App X does not exist`, while the directory, the ix-volume dataset and often a set of still-running containers stayed behind indefinitely. The only way out was to delete things by hand over SSH.

Digging into it turned up something worse and independent of the above: the damage from one broken app was never contained to that app. `_load_app_yaml` did not catch `OSError`, so an unreadable file killed `app.metadata_generate`, and `get_current_app_config` is a bare `open()` outside any try, so metadata pointing at a missing version directory killed the job too. Every lifecycle path waits on that job with `raise_error=True`, so a single broken app meant install, update, upgrade, rollback and delete all failed for every app on the system. Incomplete metadata reached similarly far: it got written into the collective metadata file, whose consumers index into it directly, and one such entry raised `KeyError: 'metadata'` that took down `app.query` box-wide.

Underlying all of it, an app's metadata was only ever checked for the keys we need, never for what those keys hold. A value of a type we cannot use — an unquoted `1.13` that yaml parses as a float, a `portals` that is a string, a mapping key that is not a string at all — flows into the query result and raises somewhere further down, and since every app is built in one pass that fails the query for everything installed rather than just the app at fault.

Worse, every key of that file landed in the app's entry with the file splatted in last, so it won every conflict with what we had determined ourselves. A file could name the app something else entirely — `app.delete` resolves by `id`, so such an app became impossible to remove, the same dead end reached by another route — or claim a state we know it is not in, or empty workloads, which hides the ports and volumes it is holding from conflict detection. With a config requested it could also point the config read at another app's directory, and a `name` yaml parsed as a list took `app.query` down outright, since that lookup sits above the guard that would have caught it.

## Solution

An app we cannot make sense of is now reported with a state of `ERROR` and an `error_reason` naming what is wrong with it — `METADATA_MISSING`, `METADATA_UNREADABLE` or `METADATA_INCOMPLETE` — and can be deleted. Every other operation refuses it, since there is nothing sensible to do without knowing which version is installed. An app whose metadata is fine but whose saved configuration cannot be read stays visible and deletable too, rather than disappearing from the API.

Detection adds no I/O on a healthy system: an app present in the collective metadata is classified by an in-memory check, and only an app absent from it has its own metadata file read. If that turns out to be intact the app is left alone as before, which is what stops an install or delete in flight — or a collective metadata file that is itself unreadable — from marking apps as broken. `app.query` also passes the set of apps with an installation in flight, since an app's directory is created shortly before its metadata is written into it.

Metadata values are now type-checked rather than merely counted, so an app carrying something unusable is reported as broken instead of crashing a caller. A key which is *absent* is still defaulted exactly as before — metadata written by an older release must not be mistaken for a broken app, since being reported as broken takes away every operation but deletion. Version comparison trusts neither the installed nor the catalog side to be parseable, portal URIs which cannot be normalised are passed through untouched, and each row is converted to an entry on its own so an app the API model cannot describe is reported like any other broken app rather than failing the query for everything installed.

Everything we determine ourselves is now written into the entry last, so metadata which was hand edited or written by a release we know nothing about cannot pass itself off as the app's name, id, state, workloads, upgrade availability or error reason. `action_required` stays ahead of it — unlike the rest, that one is the app's to set. Nothing is logged when an app is reported as broken: `app.query` is called by the attachment providers, the dataset details, the usage gather and every UI refresh, so a warning there would grow the log without bound for as long as the file stays corrupt, and the state is already carried by the entry itself, which is where a consumer looks.

`version` and `human_version` become nullable in the current API version only. A placeholder would have flowed into path joins and version comparisons, whereas null forced every consumer to be walked through explicitly. Older pinned clients still get a valid entry via `AppEntry.to_previous`, which fills both and reports `ERROR` as `CRASHED`.

Deletion works without a compose file: with no trustworthy version there is nothing to point docker at, so `compose down` runs with only the project name and docker resolves the containers, network, volumes and images from the labels it stamped on them. Failures there are logged rather than raised, because refusing is exactly what made these apps impossible to remove.

Entering this state emits no event, as it happens through changes on disk rather than anything the middleware did, so the UI learns about it on its next query. Nothing is persisted either — the state is derived, so an older version simply goes back to ignoring these apps.

CI: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/9967/
