### PR TITLE
NAS-142011 / 26.0.0-BETA.3 / `Private` API parameters (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/base/__init__.py
+++ b/src/middlewared/middlewared/api/base/__init__.py
@@ -1,5 +1,6 @@
 from .event import *  # noqa
 from .excluded import *  # noqa
 from .model import *  # noqa
+from .private import *  # noqa
 from .types import *  # noqa
 from .validators import *  # noqa

--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -8,6 +8,7 @@ import typing
 
 from .handler.accept import accept_params
 from ..base.model import BaseModel
+from .private import private_fields
 
 
 __all__ = ["api_method"]
@@ -177,6 +178,15 @@ def api_method[**P, T](
 
     check_model_module(accepts, private)
     check_model_module(returns, private)
+
+    if accepts is not None and (names := private_fields(accepts)):
+        # A top-level `Private` field is unusable: middleware itself has to pass its own params to the method
+        # positionally, and a bare value is validated (and therefore rejected) like any caller-supplied one.
+        # Nesting it in a model lets internal callers pass an already-validated instance instead.
+        raise TypeError(
+            f"{accepts.__name__} declares top-level `Private` field(s) {', '.join(map(repr, names))}. This is not "
+            f"supported. Please, move `Private` field(s) to a nested model."
+        )
 
     def wrapper(func):
         if pass_app:

--- a/src/middlewared/middlewared/api/base/handler/accept.py
+++ b/src/middlewared/middlewared/api/base/handler/accept.py
@@ -14,7 +14,8 @@ def accept_params(
     *,
     dump_models=True,
     exclude_unset=False,
-    expose_secrets=True
+    expose_secrets=True,
+    allow_private=False,
 ) -> list:
     """
     Accepts a list of `args` for a method call and validates it using `model`.
@@ -28,6 +29,8 @@ def accept_params(
     :param dump_models: it true, will dump all pydantic models.
     :param exclude_unset: if true, will not append default parameters to the list.
     :param expose_secrets: if false, will replace `Secret` parameters with a placeholder.
+    :param allow_private: if false (the default), specifying a value for a `Private` field is rejected the same
+        way an unknown key is.
     :return: a validated list of method args.
     """
     if not dump_models and not expose_secrets:
@@ -36,7 +39,7 @@ def accept_params(
     args_as_dict = model_dict_from_list(model, args)
 
     result = validate_model(model, args_as_dict, dump_models=dump_models, exclude_unset=exclude_unset,
-                            expose_secrets=expose_secrets)
+                            expose_secrets=expose_secrets, allow_private=allow_private)
 
     fields = list(model.model_fields)
     if exclude_unset:
@@ -79,6 +82,7 @@ def validate_model(
     dump_models=True,
     exclude_unset=False,
     expose_secrets=True,
+    allow_private=True,
 ) -> dict | BaseModel:
     """
     Validates `data` against the `model`, sanitizes values, sets defaults.
@@ -90,13 +94,20 @@ def validate_model(
     :param dump_models: it true, will dump all pydantic models.
     :param exclude_unset: if true, will not add default values.
     :param expose_secrets: if false, will replace `Secret` fields with a placeholder.
+    :param allow_private: if false, specifying a value for a `Private` field is rejected the same way an
+        unknown key is. Defaults to true because this function validates data that middleware itself produced;
+        the API boundary is `accept_params`, which defaults to false.
     :return: validated data.
     """
     if not dump_models and not expose_secrets:
         raise ValueError("`expose_secrets=False` is not compatible with `dump_models=False`")
 
+    context: dict[str, bool] | None = None
+    if not allow_private:
+        context = {"allow_private": False}
+
     try:
-        instance = model(**data)
+        instance = model.model_validate(data, context=context)
     except ValidationError as e:
         union_errors = defaultdict(list)
 

--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -10,6 +10,7 @@ from pydantic.main import ModelT
 from pydantic.types import SecretType
 from pydantic_core import SchemaSerializer, core_schema
 
+from middlewared.api.base.private import guard_private_fields
 from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
 from middlewared.utils.lang import undefined
 from middlewared.utils.typing_ import is_union
@@ -121,6 +122,10 @@ class _BaseModelMetaclass(ModelMetaclass):
     def __new__(mcls, name: str, bases: tuple[type[Any], ...], namespace: dict[str, Any], **kwargs: Any):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
 
+        # Attaches the guard as field-level metadata, which is where `SkipJsonSchema` (and therefore
+        # `Private`) has to stay in order to be honored.
+        has_private = guard_private_fields(cls)
+
         has_not_required = False
         for field in cls.model_fields.values():
             if field.default is NotRequired:
@@ -131,7 +136,17 @@ class _BaseModelMetaclass(ModelMetaclass):
 
         if has_not_required:
             # If any field has a default of `NotRequired`, apply the serializer to the model.
+            # This rebuilds the model, which is also required for any mutated `field.metadata`.
             _apply_model_serializer(cls, _not_required_serializer)
+        elif has_private:
+            # A mutated `field.metadata` only takes effect after the model is rebuilt.
+            cls.model_rebuild(
+                force=True,
+                # A model whose annotations contain forward references that are not defined yet cannot be
+                # built at this point. Pydantic leaves it incomplete and rebuilds it, picking up the guard,
+                # on first use.
+                raise_errors=False,
+            )
 
         return cls
 
@@ -145,6 +160,10 @@ class ForUpdateMetaclass(_BaseModelMetaclass):
 
     def __new__(mcls, name: str, bases: tuple[type[Any], ...], namespace: dict[str, Any], **kwargs: Any):
         cls = ModelMetaclass.__new__(mcls, name, bases, namespace, **kwargs)
+
+        # This bypasses `_BaseModelMetaclass.__new__`, so private fields have to be guarded here as well.
+        # No explicit rebuild is needed: `_apply_model_serializer` below rebuilds the model unconditionally.
+        guard_private_fields(cls)
 
         for field in cls.model_fields.values():
             # We want to back `default` and `default_factory` so that `model_subset` can later use them.
@@ -192,7 +211,7 @@ class BaseModel(PydanticBaseModel, metaclass=_BaseModelMetaclass):
 
                         raise TypeError(
                             f"Model {cls.__name__} has field {k} defined as {dump(v.annotation)}. {dump(option)} "
-                            "cannot be a member of an Optional or a Union, please make the whole field Private."
+                            "cannot be a member of an Optional or a Union, please make the whole field a `Secret`."
                         )
             if not v.description and (parent_field := cls.__base__.model_fields.get(k)):
                 v.description = parent_field.description

--- a/src/middlewared/middlewared/api/base/private.py
+++ b/src/middlewared/middlewared/api/base/private.py
@@ -6,7 +6,7 @@ from pydantic.fields import FieldInfo
 from pydantic.json_schema import SkipJsonSchema
 from pydantic_core import PydanticCustomError, core_schema
 
-__all__ = ["Private"]
+__all__ = ["Private", "private_fields"]
 
 
 if TYPE_CHECKING:
@@ -58,6 +58,11 @@ def is_private_guard(metadata: Any) -> bool:
 def _is_private(field: FieldInfo) -> bool:
     """Whether `field` is `Private`, i.e. must not be settable by API callers."""
     return any(isinstance(metadata, Private) for metadata in field.metadata)  # type: ignore[arg-type, misc]
+
+
+def private_fields(cls: type[PydanticBaseModel]) -> list[str]:
+    """Names of the `Private` fields declared directly on `cls` (not on its nested models)."""
+    return [name for name, field in cls.model_fields.items() if _is_private(field)]
 
 
 def _guard(field: FieldInfo) -> _RejectPrivate | None:

--- a/src/middlewared/middlewared/api/base/private.py
+++ b/src/middlewared/middlewared/api/base/private.py
@@ -1,0 +1,95 @@
+from typing import TYPE_CHECKING, Annotated, Any
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import WrapValidator
+from pydantic.fields import FieldInfo
+from pydantic.json_schema import SkipJsonSchema
+from pydantic_core import PydanticCustomError, core_schema
+
+__all__ = ["Private"]
+
+
+if TYPE_CHECKING:
+    # Like pydantic does for `SkipJsonSchema` itself, declare an alias for type checkers so that `Private[bool]`
+    # is understood as an annotation rather than as a subscripted class.
+    type Private[T] = Annotated[T, ...]
+else:
+
+    class Private(SkipJsonSchema):
+        """Marks a field that is internal to middleware.
+
+        Like `SkipJsonSchema`, the field is kept out of the published API schema. On top of that, `accept_params`
+        rejects any attempt to specify it exactly the way it rejects an unknown key.
+        """
+
+
+class _RejectPrivate:
+    """Rejects a value supplied for a `Private` field, unless that value is the field's default.
+
+    A middleware method routinely forwards its own validated params to another method, and `accept_params`
+    materializes every default in what it returns, private fields included. A forwarded dict therefore always
+    mentions them, which is not the caller specifying anything. Only a value that actually differs from the
+    default is rejected.
+    """
+
+    def __init__(self, default: Any):
+        self.default = default
+
+    def __call__(
+        self,
+        value: Any,
+        handler: core_schema.ValidatorFunctionWrapHandler,
+        info: core_schema.ValidationInfo,
+    ) -> Any:
+        # Pydantic does not validate defaults, so this only runs when a value was actually supplied.
+        if isinstance(info.context, dict) and info.context.get("allow_private") is False and value != self.default:
+            # Deliberately the same error an unknown key produces: a private field must be indistinguishable
+            # from a nonexistent one.
+            raise PydanticCustomError("", "Extra inputs are not permitted")
+
+        return handler(value)
+
+
+def is_private_guard(metadata: Any) -> bool:
+    """Whether `metadata` is the validator that `guard_private_fields` attaches."""
+    return isinstance(metadata, WrapValidator) and isinstance(metadata.func, _RejectPrivate)
+
+
+def _is_private(field: FieldInfo) -> bool:
+    """Whether `field` is `Private`, i.e. must not be settable by API callers."""
+    return any(isinstance(metadata, Private) for metadata in field.metadata)  # type: ignore[arg-type, misc]
+
+
+def _guard(field: FieldInfo) -> _RejectPrivate | None:
+    """The validator already attached to `field`, if any."""
+    for metadata in field.metadata:
+        if isinstance(metadata, WrapValidator) and isinstance(metadata.func, _RejectPrivate):
+            return metadata.func
+
+    return None
+
+
+def guard_private_fields(cls: type[PydanticBaseModel]) -> bool:
+    """Attach a rejecting validator to every `Private` field of `cls`.
+
+    :return: whether any field was modified (in which case the caller must rebuild the model).
+    """
+    modified = False
+    for field in cls.model_fields.values():
+        if not _is_private(field):
+            continue
+
+        guard = _guard(field)
+        if guard is not None and guard.default == field.default:
+            # A subclass builds its own `FieldInfo` from the (already guarded) one of its base, so the guard
+            # must not be added a second time. It is replaced rather than kept when the subclass declares a
+            # different default, since the guard has to compare against the default of the field it is on.
+            continue
+
+        field.metadata = [
+            *(metadata for metadata in field.metadata if not is_private_guard(metadata)),
+            WrapValidator(_RejectPrivate(field.default)),
+        ]
+        modified = True
+
+    return modified

--- a/src/middlewared/middlewared/api/v25_10_0/replication.py
+++ b/src/middlewared/middlewared/api/v25_10_0/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v25_10_1/replication.py
+++ b/src/middlewared/middlewared/api/v25_10_1/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v25_10_2/replication.py
+++ b/src/middlewared/middlewared/api/v25_10_2/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v25_10_3/replication.py
+++ b/src/middlewared/middlewared/api/v25_10_3/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v25_10_4/replication.py
+++ b/src/middlewared/middlewared/api/v25_10_4/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v26_0_0/replication.py
+++ b/src/middlewared/middlewared/api/v26_0_0/replication.py
@@ -13,7 +13,7 @@ __all__ = ["ReplicationEntry",
            "ReplicationCreateArgs", "ReplicationCreateResult",
            "ReplicationUpdateArgs", "ReplicationUpdateResult",
            "ReplicationDeleteArgs", "ReplicationDeleteResult",
-           "ReplicationRunArgs", "ReplicationRunResult",
+           "ReplicationRunOptions", "ReplicationRunArgs", "ReplicationRunResult",
            "ReplicationRunOnetimeArgs", "ReplicationRunOnetimeResult",
            "ReplicationListDatasetsArgs", "ReplicationListDatasetsResult",
            "ReplicationCreateDatasetArgs", "ReplicationCreateDatasetResult",
@@ -285,12 +285,27 @@ class ReplicationDeleteResult(BaseModel):
     result: bool = Field(description="Whether the replication task was successfully deleted.")
 
 
-class ReplicationRunArgs(BaseModel):
-    id: int = Field(description="ID of the replication task to run.")
+class ReplicationRunOptions(BaseModel):
     really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )
+
+
+class ReplicationRunArgs(BaseModel):
+    id: int = Field(description="ID of the replication task to run.")
+    options: ReplicationRunOptions = Field(
+        default_factory=ReplicationRunOptions,
+        description="Options for running the replication task.",
+    )
+
+    @classmethod
+    def from_previous(cls, value):
+        # `really_run` was a top-level parameter until this version.
+        if (really_run := value.pop("really_run", None)) is not None:
+            value["options"] = {"really_run": really_run}
+
+        return value
 
 
 class ReplicationRunResult(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/replication.py
+++ b/src/middlewared/middlewared/api/v26_0_0/replication.py
@@ -1,9 +1,8 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, Private,
                                   single_argument_args, single_argument_result, SnapshotNameSchema, TcpPort,
                                   UniqueList)
 from .common import CronModel, TimeCronModel
@@ -288,7 +287,7 @@ class ReplicationDeleteResult(BaseModel):
 
 class ReplicationRunArgs(BaseModel):
     id: int = Field(description="ID of the replication task to run.")
-    really_run: SkipJsonSchema[bool] = Field(
+    really_run: Private[bool] = Field(
         default=True,
         description="Internal flag to confirm the operation should proceed.",
     )

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
@@ -1,12 +1,12 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
 from middlewared.api.base import (
     BaseModel,
     NonEmptyString,
     NotRequired,
+    Private,
     UniqueList,
 )
 
@@ -360,7 +360,7 @@ class ZFSResourceQuery(BaseModel):
             " specified path(s), not from the pool root."
         ),
     )
-    exclude_internal_paths: SkipJsonSchema[bool] = Field(default=True, description="Exclude internal paths.")
+    exclude_internal_paths: Private[bool] = Field(default=True, description="Exclude internal paths.")
     get_tier: bool = Field(
         default=False,
         description=(

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_snapshot.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_snapshot.py
@@ -1,12 +1,12 @@
 from typing import Literal
 
 from pydantic import Field
-from pydantic.json_schema import SkipJsonSchema
 
 from middlewared.api.base import (
     BaseModel,
     NonEmptyString,
     NotRequired,
+    Private,
     UniqueList,
 )
 from .zfs_resource_crud import PropertyValue
@@ -240,7 +240,7 @@ class ZFSResourceSnapshotDestroyQuery(BaseModel):
         description="If True, path should be a dataset path and all its snapshots will be destroyed.",
     )
     defer: bool = Field(default=False, description="Defer destruction if snapshot is in use (e.g., has clones).")
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -260,7 +260,7 @@ class ZFSResourceSnapshotRenameQuery(BaseModel):
     current_name: NonEmptyString = Field(description="Current snapshot path (e.g., 'pool/dataset@old_name').")
     new_name: NonEmptyString = Field(description="New snapshot path (e.g., 'pool/dataset@new_name').")
     recursive: bool = Field(default=False, description="Recursively rename matching snapshots in child datasets.")
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -280,7 +280,7 @@ class ZFSResourceSnapshotCloneQuery(BaseModel):
     snapshot: NonEmptyString = Field(description="Source snapshot path to clone (e.g., 'pool/dataset@snapshot').")
     dataset: NonEmptyString = Field(description="Destination dataset path for the clone (e.g., 'pool/clone').")
     properties: dict[str, str | int] = Field(default={}, description="ZFS properties to set on the cloned dataset.")
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -308,7 +308,7 @@ class ZFSResourceSnapshotCreateQuery(BaseModel):
             "'com.company:backup_type'). Regular ZFS properties cannot be set on snapshots at creation time."
         ),
     )
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -331,7 +331,7 @@ class ZFSResourceSnapshotHoldQuery(BaseModel):
         default=False,
         description="Apply hold recursively to matching snapshots in child datasets.",
     )
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -366,7 +366,7 @@ class ZFSResourceSnapshotReleaseQuery(BaseModel):
         default=False,
         description="Release holds recursively from matching snapshots in child datasets.",
     )
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."
@@ -396,7 +396,7 @@ class ZFSResourceSnapshotRollbackQuery(BaseModel):
         default=False,
         description="Do a complete recursive rollback of each child snapshot. Fails if any child lacks the snapshot.",
     )
-    bypass: SkipJsonSchema[bool] = Field(
+    bypass: Private[bool] = Field(
         default=False,
         description=(
             "If true, will bypass the safety checks that prevent deleting zfs resources that are \"protected\"."

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -307,10 +307,11 @@ class ReplicationService(CRUDService):
         roles=["REPLICATION_TASK_WRITE"],
     )
     @job(logs=True, read_roles=["REPLICATION_TASK_READ"])
-    async def run(self, job, id_, really_run):
+    async def run(self, job, id_, options):
         """
         Run Replication Task of `id`.
         """
+        really_run = options["really_run"]
         if really_run:
             task = await self.get_instance(id_)
 

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -42,7 +42,7 @@ from zettarepl.utils.logging import (
 )
 from zettarepl.zettarepl import create_zettarepl
 
-from middlewared.api.current import PeriodicSnapshotTaskEntry
+from middlewared.api.current import PeriodicSnapshotTaskEntry, ReplicationRunOptions
 from middlewared.logger import setup_logging
 from middlewared.service.service import Service
 from middlewared.service_exception import CallError
@@ -993,7 +993,8 @@ class ZettareplService(Service):
 
                     # Start fake job if none are already running
                     if not self.replication_jobs_channels[message.task_id]:
-                        self.middleware.call_sync("replication.run", int(message.task_id[5:]), False)
+                        self.middleware.call_sync("replication.run", int(message.task_id[5:]),
+                                                  ReplicationRunOptions(really_run=False))
 
                 if isinstance(message, ReplicationTaskLog):
                     for channel in self.replication_jobs_channels[message.task_id]:

--- a/src/middlewared/middlewared/pytest/unit/api/base/test_private.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/test_private.py
@@ -1,0 +1,225 @@
+from typing import Annotated
+
+from pydantic import Field, StringConstraints
+from pydantic.json_schema import SkipJsonSchema
+import pytest
+
+from middlewared.api.base import (
+    BaseModel,
+    Excluded,
+    ForUpdateMetaclass,
+    NotRequired,
+    Private,
+    excluded_field,
+    model_subset,
+)
+from middlewared.api.base.handler.accept import accept_params, validate_model
+from middlewared.api.base.private import is_private_guard
+from middlewared.service_exception import ValidationErrors
+
+ERRMSG = "Extra inputs are not permitted"
+
+
+class Internal(BaseModel):
+    name: str
+    bypass: Private[bool] = False
+
+
+class InternalArgs(BaseModel):
+    data: Internal
+
+
+def model_args(model: type[BaseModel]) -> type[BaseModel]:
+    """Wrap `model` into an args model that accepts it as a single parameter."""
+
+    class Args(BaseModel):
+        data: model  # type: ignore[valid-type]
+
+    return Args
+
+
+def test_private_field_is_rejected():
+    """A `Private` field must be as unspecifiable as a field that does not exist at all."""
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(InternalArgs, [{"name": "ivan", "bypass": True}])
+
+    assert ve.value.errors[0].attribute == "data.bypass"
+    assert ve.value.errors[0].errmsg == ERRMSG
+
+    with pytest.raises(ValidationErrors) as nonexistent:
+        accept_params(InternalArgs, [{"name": "ivan", "nonexistent": True}])
+
+    assert nonexistent.value.errors[0].errmsg == ve.value.errors[0].errmsg
+
+
+def test_private_field_is_hidden_from_the_schema():
+    assert "bypass" not in Internal.model_json_schema()["properties"]
+    assert "bypass" not in Internal.schema_model_fields()
+
+
+def test_private_field_default_is_applied():
+    assert accept_params(InternalArgs, [{"name": "ivan"}]) == [{"name": "ivan", "bypass": False}]
+
+
+def test_private_field_is_allowed_on_opt_in():
+    assert accept_params(InternalArgs, [{"name": "ivan", "bypass": True}], allow_private=True) == [
+        {"name": "ivan", "bypass": True}
+    ]
+
+
+def test_validate_model_allows_by_default():
+    """`validate_model` validates data produced by middleware itself; `accept_params` is the API boundary."""
+    assert validate_model(Internal, {"name": "ivan", "bypass": True}) == {"name": "ivan", "bypass": True}
+
+    with pytest.raises(ValidationErrors):
+        validate_model(Internal, {"name": "ivan", "bypass": True}, allow_private=False)
+
+
+def test_model_instance_is_not_revalidated():
+    """Internal callers that build the model themselves keep working: pydantic does not revalidate instances."""
+    assert accept_params(InternalArgs, [Internal(name="ivan", bypass=True)]) == [{"name": "ivan", "bypass": True}]
+
+
+def test_validated_params_can_be_forwarded():
+    """Middleware methods routinely forward their own validated params to another method.
+
+    `accept_params` materializes every default, private fields included, so a forwarded dict always mentions
+    them. That is not the caller specifying anything, so it must be accepted.
+    """
+    forwarded = accept_params(InternalArgs, [{"name": "ivan"}])
+    assert forwarded == [{"name": "ivan", "bypass": False}]
+    assert accept_params(InternalArgs, forwarded) == forwarded
+
+
+def test_skip_json_schema_field_stays_settable():
+    """Plain `SkipJsonSchema` keeps its meaning: undocumented, but not rejected."""
+
+    class Model(BaseModel):
+        name: str
+        undocumented: SkipJsonSchema[bool] = False
+
+    class Args(BaseModel):
+        data: Model
+
+    assert accept_params(Args, [{"name": "ivan", "undocumented": True}]) == [{"name": "ivan", "undocumented": True}]
+    assert "undocumented" not in Model.model_json_schema()["properties"]
+    assert "undocumented" not in Model.schema_model_fields()
+    assert not any(is_private_guard(metadata) for metadata in Model.model_fields["undocumented"].metadata)
+
+
+def test_excluded_field_is_not_guarded():
+    """`Excluded` is `SkipJsonSchema`, not `Private`, and already rejects any supplied value on its own."""
+
+    class Object(BaseModel):
+        id: int
+        name: str
+
+    class CreateObject(Object):
+        id: Excluded = excluded_field()
+
+    assert not any(is_private_guard(metadata) for metadata in CreateObject.model_fields["id"].metadata)
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(model_args(CreateObject), [{"id": 1, "name": "ivan"}])
+
+    assert ve.value.errors[0].errmsg == ERRMSG
+
+
+def test_not_required_private_field():
+    """A `NotRequired` default must not hide `Private` from the schema or from the guard.
+
+    `_annotate_not_required` rewrites the annotation into a union, and `SkipJsonSchema` stops being honored
+    once it is nested inside a union member, so both markers have to stay at field level.
+    """
+
+    class Model(BaseModel):
+        name: str
+        bypass: Private[bool] = NotRequired
+
+    assert "bypass" not in Model.model_json_schema()["properties"]
+    assert "bypass" not in Model.schema_model_fields()
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(model_args(Model), [{"name": "ivan", "bypass": True}])
+
+    assert ve.value.errors[0].attribute == "data.bypass"
+    assert accept_params(model_args(Model), [{"name": "ivan"}]) == [{"name": "ivan"}]
+
+
+def test_not_required_constraints_are_still_applied():
+    """Guarding the field must not stop its other constraints from being enforced."""
+
+    class Model(BaseModel):
+        value: Private[Annotated[str, StringConstraints(max_length=3)]] = NotRequired
+
+    assert validate_model(Model, {"value": "abc"}) == {"value": "abc"}
+
+    with pytest.raises(ValidationErrors):
+        validate_model(Model, {"value": "abcd"})
+
+
+def test_guard_is_added_once_per_field():
+    """Each subclass rebuilds its `FieldInfo` from the already-guarded one of its base."""
+
+    class Child(Internal):
+        pass
+
+    class GrandChild(Child):
+        pass
+
+    for model in (Internal, Child, GrandChild):
+        guards = [m for m in model.model_fields["bypass"].metadata if is_private_guard(m)]
+        assert len(guards) == 1, model
+
+
+def test_subclass_may_override_the_default():
+    """The guard compares against the default of the field it is on, not the one its base declared."""
+
+    class Child(Internal):
+        bypass: Private[bool] = True
+
+    assert accept_params(model_args(Child), [{"name": "ivan", "bypass": True}]) == [{"name": "ivan", "bypass": True}]
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(model_args(Child), [{"name": "ivan", "bypass": False}])
+
+    assert ve.value.errors[0].attribute == "data.bypass"
+
+
+def test_for_update_metaclass_is_guarded():
+    """`ForUpdateMetaclass` does not go through `_BaseModelMetaclass.__new__`."""
+
+    class Update(Internal, metaclass=ForUpdateMetaclass):
+        pass
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(model_args(Update), [{"bypass": True}])
+
+    assert ve.value.errors[0].attribute == "data.bypass"
+    assert accept_params(model_args(Update), [{"name": "ivan"}]) == [{"name": "ivan"}]
+
+
+def test_model_subset_is_guarded():
+    """`model_subset` deletes fields after the class is built; the guard travels with the field it is on."""
+    Subset = model_subset(Internal, ["name", "bypass"])
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(model_args(Subset), [{"name": "ivan", "bypass": True}])
+
+    assert ve.value.errors[0].attribute == "data.bypass"
+
+
+def test_nested_private_field():
+    class Options(BaseModel):
+        delete_invalid_rows: Private[bool] = False
+
+    class Query(BaseModel):
+        options: Options = Field(default_factory=Options)
+
+    class QueryArgs(BaseModel):
+        data: Query
+
+    with pytest.raises(ValidationErrors) as ve:
+        accept_params(QueryArgs, [{"options": {"delete_invalid_rows": True}}])
+
+    assert ve.value.errors[0].attribute == "data.options.delete_invalid_rows"

--- a/src/middlewared/middlewared/pytest/unit/api/handler/result/test_secret.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/result/test_secret.py
@@ -101,7 +101,7 @@ def test_remove_secrets_type_discriminator():
     }
 
 
-def test_private_union():
+def test_secret_union():
     with pytest.raises(TypeError) as ve:
         class UserModel(BaseModel):
             username: str
@@ -109,7 +109,7 @@ def test_private_union():
 
     assert ve.value.args[0] == ("Model UserModel has field password defined as Optional[pydantic.types.Secret[str]]. "
                                 "pydantic.types.Secret[str] cannot be a member of an Optional or a Union, please make "
-                                "the whole field Private.")
+                                "the whole field a `Secret`.")
 
 
 def test_remove_secrets_optional_model():

--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -106,7 +106,7 @@ def snapshot(dataset, name, **kwargs):
 
     result = call(
         "zfs.resource.snapshot.create",
-        {"dataset": dataset, "name": name, "bypass": True, **kwargs}
+        {"dataset": dataset, "name": name, **kwargs}
     )
     id_ = f"{dataset}@{name}"
     try:

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -1,6 +1,7 @@
 import contextlib
 import random
 import string
+import time
 
 import pytest
 
@@ -360,3 +361,60 @@ def test_disable_task_preserves_state():
                 assert "last_snapshot" in state_after_disable, \
                     f"State 'last_snapshot' field should be preserved after disabling. " \
                     f"Before: {state_before_disable}, After: {state_after_disable}"
+
+
+def _poll_replication(id_, predicate, timeout, message):
+    deadline = time.monotonic() + timeout
+    while True:
+        task = call("replication.get_instance", id_)
+        if predicate(task):
+            return task
+
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"{message} (waited {timeout} seconds, task = {task!r})")
+
+        time.sleep(1)
+
+
+def test_scheduled_run_is_tracked_by_a_job():
+    """A replication task started by the scheduler is tracked by a `replication.run` job.
+
+    When zettarepl starts a task on its own schedule there is no job behind it yet, so the observer
+    starts a "fake" one (`replication.run` with `really_run=False`) for the task's progress and logs to
+    be reported through. A manual `replication.run` attaches to the task before the observer gets a
+    chance to, so only a task that runs on schedule reaches this code.
+    """
+    with dataset("scheduled_run_src") as src:
+        call("pool.snapshot.create", {"dataset": src, "name": "2022-01-01-00-00-00"})
+
+        with dataset("scheduled_run_dst") as dst:
+            with replication_task({
+                "name": "test_scheduled_run_is_tracked_by_a_job",
+                "direction": "PUSH",
+                "transport": "LOCAL",
+                "source_datasets": [src],
+                "target_dataset": dst,
+                "recursive": False,
+                "also_include_naming_schema": ["%Y-%m-%d-%H-%M-%S"],
+                # Runs at every minute boundary, so the scheduler is guaranteed to pick it up.
+                "auto": True,
+                "schedule": {"minute": "*"},
+                "retention_policy": "NONE",
+            }) as task:
+                # Two minute boundaries worth of waiting, so a tick that is missed by a fraction of a
+                # second does not fail the test.
+                _poll_replication(
+                    task["id"],
+                    lambda task: task["job"] is not None,
+                    120,
+                    "The scheduler never started a job for the replication task",
+                )
+                finished = _poll_replication(
+                    task["id"],
+                    lambda task: task["job"]["state"] in ("SUCCESS", "FAILED", "ABORTED"),
+                    60,
+                    "The job tracking the replication task never finished",
+                )
+
+                assert finished["job"]["state"] == "SUCCESS", finished["job"]["error"]
+                assert finished["state"]["state"] == "FINISHED", finished["state"]

--- a/tests/api2/test_zfs_resource_snapshot_destroy.py
+++ b/tests/api2/test_zfs_resource_snapshot_destroy.py
@@ -298,3 +298,21 @@ def test_zfs_resource_snapshot_destroy_protected_path_all_snapshots():
             {"path": "boot-pool", "all_snapshots": True},
         )
     assert "protected" in str(exc_info.value).lower()
+
+
+def test_zfs_resource_snapshot_destroy_bypass_is_not_settable():
+    """Test that an API client cannot skip the protected path check by passing `bypass`.
+
+    `bypass` is a `Private` field: it exists so that internal callers can destroy system datasets, and the
+    API must reject it the same way it rejects a key that does not exist at all. boot-pool is always
+    protected, and the check runs before the snapshot is looked up, so nothing is destroyed either way.
+    """
+    with pytest.raises(Exception) as exc_info:
+        call(
+            "zfs.resource.snapshot.destroy",
+            {"path": "boot-pool@test", "bypass": True},
+        )
+
+    error = str(exc_info.value)
+    assert "bypass" in error, error
+    assert "Extra inputs are not permitted" in error, error


### PR DESCRIPTION
API parameters annotated with `Private[...]` will be excluded from API doc, and passing them via an API call will be an error.

Original PR: https://github.com/truenas/middleware/pull/19456
