### PR TITLE
NAS-142040 / 27.0.0-BETA.1 / Add recursive option to container delete

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -18,7 +18,7 @@ __all__ = [
     "ContainerEntry",
     "ContainerCreateArgs", "ContainerCreateResult",
     "ContainerUpdateArgs", "ContainerUpdateResult",
-    "ContainerDeleteArgs", "ContainerDeleteResult",
+    "ContainerDeleteArgs", "ContainerDeleteResult", "ContainerDeleteOptions",
     "ContainerPoolChoicesArgs", "ContainerPoolChoicesResult",
     "ContainerStartArgs", "ContainerStartResult",
     "ContainerStopArgs", "ContainerStopResult",
@@ -173,6 +173,16 @@ class ContainerDeleteOptions(BaseModel):
         default=False,
         description=(
             "Force deletion of a container that is not stopped (running or suspended) by stopping it first."
+        ),
+    )
+    recursive: bool = Field(
+        default=False,
+        description=(
+            "Destroy everything the container's dataset carries along with the container: its child datasets and "
+            "snapshots, any clones of those snapshots wherever in the pool they live, and any holds held on them - "
+            "releasing a hold can break a replication task that depends on it. Deleting a container whose dataset "
+            "has child datasets or snapshots fails without this. None of what is destroyed can be recovered "
+            "afterwards."
         ),
     )
 

--- a/src/middlewared/middlewared/api/v27_0_0/container.py
+++ b/src/middlewared/middlewared/api/v27_0_0/container.py
@@ -173,6 +173,16 @@ class ContainerDeleteOptions(BaseModel):
             "Force deletion of a container that is not stopped (running or suspended) by stopping it first."
         ),
     )
+    recursive: bool = Field(
+        default=False,
+        description=(
+            "Destroy everything the container's dataset carries along with the container: its child datasets and "
+            "snapshots, any clones of those snapshots wherever in the pool they live, and any holds held on them - "
+            "releasing a hold can break a replication task that depends on it. Deleting a container whose dataset "
+            "has child datasets or snapshots fails without this. None of what is destroyed can be recovered "
+            "afterwards."
+        ),
+    )
 
 
 class ContainerDeleteArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/container/__init__.py
+++ b/src/middlewared/middlewared/plugins/container/__init__.py
@@ -111,6 +111,10 @@ class ContainerService(GenericCRUDService[ContainerEntry]):
         Delete a Container.
 
         The container must be stopped, unless ``force`` is set - which tears it down first.
+
+        A container whose dataset has child datasets or snapshots is refused unless ``recursive`` is
+        set, which destroys them along with any clones of those snapshots - data that cannot be
+        recovered afterwards.
         """
         return self._svc_part.do_delete(id_, options, audit_callback=audit_callback)
 

--- a/src/middlewared/middlewared/plugins/container/crud.py
+++ b/src/middlewared/middlewared/plugins/container/crud.py
@@ -20,10 +20,11 @@ from middlewared.api.current import (
     ContainerUpdate,
     QueryOptions,
     ZFSResourceQuery,
+    ZFSResourceSnapshotCountQuery,
     ZFSResourceSnapshotDestroyQuery,
 )
 from middlewared.pylibvirt import gather_pylibvirt_domains_states, get_pylibvirt_domain_state
-from middlewared.service import CallError, CRUDServicePart, ValidationErrors
+from middlewared.service import CallError, CRUDServicePart, ValidationError, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
@@ -276,11 +277,45 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
         audit_callback(container.name)
 
         if container.status.state in ACTIVE_STATES and not options.force:
-            raise CallError(
+            raise ValidationError(
+                'container_delete.force',
                 f'Container {container.name!r} is {container.status.state.lower()}. Stop it first, '
                 f'or pass force=True to stop and delete it.',
                 errno.EBUSY,
             )
+
+        # A dataset that is already missing - a victim of a legacy .ix-virt deletion,
+        # say - is not an error; the dangling records are still cleaned up below.
+        resources = self.call_sync2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[container.dataset], properties=None, get_children=True),
+        )
+        dataset_exists = bool(resources)
+
+        # Everything a non-recursive destroy would refuse has to be caught before libvirt is
+        # touched. Undefining the domain is not itself destructive - the next start rebuilds it
+        # from the container's configuration - but getting there kills a running container and
+        # discards a suspended one's state, and the destroy then fails anyway.
+        if dataset_exists and not options.recursive:
+            if len(resources) > 1:
+                raise ValidationError(
+                    'container_delete.recursive',
+                    f'Container {container.name!r} dataset {container.dataset!r} has child datasets. '
+                    'Set `recursive` to delete the container together with them.',
+                    errno.ENOTEMPTY,
+                )
+
+            snapshots = self.call_sync2(
+                self.s.zfs.resource.snapshot.count_impl,
+                ZFSResourceSnapshotCountQuery(paths=[container.dataset]),
+            ).get(container.dataset, 0)
+            if snapshots:
+                raise ValidationError(
+                    'container_delete.recursive',
+                    f'Container {container.name!r} dataset {container.dataset!r} has {snapshots} snapshot(s). '
+                    'Set `recursive` to delete the container together with them.',
+                    errno.ENOTEMPTY,
+                )
 
         # Deleting the domain destroys it if it is active and gives its post-stop
         # actions time to finish before undefining it, so the container's runtime
@@ -291,14 +326,14 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
 
         # Destroy the dataset first and only remove the DB records once it is actually
         # gone, so a failed destroy never orphans the dataset with no container row
-        # pointing at it. A dataset that is already missing - a victim of a legacy
-        # .ix-virt deletion, say - is not an error; fall through and clean up the
-        # now-dangling records.
-        if self.call_sync2(
-            self.s.zfs.resource.query_impl,
-            ZFSResourceQuery(paths=[container.dataset], properties=None),
-        ):
-            failed = self.call_sync2(self.s.zfs.resource.destroy_impl, container.dataset)[0]
+        # pointing at it.
+        if dataset_exists:
+            # bypass, because the container plugin owns everything under its own dataset and
+            # must keep being able to destroy it if that tree is ever marked a protected path.
+            failed = self.call_sync2(
+                self.s.zfs.resource.destroy_impl, container.dataset, recursive=options.recursive,
+                bypass=True,
+            )[0]
             if failed is not None:
                 raise CallError(f'Failed to delete container {container.name!r} dataset: {failed}')
 

--- a/tests/api2/test_container.py
+++ b/tests/api2/test_container.py
@@ -66,6 +66,14 @@ def bounding_set(capsh_print):
     return re.search("Bounding set =(.*)", capsh_print).group(1).strip().split(",")
 
 
+def dataset_exists(dataset):
+    # Asked over ssh so the test does not depend on how the dataset API treats
+    # datasets under .truenas_containers.
+    return (
+        ssh(f"zfs list {dataset}", check=False, complete_response=True)["returncode"] == 0
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def bridge():
     configure_bridge()
@@ -183,10 +191,66 @@ def test_container_delete_with_snapshot_refused(ubuntu_container):
         with pytest.raises(ClientException) as exc_info:
             call("container.delete", ubuntu_container["id"], job=True)
 
-        assert "has snapshots" in str(exc_info.value)
+        assert "snapshot(s)" in str(exc_info.value)
         assert call("container.query", [["id", "=", ubuntu_container["id"]]])
+        assert dataset_exists(ubuntu_container["dataset"])
     finally:
         ssh(f"zfs destroy {snapshot}")
+
+
+def test_container_delete_with_child_dataset_refused(ubuntu_container):
+    child = f"{ubuntu_container['dataset']}/child"
+    ssh(f"zfs create {child}")
+    try:
+        with pytest.raises(ClientException) as exc_info:
+            call("container.delete", ubuntu_container["id"], job=True)
+
+        assert "child datasets" in str(exc_info.value)
+        assert call("container.query", [["id", "=", ubuntu_container["id"]]])
+        assert dataset_exists(ubuntu_container["dataset"])
+    finally:
+        ssh(f"zfs destroy {child}")
+
+
+def test_container_delete_refused_keeps_libvirt_state(started_ubuntu_container):
+    # A libvirt domain only exists once the container has been started, so the
+    # container is started (by the fixture) and stopped to have state that a
+    # refused delete could destroy.
+    container = started_ubuntu_container
+    call("container.stop", container["id"], job=True)
+    assert container["uuid"] in ssh(f"{VIRSH} list --all")
+
+    snapshot = f"{container['dataset']}@test"
+    ssh(f"zfs snapshot {snapshot}")
+    try:
+        with pytest.raises(ClientException) as exc_info:
+            call("container.delete", container["id"], job=True)
+
+        assert "snapshot(s)" in str(exc_info.value)
+
+        # A refused delete must not touch libvirt, so the container is left exactly as
+        # it was and still starts.
+        assert container["uuid"] in ssh(f"{VIRSH} list --all")
+        call("container.start", container["id"])
+        assert (
+            call("container.get_instance", container["id"])["status"]["state"]
+            == "RUNNING"
+        )
+        call("container.stop", container["id"], job=True)
+    finally:
+        ssh(f"zfs destroy {snapshot}")
+
+
+def test_container_delete_recursive(ubuntu_container):
+    container = ubuntu_container
+    ssh(f"zfs create {container['dataset']}/child")
+    ssh(f"zfs snapshot {container['dataset']}@test")
+
+    call("container.delete", container["id"], {"recursive": True}, job=True)
+
+    assert not call("container.query", [["id", "=", container["id"]]])
+    assert not dataset_exists(container["dataset"])
+    assert container["uuid"] not in ssh(f"{VIRSH} list --all")
 
 
 def test_container_stop_force_after_timeout(ubuntu_container):


### PR DESCRIPTION
## Problem
A container whose dataset has dependents could not be deleted at all, and the attempt was not free: the libvirt domain was torn down before ZFS refused the destroy, killing a running container and discarding a suspended one's state for a delete that was never going to succeed.

## Solution
Validate the dataset up front, before any libvirt state is touched, so a delete that cannot succeed is refused cleanly and the container is left exactly as it was. Adds a `recursive` delete option that destroys the dataset together with its dependents for callers who do want it gone. Both refusals are now validation errors naming the option that lifts them, which means deleting a running container without `force` returns a validation error where it previously returned a call error.

CI: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/9941/