### PR TITLE
NAS-142015 / 26.0.0-RC.1 / Apply the VM system clock setting to the generated domain (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -1,4 +1,4 @@
-from truenas_pylibvirt import VmBootloader, VmCpuMode
+from truenas_pylibvirt import Time, VmBootloader, VmCpuMode
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -157,6 +157,7 @@ class VMService(Service):
         vm.update({
             'bootloader': VmBootloader(vm["bootloader"]),
             'cpu_mode': VmCpuMode(vm["cpu_mode"]),
+            'time': Time(vm["time"]),
             'nvram_path': vm_nvram_path(vm['id'], vm['name']),
             'tpm_path': vm_tpm_path(vm['id'], vm['name']),
             'devices': devices,

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_clock_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_clock_xml.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+from xml.etree import ElementTree
+
+import pytest
+
+from middlewared.plugins.vm.vm_lifecycle import VMService
+
+
+def make_vm(**overrides):
+    vm = {
+        "id": 1,
+        "uuid": "2f9a4a5f-0f7f-4d1e-9c3a-7c9f3b5d2e11",
+        "name": "testvm",
+        "description": "",
+        "vcpus": 1,
+        "cores": 1,
+        "threads": 1,
+        "cpuset": None,
+        "nodeset": None,
+        "memory": 1024,
+        "min_memory": None,
+        "time": "LOCAL",
+        "shutdown_timeout": 90,
+        "devices": [],
+        "arch_type": None,
+        "machine_type": None,
+        "bootloader": "UEFI",
+        "bootloader_ovmf": "OVMF_CODE.fd",
+        "cpu_mode": "CUSTOM",
+        "cpu_model": None,
+        "enable_cpu_topology_extension": False,
+        "pin_vcpus": False,
+        "ensure_display_device": True,
+        "hyperv_enlightenments": False,
+        "trusted_platform_module": False,
+        "hide_from_msr": False,
+        "enable_secure_boot": False,
+        "command_line_args": "",
+        "suspend_on_snapshot": True,
+    }
+    return vm | overrides
+
+
+def clock_xml(vm):
+    service = VMService.__new__(VMService)
+    service.middleware = Mock()
+    # `xml_generator` takes a container-only context, and `VmDomain.run()` yields nothing, so
+    # production passes `None` here for VMs too.
+    generator = service.pylibvirt_vm(vm).xml_generator(None)
+    return ElementTree.tostring(generator._clock_xml()).decode().strip()
+
+
+@pytest.mark.parametrize(
+    "time,hyperv_enlightenments,expected_xml",
+    [
+        ("LOCAL", False, '<clock offset="localtime" />'),
+        ("LOCAL", True, '<clock offset="localtime"><timer name="hypervclock" present="yes" /></clock>'),
+        ("UTC", False, '<clock offset="utc" />'),
+        ("UTC", True, '<clock offset="utc"><timer name="hypervclock" present="yes" /></clock>'),
+    ],
+)
+def test_clock_xml(time, hyperv_enlightenments, expected_xml):
+    vm = make_vm(time=time, hyperv_enlightenments=hyperv_enlightenments)
+
+    assert clock_xml(vm) == expected_xml


### PR DESCRIPTION
## Problem
`pylibvirt_vm()` builds the domain configuration by unpacking `VMEntry.model_dump()` into a plain dataclass, converting `bootloader` and `cpu_mode` into their enums but not `time`. The API model types `time` as a string literal, so the configuration held `'LOCAL'`/`'UTC'` instead of a `Time` member, and the clock offset is decided by comparing that field against `Time.LOCAL`. That comparison was always false, so every VM was defined with `<clock offset="utc">` regardless of what the user picked, and Windows guests — which expect a localtime RTC — ran off by the host's UTC offset. Containers were unaffected because their equivalent helper already does the conversion.

## Solution
Convert `time` alongside the other two enums. Every caller reaches this through `VMEntry`, whose `Literal['LOCAL', 'UTC']` guarantees a valid value, so the conversion cannot raise. Added a unit test covering both offsets with and without Hyper-V enlightenments, which restores coverage that was dropped when XML generation moved out to truenas_pylibvirt.

Original PR: https://github.com/truenas/middleware/pull/19451
