### PR TITLE
NAS-142044 / 27.0.0-BETA.1 / Protect persistent keyring

### DIFF
--- a/src/middlewared/middlewared/plugins/security/sessions.py
+++ b/src/middlewared/middlewared/plugins/security/sessions.py
@@ -9,12 +9,22 @@ from collections.abc import Generator
 from datetime import datetime
 from typing import Any
 
+import truenas_keyring
 from truenas_pam_session import iterate_sessions
 
 from middlewared.api.base import BaseModel, NonEmptyString
 from middlewared.api.current import QueryOptions
-from middlewared.service import Service, filterable_api_method
+from middlewared.service import Service, filterable_api_method, periodic
 from middlewared.utils.filter_list import filter_list
+
+# The kernel expires the uid=0 persistent keyring after
+# kernel.keys.persistent_keyring_expiry seconds of non-use (3 days by default)
+# and reaps everything linked under it, including the PAM_TRUENAS keyring that
+# holds our session records. Every keyctl_get_persistent() resets that timer,
+# which authentication performs, so this only matters on an appliance where
+# nobody has authenticated for the whole window. Touch it well inside the
+# window so an idle system does not silently lose its open session records.
+KEYRING_KEEPALIVE_INTERVAL = 86400
 
 # Currently session info is private and consumed for STIG purposes but we can
 # expose in future by moving APIs here to formal external definitions
@@ -76,3 +86,12 @@ class SystemSecuritySessionsService(Service):
         that use the PAM stack, so you'll see webshare sessions, FTP
         sessions, openssh sessions, etc. """
         return filter_list(truenas_session_iterator(), filters, options, SecuritySessionEntry)
+
+    @periodic(interval=KEYRING_KEEPALIVE_INTERVAL)
+    def keyring_keepalive(self) -> None:
+        """ Reset the expiry timer on the uid=0 persistent keyring.
+
+        get_persistent_keyring() gets or creates the keyring rather than
+        searching within it, so this succeeds before anyone has authenticated
+        and does not depend on PAM_TRUENAS existing yet. """
+        truenas_keyring.get_persistent_keyring()

--- a/src/middlewared/pyproject.toml
+++ b/src/middlewared/pyproject.toml
@@ -60,7 +60,7 @@ module = [
     "pyinotify.*",
     "pyudev.*",
     "tdb.*",
-    "trueans_keyring",
+    "truenas_keyring",
     "truenas_pam_faillog",
     "truenas_pam_session",
     "truenas_pylibsed.*",

--- a/src/middlewared/pyproject.toml
+++ b/src/middlewared/pyproject.toml
@@ -60,6 +60,7 @@ module = [
     "pyinotify.*",
     "pyudev.*",
     "tdb.*",
+    "trueans_keyring",
     "truenas_pam_faillog",
     "truenas_pam_session",
     "truenas_pylibsed.*",


### PR DESCRIPTION
This commit adds a daily periodic task to refetch the persistent keyring for uid 0. By default, persistent keyrings are garbage collected every 3 days with the timer reset on each fetch. Although there are typically background tasks that fetch the keyring for uid 0, it's better to ensure that it's always preserved since we store kerberos tickets, some session information, and API keys in it.