### PR TITLE
NAS-142051 / 26.0.0-RC.1 / Fix AttributeError in smb.set_system_sid from NAS-141946 backport

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sid.py
+++ b/src/middlewared/middlewared/plugins/smb_/sid.py
@@ -1,6 +1,5 @@
 import subprocess
 
-from middlewared.api.current import ServiceOptions
 from middlewared.service import Service, private
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils.sid import random_sid
@@ -56,7 +55,7 @@ class SMBService(Service):
         if setsid.returncode != 0:
             raise CallError(f'setlocalsid failed: {setsid.stderr.decode()}')
 
-        if (current_sid is None and not sid_read_failed) or not self.call_sync2(self.s.service.started, 'idmap'):
+        if (current_sid is None and not sid_read_failed) or not self.middleware.call_sync('service.started', 'idmap'):
             # Skip the restart when we know there was no prior SID (a fresh secrets.tdb has
             # nothing stale for winbindd to rebuild) or when winbindd isn't running. When the
             # read failed instead, current_sid is None but sid_read_failed is True, so we fall
@@ -72,6 +71,6 @@ class SMBService(Service):
             'winbindd to rebuild its view of the local SAM domain.',
             netbiosname, current_sid, server_sid
         )
-        self.call_sync2(
-            self.s.service.control, 'RESTART', 'idmap', ServiceOptions(silent=False, ha_propagate=False)
+        self.middleware.call_sync(
+            'service.control', 'RESTART', 'idmap', {'silent': False, 'ha_propagate': False}
         ).wait_sync(raise_error=True)

--- a/tests/unit/test_smb_set_system_sid.py
+++ b/tests/unit/test_smb_set_system_sid.py
@@ -11,7 +11,7 @@ so winbindd must still be restarted.
 
 import logging
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -36,6 +36,8 @@ def _smb_service(current_sid, *, idmap_started=True, sid_exc=None):
     svc.middleware = MagicMock()
     svc.logger = logging.getLogger("test_smb_set_system_sid")
 
+    restart_job = MagicMock()
+
     def call_sync(name, *args, **kwargs):
         if name == "datastore.config":
             return {"cifs_SID": SERVER_SID}
@@ -45,20 +47,13 @@ def _smb_service(current_sid, *, idmap_started=True, sid_exc=None):
             if sid_exc is not None:
                 raise sid_exc
             return current_sid
+        if name == "service.started":
+            return idmap_started
+        if name == "service.control":
+            return restart_job
         raise AssertionError(f"unexpected middleware call: {name}")
 
     svc.middleware.call_sync.side_effect = call_sync
-
-    restart_job = MagicMock()
-
-    def call_sync2(method, *args, **kwargs):
-        if method is svc.s.service.started:
-            return idmap_started
-        if method is svc.s.service.control:
-            return restart_job
-        raise AssertionError(f"unexpected call_sync2 target: {method}")
-
-    svc.call_sync2 = Mock(side_effect=call_sync2)
     svc._restart_job = restart_job
     return svc
 
@@ -66,8 +61,8 @@ def _smb_service(current_sid, *, idmap_started=True, sid_exc=None):
 def _restarted(svc):
     """True if a winbindd (idmap) RESTART was issued."""
     return any(
-        c.args[0] is svc.s.service.control and c.args[1] == "RESTART" and c.args[2] == "idmap"
-        for c in svc.call_sync2.call_args_list
+        c.args[0] == "service.control" and c.args[1] == "RESTART" and c.args[2] == "idmap"
+        for c in svc.middleware.call_sync.call_args_list
     )
 
 


### PR DESCRIPTION
The backport of NAS-141946 (#19425) kept master's typed service accessor (self.s.service) in smb_/sid.py, but the stable/26 ServiceContainer does not register a `service` attribute. Every call that reached the winbindd restart decision failed with "'ServiceContainer' object has no attribute 'service'", breaking all AD domain joins in directory services CI.

Convert both calls to the string API used elsewhere on stable/26 and rewire the unit test mocks to match.