### PR TITLE
IPA: Allow host FQDN in subdomain or outside realm

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/directory_services.py
+++ b/src/middlewared/middlewared/api/v27_0_0/directory_services.py
@@ -607,7 +607,12 @@ class IPAConfig(BaseModel):
         ),
     )
     hostname: NonEmptyString = Field(
-        description="Hostname of TrueNAS server to register in IPA during the join process. Example: \"truenasnyc\".",
+        description=(
+            "Hostname of the TrueNAS server to register in IPA during the join process. Example: \"truenasnyc\". A "
+            "bare hostname is qualified with `domain` to form the host's fully-qualified domain name. Supply a "
+            "complete FQDN instead to register the host in a DNS zone other than the IPA domain, for example a "
+            "subdomain of it or an unrelated zone. Example: \"truenasnyc.nyc.example.internal\"."
+        ),
     )
     domain: NonEmptyString = Field(description="The domain of the IPA server. Example \"ipa.internal\".")
     basedn: LDAP_DN = Field(

--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -1,20 +1,22 @@
 <%
     from middlewared.plugins.network_.global_config import HOSTS_FILE_EARMARKER
+    from middlewared.utils.directoryservices.common import ds_config_to_fqdn
     from middlewared.utils.directoryservices.constants import DSType
 
     network_config = middleware.call_sync('network.configuration.config')
     ds_config = middleware.call_sync('directoryservices.config')
     hostname = network_config['hostname_local']
-    ds_hostname = None
     domain_name = network_config['domain']
+    ds_fqdn = None
     if ds_config['enable'] and ds_config['service_type'] in (DSType.AD.value, DSType.IPA.value):
-        # In HA case the virtual hostname and local hostname may not match
-        # but must both be resolvable.
-        ds_hostname = ds_config['configuration']['hostname'].lower()
-        domain_name = ds_config['configuration']['domain'].lower()
+        # The name registered in the domain is not necessarily this server's own FQDN. In
+        # the HA case it is the virtual hostname rather than the local one, and an IPA
+        # hostname may itself be a complete FQDN placing the server in a DNS zone other
+        # than the IPA domain. Both names must resolve when they differ.
+        ds_fqdn = ds_config_to_fqdn(ds_config).lower()
 %>
-% if ds_hostname and ds_hostname != hostname:
-127.0.0.1	${ds_hostname}.${domain_name} ${ds_hostname}
+% if ds_fqdn and ds_fqdn != f'{hostname}.{domain_name}':
+127.0.0.1	${ds_fqdn} ${ds_fqdn.split('.')[0]}
 % endif
 127.0.0.1	${hostname}.${domain_name} ${hostname}
 127.0.0.1	localhost

--- a/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/datastore.py
@@ -27,6 +27,7 @@ from middlewared.service_exception import CallError, MatchNotFound, ValidationEr
 import middlewared.sqlalchemy as sa
 from middlewared.utils.directoryservices.ad import get_domain_info, lookup_dc
 from middlewared.utils.directoryservices.ad_constants import MACHINE_ACCOUNT_KT_NAME
+from middlewared.utils.directoryservices.common import ds_config_to_fqdn
 from middlewared.utils.directoryservices.constants import DEF_SVC_OPTS, DomainJoinResponse, DSCredType, DSStatus, DSType
 from middlewared.utils.directoryservices.credential import (
     validate_credential,
@@ -456,7 +457,7 @@ class DirectoryServices(ConfigService):
             return
 
         # Check whether forward lookup of our name works
-        dns_name = f'{new["configuration"]["hostname"]}.{new["configuration"]["domain"]}'
+        dns_name = ds_config_to_fqdn(new)
         try:
             dns_addresses = {
                 x.address

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -514,22 +514,27 @@ class IPAJoinMixin:
         if not hostname:
             hostname = ngc.get('hostname_virtual') or ngc['hostname_local']
 
+        # The IPA hostname may be a complete FQDN, which permits registering the host
+        # account in a DNS zone other than the IPA domain. Only the leading label is a
+        # hostname in the sense that network configuration and NetBIOS understand.
+        short_hostname = hostname.split('.')[0]
+
         # If user has specified a hostname to use for join, then overwrite other parts of config if needed
-        elif hostname != (ngc.get('hostname_virtual') or ngc['hostname_local']):
+        if short_hostname != (ngc.get('hostname_virtual') or ngc['hostname_local']):
             if ngc.get('hostname_virtual'):
-                self.middleware.call_sync('network.configuration.update', {'hostname_virtual': hostname})
+                self.middleware.call_sync('network.configuration.update', {'hostname_virtual': short_hostname})
             else:
-                self.middleware.call_sync('network.configuration.update', {'hostname': hostname})
+                self.middleware.call_sync('network.configuration.update', {'hostname': short_hostname})
 
         # Update the netbiosname to something reasonably related to our hostname
         # There are probably some legacy users who have "truenas" as the name of their server
         # because that was the default netbiosname. This isn't a great choice because if another device
         # joins AD with same generic name then it will clobber this one's computer account in AD, and so
         # we want to discourage that.
-        if smb['netbiosname'] != hostname and smb['netbiosname'] == 'truenas':
+        if smb['netbiosname'] != short_hostname and smb['netbiosname'] == 'truenas':
             # Default netbiosname. We *really* don't want to collide with other servers.
             # We'll start by trying to truncate to max netbiosname length
-            smb['netbiosname'] = hostname[:NETBIOSNAME_MAX_LEN - 1]
+            smb['netbiosname'] = short_hostname[:NETBIOSNAME_MAX_LEN - 1]
 
             # Allow job failure if our best guess at a valid netbiosname fails
             validate_netbios_name(smb['netbiosname'])

--- a/src/middlewared/middlewared/utils/directoryservices/common.py
+++ b/src/middlewared/middlewared/utils/directoryservices/common.py
@@ -1,10 +1,27 @@
 from middlewared.utils.directoryservices.constants import DSType
 
 
+def ds_hostname_is_fqdn(ds_config: dict) -> bool:
+    """ Whether the configured hostname is already a fully-qualified domain name.
+
+    IPA permits the TrueNAS host account to live in a DNS zone other than the IPA domain
+    (a subdomain of it, or an unrelated zone entirely), so the IPA hostname may be given
+    as a complete FQDN. A dot in the name is what distinguishes the two forms: a bare
+    hostname such as "truenasnyc" never contains one.
+    """
+    if ds_config['service_type'] != DSType.IPA.value:
+        return False
+
+    return '.' in ds_config['configuration']['hostname']
+
+
 def ds_config_to_fqdn(ds_config: dict) -> str:
     if ds_config['service_type'] not in (DSType.AD.value, DSType.IPA.value):
         raise ValueError(f'{ds_config["service_type"]}: service type unsupported.')
 
     # WARNING: nsupdate with GSSAPI may expect the domain component to be upper case so
     # any case normalization should be handled by consumer.
+    if ds_hostname_is_fqdn(ds_config):
+        return ds_config['configuration']['hostname']
+
     return f'{ds_config["configuration"]["hostname"]}.{ds_config["configuration"]["domain"]}'

--- a/tests/directory_services/test_ipa_join.py
+++ b/tests/directory_services/test_ipa_join.py
@@ -4,6 +4,7 @@ from middlewared.test.integration.assets.directory_service import directoryservi
 from middlewared.test.integration.assets.product import product_type
 from middlewared.test.integration.utils import call, client, ssh
 from middlewared.test.integration.utils.client import truenas_server
+from middlewared.utils.directoryservices.common import ds_config_to_fqdn
 
 
 @pytest.fixture(scope="module")
@@ -108,8 +109,10 @@ def test_admin_privilege(do_freeipa_connection, enable_ds_auth):
 
 
 def test_dns_resolution(do_freeipa_connection):
-    ipa_config = do_freeipa_connection['config']['configuration']
-    fqdn = f'{ipa_config["hostname"]}.{ipa_config["domain"]}'
+    # An IPA hostname may itself be a complete FQDN (registering the host in a DNS zone
+    # other than the IPA domain), so the name must be derived the same way the join does
+    # rather than by appending the domain unconditionally.
+    fqdn = ds_config_to_fqdn(do_freeipa_connection['config'])
 
     addresses = call('dnsclient.forward_lookup', {'names': [fqdn]})
     assert len(addresses) != 0

--- a/tests/unit/test_directoryservices_common.py
+++ b/tests/unit/test_directoryservices_common.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for the shared directory services FQDN helper.
+
+An IPA host account may live in a DNS zone other than the IPA domain (a subdomain of it
+or an unrelated zone entirely), so the IPA hostname may be supplied as a complete FQDN.
+When it is, it must be used verbatim; blindly appending the domain produced names such as
+"nas.lan.example.net.ipa.example.net" which the IPA server refuses to add.
+"""
+
+import pytest
+
+from middlewared.utils.directoryservices.common import ds_config_to_fqdn, ds_hostname_is_fqdn
+
+
+def _ds_config(service_type, hostname, domain):
+    return {
+        "service_type": service_type,
+        "configuration": {"hostname": hostname, "domain": domain},
+    }
+
+
+@pytest.mark.parametrize(
+    "hostname,domain,expected",
+    [
+        # Bare hostname is still qualified with the IPA domain.
+        ("truenasnyc", "ipa.internal", "truenasnyc.ipa.internal"),
+        # An FQDN under the IPA domain is used as-is rather than doubled up.
+        ("truenasnyc.ipa.internal", "ipa.internal", "truenasnyc.ipa.internal"),
+        # A subdomain of the IPA domain.
+        ("truenasnyc.nyc.ipa.internal", "ipa.internal", "truenasnyc.nyc.ipa.internal"),
+        # A zone entirely outside the IPA domain.
+        ("nas-nyc.lan.example.net", "ipa.example.net", "nas-nyc.lan.example.net"),
+    ],
+)
+def test__ipa_fqdn(hostname, domain, expected):
+    assert ds_config_to_fqdn(_ds_config("IPA", hostname, domain)) == expected
+
+
+def test__ad_hostname_is_always_qualified():
+    """Active Directory takes a bare hostname; the domain is always appended."""
+    assert ds_config_to_fqdn(_ds_config("ACTIVEDIRECTORY", "truenasnyc", "ad.internal")) == "truenasnyc.ad.internal"
+    assert not ds_hostname_is_fqdn(_ds_config("ACTIVEDIRECTORY", "truenasnyc", "ad.internal"))
+
+
+def test__unsupported_service_type():
+    with pytest.raises(ValueError):
+        ds_config_to_fqdn(_ds_config("LDAP", "truenasnyc", "ldap.internal"))


### PR DESCRIPTION
This allows an FQDN to be entered in the hostname field for registering a machine to an IPA. This replaces the contcat method that disallows subdomains or machines in domains outside of the IPA domain.

I chose to simply allow FQDNs in the existing field instead of migrating to a new field. This should make it easier to backport/make this change more minimal.

It would be great if this could be backported to 25.x and 26.x. Please let me know if I should open a different PR/change this PR to do that.

This fixes [NAS-142043](https://ixsystems.atlassian.net/browse/NAS-142043).

Thanks!