### PR TITLE
NAS-142038 / 27.0.0-BETA.1 / Openspec specification for how current update system works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __pycache__
 *.xml
 .cache
+.claude
 .coverage
 .pytest_cache
 /tests/auto_config.py

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,8 @@
+schema: spec-driven
+
+context: |
+  Product: Linux rootfs image shipped as a whole. This project is a Python daemon running inside that image.
+
+  Scope of THIS project: check the CDN state, decide whether one of the available updates should be downloaded.
+
+  Update subsystem: src/middlewared/middlewared/plugins/update_/

--- a/openspec/specs/update-profiles/spec.md
+++ b/openspec/specs/update-profiles/spec.md
@@ -1,0 +1,233 @@
+# Update Profiles
+
+## Purpose
+
+Update profiles express how much field testing an operator requires of a system version before
+accepting it as an update. This capability defines the profile ladder, how a profile is assigned to a
+release and to the running system, which profiles an operator may select, and how the system reports
+compliance with the selected profile.
+
+## Requirements
+
+### Requirement: Profile ladder ordering and terminology
+
+The system SHALL define exactly four update profiles, totally ordered. In ascending order they are
+`DEVELOPER`, `EARLY_ADOPTER`, `GENERAL`, `MISSION_CRITICAL`, carrying the ordinal values 0, 1, 2 and 3
+respectively. Every comparison between profiles SHALL use this ordering.
+
+Wherever profiles are reasoned about, the following terms SHALL carry these meanings:
+
+| Term | Meaning |
+| --- | --- |
+| **rank** | a profile's position in the ordering above |
+| **higher**, **above** | greater ordinal value; nearer `MISSION_CRITICAL` |
+| **lower**, **below** | smaller ordinal value; nearer `DEVELOPER` |
+| **at or above** | greater than or equal in rank; the comparison used by the profile match test |
+| **at or below** | less than or equal in rank |
+| **highest**, **lowest** | the greatest-ranked and least-ranked member of a set of profiles |
+| **maturity** | the extent of field testing a release is held to have received; a release's rank is a statement of its maturity |
+| **promoted** | re-labelled from a lower rank to a higher one as field data accumulates |
+| **attained** | the rank a release has been promoted to so far |
+
+Rank direction SHALL NOT be read as permissiveness. A release at a higher rank is acceptable to more
+configurations, whereas a configured profile at a higher rank accepts fewer releases. Raising the
+configured profile therefore narrows the set of acceptable releases and lowering it widens that set:
+`DEVELOPER` as a configured profile accepts every release, and `MISSION_CRITICAL` as a configured
+profile accepts only releases promoted to `MISSION_CRITICAL`.
+
+#### Scenario: Two profiles are compared
+
+- **WHEN** any two profiles are compared
+- **THEN** `DEVELOPER` ranks lowest, `MISSION_CRITICAL` ranks highest, and `EARLY_ADOPTER` and
+  `GENERAL` rank between them in that order
+
+#### Scenario: The configured profile is raised
+
+- **WHEN** the configured profile is changed to a higher rank
+- **THEN** fewer releases are acceptable, because acceptability requires a release to rank at or above
+  the configured profile
+
+#### Scenario: A release is promoted
+
+- **WHEN** a release is re-labelled from a lower rank to a higher one
+- **THEN** its attained maturity has increased, and it becomes acceptable to configurations that
+  previously declined it
+
+### Requirement: Profile meaning depends on where it is attached
+
+The same profile name SHALL carry a different meaning depending on what it is attached to:
+
+- on a **release**, the maturity that release has been promoted to;
+- on a **train**, the highest profile attained by any release in that train;
+- in the **system configuration**, the *minimum* maturity the operator will accept.
+
+A release is therefore expected to be re-labelled upward over its lifetime as field data accumulates.
+
+The configured profile SHALL NOT be understood as selecting a separate stream of builds. Every system
+draws from the same trains and the same releases; the configured profile sets how much field history a
+release must have accumulated before that system will accept it. Two systems on different profiles
+therefore generally receive the same release at different times, rather than different releases.
+
+This holds only as far as promotion goes. A release that is never promoted to the configured profile is
+skipped rather than delayed, and a train whose declared highest profile never reaches the configured
+profile is never considered at all.
+
+#### Scenario: Operator selects the lowest profile
+
+- **WHEN** the configured profile is `DEVELOPER`
+- **THEN** releases at every maturity are acceptable, because every profile ranks at or above
+  `DEVELOPER`
+
+#### Scenario: Operator selects the highest profile
+
+- **WHEN** the configured profile is `MISSION_CRITICAL`
+- **THEN** only releases promoted to `MISSION_CRITICAL` are acceptable
+
+### Requirement: Profile match test
+
+A release SHALL be considered acceptable under a configured profile when the release's profile ranks
+at or above the configured profile.
+
+#### Scenario: Release is more mature than required
+
+- **WHEN** a release is labelled `GENERAL` and the configured profile is `EARLY_ADOPTER`
+- **THEN** the release is acceptable
+
+#### Scenario: Release is less mature than required
+
+- **WHEN** a release is labelled `EARLY_ADOPTER` and the configured profile is `GENERAL`
+- **THEN** the release is not acceptable
+
+### Requirement: Profile of the running version
+
+The system SHALL determine the profile of the running version by looking that version up in the
+release file of the train recorded in the local update manifest, and reading the release's profile.
+The recorded train SHALL be used as-is for this lookup, without applying train redirection.
+
+If the running version is absent from that release file, the system SHALL treat the version as
+`DEVELOPER` when its version string contains `CUSTOM`, `INTERNAL`, or `MASTER`, and SHALL otherwise
+fail, because a version that cannot be placed on the ladder cannot be reasoned about.
+
+#### Scenario: Running version is listed in its train
+
+- **WHEN** the running version appears in its recorded train's release file
+- **THEN** the profile recorded for that release is the running version's profile
+
+#### Scenario: Running version is a development build
+
+- **WHEN** the running version is absent from the release file and its version string contains
+  `CUSTOM`, `INTERNAL`, or `MASTER`
+- **THEN** the running version's profile is `DEVELOPER`
+
+#### Scenario: Running version cannot be placed on the ladder
+
+- **WHEN** the running version is absent from the release file and its version string contains none of
+  those markers
+- **THEN** the system reports an error rather than assuming a profile
+
+### Requirement: Profile visibility by product type
+
+The set of profiles offered to the operator SHALL depend on the product type. A non-enterprise system
+SHALL be offered every profile at or below `GENERAL`. An enterprise system SHALL be offered every
+profile at or above `GENERAL`. `GENERAL` SHALL be annotated as the default on non-enterprise systems
+and as not recommended on enterprise systems.
+
+#### Scenario: Non-enterprise system lists profiles
+
+- **WHEN** an operator on a non-enterprise system lists profile choices
+- **THEN** `DEVELOPER`, `EARLY_ADOPTER`, and `GENERAL` are offered, and `GENERAL` is annotated as the
+  default
+
+#### Scenario: Enterprise system lists profiles
+
+- **WHEN** an operator on an enterprise system lists profile choices
+- **THEN** `GENERAL` and `MISSION_CRITICAL` are offered, and `GENERAL` is annotated as not recommended
+
+### Requirement: Profile selectability ceiling
+
+A profile SHALL be selectable only when it ranks at or below the profile of the running version, or
+when it is already the configured profile. An operator SHALL NOT be able to demand more maturity than
+the version they are running has attained.
+
+This ceiling constrains only changes to the configured profile. It SHALL NOT prevent an update from
+being offered or installed.
+
+#### Scenario: Operator raises the requirement above the running version
+
+- **WHEN** the running version is labelled `EARLY_ADOPTER` and the operator attempts to select
+  `GENERAL`
+- **THEN** the selection is rejected as unavailable
+
+#### Scenario: Configured profile already exceeds the ceiling
+
+- **WHEN** the configured profile ranks above the running version's profile
+- **THEN** that profile remains selectable, so the existing configuration is never rendered invalid
+
+#### Scenario: Ceiling does not block updating
+
+- **WHEN** the running version's profile is below the configured profile
+- **THEN** update candidates are still evaluated and offered normally
+
+### Requirement: Compliance reporting
+
+The system SHALL report whether the running version satisfies the configured profile, and SHALL raise
+a warning alert while it does not.
+
+#### Scenario: Running version satisfies the configured profile
+
+- **WHEN** the running version's profile ranks at or above the configured profile
+- **THEN** the system reports the running version as matching the profile and raises no profile alert
+
+#### Scenario: Running version falls short of the configured profile
+
+- **WHEN** the running version's profile ranks below the configured profile
+- **THEN** the system reports the running version as not matching the profile and raises a warning
+  alert naming both the running and the selected profile
+
+### Requirement: Enterprise licensing forces the highest profile
+
+When an enterprise license is applied to a system that did not previously hold one, the system SHALL
+set the configured profile to `MISSION_CRITICAL`. This assignment SHALL bypass the selectability
+ceiling, and SHALL be performed without contacting the update server, because network access may be
+unavailable at that moment.
+
+#### Scenario: License applied to a system running a less mature version
+
+- **WHEN** an enterprise license is first applied to a system whose running version is labelled below
+  `MISSION_CRITICAL`
+- **THEN** the configured profile becomes `MISSION_CRITICAL`, the ceiling is not enforced, and the
+  system subsequently reports itself as not matching the profile until it is updated
+
+### Requirement: Configured profile is backfilled on first use
+
+When no profile has been configured, the ordinary read path SHALL adopt the profile of the running
+version and persist it. Determining the running version's profile requires reading a release file from
+the update server, so this backfill SHALL fail when the update server is unreachable. Once a profile is
+stored, the ordinary read path SHALL NOT contact the update server.
+
+A second read path SHALL therefore be available that returns the stored configuration without
+backfilling, and SHALL NOT contact the update server under any circumstances. It exists for callers
+that need the configuration for reasons other than selecting an update — deciding whether to schedule
+the nightly check, and assigning the profile when a license is applied — neither of which may fail
+because the system is offline.
+
+#### Scenario: Profile has never been configured and the update server is reachable
+
+- **WHEN** the update configuration is read through the ordinary path and no profile is stored
+- **THEN** the running version's profile is determined, stored, and returned
+
+#### Scenario: Profile has never been configured and the update server is unreachable
+
+- **WHEN** the update configuration is read through the ordinary path and no profile is stored
+- **THEN** the read fails, because the running version's profile cannot be determined
+
+#### Scenario: Profile is already configured
+
+- **WHEN** the update configuration is read through the ordinary path and a profile is stored
+- **THEN** the stored profile is returned without contacting the update server
+
+#### Scenario: Configuration is read without backfilling
+
+- **WHEN** the update configuration is read through the path that does not backfill
+- **THEN** the stored configuration is returned as it stands, including an unconfigured profile, and
+  the update server is not contacted

--- a/openspec/specs/update-server-publishing/spec.md
+++ b/openspec/specs/update-server-publishing/spec.md
@@ -1,0 +1,437 @@
+# Update Server Publishing
+
+## Purpose
+
+This capability defines the contract that content published on the update server must satisfy in order
+for TrueNAS systems to resolve their own version, decide which version to offer as an update, and
+download it. It is addressed to the party that publishes update server content, and states obligations
+on that content rather than on any consuming system.
+
+Consuming systems assume this contract holds. Most of it is not validated at runtime, so a violation
+does not surface as a diagnostic — it surfaces as systems selecting the wrong version, being offered no
+version, or reporting an error status.
+
+## Published Layout
+
+A worked example of a conforming server. The requirements below refer back to it.
+
+```
+https://auto-public.sys.truenas.net/
+├── trains_v2.json
+├── TrueNAS-SCALE-Fangtooth/
+│   ├── releases.json
+│   ├── TrueNAS-SCALE-25.04.2.update
+│   └── TrueNAS-SCALE-25.04.2.release-notes.txt
+├── TrueNAS-Goldeye-BETA/
+│   └── releases.json          ← redirected; frozen, still served
+├── TrueNAS-Goldeye-RC/
+│   ├── releases.json
+│   └── TrueNAS-26.0.0-RC.1.update
+└── TrueNAS-Goldeye/
+    ├── releases.json
+    ├── TrueNAS-26.0.0.update
+    ├── TrueNAS-26.0.0.release-notes.txt
+    └── TrueNAS-26.0.1.update
+```
+
+`trains_v2.json`:
+
+```json
+{
+  "trains": {
+    "TrueNAS-SCALE-Fangtooth": {
+      "description": "TrueNAS 25.04 [release]",
+      "stable": true,
+      "max_profile": "MISSION_CRITICAL"
+    },
+    "TrueNAS-Goldeye-RC": {
+      "description": "TrueNAS 26.0 [release candidate]",
+      "stable": false,
+      "max_profile": "EARLY_ADOPTER"
+    },
+    "TrueNAS-Goldeye": {
+      "description": "TrueNAS 26.0 [release]",
+      "stable": true,
+      "max_profile": "GENERAL"
+    }
+  },
+  "trains_redirection": {
+    "TrueNAS-Goldeye-BETA": "TrueNAS-Goldeye-RC"
+  }
+}
+```
+
+Note that `TrueNAS-Goldeye-BETA` appears only as a redirection source. A superseded train is removed
+from `trains`, but its release file is still served, because systems running a version from it resolve
+their own version and profile there — see *Train redirection* below.
+
+This is the usual progression: once the release candidate train opens, the beta train stops receiving
+releases and is redirected onto it, carrying beta testers forward without their having to reinstall.
+When the release candidate train is in turn superseded by the general release train, the beta
+redirection SHALL be re-pointed at the same time — see *Train redirection* below.
+
+`TrueNAS-Goldeye/releases.json`:
+
+```json
+{
+  "26.0.0": {
+    "filename": "TrueNAS-26.0.0.update",
+    "version": "26.0.0",
+    "date": "2026-04-14",
+    "changelog": "https://truenas.com/docs/goldeye/26.0.0/",
+    "checksum": "3b1f8a02c47d5e9061b8d4c2f7a930e5c81d64ab29f70e3d5c8b1a4f6e2d90c7",
+    "filesize": 2483027968,
+    "profile": "GENERAL"
+  },
+  "26.0.1": {
+    "filename": "TrueNAS-26.0.1.update",
+    "version": "26.0.1",
+    "date": "2026-06-02",
+    "changelog": "https://truenas.com/docs/goldeye/26.0.1/",
+    "checksum": "9c4e7d1a6b3f0582ae4c9d7b1e63a8e05d2c7419b8e6a3d0f5c1b9e7a24d68f3",
+    "filesize": 2491416576,
+    "profile": "EARLY_ADOPTER"
+  }
+}
+```
+
+This illustrates several obligations at once:
+
+- Releases are ordered **oldest first**, so `26.0.1` being last is what makes it the newest.
+- The train's `max_profile` is `GENERAL` — the highest profile across *all* its releases, which here is
+  the older one. It is not the profile of the newest release.
+- A system configured for `GENERAL` is therefore offered `26.0.0`, not `26.0.1`, because `26.0.1` has
+  not yet been promoted that far.
+- Version numbers do not reliably convey order across the product's history. The scheme changed within
+  the 26 series, so a system on `26.04.x` updates forward onto `26.0.0` even though `26.0.0` ranks
+  lower component-wise. Recency comes from train order and file order, never from comparing version
+  strings.
+
+## Requirements
+
+### Requirement: Train list document
+
+The update server SHALL publish a train list at `trains_v2.json` in the server root, containing a
+`trains` member mapping each train name to a train description, and optionally a `trains_redirection`
+member mapping a train name to the name of the train that supersedes it.
+
+Each train description MAY declare `description`, `stable`, and `max_profile`. Any member that is
+omitted SHALL take its default: an empty description, `stable` true, and a `max_profile` of
+`DEVELOPER`.
+
+Publishers SHALL treat those defaults as significant rather than neutral. A train published with no
+declared members halts the forward walk at itself and is excluded from every configuration other than
+`DEVELOPER`:
+
+```json
+"TrueNAS-Halfmoon": {}
+```
+
+is equivalent to, and behaves as:
+
+```json
+"TrueNAS-Halfmoon": {
+  "description": "",
+  "stable": true,
+  "max_profile": "DEVELOPER"
+}
+```
+
+The least-specified train is therefore the most restrictive one. Any train intended to be reachable
+SHALL declare `max_profile` explicitly, and any pre-release train SHALL declare `stable` explicitly.
+
+#### Scenario: A train omits its properties
+
+- **WHEN** a train is published with no `stable` or `max_profile` declared
+- **THEN** it is treated as stable and as containing nothing above `DEVELOPER`, which stops the search
+  at that train and hides it from all but `DEVELOPER` configurations
+
+#### Scenario: No redirections are in force
+
+- **WHEN** `trains_redirection` is omitted
+- **THEN** no train is treated as superseded
+
+### Requirement: Train sequence order is significant
+
+Trains SHALL be listed in `trains_v2.json` in ascending release order, oldest first. Consuming systems
+determine which trains a system may advance to by taking the entries positioned after its current
+train, and SHALL NOT sort the list or compare train names.
+
+#### Scenario: Trains are listed out of order
+
+- **WHEN** a train is positioned earlier in the list than a train it supersedes
+- **THEN** systems on the superseded train do not see it as an upgrade candidate, and systems on it may
+  be offered an older train's releases
+
+### Requirement: Stable trains are mandatory stepping stones
+
+A train that constitutes a release systems must pass through SHALL be published with `stable` true.
+Consuming systems stop their forward walk at the first stable train and SHALL NOT skip past it, so
+pre-release trains such as nightly, alpha, beta, and release candidate trains SHALL be published with
+`stable` false.
+
+#### Scenario: A pre-release train is published as stable
+
+- **WHEN** a release candidate train is published with `stable` true or without the member
+- **THEN** the forward walk halts there and systems are never offered the general release beyond it
+
+#### Scenario: Intermediate pre-release trains precede a stable train
+
+- **WHEN** one or more trains with `stable` false are followed by a train with `stable` true
+- **THEN** all of them are candidates, and the search stops at the stable train
+
+### Requirement: Declared highest profile is accurate
+
+A train's declared highest profile, carried in the `max_profile` member, SHALL name the highest profile
+attained by any release in that train's release file. It SHALL be updated when a release in the train is
+promoted past the currently declared value.
+
+Consuming systems use this member to skip trains without fetching them. Declaring it below the true
+highest hides releases; declaring it above causes trains to be fetched needlessly.
+
+Given a train whose releases carry `GENERAL`, `EARLY_ADOPTER`, and `EARLY_ADOPTER`, the correct
+declaration is the highest across all of them, not the profile of the newest:
+
+```json
+"TrueNAS-Goldeye": { "stable": true, "max_profile": "GENERAL" }
+```
+
+When `26.0.1` is later promoted from `EARLY_ADOPTER` to `MISSION_CRITICAL`, both the release entry and
+the train's declaration are updated:
+
+```json
+"TrueNAS-Goldeye": { "stable": true, "max_profile": "MISSION_CRITICAL" }
+```
+
+#### Scenario: A train's declared highest profile is understated
+
+- **WHEN** a train contains a `GENERAL` release but declares `max_profile` as `EARLY_ADOPTER`
+- **THEN** systems configured for `GENERAL` exclude the train without fetching it, and never see that
+  release
+
+#### Scenario: A release is promoted past the declared highest profile
+
+- **WHEN** a release in a train is promoted to a profile above the train's declared `max_profile`
+- **THEN** the train's `max_profile` is raised to match, so that systems requiring that profile begin
+  considering the train
+
+### Requirement: Release file
+
+For each train, the update server SHALL publish a release file at `<train>/releases.json`, mapping each
+version string to a release description. Every release description SHALL carry all of `filename`,
+`version`, `date`, `changelog`, `checksum`, `filesize`, and `profile`. None of these have defaults, and
+omitting any one SHALL be understood to invalidate the entire train for consuming systems, not merely
+the affected release.
+
+The `profile` member SHALL be one of `DEVELOPER`, `EARLY_ADOPTER`, `GENERAL`, or `MISSION_CRITICAL`.
+
+#### Scenario: A release omits a required member
+
+- **WHEN** any release in a train's release file omits one of the required members
+- **THEN** the whole release file fails to parse and systems treat the train as unavailable
+
+### Requirement: Release order is significant
+
+Releases SHALL be listed within a release file in ascending order, oldest first, so that the last entry
+is the newest release in that train. Consuming systems read the file in reverse to find the newest
+acceptable release, and SHALL NOT sort entries or compare version numbers to establish recency.
+
+Version numbers SHALL NOT be relied upon to convey order. They have not increased monotonically across
+the product's history — `26.04.x` is followed by `26.0.0` — so file position is the only expression of
+recency available to consuming systems.
+
+#### Scenario: A newer release is inserted before an older one
+
+- **WHEN** a release is positioned earlier in the release file than a release it supersedes
+- **THEN** consuming systems treat the older release as newer and may select it instead
+
+### Requirement: Releases are promoted as they mature
+
+A release's `profile` SHALL state the maturity that release has attained. While its train is still
+receiving releases, that profile SHALL be raised as field data accumulates.
+
+Consuming systems derive an operator's permitted configuration range from the profile of the version
+they are running. Leaving a release at its initial profile while its train is still live holds every
+system running it below the configuration range its maturity would justify.
+
+Promotion necessarily ends when a train is superseded, because its release file is frozen from that
+point — see *Train redirection*. Releases in a superseded train permanently retain the profile they
+held at the moment of supersession, and this is not a defect: a system running one of them draws its
+update candidates from the redirection target, whose releases are still being promoted, so the frozen
+profile lasts only until that system's next update.
+
+#### Scenario: A release accumulates field history
+
+- **WHEN** a release published at `EARLY_ADOPTER` in a live train proves stable in the field
+- **THEN** its `profile` is raised, and systems running it become able to select the higher profile
+
+#### Scenario: A release's train is superseded
+
+- **WHEN** a train is superseded and its release file frozen
+- **THEN** the profiles of its releases stop changing, and systems running them retain that profile
+  until they update onto the redirection target
+
+### Requirement: Train redirection
+
+A train that is no longer receiving releases MAY be superseded by naming its replacement in
+`trains_redirection`. For every such redirection the publisher SHALL guarantee that:
+
+- the superseded train's release file is frozen and continues to be served in perpetuity, because
+  systems still running a version from it resolve their own version and profile from that file;
+- the superseded train SHALL NOT remain listed in `trains`, and is named only as a redirection source,
+  so that systems on earlier trains do not walk forward into a train that no longer receives releases;
+- the redirection does not chain, meaning the target of a redirection is never itself the source of
+  another;
+- the target train is present in `trains_v2.json`.
+
+Removing a superseded train from `trains` does not strand the systems running its releases. They
+resolve their current train through the redirection and draw candidates from the target, and they read
+their own profile from the frozen release file directly rather than through the train list.
+
+Because redirections may not chain, superseding a train that is *already* a redirection target imposes
+a simultaneous obligation: every redirection pointing at it SHALL be re-pointed at the new target in
+the same publication. Redirections accumulate on the way through a release cycle, so this applies to
+all of them, not only the most recent.
+
+Following a release cycle through, with each state a complete `trains_redirection`:
+
+```json
+{ "TrueNAS-Goldeye-BETA": "TrueNAS-Goldeye-RC" }
+```
+
+Then the general release train opens and the release candidate train is superseded. Both entries change
+together — the beta entry is re-pointed rather than left to chain through the release candidate train:
+
+```json
+{
+  "TrueNAS-Goldeye-BETA": "TrueNAS-Goldeye",
+  "TrueNAS-Goldeye-RC": "TrueNAS-Goldeye"
+}
+```
+
+Publishing only the second entry would leave `TrueNAS-Goldeye-BETA` pointing at a train that is itself
+a redirection source, which resolves one hop and strands beta systems on the superseded release
+candidate train.
+
+#### Scenario: A train stops receiving releases
+
+- **WHEN** a train is superseded and redirected
+- **THEN** it is removed from `trains` and named only in `trains_redirection`, its release file
+  continues to be served unchanged, and systems running versions from it draw their update candidates
+  from the target train
+
+#### Scenario: A superseded train is left listed among the trains
+
+- **WHEN** a train is redirected but not removed from `trains`
+- **THEN** systems on earlier trains treat it as an upgrade candidate and may select one of its frozen
+  releases, landing on a train they must immediately leave again
+
+#### Scenario: A redirection target is itself superseded
+
+- **WHEN** a train that is already the target of one or more redirections is superseded
+- **THEN** those redirections are re-pointed at the new target in the same publication, so that no
+  redirection resolves to another redirection source
+
+#### Scenario: A superseded train's release file is withdrawn
+
+- **WHEN** a redirected train's release file stops being served
+- **THEN** systems still running a version from it can no longer determine their own profile and report
+  an error status instead of an available update
+
+#### Scenario: A redirection target is itself redirected
+
+- **WHEN** a train is redirected to a train that is also a redirection source
+- **THEN** only one hop is resolved, and systems land on a train that is no longer current
+
+### Requirement: A version belongs to exactly one train
+
+A given version string SHALL appear in the release file of exactly one train. Consuming systems resolve
+the profile of the version they are running by looking it up in the release file of the train recorded
+in their shipped image, and rely on that lookup being unambiguous.
+
+#### Scenario: A version is published in two trains
+
+- **WHEN** the same version string appears in two trains' release files
+- **THEN** which record governs a running system's profile depends on the train recorded in its image
+  rather than on the train it draws updates from, and the two records may disagree
+
+### Requirement: Every shipped version is published in its train
+
+For every image shipped to systems, the version string recorded in that image SHALL appear as an entry
+in the release file of the train recorded in that same image.
+
+A system whose version is absent from its train's release file cannot determine its own profile, and
+SHALL report an error rather than assuming one, except where its version string contains `CUSTOM`,
+`INTERNAL`, or `MASTER`, which are treated as development builds.
+
+#### Scenario: A shipped version is absent from its train
+
+- **WHEN** a system's version does not appear in its recorded train's release file and is not marked as
+  a development build
+- **THEN** the system cannot determine its profile and reports an error status
+
+### Requirement: Metadata documents are always available
+
+`trains_v2.json` and every release file referenced from it SHALL remain available for retrieval at all
+times. A document that cannot be retrieved SHALL be understood to fail the entire update check for
+every system that reaches it, rather than to indicate that no update is available.
+
+#### Scenario: A release file cannot be retrieved
+
+- **WHEN** a train's release file cannot be retrieved
+- **THEN** consuming systems report an error, and no update is offered even if every other train is
+  intact
+
+### Requirement: Update file
+
+For every release in a train listed in `trains`, the update file SHALL be available at
+`<train>/<filename>`, using the `filename` declared for that release. Its size SHALL equal the
+release's declared `filesize`, and its SHA-256 digest SHALL equal the release's declared `checksum`.
+
+The update files of a superseded train MAY be withdrawn once that train is redirected, because a
+superseded train never supplies update candidates: systems running its releases draw candidates from
+the redirection target. Its release file SHALL nonetheless be retained and served in perpetuity, as
+*Train redirection* requires. The distinction is deliberate — the release file is what those systems
+read to resolve their own profile and is small, whereas retaining every superseded pre-release image
+indefinitely is not.
+
+A file that disagrees with its release entry SHALL be understood to be unusable rather than merely
+suspect: consuming systems discard it and download it again, so a lasting disagreement presents as a
+download that never completes rather than as a reported error.
+
+An update file SHALL NOT be replaced in place without its release entry being updated in the same
+publication. Publishing a rebuilt file under an unchanged `checksum` and `filesize` leaves systems that
+already hold the previous file and systems fetching the new one unable to agree on which is valid.
+
+#### Scenario: An update file disagrees with its release entry
+
+- **WHEN** an update file's digest or size differs from the values declared for that release
+- **THEN** consuming systems discard the downloaded file and attempt the download again, and never
+  install it
+
+#### Scenario: An update file is rebuilt
+
+- **WHEN** a release's update file is replaced with a rebuilt file
+- **THEN** that release's `checksum` and `filesize` are updated in the same publication to match it
+
+#### Scenario: A superseded train's update files are withdrawn
+
+- **WHEN** a train has been redirected and its update files are removed from the server
+- **THEN** systems running its releases are unaffected, because they read only its retained release
+  file and download their candidates from the redirection target
+
+### Requirement: Release notes are optional
+
+Release notes for a release MAY be published at `<train>/<filename without its .update suffix>.release-notes.txt`.
+Consuming systems SHALL treat their absence as acceptable, and are not obliged to re-check for them
+promptly once observed absent.
+
+#### Scenario: Release notes are not published
+
+- **WHEN** no release notes document exists for a release
+- **THEN** the release is still offered, with no release notes attached
+
+#### Scenario: Release notes are published after the release
+
+- **WHEN** release notes are added for a release whose absence has already been observed
+- **THEN** consuming systems may continue to report them as absent for a period before observing them

--- a/openspec/specs/update-version-selection/spec.md
+++ b/openspec/specs/update-version-selection/spec.md
@@ -1,0 +1,259 @@
+# Update Version Selection
+
+## Purpose
+
+This capability defines how the system reads the state published on the update server and decides
+which single version, if any, it should offer and download as the next update. Selection walks two
+axes in a fixed order: first the sequence of trains, then the releases within a train. Profiles are an
+input to this decision and are defined in the `update-profiles` capability.
+
+## Requirements
+
+### Requirement: Reliance on published content
+
+Selection SHALL rely on the update server content satisfying the `update-server-publishing`
+capability, and SHALL NOT verify those guarantees at runtime.
+
+Where this capability depends on a property of published content — the order of trains, the order of
+releases within a train, the accuracy of a train's declared highest profile, the permanence of a
+redirected train's release file, or a version appearing in exactly one train — that property is an
+obligation on the publisher and is specified there rather than restated here.
+
+#### Scenario: Published content satisfies the contract
+
+- **WHEN** published content satisfies the `update-server-publishing` capability
+- **THEN** the selection behavior specified below holds
+
+#### Scenario: Published content violates the contract
+
+- **WHEN** published content does not satisfy that capability
+- **THEN** selection yields an incorrect or absent result rather than reporting a contract violation,
+  because these properties are not checked
+
+### Requirement: Current train resolution
+
+The system SHALL take the current train from the local update manifest, and SHALL substitute the
+redirect target when the update server declares a redirection for that train. Resolution SHALL apply
+exactly one redirection hop.
+
+If the resolved current train is absent from the published train list, the system SHALL treat it as
+present with default properties, which places it last in the train sequence.
+
+#### Scenario: Current train is not redirected
+
+- **WHEN** the manifest's train has no redirection entry
+- **THEN** the manifest's train is the current train
+
+#### Scenario: Current train is redirected
+
+- **WHEN** the manifest's train has a redirection entry
+- **THEN** the redirect target is the current train, and update candidates are drawn from that target
+
+### Requirement: Identity is read from the frozen train, targets from the live train
+
+For a system whose train has been redirected, the frozen release file of the recorded train SHALL
+supply only the identity of the running version, while all update candidates SHALL be drawn from the
+redirect target, which continues to receive new releases.
+
+Because every update moves the running version onto a release published in the live target train, a
+profile derived from a frozen release file SHALL persist only until the next update, and SHALL never
+prevent that update from being offered.
+
+#### Scenario: System is running a version from a redirected train
+
+- **WHEN** the running version belongs to a train that has since been redirected
+- **THEN** its profile is read from that train's frozen release file, and its update candidates are
+  drawn from the redirect target
+
+#### Scenario: System updates off a redirected train
+
+- **WHEN** a system running a version from a redirected train installs a candidate from the redirect
+  target
+- **THEN** its profile is thereafter read from the target's live release file and tracks subsequent
+  promotions
+
+### Requirement: Candidate train list
+
+The system SHALL build the list of candidate trains by walking the published train sequence forward
+from the current train, and SHALL:
+
+- include a train only when the train's declared highest profile ranks at or above the configured
+  profile, so that trains which cannot contain an acceptable release are never fetched;
+- stop after the first train marked stable, because stable trains are mandatory stepping stones and
+  SHALL NOT be skipped;
+- treat a train as stable, and as reaching only `DEVELOPER`, when it does not declare otherwise;
+- order the collected trains newest first, and append the current train last, so that a release on the
+  train already in use is chosen only when no newer train offers an acceptable one.
+
+The current train SHALL be appended unconditionally and SHALL NOT be subject to the profile filter
+applied to the trains beyond it.
+
+#### Scenario: A stable train is reached
+
+- **WHEN** walking forward encounters a train marked stable
+- **THEN** that train is the last one considered, and trains beyond it are not candidates
+
+#### Scenario: A train cannot contain an acceptable release
+
+- **WHEN** a train beyond the current one declares a highest profile ranking below the
+  configured profile
+- **THEN** that train is excluded before its release file is fetched
+
+#### Scenario: No newer train qualifies
+
+- **WHEN** every train beyond the current one is excluded
+- **THEN** the current train alone remains a candidate, and is still scanned
+
+### Requirement: Train order takes strict priority over version order
+
+Selection SHALL treat the candidate train order as a strict priority ranking. The first candidate
+train containing any acceptable release SHALL win outright, and its chosen release SHALL be the
+answer even if a later candidate train contains a higher version number. The system SHALL NOT compare
+version numbers across trains.
+
+Note that version numbers are not a safe substitute for this ordering. Version numbers do not increase
+monotonically across the product's history: `26.04.x` is followed by `26.0.0`, so a component-wise
+comparison ranks the newer release below the older one, and update eligibility carries an explicit
+rule for that transition. A rule of the form "the highest version number across all candidate trains
+wins" would therefore not preserve the behavior specified here.
+
+#### Scenario: An earlier candidate train yields a lower version number
+
+- **WHEN** the first candidate train contains an acceptable release whose version number is lower than
+  an acceptable release in a later candidate train
+- **THEN** the release from the first candidate train is chosen
+
+#### Scenario: A candidate train yields nothing
+
+- **WHEN** a candidate train contains no acceptable release
+- **THEN** the next candidate train is scanned
+
+### Requirement: Release recency follows release file order
+
+Within a train, the system SHALL treat the order of entries in the published release file as the
+authoritative statement of recency, scanning it in reverse so that the last entry is considered
+newest. The system SHALL NOT sort or otherwise compare version numbers to establish this order.
+
+#### Scenario: A train's releases are scanned
+
+- **WHEN** a candidate train's release file is scanned for an acceptable release
+- **THEN** entries are considered from last to first, and the first acceptable entry is chosen
+
+### Requirement: Selection outcome
+
+Having chosen a release, the system SHALL report one of the following outcomes:
+
+- when the chosen release is the running version, that no new version is available;
+- when the chosen release is a version the running version may update to, that version as the new
+  version, together with its manifest and release notes;
+- when the chosen release is not a version the running version may update to, an error stating that
+  the installed version is newer than the newest version the winning train provides.
+
+The system SHALL NOT fall back to another train or to an older release once a release has been chosen.
+
+#### Scenario: System is up to date
+
+- **WHEN** the chosen release is the running version
+- **THEN** the system reports no new version, rather than an error
+
+#### Scenario: An update is available
+
+- **WHEN** the chosen release differs from the running version and may be updated to
+- **THEN** that release is reported as the new version
+
+#### Scenario: The winning train has fallen behind the running version
+
+- **WHEN** the chosen release may not be updated to because the running version is newer
+- **THEN** the system reports an error and does not reconsider other candidates
+
+#### Scenario: No candidate train contains an acceptable release
+
+- **WHEN** every candidate train has been scanned without finding a release matching the configured
+  profile
+- **THEN** the system reports an error stating that no releases match the configured update profile
+
+### Requirement: Conditions reported instead of a version
+
+The system SHALL report the following conditions in place of a selection outcome, each distinguishable
+by the caller:
+
+- an update has already been applied and the system is awaiting reboot;
+- the system is licensed for high availability but high availability is currently unavailable;
+- the published update server content could not be retrieved or parsed.
+
+#### Scenario: An update is already applied
+
+- **WHEN** an update has been applied and the system has not yet rebooted
+- **THEN** the system reports that a reboot is required, without evaluating candidates
+
+#### Scenario: High availability is degraded
+
+- **WHEN** the system is licensed for high availability and high availability is unavailable
+- **THEN** the system reports that condition, without evaluating candidates
+
+#### Scenario: The update server cannot be reached
+
+- **WHEN** retrieving or parsing published update server content fails
+- **THEN** the system reports an error carrying the failure reason, rather than reporting that no
+  update is available
+
+### Requirement: Automatic download decision
+
+When automatic checking is enabled, the system SHALL check the update server once nightly and download
+the selected version if one is available. When automatic checking is disabled, no such check SHALL be
+scheduled.
+
+The nightly download SHALL reuse the selection outcome rather than applying its own policy, and SHALL
+take no action when the selection reports no new version.
+
+#### Scenario: Automatic checking is enabled and an update is available
+
+- **WHEN** the nightly check runs and selection reports a new version
+- **THEN** that version is downloaded
+
+#### Scenario: Automatic checking is enabled and no update is available
+
+- **WHEN** the nightly check runs and selection reports no new version
+- **THEN** nothing is downloaded
+
+#### Scenario: Automatic checking is toggled
+
+- **WHEN** automatic checking is enabled or disabled
+- **THEN** the nightly schedule is added or removed accordingly
+
+### Requirement: Explicitly requested versions bypass the profile
+
+A caller MAY request a specific train and version for download or installation. Such a request SHALL be
+validated only against whether the running version may update to it, and SHALL NOT be checked against
+the configured profile.
+
+A request SHALL specify both a train and a version, or neither; specifying one alone SHALL be rejected.
+
+#### Scenario: A caller requests a version below the configured profile
+
+- **WHEN** a caller requests a specific train and version whose profile ranks below the configured
+  profile
+- **THEN** the request proceeds, because the configured profile governs only automatic selection
+
+#### Scenario: A caller requests a version that cannot be updated to
+
+- **WHEN** a caller requests a specific train and version the running version may not update to
+- **THEN** the request is rejected
+
+#### Scenario: A caller supplies an incomplete request
+
+- **WHEN** a caller supplies a train without a version, or a version without a train
+- **THEN** the request is rejected
+
+### Requirement: Enumeration of available versions
+
+The system SHALL expose an enumeration of the versions present in every candidate train. Because the
+candidate train list is itself constrained by the configured profile, the enumeration inherits that
+train-level constraint. Within those trains, however, releases SHALL be filtered only by whether the
+running version may update to them, and SHALL NOT be filtered by their own profile.
+
+#### Scenario: Versions are enumerated
+
+- **WHEN** the available versions are enumerated
+- **THEN** every version in every candidate train that the running version may update to is returned,
+  including versions whose own profile ranks below the configured profile


### PR DESCRIPTION
Adds openspec-related skills to the repo and outlines three update system-related specifications:
- `update-profiles` - how update profiles work
- `update-version-selection` - how the systems selects the next version to update to
- `update-server-publishing` - what our update CDN should look like (specs above use this as ground truth)