### PR TITLE
NAS-142059 / 27.0.0-BETA.1 / Directory services cache fixes

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -79,12 +79,12 @@ class DirectoryServices(Service):
         This method refreshes the directory services cache for users and groups that is
         used as a backing for :method:`user.query` and :method:`group.query` methods. The first cache fill in
         an Active Directory domain may take a significant amount of time to complete and
-        so it is performed as within a job. The most likely situation in which a user may
-        desire to refresh the directory services cache is after new users or groups  to a remote
-        directory server with the intention to have said users or groups appear in the
-        results of the aforementioned account-related methods.
+        so it is performed within a job. The most likely situation in which a user may
+        desire to refresh the directory services cache is after new users or groups are
+        added to a remote directory server with the intention to have said users or groups
+        appear in the results of the aforementioned account-related methods.
 
-        A cache refresh is not required in order to use newly-added users and groups for in
+        A cache refresh is not required in order to use newly-added users and groups in
         permissions and ACL related methods. Likewise, a cache refresh will not resolve issues
         with users being unable to authenticate to shares.
         """

--- a/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
@@ -1,10 +1,9 @@
-from collections import defaultdict
 from collections.abc import Iterable
+from contextlib import suppress
 from datetime import datetime, timedelta
 import enum
 from itertools import batched
 import os
-from threading import Lock
 from uuid import uuid4
 
 from middlewared.job import Job
@@ -39,8 +38,6 @@ from middlewared.utils.time_utils import utc_now
 # first is as expensive as generating the cache itself.
 LOG_CACHE_ENTRY_INTERVAL = 10  # Update progress of job every nth user / group
 
-TDB_LOCKS = defaultdict(Lock)
-
 CACHE_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.JSON)
 CACHE_DIR = '/var/db/system/directory_services'
 
@@ -64,11 +61,12 @@ class DSCacheFill:
     users and groups that contain same keys as results for user.query and group.query
     via the method `fill_cache()` once the cache is filled. The temporary TDB
     files are renamed over the current ones in-use by middleware. On context manager
-    exit the handles on the TDB files are closed.
+    exit the handles on the TDB files are closed and any temporary file that was not
+    renamed over a live cache is removed.
 
-    NOTE: cache fill here is performed without taking on the USER_TDB_LOCK or
-    GROUP_TDB_LOCK because the middleware caches will only be renamed over when fill
-    is complete. This is to ensure relative continuity in cache results.
+    NOTE: cache fill here is performed without taking the handle lock in
+    `middlewared.utils.tdb` because the middleware caches will only be renamed over when
+    fill is complete. This is to ensure relative continuity in cache results.
     """
     users_handle = None
     groups_handle = None
@@ -76,31 +74,53 @@ class DSCacheFill:
     def __enter__(self):
         os.makedirs(CACHE_DIR, mode=0o700, exist_ok=True)
         file_prefix = f'directory_service_cache_tmp_{uuid4()}'
-        self.users_handle = TDBHandle(os.path.join(CACHE_DIR, f'{file_prefix}_user.tdb'), CACHE_OPTIONS)
-        self.groups_handle = TDBHandle(os.path.join(CACHE_DIR, f'{file_prefix}_group.tdb'), CACHE_OPTIONS)
-        # Ensure we have clean initial state and restrictive permissions
-        self.users_handle.clear()
-        os.chmod(self.users_handle.full_path, 0o600)
-        self.groups_handle.clear()
-        os.chmod(self.groups_handle.full_path, 0o600)
+        try:
+            self.users_handle = TDBHandle(os.path.join(CACHE_DIR, f'{file_prefix}_user.tdb'), CACHE_OPTIONS)
+            self.groups_handle = TDBHandle(os.path.join(CACHE_DIR, f'{file_prefix}_group.tdb'), CACHE_OPTIONS)
+            # Ensure we have clean initial state and restrictive permissions
+            self.users_handle.clear()
+            os.chmod(self.users_handle.full_path, 0o600)
+            self.groups_handle.clear()
+            os.chmod(self.groups_handle.full_path, 0o600)
+        except Exception:
+            # __exit__ is not called if __enter__ raises, so clean up here or the
+            # partially-created temporary files are stranded on the system dataset.
+            self._close_and_remove_temporary_files()
+            raise
+
         return self
 
     def __exit__(self, tp, value, tb):
-        stored_exception = None
-        try:
-            if self.users_handle:
-                self.users_handle.close()
-        except Exception as exc:
-            stored_exception = exc
-
-        try:
-            if self.groups_handle:
-                self.groups_handle.close()
-        except Exception as exc:
-            stored_exception = exc
-
+        stored_exception = self._close_and_remove_temporary_files()
         if stored_exception:
             raise stored_exception
+
+    def _close_and_remove_temporary_files(self) -> Exception | None:
+        """ Close both handles and unlink any temporary file that is still present.
+
+        A successful `_commit()` has already renamed the temporary files over the live
+        ones, so the unlink is a no-op in that case. If the fill failed partway (which is
+        expected for the errors documented on `fill_cache`), this is what keeps the
+        temporary files from accumulating in CACHE_DIR.
+
+        Returns the last exception raised while closing, if any.
+        """
+        stored_exception = None
+
+        for handle in (self.users_handle, self.groups_handle):
+            if handle is None:
+                continue
+
+            try:
+                handle.close()
+            except Exception as exc:
+                stored_exception = exc
+
+            if handle.full_path:
+                with suppress(FileNotFoundError):
+                    os.remove(handle.full_path)
+
+        return stored_exception
 
     def _commit(self):
         """
@@ -398,7 +418,7 @@ def insert_cache_entry(
     with get_tdb_handle(DSCacheFile[id_type.name].path, CACHE_OPTIONS) as handle:
         handle.batch_op([
             TDBBatchOperation(action=TDBBatchAction.SET, key=f'ID_{xid}', value=entry),
-            TDBBatchOperation(action=TDBBatchAction.SET, key=f'NAME_{xid}', value=entry),
+            TDBBatchOperation(action=TDBBatchAction.SET, key=f'NAME_{name}', value=entry),
         ])
 
 
@@ -406,7 +426,7 @@ def retrieve_cache_entry(
     id_type: IDType,
     name: str,
     xid: int
-) -> None:
+) -> dict:
     """
     Retrieve cache entry under lock using stored handle. If both name and xid
     are specified, preference is given to xid.
@@ -509,7 +529,7 @@ def expire_cache() -> None:
     NOTE: this is used in the CI pipeline for tests/directory_services. """
 
     # generate a timestamp in the past that's old enough to definitely trigger rebuild
-    ts = utc_now(naive=True) - timedelta(days=2)
+    ts = utc_now(naive=False) - timedelta(days=2)
 
     for cache_file in DSCacheFile:
         with get_tdb_handle(cache_file.path, CACHE_OPTIONS) as hdl:

--- a/tests/unit/test_directoryservices_util_cache.py
+++ b/tests/unit/test_directoryservices_util_cache.py
@@ -30,33 +30,33 @@ from middlewared.service_exception import MatchNotFound
 from middlewared.utils.tdb import TDB_HANDLES
 from middlewared.utils.time_utils import utc_now
 
-TEST_VERSION = '27.0.0-TEST'
+TEST_VERSION = "27.0.0-TEST"
 
 
 def user_entry(uid: int, username: str) -> dict:
     return {
-        'id': 100000000 + uid,
-        'uid': uid,
-        'username': username,
-        'home': f'/home/{username}',
-        'shell': '/usr/bin/sh',
-        'full_name': username,
-        'local': False,
-        'smb': True,
-        'sid': f'S-1-5-21-1-2-3-{uid}',
-        'roles': [],
+        "id": 100000000 + uid,
+        "uid": uid,
+        "username": username,
+        "home": f"/home/{username}",
+        "shell": "/usr/bin/sh",
+        "full_name": username,
+        "local": False,
+        "smb": True,
+        "sid": f"S-1-5-21-1-2-3-{uid}",
+        "roles": [],
     }
 
 
 @pytest.fixture
 def cache_dir(tmp_path, monkeypatch):
-    """ Point the cache helpers at a temporary directory.
+    """Point the cache helpers at a temporary directory.
 
     `DSCacheFile.path` reads the module-level CACHE_DIR at call time, so patching the
     module attribute is sufficient. TDB handles are cached process-wide by path, so drop
     any handle this test opened to keep tests independent.
     """
-    monkeypatch.setattr(util_cache, 'CACHE_DIR', str(tmp_path))
+    monkeypatch.setattr(util_cache, "CACHE_DIR", str(tmp_path))
     yield tmp_path
 
     for path in [p for p in TDB_HANDLES if p.startswith(str(tmp_path))]:
@@ -67,7 +67,7 @@ def cache_dir(tmp_path, monkeypatch):
 
 
 def build_cache(entries=None, version=TEST_VERSION, expiration=None):
-    """ Produce a committed pair of cache files, optionally seeded with user entries. """
+    """Produce a committed pair of cache files, optionally seeded with user entries."""
     if expiration is None:
         expiration = utc_now(naive=False) + CACHE_LIFETIME
 
@@ -77,48 +77,48 @@ def build_cache(entries=None, version=TEST_VERSION, expiration=None):
             _tdb_add_expiration(hdl, expiration)
 
         for entry in entries or []:
-            util_cache._tdb_add_entry(dc.users_handle, entry['uid'], entry['username'], entry)
+            util_cache._tdb_add_entry(dc.users_handle, entry["uid"], entry["username"], entry)
 
         dc._commit()
 
 
 def temp_files(cache_dir) -> list:
-    return sorted(p.name for p in cache_dir.glob('directory_service_cache_tmp_*'))
+    return sorted(p.name for p in cache_dir.glob("directory_service_cache_tmp_*"))
 
 
 def test__insert_cache_entry_is_retrievable_by_id_and_name(cache_dir):
-    """ Lazy insertion must write both the ID_ and NAME_ keys.
+    """Lazy insertion must write both the ID_ and NAME_ keys.
 
     Regression test: the NAME_ key was previously built from the numeric id, so a lazily
     inserted entry could never be found by name and every by-name lookup fell through to
     a fresh NSS + idmap round-trip.
     """
-    entry = user_entry(10001, 'TESTDOM\\jdoe')
-    insert_cache_entry(IDType.USER, entry['uid'], entry['username'], entry)
+    entry = user_entry(10001, "TESTDOM\\jdoe")
+    insert_cache_entry(IDType.USER, entry["uid"], entry["username"], entry)
 
-    assert retrieve_cache_entry(IDType.USER, None, entry['uid']) == entry
-    assert retrieve_cache_entry(IDType.USER, entry['username'], None) == entry
+    assert retrieve_cache_entry(IDType.USER, None, entry["uid"]) == entry
+    assert retrieve_cache_entry(IDType.USER, entry["username"], None) == entry
 
 
 def test__retrieve_cache_entry_miss_raises(cache_dir):
-    insert_cache_entry(IDType.USER, 10001, 'TESTDOM\\jdoe', user_entry(10001, 'TESTDOM\\jdoe'))
+    insert_cache_entry(IDType.USER, 10001, "TESTDOM\\jdoe", user_entry(10001, "TESTDOM\\jdoe"))
 
     with pytest.raises(MatchNotFound):
-        retrieve_cache_entry(IDType.USER, 'TESTDOM\\nobody', None)
+        retrieve_cache_entry(IDType.USER, "TESTDOM\\nobody", None)
 
     with pytest.raises(MatchNotFound):
         retrieve_cache_entry(IDType.USER, None, 99999)
 
 
 def test__query_cache_entries_returns_id_keyed_entries_once(cache_dir):
-    """ Query walks ID_-prefixed keys only, so each entry appears exactly once even
-    though it is stored under both an ID_ and a NAME_ key. """
-    entries = [user_entry(10001 + i, f'TESTDOM\\user{i}') for i in range(3)]
+    """Query walks ID_-prefixed keys only, so each entry appears exactly once even
+    though it is stored under both an ID_ and a NAME_ key."""
+    entries = [user_entry(10001 + i, f"TESTDOM\\user{i}") for i in range(3)]
     build_cache(entries)
 
     found = query_cache_entries(IDType.USER, [], {})
 
-    assert sorted(e['uid'] for e in found) == [10001, 10002, 10003]
+    assert sorted(e["uid"] for e in found) == [10001, 10002, 10003]
     assert len(found) == len(entries)
 
 
@@ -131,15 +131,15 @@ def test__dscachefill_commit_leaves_no_temp_files(cache_dir):
 
 
 def test__dscachefill_failure_removes_temp_files(cache_dir):
-    """ A fill that raises before _commit() must not strand its temporary files.
+    """A fill that raises before _commit() must not strand its temporary files.
 
     NssError / WBCErr / job abort are all documented as expected failures for
     fill_cache, so this is the common path rather than an edge case.
     """
-    with pytest.raises(RuntimeError, match='fill failed'):
+    with pytest.raises(RuntimeError, match="fill failed"):
         with DSCacheFill():
             assert temp_files(cache_dir) != []
-            raise RuntimeError('fill failed')
+            raise RuntimeError("fill failed")
 
     assert temp_files(cache_dir) == []
     # a failed fill must leave the live cache untouched
@@ -147,14 +147,14 @@ def test__dscachefill_failure_removes_temp_files(cache_dir):
 
 
 def test__dscachefill_failure_preserves_previous_cache(cache_dir):
-    build_cache([user_entry(10001, 'TESTDOM\\jdoe')])
+    build_cache([user_entry(10001, "TESTDOM\\jdoe")])
 
     with pytest.raises(RuntimeError):
         with DSCacheFill():
-            raise RuntimeError('fill failed')
+            raise RuntimeError("fill failed")
 
     assert temp_files(cache_dir) == []
-    assert query_cache_entries(IDType.USER, [], {})[0]['uid'] == 10001
+    assert query_cache_entries(IDType.USER, [], {})[0]["uid"] == 10001
 
 
 def test__check_cache_version_keeps_matching_cache(cache_dir):
@@ -167,7 +167,7 @@ def test__check_cache_version_keeps_matching_cache(cache_dir):
 
 
 def test__check_cache_version_removes_mismatched_cache(cache_dir):
-    build_cache(version='26.04.0')
+    build_cache(version="26.04.0")
 
     check_cache_version(TEST_VERSION)
 
@@ -186,7 +186,7 @@ def test__check_cache_expired_true_for_missing_cache(cache_dir):
 
 
 def test__expire_cache_marks_cache_expired(cache_dir):
-    """ expire_cache must write a timestamp that check_cache_expired reads as expired.
+    """expire_cache must write a timestamp that check_cache_expired reads as expired.
 
     Both sides deal in timezone-aware UTC; this pins that they stay consistent rather
     than relying on ejson attaching UTC when the value is read back.

--- a/tests/unit/test_directoryservices_util_cache.py
+++ b/tests/unit/test_directoryservices_util_cache.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for the directory services cache helpers in
+`middlewared.plugins.directoryservices_.util_cache`.
+
+These cover the storage-level behaviour that is otherwise only exercised against a live
+AD / IPA / LDAP domain: the id/name key schema, temporary-file handling during a cache
+fill, and the version / expiration bookkeeping.
+"""
+
+import os
+
+import pytest
+
+from middlewared.plugins.directoryservices_ import util_cache
+from middlewared.plugins.directoryservices_.util_cache import (
+    CACHE_LIFETIME,
+    DSCacheFile,
+    DSCacheFill,
+    _tdb_add_expiration,
+    _tdb_add_version,
+    check_cache_expired,
+    check_cache_version,
+    expire_cache,
+    insert_cache_entry,
+    query_cache_entries,
+    retrieve_cache_entry,
+)
+from middlewared.plugins.idmap_.idmap_constants import IDType
+from middlewared.service_exception import MatchNotFound
+from middlewared.utils.tdb import TDB_HANDLES
+from middlewared.utils.time_utils import utc_now
+
+TEST_VERSION = '27.0.0-TEST'
+
+
+def user_entry(uid: int, username: str) -> dict:
+    return {
+        'id': 100000000 + uid,
+        'uid': uid,
+        'username': username,
+        'home': f'/home/{username}',
+        'shell': '/usr/bin/sh',
+        'full_name': username,
+        'local': False,
+        'smb': True,
+        'sid': f'S-1-5-21-1-2-3-{uid}',
+        'roles': [],
+    }
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    """ Point the cache helpers at a temporary directory.
+
+    `DSCacheFile.path` reads the module-level CACHE_DIR at call time, so patching the
+    module attribute is sufficient. TDB handles are cached process-wide by path, so drop
+    any handle this test opened to keep tests independent.
+    """
+    monkeypatch.setattr(util_cache, 'CACHE_DIR', str(tmp_path))
+    yield tmp_path
+
+    for path in [p for p in TDB_HANDLES if p.startswith(str(tmp_path))]:
+        try:
+            TDB_HANDLES.pop(path).close()
+        except Exception:
+            pass
+
+
+def build_cache(entries=None, version=TEST_VERSION, expiration=None):
+    """ Produce a committed pair of cache files, optionally seeded with user entries. """
+    if expiration is None:
+        expiration = utc_now(naive=False) + CACHE_LIFETIME
+
+    with DSCacheFill() as dc:
+        for hdl in (dc.users_handle, dc.groups_handle):
+            _tdb_add_version(hdl, version)
+            _tdb_add_expiration(hdl, expiration)
+
+        for entry in entries or []:
+            util_cache._tdb_add_entry(dc.users_handle, entry['uid'], entry['username'], entry)
+
+        dc._commit()
+
+
+def temp_files(cache_dir) -> list:
+    return sorted(p.name for p in cache_dir.glob('directory_service_cache_tmp_*'))
+
+
+def test__insert_cache_entry_is_retrievable_by_id_and_name(cache_dir):
+    """ Lazy insertion must write both the ID_ and NAME_ keys.
+
+    Regression test: the NAME_ key was previously built from the numeric id, so a lazily
+    inserted entry could never be found by name and every by-name lookup fell through to
+    a fresh NSS + idmap round-trip.
+    """
+    entry = user_entry(10001, 'TESTDOM\\jdoe')
+    insert_cache_entry(IDType.USER, entry['uid'], entry['username'], entry)
+
+    assert retrieve_cache_entry(IDType.USER, None, entry['uid']) == entry
+    assert retrieve_cache_entry(IDType.USER, entry['username'], None) == entry
+
+
+def test__retrieve_cache_entry_miss_raises(cache_dir):
+    insert_cache_entry(IDType.USER, 10001, 'TESTDOM\\jdoe', user_entry(10001, 'TESTDOM\\jdoe'))
+
+    with pytest.raises(MatchNotFound):
+        retrieve_cache_entry(IDType.USER, 'TESTDOM\\nobody', None)
+
+    with pytest.raises(MatchNotFound):
+        retrieve_cache_entry(IDType.USER, None, 99999)
+
+
+def test__query_cache_entries_returns_id_keyed_entries_once(cache_dir):
+    """ Query walks ID_-prefixed keys only, so each entry appears exactly once even
+    though it is stored under both an ID_ and a NAME_ key. """
+    entries = [user_entry(10001 + i, f'TESTDOM\\user{i}') for i in range(3)]
+    build_cache(entries)
+
+    found = query_cache_entries(IDType.USER, [], {})
+
+    assert sorted(e['uid'] for e in found) == [10001, 10002, 10003]
+    assert len(found) == len(entries)
+
+
+def test__dscachefill_commit_leaves_no_temp_files(cache_dir):
+    build_cache()
+
+    assert temp_files(cache_dir) == []
+    assert os.path.exists(DSCacheFile.USER.path)
+    assert os.path.exists(DSCacheFile.GROUP.path)
+
+
+def test__dscachefill_failure_removes_temp_files(cache_dir):
+    """ A fill that raises before _commit() must not strand its temporary files.
+
+    NssError / WBCErr / job abort are all documented as expected failures for
+    fill_cache, so this is the common path rather than an edge case.
+    """
+    with pytest.raises(RuntimeError, match='fill failed'):
+        with DSCacheFill():
+            assert temp_files(cache_dir) != []
+            raise RuntimeError('fill failed')
+
+    assert temp_files(cache_dir) == []
+    # a failed fill must leave the live cache untouched
+    assert not os.path.exists(DSCacheFile.USER.path)
+
+
+def test__dscachefill_failure_preserves_previous_cache(cache_dir):
+    build_cache([user_entry(10001, 'TESTDOM\\jdoe')])
+
+    with pytest.raises(RuntimeError):
+        with DSCacheFill():
+            raise RuntimeError('fill failed')
+
+    assert temp_files(cache_dir) == []
+    assert query_cache_entries(IDType.USER, [], {})[0]['uid'] == 10001
+
+
+def test__check_cache_version_keeps_matching_cache(cache_dir):
+    build_cache()
+
+    check_cache_version(TEST_VERSION)
+
+    assert os.path.exists(DSCacheFile.USER.path)
+    assert os.path.exists(DSCacheFile.GROUP.path)
+
+
+def test__check_cache_version_removes_mismatched_cache(cache_dir):
+    build_cache(version='26.04.0')
+
+    check_cache_version(TEST_VERSION)
+
+    assert not os.path.exists(DSCacheFile.USER.path)
+    assert not os.path.exists(DSCacheFile.GROUP.path)
+
+
+def test__check_cache_expired_false_for_fresh_cache(cache_dir):
+    build_cache()
+
+    assert check_cache_expired() is False
+
+
+def test__check_cache_expired_true_for_missing_cache(cache_dir):
+    assert check_cache_expired() is True
+
+
+def test__expire_cache_marks_cache_expired(cache_dir):
+    """ expire_cache must write a timestamp that check_cache_expired reads as expired.
+
+    Both sides deal in timezone-aware UTC; this pins that they stay consistent rather
+    than relying on ejson attaching UTC when the value is read back.
+    """
+    build_cache()
+    assert check_cache_expired() is False
+
+    expire_cache()
+
+    assert check_cache_expired() is True


### PR DESCRIPTION
insert_cache_entry() built the NAME_ key from the numeric id rather than the name, so entries added by the lazy insertion path were only reachable by id. A by-name lookup for such an entry missed the cache and fell through to NSS plus idmap.synthetic_user. The bulk fill path was unaffected, and query_cache_entries() reads only ID_-prefixed keys, so enumeration results did not change.

DSCacheFill did not remove its temporary files when `fill_cache()` raised `before _commit()`, so a failed fill can leave `directory_service_cache_tmp_*` files behind in the cache `directory. fill_cache()` documents NssError, WBCErr and job abort as reachable, and nothing else removes those files. Cleanup now also covers a failure partway through `__enter__`, which does not invoke `__exit__`.

expire_cache() now writes a timezone-aware UTC timestamp, matching fill_cache() and check_cache_expired().

Also drop the unused TDB_LOCKS defaultdict, correct the retrieve_cache_entry() return annotation, and fix docstrings: stale lock references in util_cache and grammatical errors in the rendered directoryservices.cache_refresh description.

Add unit tests for the key schema, temporary file handling, and the version and expiration bookkeeping.