### PR TITLE
NAS-142042 / 26.0.0-RC.1 / Keep container records unless their pool was really destroyed (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -112,6 +112,19 @@ class FSAttachmentDelegate(ServiceChangeMixin):
         if attachments:
             await self.start(attachments)
 
+    async def start_on_import(self, path):
+        """
+        Bring this delegate's attachments back up after the pool mounted at `path` was re-imported.
+
+        :param path: mountpoint of the re-imported pool (e.g. "/mnt/tank")
+
+        The default implementation starts the share/service style attachments that the generic
+        `query`/`start` contract describes. Stateful workloads (VMs, containers) override this to
+        honor their autostart configuration rather than booting everything that lives on the pool.
+        """
+        if attachments := await self.query(path, False):
+            await self.start(attachments)
+
     async def disable(self, attachments):
         """
         Disable said items, this is used when we export pool but do not want to delete
@@ -120,6 +133,26 @@ class FSAttachmentDelegate(ServiceChangeMixin):
         :return: None
         """
         await self.toggle(attachments, False)
+
+    async def destroy(self, path):
+        """
+        Discard whatever only made sense while the data on `path` existed, now that the pool
+        mounted there has actually been destroyed.
+
+        :param path: mountpoint of the destroyed pool (e.g. "/mnt/tank")
+
+        Called once per delegate by `pool.export`, only when the export was cascaded *and* the
+        pool's data really went away, and only after the zpool destroy has returned: `delete` has
+        to run first so the datasets are released, whereas discarding configuration is safe only
+        once the data it describes is confirmed gone.
+
+        Do not assume `delete` saw the same items. It is driven by `query(path, True)`, which
+        reports only running attachments and also matches items that merely reference this pool
+        from storage elsewhere, so this is handed the pool and selects for itself.
+
+        The default is a no-op: `delete` already disposed of the share/task style attachments
+        while the pool was still there.
+        """
 
 
 class LockableFSAttachmentDelegate[E](FSAttachmentDelegate):

--- a/src/middlewared/middlewared/plugins/container/attachments.py
+++ b/src/middlewared/middlewared/plugins/container/attachments.py
@@ -1,5 +1,6 @@
 import os.path
 
+from middlewared.api.current import ZFSResourceQuery
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
 
@@ -78,9 +79,31 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
             if await self.container_on_paths(container, paths):
                 yield container
 
+    async def containers_on_pool(self, pool):
+        # Every container whose *root* dataset lives on `pool`, regardless of runtime state. This is
+        # the pool-identity counterpart to `containers_on_paths`, which answers the subtree question
+        # -- and includes bind-mount sources -- for the query and start paths; the two are not
+        # interchangeable, see `destroy`. Matched by name rather than through `filesystem.is_child`
+        # because its only caller runs once the pool is gone, leaving nothing to resolve against.
+        return [
+            container for container in await self.middleware.call('container.query')
+            if container['dataset'].split('/')[0] == pool
+        ]
+
     def storage_paths(self, container):
         # The paths whose datasets the container needs to run: its root dataset and every FILESYSTEM
         # device source.
+        #
+        # The root entry is deliberately derived from the dataset *name*, not from where the
+        # dataset is actually mounted (`container_instance_dataset_mountpoint`, which yields
+        # `/mnt/.truenas_containers/<pool>/containers/<name>`). Both consumers of this list need
+        # the name-derived form:
+        # - `filesystem.is_child` is asked whether the container lives under `/mnt/<pool>`, which
+        #   the real mountpoint is not a child of.
+        # - `pool.dataset.path_in_locked_datasets` strips `/mnt/` and re-parses the remainder as a
+        #   dataset name.
+        # Switching this to the real mountpoint would silently stop matching containers on pool
+        # export and pool lock.
         paths = [os.path.join('/mnt', container['dataset'])]
         for device in container['devices']:
             if device['attributes']['dtype'] == 'FILESYSTEM' and (source := device['attributes'].get('source')):
@@ -103,14 +126,57 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
         return False
 
     async def delete(self, attachments):
+        # Tear the domain down through the libvirt delete rather than `stop`: our callers destroy the
+        # storage as soon as this returns, and `stop` comes back while the container's runtime mounts
+        # -- the idmapped root under /run/truenas_containers/ and every FILESYSTEM bind mount -- are
+        # still being unwound by the domain's stop event, so the destroy then fails on a busy dataset.
+        # Deleting the domain destroys it and gives that teardown time to finish before undefining it.
+        #
+        # Never remove the container's records here. The database row is the only copy of a
+        # container's definition (init, environment, devices, capabilities), and its rootfs dataset
+        # outlives this delegate: a pool may simply have been exported, in which case the storage is
+        # still there and is orphaned the moment the row goes. Freeing the container's idmap slice
+        # makes that unrecoverable, because a later container can claim the UID range the surviving
+        # rootfs is still owned by.
+        #
+        # Records are removed only where nothing recoverable is left -- when the pool was both
+        # cascaded and destroyed -- which `destroy` below handles, because that runs once the data
+        # is confirmed gone.
         for attachment in attachments:
             try:
                 container = await self.middleware.call('container.get_instance', attachment['id'])
                 await self.middleware.call('container.delete_container_from_libvirt', container)
+            except Exception:
+                self.logger.warning('%r: failed to tear down container', attachment['id'], exc_info=True)
+
+    async def destroy(self, path):
+        # The pool's data is gone, so the rootfs a container's record describes is gone with it. This
+        # is the one place where dropping the record loses nothing that still exists -- the
+        # definition can no longer be reunited with a rootfs, and its idmap slice is finally safe to
+        # hand out again -- which is why `delete` never does it.
+        #
+        # Deliberately not driven by the attachments `delete` was given:
+        # - it must ignore runtime state, or a pool holding only stopped containers keeps every
+        #   record while a pool of running ones is cleaned out;
+        # - it must match the *root* dataset only, or a container rooted on another pool that merely
+        #   bind-mounts this one loses its whole definition while its rootfs is still there.
+        #
+        # For the first of those reasons it also cannot assume `delete` already tore these domains
+        # down, hence the libvirt delete here as well -- it is idempotent.
+        removed = False
+        for container in await self.containers_on_pool(path.removeprefix('/mnt/')):
+            try:
+                await self.middleware.call('container.delete_container_from_libvirt', container)
                 await self.middleware.call('container.delete_container_from_db', container)
             except Exception:
-                self.logger.warning('Unable to delete %r container', attachment['id'])
-        else:
+                self.logger.error(
+                    '%s: failed to remove container records after its pool was destroyed',
+                    container['name'], exc_info=True,
+                )
+            else:
+                removed = True
+
+        if removed:
             await self.middleware.call('etc.generate', 'libvirt_guests')
 
     async def toggle(self, attachments, enabled):
@@ -141,9 +207,17 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
             mountpoint for dataset, mountpoint in datasets
             if dataset['type'] == 'FILESYSTEM' and mountpoint
         ]
-        if not paths:
-            return
+        if paths:
+            await self.start_autostart_on_paths(paths)
 
+    async def start_on_import(self, path):
+        # Same reasoning as `start_on_unlock`: the generic path would start every stopped container
+        # on the pool, ignoring autostart entirely.
+        await self.start_autostart_on_paths([path])
+
+    async def start_autostart_on_paths(self, paths):
+        # (Re)start the autostart containers whose storage lives on `paths`, now that those paths
+        # have become available again.
         containers = await self.middleware.call(
             'container.query', [('autostart', '=', True)], {'force_sql_filters': True}
         )
@@ -161,7 +235,8 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
                 state = (await self.middleware.call('container.get_instance', container['id']))['status']['state']
             except Exception:
                 self.logger.warning(
-                    'Unable to query %r container after unlock', container['id'], exc_info=True
+                    'Unable to query %r container after its storage became available',
+                    container['id'], exc_info=True
                 )
                 continue
 
@@ -182,9 +257,82 @@ class ContainerFSAttachmentDelegate(FSAttachmentDelegate):
             try:
                 await self.middleware.call('container.start', container['id'])
             except Exception:
-                self.logger.error('Failed to start %r container after unlock', container['id'], exc_info=True)
+                self.logger.error(
+                    'Failed to start %r container after its storage became available',
+                    container['id'], exc_info=True
+                )
+
+
+async def pool_post_import(middleware, pool=None, **kwargs):
+    """Re-point containers at their storage after their pool was imported under a new name.
+
+    A container's dataset is always `<pool>/.truenas_containers/containers/<name>`, so the location
+    under the newly imported pool is derived rather than guessed. The remap is only committed when
+    the old pool is genuinely gone, the derived dataset actually exists, and no other container
+    already claims it -- otherwise the record is left alone for the user to sort out, which is the
+    safer failure.
+    """
+    if pool is None:
+        # Fired with no pool on boot
+        return
+
+    containers = await middleware.call('container.query')
+    known_pools = {p['name'] for p in await middleware.call('pool.query')}
+    claimed = {container['dataset'] for container in containers}
+
+    for container in containers:
+        old_pool = container['dataset'].split('/')[0]
+        if old_pool == pool['name'] or old_pool in known_pools:
+            continue
+
+        dataset = f'{container_dataset(pool["name"])}/containers/{container["name"]}'
+        if dataset in claimed:
+            middleware.logger.warning(
+                '%s: not re-pointing container at %r after pool rename, another container already uses it',
+                container['name'], dataset,
+            )
+            continue
+
+        if not await middleware.call2(
+            middleware.services.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[dataset], properties=None),
+        ):
+            continue
+
+        # Written through the datastore rather than `container.update` / `container.device.update`
+        # so that validation of an unrelated part of the container (a missing bridge device, say)
+        # cannot fail the pool import. One container failing must not abort the import or stop the
+        # rest from being re-pointed, so each is applied behind its own boundary.
+        try:
+            for device in container['devices']:
+                if device['attributes']['dtype'] != 'FILESYSTEM':
+                    continue
+                if not (source := device['attributes'].get('source')):
+                    continue
+
+                if source == f'/mnt/{old_pool}' or source.startswith(f'/mnt/{old_pool}/'):
+                    attributes = dict(device['attributes'])
+                    attributes['source'] = f'/mnt/{pool["name"]}' + source[len(f'/mnt/{old_pool}'):]
+                    await middleware.call(
+                        'datastore.update', 'container.device', device['id'], {'attributes': attributes}
+                    )
+
+            await middleware.call('datastore.update', 'container.container', container['id'], {'dataset': dataset})
+        except Exception:
+            middleware.logger.error(
+                '%s: failed to re-point container at %r after pool rename', container['name'], dataset,
+                exc_info=True,
+            )
+            continue
+
+        claimed.add(dataset)
+        middleware.logger.info(
+            '%s: re-pointed container at %r after its pool was renamed from %r',
+            container['name'], dataset, old_pool,
+        )
 
 
 async def setup(middleware):
     await middleware.call('pool.dataset.register_attachment_delegate', LXCFSAttachmentDelegate(middleware))
     await middleware.call('pool.dataset.register_attachment_delegate', ContainerFSAttachmentDelegate(middleware))
+    middleware.register_hook('pool.post_import', pool_post_import, sync=True)

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -41,6 +41,32 @@ class PoolService(Service):
         except Exception:
             self.logger.warning('Failed to remove remaining directories after export', exc_info=True)
 
+    async def _destroy_pool_attachments(self, path, options, destroyed):
+        """
+        Let the attachment delegates discard configuration whose data went away with the pool.
+
+        Deliberately not folded into the `delete`/`disable` loop in `export`: that has to run before
+        the zpool is destroyed so the datasets are released, whereas discarding configuration is
+        only safe once the data it describes is confirmed unrecoverable. Everything in between --
+        the `pool.pre_export` hook, `kill_processes`, and the destroy itself -- can abort the job
+        with the pool still fully intact.
+
+        `cascade` still decides whether configuration may be discarded at all; `destroyed` on its
+        own does not, because destroying an OFFLINE pool leaves it untouched on its disks.
+        """
+        if not (options['cascade'] and destroyed):
+            return
+
+        for delegate in await self.middleware.call('pool.dataset.get_attachment_delegates_for_stop'):
+            # The pool is already gone, so a delegate failure here must not fail the export job
+            try:
+                await delegate.destroy(path)
+            except Exception:
+                self.logger.error(
+                    '%s: failed to clean up attachments after the pool was destroyed',
+                    delegate.name, exc_info=True,
+                )
+
     @api_method(PoolExportArgs, PoolExportResult, audit="Pool Export", audit_callback=True, roles=['POOL_WRITE'])
     @job(lock='pool_export')
     async def export(self, job, audit_callback, oid, options):
@@ -137,10 +163,18 @@ class PoolService(Service):
 
         await self.middleware.call_hook('pool.pre_export', pool=pool['name'], options=options, job=job)
 
+        # Whether the pool's data is really gone by the end of this job. `options['destroy']` alone
+        # does not answer that: an OFFLINE pool is not imported, so it is neither destroyed nor
+        # wiped and its contents survive on the disks. This is what gates
+        # `_destroy_pool_attachments` below, because a delegate that discards configuration on the
+        # strength of the data being unrecoverable cannot key off the requested option.
+        destroyed = False
+
         if pool['status'] == 'OFFLINE':
             # Pool exists only in database, it's not imported
             pass
         elif options['destroy']:
+            destroyed = True
             job.set_progress(60, 'Destroying pool')
             await self.middleware.call('zfs.pool.delete', pool['name'])
 
@@ -189,6 +223,8 @@ class PoolService(Service):
 
         # scrub needs to be regenerated in crontab
         await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
+
+        await self._destroy_pool_attachments(pool['path'], options, destroyed)
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
         self.middleware.send_event('pool.query', 'REMOVED', id=oid)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -309,9 +309,14 @@ class PoolService(Service):
 
         job.set_progress(80, 'Re-enabling services')
 
-        for delegate in await self.middleware.call('pool.dataset.get_attachment_delegates'):
-            if attachments := await delegate.query(pool['path'], False):
-                await delegate.start(attachments)
+        for delegate in await self.middleware.call('pool.dataset.get_attachment_delegates_for_start'):
+            # The pool is already imported, so a delegate failure here must not abort the reimport
+            try:
+                await delegate.start_on_import(pool['path'])
+            except Exception:
+                self.logger.error(
+                    '%s: failed to start attachments after pool reimport', delegate.name, exc_info=True
+                )
 
         job.set_progress(90, 'Running post-import tasks')
 

--- a/src/middlewared/middlewared/plugins/vm/attachments.py
+++ b/src/middlewared/middlewared/plugins/vm/attachments.py
@@ -169,6 +169,17 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
             # the dataset's filesystem is mounted
             paths.add(os.path.join('/mnt', dataset['name']))
 
+        if paths:
+            await self.start_autostart_on_paths(paths)
+
+    async def start_on_import(self, path):
+        # Same reasoning as `start_on_unlock`: the generic path would start every stopped VM on the
+        # pool, ignoring autostart entirely.
+        await self.start_autostart_on_paths({path})
+
+    async def start_autostart_on_paths(self, paths):
+        # (Re)start the autostart VMs whose disks live on `paths`, now that those paths have become
+        # available again.
         vms = await self.middleware.call('vm.query', [('autostart', '=', True)], {'force_sql_filters': True})
         for vm in vms:
             if not await self.vm_on_paths(vm, paths):
@@ -184,7 +195,9 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
                 # while earlier VMs in this loop were being restarted (or a VM may have been deleted since)
                 state = (await self.middleware.call('vm.status', vm['id']))['state']
             except Exception:
-                self.logger.warning('Unable to query %r VM after unlock', vm['name'], exc_info=True)
+                self.logger.warning(
+                    'Unable to query %r VM after its storage became available', vm['name'], exc_info=True
+                )
                 continue
 
             if state == 'RUNNING':
@@ -206,7 +219,9 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
             try:
                 await self.middleware.call('vm.start', vm['id'])
             except Exception:
-                self.logger.error('Failed to start %r VM after unlock', vm['name'], exc_info=True)
+                self.logger.error(
+                    'Failed to start %r VM after its storage became available', vm['name'], exc_info=True
+                )
 
     async def vm_on_paths(self, vm, paths):
         # A VM is tied to the unlocked datasets if a DISK/RAW disk lives there: it cannot run without

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_destroy_pool_attachments.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_destroy_pool_attachments.py
@@ -1,0 +1,52 @@
+import pytest
+
+from middlewared.plugins.pool_.export import PoolService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+class Delegate:
+    name = "test"
+
+    def __init__(self, raises=False):
+        self.destroyed = []
+        self.raises = raises
+
+    async def destroy(self, path):
+        self.destroyed.append(path)
+        if self.raises:
+            raise Exception("delegate blew up")
+
+
+def service(delegate):
+    m = Middleware()
+    m["pool.dataset.get_attachment_delegates_for_stop"] = lambda *args: [delegate]
+    return PoolService(m)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cascade, destroyed, expected",
+    (
+        # The only combination where nothing recoverable is left
+        (True, True, ["/mnt/tank"]),
+        # The pool was exported intact and is going somewhere else -- discarding configuration here
+        # would orphan storage that is still perfectly usable
+        (True, False, []),
+        # `cascade=False` means the user asked to keep their attachment configuration, and the pool
+        # having been destroyed does not override that
+        (False, True, []),
+        (False, False, []),
+    ),
+)
+async def test_destroy_is_gated_on_cascade_and_destroyed(cascade, destroyed, expected):
+    delegate = Delegate()
+    await service(delegate)._destroy_pool_attachments("/mnt/tank", {"cascade": cascade, "destroy": True}, destroyed)
+    assert delegate.destroyed == expected
+
+
+@pytest.mark.asyncio
+async def test_destroy_failure_does_not_abort_the_export():
+    # The pool is already gone by this point; the rest of the export job still has to run
+    delegate = Delegate(raises=True)
+    await service(delegate)._destroy_pool_attachments("/mnt/tank", {"cascade": True, "destroy": True}, True)
+    assert delegate.destroyed == ["/mnt/tank"]

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_attachment_delegate_is_child_path.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_attachment_delegate_is_child_path.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.plugins.smb import SMBFSAttachmentDelegate
 from middlewared.pytest.unit.middleware import Middleware
 
@@ -17,3 +18,20 @@ async def test_attachment_is_child(resource, path, check_parent, exact_match, is
     m['filesystem.is_child'] = lambda *arg: is_child
     smb_attachment = SMBFSAttachmentDelegate(m)
     assert (await smb_attachment.is_child_of_path(resource, path, check_parent, exact_match)) == expected_output
+
+
+@pytest.mark.asyncio
+async def test_destroy_defaults_to_a_no_op():
+    # `delete` already disposed of a share/task style attachment while the pool was still there, so
+    # the default must not go looking for it again -- these stubs raise if it does.
+    class Delegate(FSAttachmentDelegate):
+        name = 'test'
+        title = 'Test'
+
+        async def query(self, path, enabled, options=None):
+            raise AssertionError('the default destroy must not query')
+
+        async def delete(self, attachments):
+            raise AssertionError('the default destroy must not delete')
+
+    assert await Delegate(Middleware()).destroy('/mnt/tank') is None

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_container_attachment_matching.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_container_attachment_matching.py
@@ -4,12 +4,19 @@ from middlewared.plugins.container.attachments import ContainerFSAttachmentDeleg
 from middlewared.pytest.unit.middleware import Middleware
 
 
-def fs_device(source):
-    return {"attributes": {"dtype": "FILESYSTEM", "source": source}}
+def fs_device(source, id_=1):
+    return {"id": id_, "attributes": {"dtype": "FILESYSTEM", "source": source}}
 
 
-def container(dataset, devices=None):
-    return {"id": 1, "name": "c", "dataset": dataset, "devices": devices or []}
+def container(dataset, devices=None, state="STOPPED", autostart=True, id_=1, name="c"):
+    return {
+        "id": id_,
+        "name": name,
+        "dataset": dataset,
+        "autostart": autostart,
+        "devices": devices or [],
+        "status": {"state": state},
+    }
 
 
 def test_storage_paths_gathers_root_and_filesystem_sources():
@@ -60,3 +67,181 @@ async def test_storage_locked_considers_root_and_filesystem_sources():
     # A still-locked bind-mount source defers the start
     locked.add("/mnt/other/data")
     assert await delegate.storage_locked(c) is True
+
+
+@pytest.mark.asyncio
+async def test_container_on_paths_matches_pool_path_via_name_derived_root():
+    # The root entry of `storage_paths` is derived from the dataset name, so it is a child of
+    # `/mnt/<pool>`. The dataset's real mountpoint is `/mnt/.truenas_containers/<pool>/...`, which
+    # is not -- switching to it would silently stop matching containers on pool export and lock.
+    m = Middleware()
+    m["filesystem.is_child"] = lambda child, parent: any(
+        c == p or c.startswith(f"{p}/") for c in child for p in parent
+    )
+    delegate = ContainerFSAttachmentDelegate(m)
+    c = container("tank/.truenas_containers/containers/c")
+
+    assert await delegate.container_on_paths(c, ["/mnt/tank"]) is True
+
+
+class StopJob:
+    async def wait(self, raise_error=False):
+        pass
+
+
+class StartDriver:
+    """Drives the autostart start paths and `delete` against a single container, recording actions."""
+
+    def __init__(self, state, devices=None, locked_paths=(), autostart=True):
+        self.actions = []
+        self.container = container("tank/ds", devices, state=state, autostart=autostart)
+        self.middleware = Middleware()
+        self.middleware["filesystem.is_child"] = lambda child, parent: True
+        self.middleware["pool.dataset.path_in_locked_datasets"] = lambda path: path in locked_paths
+        self.middleware["container.query"] = self._query
+        self.middleware["container.get_instance"] = lambda *args: self.container
+        self.middleware["container.start"] = self._record("start")
+        self.middleware["container.stop"] = self._record("stop", StopJob())
+        self.middleware["container.delete_container_from_libvirt"] = self._record("teardown")
+        self.middleware["container.delete_container_from_db"] = self._record("remove")
+        self.delegate = ContainerFSAttachmentDelegate(self.middleware)
+
+    def _query(self, filters=None, *args):
+        # Honor the `autostart` filter the autostart-aware start paths pass down
+        if filters and ("autostart", "=", True) in filters and not self.container["autostart"]:
+            return []
+        return [self.container]
+
+    def _record(self, action, result=None):
+        def record(*args):
+            self.actions.append(action)
+            return result
+
+        return record
+
+    async def run_import(self):
+        await self.delegate.start_on_import("/mnt/tank")
+        return self.actions
+
+    async def run_delete(self):
+        await self.delegate.delete([{"id": self.container["id"], "name": self.container["name"]}])
+        return self.actions
+
+
+@pytest.mark.asyncio
+async def test_start_on_import_starts_autostart_container():
+    assert await StartDriver("STOPPED").run_import() == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_start_on_import_skips_non_autostart_container():
+    # A pool being re-imported must not boot containers the user never asked to autostart
+    assert await StartDriver("STOPPED", autostart=False).run_import() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_tears_down_the_domain_without_removing_records():
+    # The container's database row is the only copy of its definition and its rootfs dataset
+    # outlives the delegate, so `delete` must never remove records. It must go through the libvirt
+    # teardown rather than `stop`: our caller destroys the storage as soon as this returns, and
+    # `stop` comes back while the container's runtime mounts are still pinning it.
+    assert await StartDriver("RUNNING").run_delete() == ["teardown"]
+
+
+@pytest.mark.asyncio
+async def test_delete_of_bind_mount_source_keeps_the_container():
+    # Deleting a dataset a container merely bind-mounts reaches the delegate through `query`, and
+    # must cost the user the mount, not the whole container.
+    driver = StartDriver("RUNNING", devices=[fs_device("/mnt/tank/media")])
+    attachments = await driver.delegate.query("/mnt/tank/media", True)
+    assert attachments == [{"id": 1, "name": "c"}]
+
+    await driver.delegate.delete(attachments)
+    assert driver.actions == ["teardown"]
+
+
+class DestroyDriver:
+    """Drives `destroy` against a set of containers, recording every (action, container name)."""
+
+    def __init__(self, containers, failing_db_removal=()):
+        self.actions = []
+        self.etc_generated = []
+        self.containers = containers
+        self.failing_db_removal = failing_db_removal
+        self.middleware = Middleware()
+        self.middleware["etc.generate"] = self.etc_generated.append
+        self.middleware["container.query"] = lambda *args: list(containers)
+        self.middleware["container.delete_container_from_libvirt"] = self._record("teardown")
+        self.middleware["container.delete_container_from_db"] = self._record("remove", self.failing_db_removal)
+        self.delegate = ContainerFSAttachmentDelegate(self.middleware)
+
+    def _record(self, action, failing=()):
+        def record(container):
+            self.actions.append((action, container["name"]))
+            if container["name"] in failing:
+                raise Exception(f"{container['name']} blew up")
+
+        return record
+
+    async def run(self, path="/mnt/tank"):
+        await self.delegate.destroy(path)
+        return self.actions
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["STOPPED", "RUNNING"])
+async def test_destroy_removes_records_whatever_the_runtime_state(state):
+    # Runtime state must not decide this: `query` only reports active containers, so a cleanup keyed
+    # off it would drop the records of running containers and keep those of stopped ones.
+    driver = DestroyDriver([container("tank/.truenas_containers/containers/c", state=state)])
+    assert await driver.run() == [("teardown", "c"), ("remove", "c")]
+    assert driver.etc_generated == ["libvirt_guests"]
+
+
+@pytest.mark.asyncio
+async def test_destroy_keeps_container_rooted_on_another_pool():
+    # The container merely bind-mounts the destroyed pool; its rootfs is intact on `other`, and its
+    # record is the only thing pointing at it.
+    driver = DestroyDriver(
+        [container("other/.truenas_containers/containers/c", devices=[fs_device("/mnt/tank/media")])]
+    )
+    assert await driver.run() == []
+    assert driver.etc_generated == []
+
+
+@pytest.mark.asyncio
+async def test_destroy_removes_container_rooted_outside_the_container_dataset():
+    # A legacy container migration may leave the rootfs outside `.truenas_containers`; it is still on
+    # the destroyed pool, so matching on the pool name rather than on that prefix is what catches it.
+    driver = DestroyDriver([container("tank/.ix-virt/containers/legacy", name="legacy")])
+    assert await driver.run() == [("teardown", "legacy"), ("remove", "legacy")]
+
+
+@pytest.mark.asyncio
+async def test_destroy_does_not_match_a_pool_whose_name_shares_a_prefix():
+    driver = DestroyDriver([
+        container("tank/.truenas_containers/containers/a", id_=1, name="a"),
+        container("tank2/.truenas_containers/containers/b", id_=2, name="b"),
+    ])
+    assert await driver.run() == [("teardown", "a"), ("remove", "a")]
+
+
+@pytest.mark.asyncio
+async def test_destroy_isolates_per_container_failures():
+    # One container failing must not leave the rest of the pool's records behind
+    driver = DestroyDriver(
+        [
+            container("tank/.truenas_containers/containers/a", id_=1, name="a"),
+            container("tank/.truenas_containers/containers/b", id_=2, name="b"),
+        ],
+        failing_db_removal=("a",),
+    )
+    assert await driver.run() == [("teardown", "a"), ("remove", "a"), ("teardown", "b"), ("remove", "b")]
+    assert driver.etc_generated == ["libvirt_guests"]
+
+
+@pytest.mark.asyncio
+async def test_destroy_skips_etc_generate_when_nothing_was_removed():
+    driver = DestroyDriver([container("other/.truenas_containers/containers/c")])
+    await driver.run()
+    assert driver.etc_generated == []

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_vm_attachment_matching.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_vm_attachment_matching.py
@@ -87,3 +87,60 @@ async def test_storage_locked_only_considers_disk_and_raw():
     # A locked CDROM (removable) must not block the VM from starting
     cdrom_vm = {"devices": [disk("CDROM", "/mnt/other/b.img")]}
     assert await delegate.storage_locked(cdrom_vm) is False
+
+
+class StopJob:
+    error = None
+
+    async def wait(self, raise_error=False):
+        pass
+
+
+class StartOnImportDriver:
+    """Drives `start_on_import` against a single autostart VM, recording the actions it takes."""
+
+    def __init__(self, state, autostart=True):
+        self.actions = []
+        self.vm = {
+            "id": 1,
+            "name": "myvm",
+            "autostart": autostart,
+            "devices": [disk("RAW", "/mnt/tank/ds/disk.img")],
+            "status": {"state": state},
+        }
+        self.middleware = Middleware()
+        self.middleware["filesystem.is_child"] = lambda child, parent: True
+        self.middleware["pool.dataset.path_in_locked_datasets"] = lambda path: False
+        self.middleware["vm.query"] = self._query
+        self.middleware["vm.status"] = lambda *args: self.vm["status"]
+        self.middleware["vm.start"] = self._record("start")
+        self.middleware["vm.stop"] = self._record("stop", StopJob())
+        self.delegate = VMFSAttachmentDelegate(self.middleware)
+
+    def _query(self, filters=None, *args):
+        # Honor the `autostart` filter the autostart-aware start paths pass down
+        if filters and ("autostart", "=", True) in filters and not self.vm["autostart"]:
+            return []
+        return [self.vm]
+
+    def _record(self, action, result=None):
+        def record(*args):
+            self.actions.append(action)
+            return result
+
+        return record
+
+    async def run(self):
+        await self.delegate.start_on_import("/mnt/tank")
+        return self.actions
+
+
+@pytest.mark.asyncio
+async def test_start_on_import_starts_autostart_vm():
+    assert await StartOnImportDriver("STOPPED").run() == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_start_on_import_skips_non_autostart_vm():
+    # A pool being re-imported must not boot VMs the user never asked to autostart
+    assert await StartOnImportDriver("STOPPED", autostart=False).run() == []

--- a/tests/api2/test_container_pool_export.py
+++ b/tests/api2/test_container_pool_export.py
@@ -1,0 +1,165 @@
+import pytest
+
+from middlewared.test.integration.assets.container import (
+    ALPINE_IMAGE_NAME,
+    configure_bridge,
+    container,
+    filesystem_device,
+    resolve_image,
+)
+from middlewared.test.integration.assets.pool import another_pool, dataset
+from middlewared.test.integration.utils import call, ssh
+
+# Every test here runs against a throwaway pool so that exporting/destroying it can never
+# touch a pool the system actually depends on.
+POOL_NAME = "test_container_export"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    configure_bridge()
+
+
+@pytest.fixture(scope="module")
+def image():
+    yield resolve_image(ALPINE_IMAGE_NAME)
+
+
+def container_exists(id_):
+    return bool(call("container.query", [["id", "=", id_]]))
+
+
+def test_cascade_export_keeps_container_records(image):
+    """A cascaded export of a pool that is not destroyed must not drop container records.
+
+    The rootfs datasets go with the pool and are still there, so removing the records
+    would orphan live storage with no way to get it back -- the container's definition
+    and its idmap slice exist nowhere else.
+    """
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}, start=True) as c:
+            call("pool.export", pool["id"], {"cascade": True, "destroy": False}, job=True)
+
+            assert container_exists(c["id"]), "cascaded export destroyed the container's records"
+
+            call("pool.import_pool", {"guid": pool["guid"], "name": POOL_NAME}, job=True)
+
+            # The record still points at storage that is really there, so it runs again
+            assert call("container.get_instance", c["id"])["dataset"] == c["dataset"]
+            call("container.start", c["id"])
+            assert call("container.get_instance", c["id"])["status"]["state"] == "RUNNING"
+
+
+def test_cascade_destroy_removes_container_records(image):
+    """Destroying the pool as well is the one case where the records are safe to drop.
+
+    Both a running and a stopped container are checked: the delegate only ever saw
+    active containers, which made the old cleanup drop the records of running
+    containers and keep those of stopped ones.
+    """
+    with another_pool({"name": POOL_NAME}) as pool:
+        with (
+            container(image, options={"pool": POOL_NAME}, name="running", start=True) as running,
+            container(image, options={"pool": POOL_NAME}, name="stopped") as stopped,
+        ):
+            call("pool.export", pool["id"], {"cascade": True, "destroy": True}, job=True)
+
+            assert not container_exists(running["id"])
+            assert not container_exists(stopped["id"]), "records of stopped containers survived a cascaded destroy"
+
+
+def test_destroy_without_cascade_keeps_container_records(image):
+    """`cascade=False` means the user asked to keep their attachment configuration.
+
+    The pool having been destroyed does not override that, so the records survive even
+    though their storage is gone -- the user is left to delete the containers themselves.
+    """
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}) as c:
+            call("pool.export", pool["id"], {"cascade": False, "destroy": True}, job=True)
+
+            assert container_exists(c["id"]), "a non-cascaded export discarded container records"
+
+
+def test_cascade_destroy_of_offline_pool_keeps_container_records(image):
+    """Destroying an OFFLINE pool destroys nothing, so the records must stay.
+
+    An OFFLINE pool is not imported, so `pool.export` skips both the zpool destroy and
+    the disk wipe and the container's rootfs survives untouched. Keying the cleanup off
+    the requested `destroy` option instead of what actually happened would orphan that
+    storage -- the exact failure this whole change exists to prevent.
+    """
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}) as c:
+            try:
+                ssh(f"zpool export {POOL_NAME}")
+                assert call("pool.get_instance", pool["id"])["status"] == "OFFLINE"
+
+                call(
+                    "pool.export",
+                    pool["id"],
+                    {"cascade": True, "destroy": True},
+                    job=True,
+                )
+
+                assert container_exists(c["id"]), "records were dropped for a pool that was never actually destroyed"
+            finally:
+                # Bring the pool back so the container and the pool tear down normally.
+                if any(p["guid"] == pool["guid"] for p in call("pool.import_find", job=True)):
+                    call(
+                        "pool.import_pool",
+                        {"guid": pool["guid"], "name": POOL_NAME},
+                        job=True,
+                    )
+
+
+def test_dataset_delete_of_bind_mount_source_keeps_container(image):
+    """Deleting a bind-mounted dataset costs the container the mount, not its definition.
+
+    `pool.dataset.delete` has no cascade flag, so it can only ever take the conservative
+    action.
+    """
+    with another_pool({"name": POOL_NAME}):
+        with dataset("media", pool=POOL_NAME) as media:
+            with container(image, options={"pool": POOL_NAME}) as c:
+                with filesystem_device(c["id"], f"/mnt/{media}", "/data"):
+                    call("container.start", c["id"])
+                    instance = call("container.get_instance", c["id"])
+                    assert instance["status"]["state"] == "RUNNING"
+
+                    call("pool.dataset.delete", media, {"recursive": True})
+
+                    assert container_exists(c["id"]), "deleting a bind-mount source deleted the container"
+                    instance = call("container.get_instance", c["id"])
+                    assert instance["status"]["state"] == "STOPPED"
+
+
+def test_container_storage_remapped_after_pool_rename(image):
+    """A pool imported under a new name leaves container records pointing at the old one.
+
+    The dataset is always `<pool>/.truenas_containers/containers/<name>`, so the new
+    location is derived rather than guessed, and the container is usable again after the
+    import.
+    """
+    renamed = f"{POOL_NAME}_renamed"
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}) as c:
+            assert c["dataset"].startswith(f"{POOL_NAME}/")
+
+            call(
+                "pool.export",
+                pool["id"],
+                {"cascade": False, "destroy": False},
+                job=True,
+            )
+            call("pool.import_pool", {"guid": pool["guid"], "name": renamed}, job=True)
+
+            # `another_pool` tears down by guid, so it finds the renamed pool on its own.
+            remapped = call("container.get_instance", c["id"])["dataset"]
+            assert remapped == c["dataset"].replace(POOL_NAME, renamed, 1), (
+                f"container was left pointing at the old pool: {remapped}"
+            )
+
+            call("container.start", c["id"])
+            assert call("container.get_instance", c["id"])["status"]["state"] == "RUNNING"
+            call("container.stop", c["id"], {"force": True}, job=True)


### PR DESCRIPTION
## Problem
The container FS attachment delegate was the only stateful-workload delegate whose `delete()` destroyed configuration: it undefined the libvirt domain and removed the `container_container` and `container_device` rows, while deliberately leaving the rootfs dataset alone. VMs and apps only stop. That made `pool.export(cascade=True, destroy=False)` — the flow that exists precisely because the pool is moving elsewhere intact — permanently orphan live storage. A container's definition, devices and idmap slice live only in SQLite, nothing on disk can rebuild them (unlike the migrated incus containers, we write no manifest), and a freed idmap slice can be reissued to another container while the surviving rootfs still carries its UID range.

`pool.dataset.delete` reached the same code with no cascade flag at all, so deleting a dataset that a container merely bind-mounted as a FILESYSTEM device destroyed the whole container. And since `query()` only reports containers in ACTIVE_STATES, the cleanup was not even coherent — it dropped the records of running containers and kept those of stopped ones.

## Solution
- **`delete()` is now stop-only**, matching the VM and apps delegates. Records are never removed from the delegate.
- **Record removal moved to a new `destroy()` step on the attachment delegate**, which `pool.export` calls once the zpool destroy has returned — the only point that can see whether the data actually went away. `delete()` still has to run first so the datasets are released, whereas discarding configuration is safe only once the data it describes is confirmed gone, and everything in between (the `pool.pre_export` hook, `kill_processes`, the destroy itself) can abort the job with the pool still fully intact. It is gated on `cascade` together with a `destroyed` flag reflecting what the export really did rather than `options['destroy']`: asking to destroy an OFFLINE pool leaves it untouched on its disks, so the requested option on its own would still have discarded records whose storage was intact. The base implementation is a no-op, since the share/task delegates already disposed of their attachments in `delete()` while the pool was still there; the container one matches on the pool its root dataset lives on and ignores runtime state, so stopped containers are cleaned up too, and a container merely bind-mounting the destroyed pool keeps its definition.
- **Containers are re-pointed at their storage when a pool is imported under a new name.** The dataset is always `<pool>/.truenas_containers/containers/<name>`, so the new location is derived rather than guessed. The remap is committed only when the old pool is genuinely gone, the derived dataset exists, and no other container claims it; each container is applied behind its own boundary so one failure cannot abort the import or block the rest.
- **`pool.reimport` no longer starts everything on the pool.** It walks the delegates in start-priority order (it was using registration order, quietly defeating the docker/apps ordering) and calls a new `start_on_import`, which containers and VMs override to honour `autostart`. Previously every stopped container and VM on the pool came up regardless.

Also documents why `storage_paths()` derives the container root from the dataset name rather than its real mountpoint — both consumers need the name-derived form, and switching to the mountpoint would silently stop matching containers on pool export and lock.



Original PR: https://github.com/truenas/middleware/pull/19461
