### PR TITLE
NAS-142061 / 27.0.0-BETA.1 / Consolidate the managed-dataset registries and guard every mutator

### DIFF
--- a/src/middlewared/middlewared/alert/source/datasets.py
+++ b/src/middlewared/middlewared/alert/source/datasets.py
@@ -28,14 +28,9 @@ class UnencryptedDatasetsAlertSource(AlertSource):
     async def check(self) -> list[Alert[Any]] | Alert[Any] | None:
         unencrypted_datasets = []
         for dataset in await self.middleware.call('pool.dataset.query', [['encrypted', '=', True]]):
+            # No apps-dataset skip is needed here: pool.dataset.query already omits the datasets
+            # middleware manages, and it never descends into one, so no child can be under them.
             for child in dataset['children']:
-                if child['name'] in (
-                    f'{child["pool"]}/ix-applications', f'{child["pool"]}/ix-apps'
-                ) or child['name'].startswith((
-                    f'{child["pool"]}/ix-applications/', f'{child["pool"]}/ix-apps/'
-                )):
-                    continue
-
                 if not child['encrypted']:
                     unencrypted_datasets.append(child['name'])
 

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -398,7 +398,7 @@ class AuditService(ConfigService):
         if not payload:
             return
 
-        args = UpdateImplArgs(name=ds['name'], zprops=zprops, uprops=uprops)
+        args = UpdateImplArgs(name=ds['name'], zprops=zprops, uprops=uprops, bypass=True)
         await self.middleware.call('pool.dataset.update_impl', args)
         if await self.middleware.call('failover.status') == 'MASTER':
             try:
@@ -490,7 +490,7 @@ class AuditService(ConfigService):
             try:
                 await self.middleware.call(
                     'pool.dataset.update_impl',
-                    UpdateImplArgs(name=ds_name, zprops=zprops)
+                    UpdateImplArgs(name=ds_name, zprops=zprops, bypass=True)
                 )
             except Exception:
                 self.logger.error(

--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -8,11 +8,11 @@ from middlewared.api.base.model import model_subset
 from middlewared.api.current import CloudTaskAttributes, CredentialsEntry, ZFSResourceQuery
 from middlewared.plugins.cloud.rclone.base import BaseRcloneRemote
 from middlewared.plugins.cloud.remotes import REMOTES
-from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs.zvol_utils import zvol_path_to_name
 from middlewared.service import CallError, SharingTaskServicePart
 from middlewared.service_exception import InstanceNotFound, ValidationErrors
 from middlewared.utils.privilege import credential_has_full_admin
+from middlewared.utils.zfs.managed_datasets import blocked_from_mutation
 
 if TYPE_CHECKING:
     from middlewared.api.base import BaseModel
@@ -187,7 +187,7 @@ class CloudTaskServiceMixin[
                 verrors.add(f"{name}.{self.path_field}", "Volume does not exist")
             elif not zz[0]["type"] == "VOLUME":
                 verrors.add(f"{name}.{self.path_field}", f"{zvol!r} is not a volume")
-            elif has_internal_path(zz[0]["name"]):
+            elif blocked_from_mutation(zz[0]["name"]):
                 verrors.add(f"{name}.{self.path_field}", f"{zvol!r} is an invalid location")
             else:
                 try:

--- a/src/middlewared/middlewared/plugins/container/migrate.py
+++ b/src/middlewared/middlewared/plugins/container/migrate.py
@@ -286,7 +286,8 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
                         UpdateImplArgs(
                             name=ds,
                             zprops={'readonly': 'off'},
-                            iprops={'mountpoint'}
+                            iprops={'mountpoint'},
+                            bypass=True,
                         )
                     )
 
@@ -299,6 +300,7 @@ def migrate_specific_pool(context: ServiceContext, job: Job, pool: str, existing
                     name=dataset['name'],
                     zprops={'canmount': 'on'},
                     iprops={'mountpoint'},
+                    bypass=True,
                 )
             )
             context.call_sync2(context.s.zfs.resource.mount, dataset['name'])
@@ -409,6 +411,7 @@ def revert_incus_mount_properties(context: ServiceContext, job: Job, container_d
             UpdateImplArgs(
                 name=container_ds,
                 zprops={'canmount': 'noauto', 'mountpoint': 'legacy'},
+                bypass=True,
             ),
         )
     except Exception:
@@ -433,7 +436,7 @@ def restore_legacy_parent_mountpoints(context: ServiceContext, pool: str) -> Non
         try:
             context.middleware.call_sync(
                 'pool.dataset.update_impl',
-                UpdateImplArgs(name=ds, zprops={'mountpoint': 'legacy'}),
+                UpdateImplArgs(name=ds, zprops={'mountpoint': 'legacy'}, bypass=True),
             )
         except Exception:
             context.logger.warning('%s: failed to restore mountpoint after migration', ds, exc_info=True)
@@ -532,7 +535,7 @@ def relocate_container_origin(context: ServiceContext, container_ds: str) -> str
     try:
         context.middleware.call_sync(
             'pool.dataset.update_impl',
-            UpdateImplArgs(name=origin_dataset, zprops={'canmount': 'noauto'}),
+            UpdateImplArgs(name=origin_dataset, zprops={'canmount': 'noauto'}, bypass=True),
         )
         context.call_sync2(context.s.zfs.resource.rename, origin_dataset, final_target)
     except Exception:

--- a/src/middlewared/middlewared/plugins/container/utils.py
+++ b/src/middlewared/middlewared/plugins/container/utils.py
@@ -2,6 +2,8 @@ import os
 
 from truenas_os_pyutils.io import atomic_write
 
+from middlewared.utils.zfs.managed_datasets import CONTAINER_DS_NAME
+
 __all__ = (
     "CONTAINER_DS_NAME",
     "container_dataset",
@@ -10,8 +12,6 @@ __all__ = (
     "update_etc_hosts",
     "write_etc_hostname",
 )
-
-CONTAINER_DS_NAME = ".truenas_containers"
 
 
 def container_dataset(pool: str) -> str:

--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -7,6 +7,7 @@ from middlewared.api.current import ZFSResourceQuery
 from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.service import CallError, ServiceContext, ValidationError
 from middlewared.utils.filesystem.perms import enforce_mountpoint_perms
+from middlewared.utils.zfs.managed_datasets import is_boot_pool_path
 
 from .state_utils import IX_APPS_MOUNT_PATH, Status, docker_dataset_custom_props
 
@@ -34,7 +35,7 @@ async def ensure_ix_apps_mount_point(context: ServiceContext, docker_ds: str) ->
     if ds[0]["properties"]["mountpoint"]["value"] != IX_APPS_MOUNT_PATH:
         mp = docker_dataset_custom_props(docker_ds.split("/")[-1])["mountpoint"]
         await context.middleware.call(
-            "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, zprops={"mountpoint": mp})
+            "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, zprops={"mountpoint": mp}, bypass=True)
         )
 
 
@@ -49,7 +50,9 @@ async def ix_apps_is_mounted(context: ServiceContext, dataset_to_check: str | No
             return False
         raise
 
-    if fs_details.source.startswith("boot-pool/"):
+    # A rollback to a release without app support resets the mountpoint, which leaves the boot pool's
+    # root dataset mounted here. That is not the apps dataset, whichever boot pool this system has.
+    if is_boot_pool_path(fs_details.source):
         return False
 
     if dataset_to_check:
@@ -92,7 +95,7 @@ async def common_func(context: ServiceContext, mount: bool) -> Job | None:
                 raise
 
             await context.middleware.call(
-                "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, iprops={"mountpoint"})
+                "pool.dataset.update_impl", UpdateImplArgs(name=docker_ds, iprops={"mountpoint"}, bypass=True)
             )
         try:
             return await context.middleware.call("catalog.sync")  # type: ignore[no-any-return]

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -100,7 +100,7 @@ def create_update_docker_datasets(context: ServiceContext, docker_ds: str) -> No
                 # if any of the zfs properties don't match what we expect we'll update all properties
                 context.middleware.call_sync(
                     'pool.dataset.update_impl',
-                    UpdateImplArgs(name=dataset_name, zprops=update_props)
+                    UpdateImplArgs(name=dataset_name, zprops=update_props, bypass=True)
                 )
         else:
             move_conflicting_dir(dataset_name)

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -20,7 +20,6 @@ from middlewared.api.current import (
     ZFSResourceQuery,
 )
 from middlewared.plugins.container.utils import CONTAINER_DS_NAME
-from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 from middlewared.service import (
     CallError,
@@ -33,9 +32,8 @@ from middlewared.service import (
 )
 from middlewared.service.decorators import pass_thread_local_storage
 import middlewared.sqlalchemy as sa
-from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
 from middlewared.utils.filesystem import attrs as fs_attrs
-from middlewared.utils.filter_list import filter_list
+from middlewared.utils.zfs.managed_datasets import blocked_from_mutation, deny_protected_path
 
 from .dataset_query_utils import generic_query
 from .utils import (
@@ -90,21 +88,6 @@ class PoolDatasetService(CRUDService):
             }
         )
 
-    @private
-    async def internal_datasets_filters(self):
-        # We get filters here which ensure that we don't match an internal dataset
-        return [
-            ['pool', 'nin', BOOT_POOL_NAME_VALID],
-            ['id', 'rnin', '/.system'],
-            ['id', 'rnin', '/ix-applications/'],
-            ['id', 'rnin', '/ix-apps'],
-        ]
-
-    @private
-    async def is_internal_dataset(self, dataset):
-        pool = dataset.split('/')[0]
-        return not bool(filter_list([{'id': dataset, 'pool': pool}], await self.internal_datasets_filters()))
-
     @filterable_api_method(
         item=PoolDatasetEntry,
         pass_thread_local_storage=True,
@@ -141,8 +124,22 @@ class PoolDatasetService(CRUDService):
         ``snapshots_properties`` *(list)*:
             List of snapshot properties to retrieve.
         """
+        return self.__query(tls, filters, options)
+
+    @private
+    @pass_thread_local_storage
+    def query_impl(self, tls, filters, options, exclude_internal_datasets: bool = True):
+        """
+        Internal implementation for querying pool datasets.
+
+        Args:
+            exclude_internal_datasets: Set to False to include the datasets middleware manages on
+                the user's behalf.
+        """
+        return self.__query(tls, filters, options, exclude_internal_datasets=exclude_internal_datasets)
+
+    def __query(self, tls, filters, options, exclude_internal_datasets: bool = True):
         extra = options.pop('extra', {})
-        exclude_internal_datasets = extra.pop('exclude_internal_datasets', True)
         tier_enabled = self.call_sync2(self.s.zfs.tier.config).enabled
 
         return generic_query(
@@ -173,7 +170,7 @@ class PoolDatasetService(CRUDService):
                 {'extra': {'retrieve_children': False}}
             )
 
-        if await self.is_internal_dataset(data['name']):
+        if mode == 'CREATE' and blocked_from_mutation(data['name']):
             verrors.add(
                 f'{schema}.name',
                 f'{data["name"]!r} is using system internal managed dataset. Please specify a different parent.'
@@ -765,6 +762,9 @@ class PoolDatasetService(CRUDService):
     @private
     @pass_thread_local_storage
     def update_impl(self, tls, data: UpdateImplArgs):
+        """Set, or inherit, properties on `data['name']`."""
+        deny_protected_path('pool.dataset.update', data['name'], data.get('bypass', False))
+
         # Convert TypedDict to dataclass to handle defaults for missing fields
         args = UpdateImplArgsDataclass(
             name=data['name'],
@@ -797,6 +797,10 @@ class PoolDatasetService(CRUDService):
                 }]
             }
         """
+        # Ahead of the query below, which hides the datasets middleware manages and would otherwise
+        # answer for them with a misleading "does not exist".
+        deny_protected_path('pool.dataset.update', id_)
+
         verrors = ValidationErrors()
 
         dataset = await self.middleware.call(
@@ -912,8 +916,7 @@ class PoolDatasetService(CRUDService):
                 "params": ["tank/myuser"]
             }
         """
-        if has_internal_path(id_):
-            raise ValidationError('pool.dataset.delete', f'{id_} is an invalid location')
+        deny_protected_path('pool.dataset.delete', id_)
 
         if not options['recursive']:
             ds = await self.call2(

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -327,7 +327,7 @@ class PoolDatasetService(Service):
                         f'{name}/'
                     ) and check_key(d)
                 ),
-                self.middleware.call_sync('pool.dataset.query', [], {'extra': {'exclude_internal_datasets': False}})
+                self.middleware.call_sync('pool.dataset.query_impl', [], {}, False)
             )
         ))
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -20,6 +20,7 @@ from middlewared.service import CallError, Service, ValidationErrors, job, priva
 from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.utils.filesystem import attrs as fs_attrs
 from middlewared.utils.filesystem.directory import directory_is_empty
+from middlewared.utils.zfs.managed_datasets import deny_protected_path
 
 from .utils import (
     ZFSKeyFormat,
@@ -45,6 +46,11 @@ class PoolDatasetService(Service):
         the dataset was mounted before it was locked making sure that the path cannot be modified. Once the dataset
         is unlocked, it will not be affected by this change and consumers can continue consuming it.
         """
+        # `zfs.resource.unload_key` below is the chokepoint that actually refuses the datasets
+        # middleware manages, but it sits behind the lookup a few lines down, which hides those
+        # datasets and would answer with a misleading ENOENT instead.
+        deny_protected_path('pool.dataset.lock', id_)
+
         ds = await self.middleware.call('pool.dataset.get_instance_quick', id_, {
             'encryption': True,
         })
@@ -316,7 +322,12 @@ class PoolDatasetService(Service):
             to_mount_names = {d['name'] for d in to_mount}
             if not to_mount_names.intersection(unlocked):
                 try:
-                    self.call_sync2(self.s.zfs.resource.unload_key, name)
+                    # Undoing the `load_key` a few lines up, so this caller owns the key it is
+                    # unloading whatever the dataset is. Without saying so, unlocking the pool that
+                    # hosts the system dataset at boot would be refused here -- and because the
+                    # refusal is swallowed below, it would degrade to a warning and leave the
+                    # dataset effectively unlocked.
+                    self.call_sync2(self.s.zfs.resource.unload_key, name, bypass=True)
                 except Exception:
                     self.logger.warning(
                         '%s: failed to unload key after mount failures', name, exc_info=True

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_operations.py
@@ -11,6 +11,7 @@ from middlewared.plugins.zfs.encryption import change_encryption_root, change_ke
 from middlewared.service import CallError, Service, ValidationErrors, job, private
 from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.utils import secrets
+from middlewared.utils.zfs.managed_datasets import deny_protected_path
 
 from .utils import DATASET_DATABASE_MODEL_NAME, ZFSKeyFormat
 
@@ -130,6 +131,11 @@ class PoolDatasetService(Service):
         1. It has encrypted roots as children that are encrypted with a key.
         2. It is a root dataset where the system dataset is located.
         """
+        # `change_key` reaches libzfs through a free function that only knows how to raise
+        # `ZFSException`, so there is no chokepoint below this to hang the refusal off. It goes
+        # first so that a managed dataset is refused before the lookup that would hide it.
+        deny_protected_path('pool.dataset.change_key', id_)
+
         ds = self.middleware.call_sync('pool.dataset.get_instance_quick', id_, {
             'encryption': True,
         })
@@ -223,6 +229,10 @@ class PoolDatasetService(Service):
         Allows inheriting parent's encryption root discarding its current encryption settings. This
         can only be done where ``id`` has an encrypted parent and ``id`` itself is an encryption root.
         """
+        # As in `change_key`: `change_encryption_root` is a free function with no schema of its own,
+        # so the refusal belongs here, ahead of the lookup that hides managed datasets.
+        deny_protected_path('pool.dataset.inherit_parent_encryption_properties', id_)
+
         ds = self.middleware.call_sync('pool.dataset.get_instance_quick', id_, {
             'encryption': True,
         })

--- a/src/middlewared/middlewared/plugins/pool_/dataset_query_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_query_utils.py
@@ -5,30 +5,16 @@ from typing import TypeAlias
 import truenas_pyfilter as _tf
 import truenas_pylibzfs
 
-from middlewared.plugins.container.utils import CONTAINER_DS_NAME
 from middlewared.plugins.zfs.tier import get_dataset_tier_info_cached
 from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
 from middlewared.utils.filter_list import compile_filters, compile_options
 from middlewared.utils.size import format_size
+from middlewared.utils.zfs.managed_datasets import hidden_from_dataset_listing
 
 __all__ = ("generic_query",)
 
 
-INTERNAL_DATASETS = (
-    ".system",
-    "ix-applications",
-    "ix-apps",
-    CONTAINER_DS_NAME,
-)
-"""
-Tuple of internal dataset name patterns that should be filtered out by default.
-
-These patterns represent system-managed datasets that are typically hidden
-from user interfaces. Used by is_internal_dataset() to perform efficient
-string prefix matching.
-"""
 # String type annotations to prevent github CI
 # from exploding since truenas_pylibzfs module
 # isn't installed
@@ -130,9 +116,9 @@ class QueryFiltersCallbackState:
     """the count of objects if count_only == True"""
     exclude_internal_datasets: bool = True
     """Flag to control whether internal datasets should be filtered out.
-    When True, system datasets matching INTERNAL_DATASETS patterns and boot
-    pools will be excluded from query results. Allows for flexible control
-    over when system datasets should be included in results."""
+    When True, the datasets middleware manages on the user's behalf are
+    excluded from query results. Allows for flexible control over when
+    those datasets should be included in results."""
     tier_enabled: bool = False
     """When True, tier info is fetched per FILESYSTEM row inside generic_query_callback."""
     pool_special_cache: dict = field(default_factory=dict)
@@ -867,30 +853,6 @@ def snapshot_callback(snap_hdl, info):
     return True
 
 
-def is_internal_dataset(hdl):
-    """
-    Check if a dataset is an internal system dataset that should be filtered out.
-
-    Detects system datasets by checking against known boot pool names and
-    internal dataset patterns defined in INTERNAL_DATASETS.
-
-    Args:
-        hdl: ZFS handle from truenas_pylibzfs
-
-    Returns:
-        bool: True if the dataset is internal and should be filtered out,
-              False if it should be included in results
-    """
-    name = hdl.name
-    for i in BOOT_POOL_NAME_VALID:
-        if name == i or name.startswith(f"{i}/"):
-            return True
-    for i in INTERNAL_DATASETS:
-        if f"/{i}" in name:
-            return True
-    return False
-
-
 def generic_query_callback(hdl, state: QueryFiltersCallbackState):
     """
     Callback function for processing individual ZFS resources during iteration.
@@ -904,7 +866,7 @@ def generic_query_callback(hdl, state: QueryFiltersCallbackState):
     6. Recursively processing children if requested
 
     The function uses two focused filtering approaches:
-    - is_internal_dataset() for configurable system dataset filtering
+    - hidden_from_dataset_listing() for configurable system dataset filtering
     - exact_match_filters_specified_and_did_not_match() for performance optimization
 
     Args:
@@ -914,7 +876,7 @@ def generic_query_callback(hdl, state: QueryFiltersCallbackState):
     Returns:
         bool: True to continue iteration, False to halt iteration
     """
-    if state.exclude_internal_datasets and is_internal_dataset(hdl):
+    if state.exclude_internal_datasets and hidden_from_dataset_listing(hdl.name):
         # is an internal dataset and told to exclude them from results
         return True
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
@@ -15,6 +15,7 @@ from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.service_exception import ValidationError
 from middlewared.utils.filter_list import filter_list
 from middlewared.utils.nss import grp, pwd
+from middlewared.utils.zfs.managed_datasets import deny_protected_path
 
 
 def quota_cb(quota, state):
@@ -110,7 +111,9 @@ class PoolDatasetService(Service):
 
     @private
     @pass_thread_local_storage
-    def get_quota_impl(self, tls, ds, quota_type):
+    def get_quota_impl(self, tls, ds, quota_type, bypass: bool = False):
+        deny_protected_path('pool.dataset.get_quota', ds, bypass)
+
         rsrc = tls.lzh.open_resource(name=ds)
         quota_type = quota_type.upper()
         match quota_type:
@@ -166,7 +169,9 @@ class PoolDatasetService(Service):
 
     @private
     @pass_thread_local_storage
-    def set_quota_impl(self, tls, ds, inquotas):
+    def set_quota_impl(self, tls, ds, inquotas, bypass: bool = False):
+        deny_protected_path('pool.dataset.set_quota', ds, bypass)
+
         ds_quotas, quotas = dict(), list()
         for i in inquotas:
             if i['quota_type'] == 'DATASET':

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -58,7 +58,7 @@ class PoolService(Service):
                     # we'll need iterate all children no matter what.
                     await self.middleware.call(
                         'pool.dataset.update_impl',
-                        UpdateImplArgs(name=i['name'], iprops={'mountpoint'})
+                        UpdateImplArgs(name=i['name'], iprops={'mountpoint'}, bypass=True)
                     )
                     to_inherit.append(pool_name)
                     break
@@ -79,7 +79,7 @@ class PoolService(Service):
                     # unintentionally share it via SMB, NFS, etc.
                     await self.middleware.call(
                         'pool.dataset.update_impl',
-                        UpdateImplArgs(name=i['name'], zprops={'mountpoint': container_mnt})
+                        UpdateImplArgs(name=i['name'], zprops={'mountpoint': container_mnt}, bypass=True)
                     )
 
                 # We do not do anything if the mountpoint is already correct
@@ -99,7 +99,7 @@ class PoolService(Service):
                 try:
                     await self.middleware.call(
                         'pool.dataset.update_impl',
-                        UpdateImplArgs(name=i.name, iprops={'mountpoint'})
+                        UpdateImplArgs(name=i.name, iprops={'mountpoint'}, bypass=True)
                     )
                 except Exception:
                     self.logger.exception('Failed inheriting mountpoint property for %r', i.name)
@@ -429,7 +429,9 @@ class PoolService(Service):
         if opts:
             try:
                 self.logger.debug('Calling pool.dateset.update_impl on %r with opts %r', vol_name, opts)
-                self.middleware.call_sync('pool.dataset.update_impl', UpdateImplArgs(name=vol_name, zprops=opts))
+                self.middleware.call_sync(
+                    'pool.dataset.update_impl', UpdateImplArgs(name=vol_name, zprops=opts, bypass=True)
+                )
             except Exception:
                 self.logger.warning('%r: failed to normalize properties of root-level dataset', vol_name, exc_info=True)
             else:

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -650,7 +650,7 @@ class PoolService(CRUDService):
             # making it a "local" source.
             await self.middleware.call(
                 'pool.dataset.update_impl',
-                UpdateImplArgs(name=data['name'], iprops={'mountpoint'})
+                UpdateImplArgs(name=data['name'], iprops={'mountpoint'}, bypass=True)
             )
             await self.call2(self.s.zfs.resource.mount, data['name'])
 

--- a/src/middlewared/middlewared/plugins/pool_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot.py
@@ -26,6 +26,7 @@ from middlewared.api.current import (
     ZFSResourceSnapshotHoldQuery,
     ZFSResourceSnapshotQuery,
     ZFSResourceSnapshotReleaseQuery,
+    ZFSResourceSnapshotRenameQuery,
     ZFSResourceSnapshotRollbackQuery,
 )
 from middlewared.plugins.zfs.exceptions import ZFSPathAlreadyExistsException, ZFSPathNotFoundException
@@ -442,4 +443,8 @@ class PoolSnapshotService(CRUDService):
                 'pool.snapshot.rename.new_name',
                 'Old and new snapshot must be part of the same ZFS dataset'
             )
-        await self.call2(self.s.zfs.resource.rename, id_, options['new_name'], options['recursive'])
+        await self.call2(self.s.zfs.resource.snapshot.rename, ZFSResourceSnapshotRenameQuery(
+            current_name=id_,
+            new_name=options['new_name'],
+            recursive=options['recursive'],
+        ))

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -84,6 +84,9 @@ class UpdateImplArgs(TypedDict, total=False):
     """ZFS user properties to be applied during creation."""
     iprops: set
     """ZFS properties to be inherited from parent."""
+    bypass: bool
+    """Set by the subsystem that owns the dataset, which lifts the refusal to touch a dataset
+    middleware manages on the user's behalf."""
 
 
 @dataclasses.dataclass(slots=True, kw_only=True)

--- a/src/middlewared/middlewared/plugins/replication/__init__.py
+++ b/src/middlewared/middlewared/plugins/replication/__init__.py
@@ -153,6 +153,12 @@ class ReplicationService(GenericCRUDService[ReplicationEntry]):
         """
         return await _methods.list_datasets(self.context, transport, ssh_credentials)
 
+    # Deliberately does not refuse the datasets middleware manages on the user's behalf, unlike the
+    # other methods that bring a dataset into existence. Replication is how those datasets get
+    # backed up and restored in the first place, so refusing them here would take that away. It
+    # would also be answering the wrong question: the dataset is created by a shell `zfs create`
+    # run by zettarepl on the far side of the transport, which may well be a different system, and
+    # this one has no way to reason about which of that system's paths are managed.
     @api_method(
         ReplicationCreateDatasetArgs,
         ReplicationCreateDatasetResult,

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -796,7 +796,7 @@ class SystemDatasetService(ConfigService):
                 if update_props:
                     await self.middleware.call(
                         'pool.dataset.update_impl',
-                        UpdateImplArgs(name=dataset, zprops=update_props),
+                        UpdateImplArgs(name=dataset, zprops=update_props, bypass=True),
                     )
 
         return list(datasets.values())
@@ -1094,7 +1094,7 @@ class SystemDatasetService(ConfigService):
         if 'POSIXACL' in sysds_mntinfo['super_opts'] or 'NFSV4ACL' in sysds_mntinfo['super_opts']:
             self.middleware.call_sync(
                 'pool.dataset.update_impl',
-                UpdateImplArgs(name=config['basename'], zprops={'acltype': 'off'}),
+                UpdateImplArgs(name=config['basename'], zprops={'acltype': 'off'}, bypass=True),
             )
 
         self._bind_cores_to_coredump()

--- a/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
@@ -9,10 +9,10 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 
 from middlewared.api.current import FilesystemStatData, VMDeviceConvert, VMDiskDevice, ZFSResourceQuery
-from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.service import CallError, ServiceContext
 from middlewared.service_exception import InstanceNotFound, ValidationError
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
+from middlewared.utils.zfs.managed_datasets import blocked_from_mutation
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -99,7 +99,7 @@ def validate_convert_disk_image(
                 raise ValidationError(schema, f'{dip!r} is not a file', errno.EINVAL)
 
             vfs = context.middleware.call_sync('filesystem.statfs', dip)
-            if has_internal_path(vfs.source):
+            if blocked_from_mutation(vfs.source):
                 raise ValidationError(
                     schema,
                     f'{dip!r} is in a protected system path ({vfs.source})',
@@ -129,7 +129,7 @@ def validate_convert_disk_image(
                 raise ValidationError(schema, f'{sp!r} is not a directory', errno.EINVAL)
 
             vfs = context.middleware.call_sync('filesystem.statfs', dst.realpath)
-            if has_internal_path(vfs.source):
+            if blocked_from_mutation(vfs.source):
                 raise ValidationError(
                     schema,
                     f'{sp!r} is in a protected system path ({vfs.source})',
@@ -156,7 +156,7 @@ def validate_convert_zvol(
         raise ValidationError(schema, f'{ptn!r} does not exist', errno.ENOENT)
     elif zv[0]['type'] != 'VOLUME':
         raise ValidationError(schema, f'{ptn!r} is not a volume', errno.EINVAL)
-    elif has_internal_path(ptn):
+    elif blocked_from_mutation(ptn):
         raise ValidationError(schema, f'{ptn!r} is in a protected system path', errno.EACCES)
     elif not os.path.exists(ntp):
         raise ValidationError(schema, f'{ntp!r} does not exist', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -8,7 +8,6 @@ import logging
 import multiprocessing
 import os
 import queue
-import re
 import signal
 import socket
 import threading
@@ -65,12 +64,7 @@ from middlewared.utils.string import make_sentence
 from middlewared.utils.threading import start_daemon_thread
 from middlewared.utils.time_utils import utc_now
 from middlewared.utils.timezone_choices import effective_timezone
-
-INVALID_DATASETS = (
-    re.compile(r"boot-pool($|/)"),
-    re.compile(r"freenas-boot($|/)"),
-    re.compile(r"[^/]+/\.system($|/)")
-)
+from middlewared.utils.zfs.managed_datasets import excluded_from_replication
 
 
 def lifetime_timedelta(value, unit):
@@ -578,7 +572,7 @@ class ZettareplService(Service):
         return [
             ds
             for ds in datasets
-            if not any(r.match(ds) for r in INVALID_DATASETS)
+            if not excluded_from_replication(ds)
         ]
 
     async def create_dataset(self, dataset, transport, ssh_credentials=None):

--- a/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
@@ -68,7 +68,6 @@ def destroy_impl(
     path: str,
     recursive: bool,
     all_snapshots: bool,
-    bypass: bool,
     defer: bool,
 ) -> tuple[str | None, int | None]:
     """
@@ -80,10 +79,6 @@ def destroy_impl(
             release any holds and destroy any clones or snapshots.
         all_snapshots: If true, will delete all snapshots ONLY for the
             given zfs resource. Will not delete the resource itself.
-        bypass: If true, will bypass the safety checks that prevent
-            deleting zfs resources that are "protected".
-            NOTE: This is only ever set by internal callers and is
-            not exposed to the public API.
         defer: Rather than returning error if the given snapshot is ineligible for immediate destruction,
             mark it for deferred, automatic destruction once it becomes eligible.
     """

--- a/src/middlewared/middlewared/plugins/zfs/query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/query_impl.py
@@ -3,11 +3,12 @@ from typing import Any
 
 from truenas_pylibzfs import ZFSError, ZFSException
 
+from middlewared.utils.zfs.managed_datasets import hidden_from_zfs_listing
+
 from .exceptions import ZFSPathNotFoundException
 from .normalization import normalize_asdict_result
 from .property_management import DeterminedProperties, build_set_of_zfs_props
 from .tier import get_dataset_tier_info_cached
-from .utils import has_internal_path
 
 __all__ = ("query_impl",)
 
@@ -30,7 +31,7 @@ class CallbackState:
 
 
 def __query_impl_callback(hdl: Any, state: CallbackState) -> bool:
-    if state.eip and has_internal_path(hdl.name):
+    if state.eip and hidden_from_zfs_listing(hdl.name):
         # returning False here will halt the iteration
         # entirely which is not what we want to do
         return True
@@ -97,7 +98,7 @@ def __query_impl_roots(hdl: Any, state: CallbackState) -> None:
 
 def __should_exclude_internal_paths(data: dict[str, Any]) -> bool:
     for path in data["paths"]:
-        if has_internal_path(path):
+        if hidden_from_zfs_listing(path):
             # somone is explicilty querying an
             # internal path
             return False

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -19,6 +19,7 @@ from middlewared.service import Service, private
 from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.service_exception import ValidationError
 from middlewared.utils.filter_list import filter_list
+from middlewared.utils.zfs.managed_datasets import deny_protected_path
 
 from .destroy_impl import destroy_impl
 from .exceptions import (
@@ -41,7 +42,7 @@ from .rename_promote_clone_impl import (
     promote_impl,
     rename_impl,
 )
-from .utils import group_paths_by_parents, has_internal_path
+from .utils import group_paths_by_parents
 from .zvol_utils import get_zvol_attachments_impl, unlocked_zvols_fast_impl
 
 if typing.TYPE_CHECKING:
@@ -93,14 +94,18 @@ class ZFSResourceService(Service):
 
     @private
     @pass_thread_local_storage
-    def promote(self, tls: typing.Any, current_name: str) -> None:
+    def promote(self, tls: typing.Any, current_name: str, bypass: bool = False) -> None:
         """
         Promote a ZFS clone to be independent of its origin snapshot.
 
         Args:
             current_name: The name of the zfs resource to be promoted.
+            bypass: Set by the subsystem that owns the path, which lifts the refusal to touch a
+                dataset middleware manages on the user's behalf.
         """
         schema = "zfs.resource.promote"
+        deny_protected_path(schema, current_name, bypass)
+
         try:
             promote_impl(tls, current_name)
         except ZFSPathInvalidException:
@@ -112,6 +117,10 @@ class ZFSResourceService(Service):
         except ZFSPathNotFoundException as e:
             raise ValidationError(schema, e.message, errno.ENOENT)
 
+    # `mount` and `unmount` are deliberately left unguarded against the datasets middleware manages
+    # on the user's behalf. Unlike every other mutator here they create, destroy and rename nothing,
+    # and the docker plugin mounts and unmounts `<pool>/ix-apps` as part of normal operation, so a
+    # guard here would break it.
     @private
     @pass_thread_local_storage
     def mount(
@@ -212,7 +221,12 @@ class ZFSResourceService(Service):
     @private
     @pass_thread_local_storage
     def unload_key(
-        self, tls: typing.Any, filesystem: str, recursive: bool = False, force_unmount: bool = False
+        self,
+        tls: typing.Any,
+        filesystem: str,
+        recursive: bool = False,
+        force_unmount: bool = False,
+        bypass: bool = False,
     ) -> None:
         """
         Unload the encryption key from ZFS.
@@ -225,8 +239,12 @@ class ZFSResourceService(Service):
             recursive: Recursively unload encryption keys for any child resources of the
                 parent.
             force_unmount: Forcefully unmount the resource before unloading the encryption key.
+            bypass: Set by the subsystem that owns the path, which lifts the refusal to touch a
+                dataset middleware manages on the user's behalf.
         """
         schema = "zfs.resource.unload_key"
+        deny_protected_path(schema, filesystem, bypass)
+
         try:
             unload_key_impl(tls, filesystem, recursive, force_unmount)
         except ZFSPathNotProvidedException:
@@ -244,6 +262,7 @@ class ZFSResourceService(Service):
         recursive: bool = False,
         no_unmount: bool = False,
         force_unmount: bool = True,
+        bypass: bool = False,
     ) -> None:
         """
         Rename a ZFS resource.
@@ -268,8 +287,22 @@ class ZFSResourceService(Service):
                 property is set to legacy or none, the file system is not unmounted even
                 if this option is False (default).
             force_unmount: Force unmount any file systems that need to be unmounted in the process.
+            bypass: Set by the subsystem that owns the paths, which lifts the refusal to touch a
+                dataset middleware manages on the user's behalf.
         """
         schema = "zfs.resource.rename"
+
+        # Both ends are guarded, and before the snapshot rejection below. Guarding the destination
+        # is what stops a rename from *creating* a dataset at a protected path.
+        #
+        # The guard does not strip a snapshot suffix, so which of the two answers a snapshot name
+        # gets depends on how its dataset is matched. A boot pool is matched on the first path
+        # component, which a suffix never touches, so `boot-pool/ROOT@snap` is refused here and
+        # never reaches the hint. `tank/.system@snap` is matched on the second component, and the
+        # suffix is on it, so the guard sees nothing managed and the hint below is what answers.
+        deny_protected_path(schema, current_name, bypass)
+        deny_protected_path(schema, new_name, bypass)
+
         if "@" in current_name:
             raise ValidationError(
                 schema,
@@ -401,12 +434,13 @@ class ZFSResourceService(Service):
             raise ValidationError(
                 schema, "Path must not end with a forward-slash.", errno.EINVAL
             )
-        elif not bypass and has_internal_path(path):
-            # NOTE: `bypass` is a value only exposed to
-            # internal callers and not to our public API.
-            raise ValidationError(
-                schema, f"{path!r} is a protected path.", errno.EACCES
-            )
+
+        # Deliberately not stripping a snapshot suffix here, so `tank/.system@snap` falls through to
+        # the message below that points the caller at `zfs.resource.snapshot.destroy`: that shape is
+        # matched on the second path component and the suffix is on it, so the guard sees nothing
+        # managed. A boot pool is matched on the first component, which a suffix never touches, so
+        # `boot-pool/ROOT@snap` is refused here and never reaches the hint.
+        deny_protected_path(schema, path, bypass)
 
         if "@" in path:
             raise ValidationError(
@@ -442,7 +476,7 @@ class ZFSResourceService(Service):
                         schema, f"{path!r} has snapshots. {extra}", errno.ENOTEMPTY
                     )
 
-        return destroy_impl(tls, path, recursive, all_snapshots, bypass, defer)
+        return destroy_impl(tls, path, recursive, all_snapshots, defer)
 
     @api_method(
         ZFSResourceDestroyArgs,

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_count_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_count_impl.py
@@ -16,8 +16,9 @@ from middlewared.utils.tdb import (
     TDBPathType,
     get_tdb_handle,
 )
+from middlewared.utils.zfs.managed_datasets import hidden_from_snapshot_listing
 
-from .utils import has_internal_path, open_resource
+from .utils import open_resource
 
 __all__ = ("count_snapshots_impl",)
 
@@ -149,7 +150,7 @@ def __dataset_count_callback(ds_hdl: Any, state: SnapshotCountState) -> bool:
     ds_name = ds_hdl.name
 
     # Check if internal path should be excluded
-    if state.eip and has_internal_path(ds_name):
+    if state.eip and hidden_from_snapshot_listing(ds_name):
         return True
 
     # Count snapshots for this dataset (with caching)
@@ -166,7 +167,7 @@ def __dataset_count_callback(ds_hdl: Any, state: SnapshotCountState) -> bool:
 def __should_exclude_internal_paths(data: ZFSResourceSnapshotCountQuery) -> bool:
     """Determine if internal paths should be excluded from counts."""
     for path in data.paths:
-        if has_internal_path(path):
+        if hidden_from_snapshot_listing(path):
             return False
     return True
 
@@ -212,6 +213,10 @@ def count_snapshots_impl(tls: Any, data: ZFSResourceSnapshotCountQuery) -> dict[
         for path in paths:
             rsrc = open_resource(tls, path)
             if rsrc.type == ZFSType.ZFS_TYPE_SNAPSHOT:
+                # The same filter __dataset_count_callback applies, on the branch that never
+                # reaches it.
+                if state.eip and hidden_from_snapshot_listing(rsrc.name):
+                    continue
                 dataset = rsrc.name.split("@", 1)[0]
                 state.counts[dataset] = state.counts.get(dataset, 0) + 1
             else:

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -39,6 +39,7 @@ from middlewared.api.current import (
 from middlewared.service import Service, private
 from middlewared.service.decorators import pass_thread_local_storage
 from middlewared.service_exception import ValidationError
+from middlewared.utils.zfs.managed_datasets import deny_protected_path, deny_protected_snapshot
 
 from .destroy_impl import destroy_impl
 from .exceptions import (
@@ -54,7 +55,7 @@ from .snapshot_create_impl import create_snapshots_impl
 from .snapshot_hold_release_impl import hold_impl, release_impl
 from .snapshot_query_impl import query_snapshots_impl
 from .snapshot_rollback_impl import rollback_impl
-from .utils import group_paths_by_parents, has_internal_path, open_resource
+from .utils import group_paths_by_parents, open_resource
 
 
 class ZFSResourceSnapshotService(Service):
@@ -214,18 +215,13 @@ class ZFSResourceSnapshotService(Service):
     def destroy_impl(self, tls: Any, data: ZFSResourceSnapshotDestroyQuery) -> tuple[str | None, int | None]:
         schema = "zfs.resource.snapshot.destroy"
 
-        # Check for internal path protection
-        # For snapshot paths, extract the dataset portion
-        check_path = data.path.split("@")[0] if "@" in data.path else data.path
-        if not data.bypass and has_internal_path(check_path):
-            raise ValidationError(schema, f"{data.path!r} is a protected path.", errno.EACCES)
+        deny_protected_snapshot(schema, data.path, data.bypass)
 
         return destroy_impl(
             tls,
             data.path,
             data.recursive,
             data.all_snapshots,
-            data.bypass,
             data.defer,
         )
 
@@ -320,11 +316,13 @@ class ZFSResourceSnapshotService(Service):
     def rename_impl(self, tls: Any, data: ZFSResourceSnapshotRenameQuery) -> None:
         schema = "zfs.resource.snapshot.rename"
 
-        # Check for internal path protection
-        # For snapshot paths, extract the dataset portion
-        check_path = data.current_name.split("@")[0] if "@" in data.current_name else data.current_name
-        if not data.bypass and has_internal_path(check_path):
-            raise ValidationError(schema, f"{data.current_name!r} is a protected path.", errno.EACCES)
+        # Both ends are guarded, matching every other mutator that takes a source and a destination.
+        # The destination guard cannot fire today: the public method above refuses a rename whose
+        # new_name names a different dataset, so by the time this runs the two names always share a
+        # dataset and always get the same answer. It is here so that relaxing that check later
+        # cannot quietly open a route to creating a snapshot under a protected dataset.
+        deny_protected_snapshot(schema, data.current_name, data.bypass)
+        deny_protected_snapshot(schema, data.new_name, data.bypass)
 
         return rename_impl(
             tls,
@@ -413,14 +411,11 @@ class ZFSResourceSnapshotService(Service):
                     errno.EINVAL,
                 )
 
-        # Check for internal path protection on BOTH source and destination
-        if not data.bypass:
-            # For snapshot paths, extract the dataset portion
-            source_check = data.snapshot.split("@")[0] if "@" in data.snapshot else data.snapshot
-            if has_internal_path(source_check):
-                raise ValidationError(schema, f"{data.snapshot!r} is a protected path.", errno.EACCES)
-            if has_internal_path(data.dataset):
-                raise ValidationError(schema, f"{data.dataset!r} is a protected path.", errno.EACCES)
+        # Both ends are guarded: cloning a protected snapshot is as much a mutation as landing a
+        # clone on top of a protected dataset. The source is a snapshot name, the destination is a
+        # dataset name, so they take different guards.
+        deny_protected_snapshot(schema, data.snapshot, data.bypass)
+        deny_protected_path(schema, data.dataset, data.bypass)
 
         return clone_impl(
             tls,
@@ -500,9 +495,7 @@ class ZFSResourceSnapshotService(Service):
     def create_impl(self, tls: Any, data: ZFSResourceSnapshotCreateQuery) -> Any:
         schema = "zfs.resource.snapshot.create"
 
-        # Check for internal path protection
-        if not data.bypass and has_internal_path(data.dataset):
-            raise ValidationError(schema, f"{data.dataset!r} is a protected path.", errno.EACCES)
+        deny_protected_path(schema, data.dataset, data.bypass)
 
         return create_snapshots_impl(
             tls,
@@ -584,11 +577,7 @@ class ZFSResourceSnapshotService(Service):
     def hold_impl(self, tls: Any, data: ZFSResourceSnapshotHoldQuery) -> None:
         schema = "zfs.resource.snapshot.hold"
 
-        # Check for internal path protection
-        if not data.bypass:
-            check_path = data.path.split("@")[0] if "@" in data.path else data.path
-            if has_internal_path(check_path):
-                raise ValidationError(schema, f"{data.path!r} is a protected path.", errno.EACCES)
+        deny_protected_snapshot(schema, data.path, data.bypass)
 
         return hold_impl(
             tls,
@@ -699,11 +688,7 @@ class ZFSResourceSnapshotService(Service):
     def release_impl(self, tls: Any, data: ZFSResourceSnapshotReleaseQuery) -> None:
         schema = "zfs.resource.snapshot.release"
 
-        # Check for internal path protection
-        if not data.bypass:
-            check_path = data.path.split("@")[0] if "@" in data.path else data.path
-            if has_internal_path(check_path):
-                raise ValidationError(schema, f"{data.path!r} is a protected path.", errno.EACCES)
+        deny_protected_snapshot(schema, data.path, data.bypass)
 
         return release_impl(
             tls,
@@ -768,11 +753,7 @@ class ZFSResourceSnapshotService(Service):
     def rollback_impl(self, tls: Any, data: ZFSResourceSnapshotRollbackQuery) -> None:
         schema = "zfs.resource.snapshot.rollback"
 
-        # Check for internal path protection
-        if not data.bypass:
-            check_path = data.path.split("@")[0] if "@" in data.path else data.path
-            if has_internal_path(check_path):
-                raise ValidationError(schema, f"{data.path!r} is a protected path.", errno.EACCES)
+        deny_protected_snapshot(schema, data.path, data.bypass)
 
         return rollback_impl(
             tls,

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_query_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_query_impl.py
@@ -3,9 +3,10 @@ from typing import Any
 
 from truenas_pylibzfs import ZFSError, ZFSException, ZFSType
 
+from middlewared.utils.zfs.managed_datasets import hidden_from_snapshot_listing
+
 from .exceptions import ZFSPathNotFoundException
 from .property_management import DeterminedProperties, build_set_of_zfs_snapshot_props
-from .utils import has_internal_path
 
 __all__ = ("query_snapshots_impl",)
 
@@ -58,12 +59,6 @@ def __snapshot_callback(snap_hdl: Any, state: SnapshotQueryState) -> bool:
 
     Returns True to continue iteration, False to stop.
     """
-    snap_name = snap_hdl.name
-
-    # Check if internal path should be excluded
-    if state.eip and has_internal_path(snap_name):
-        return True
-
     # Apply txg filtering
     createtxg = snap_hdl.createtxg
     min_txg = state.query_args["min_txg"]
@@ -108,7 +103,7 @@ def __dataset_iter_callback(ds_hdl: Any, state: SnapshotQueryState) -> bool:
     ds_name = ds_hdl.name
 
     # Check if internal path should be excluded
-    if state.eip and has_internal_path(ds_name):
+    if state.eip and hidden_from_snapshot_listing(ds_name):
         return True
 
     # Set parent type for snapshot property resolution
@@ -127,11 +122,12 @@ def __dataset_iter_callback(ds_hdl: Any, state: SnapshotQueryState) -> bool:
 def __should_exclude_internal_paths(data: dict[str, Any]) -> bool:
     """Determine if internal paths should be excluded from results."""
     for path in data.get("paths", []):
-        if has_internal_path(path):
+        if hidden_from_snapshot_listing(path):
             # Someone is explicitly querying an internal path
             return False
-    # Exclude internal paths by default
-    return data.get("exclude_internal_paths", True)  # type: ignore[no-any-return]
+    # Exclude internal paths by default. There is no request field to override this: the decision
+    # belongs to the caller rather than the request, and the loop above is the only way out of it.
+    return True
 
 
 def __query_snapshot_directly(hdl: Any, snap_path: str, state: SnapshotQueryState) -> None:
@@ -141,6 +137,14 @@ def __query_snapshot_directly(hdl: Any, snap_path: str, state: SnapshotQueryStat
     """
     # Parse dataset name from snapshot path
     dataset_name = snap_path.split("@")[0]
+
+    # The listing filter for this branch. The iteration branch asks about the dataset once in
+    # __dataset_iter_callback and every snapshot below it inherits that answer; this branch reaches
+    # a snapshot without ever asking, so it asks here. It cannot fire while the opt-out above stays
+    # request-wide -- naming a managed path is exactly what turns state.eip off -- and it is what
+    # begins filtering if that ever becomes per-path.
+    if state.eip and hidden_from_snapshot_listing(snap_path):
+        return
 
     try:
         # Open parent dataset to get its type

--- a/src/middlewared/middlewared/plugins/zfs/tier.py
+++ b/src/middlewared/middlewared/plugins/zfs/tier.py
@@ -57,6 +57,7 @@ from middlewared.service import CallError, ConfigServicePart, GenericConfigServi
 from middlewared.service.decorators import pass_thread_local_storage
 import middlewared.sqlalchemy as sa
 from middlewared.utils.filter_list import filter_list
+from middlewared.utils.zfs.managed_datasets import deny_protected_path
 
 SPECIAL_SMALL_BLOCKS_PERFORMANCE = str(16 * 1024 * 1024)  # 16 MiB
 SPECIAL_SMALL_BLOCKS_REGULAR = "0"
@@ -401,6 +402,12 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def rewrite_job_create(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """Create a new rewrite job for the specified ZFS dataset."""
+        # Nothing below is a chokepoint -- the job is created by an out-of-process daemon over its
+        # own socket -- so the refusal has to live here. It goes ahead of the "tiering is globally
+        # disabled" check because whether a dataset may be touched at all is a fact about the
+        # dataset, not about whether the daemon happens to be turned on.
+        deny_protected_path("zfs_tier_rewrite_job_create.dataset_name", data["dataset_name"])
+
         dataset_name = data["dataset_name"]
         field = "zfs_tier_rewrite_job_create.dataset_name"
 
@@ -491,6 +498,9 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
 
         return filter_list(failures, data.get("query-filters") or [], data.get("query-options") or {})
 
+    # Deliberately not refused for a managed dataset, unlike the rest of the rewrite job methods.
+    # Cancelling is the only way to stop a rewrite that is already moving blocks around, and being
+    # unable to stop one is worse than anything the refusal would prevent.
     @api_method(
         ZfsTierRewriteJobCancelArgs,
         ZfsTierRewriteJobCancelResult,
@@ -517,6 +527,11 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     async def rewrite_job_recover(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """Recover a rewrite job in ERROR state by reissuing failed rewrites."""
         dataset_name, job_uuid = _parse_tier_job_id(data["tier_job_id"])
+        # Recovery reissues rewrites, so it writes to the dataset. `rewrite_job_create` is the only
+        # way to produce a job through middleware and it already refuses managed datasets, which
+        # makes this unreachable in practice -- but the daemon holds its own job state across
+        # restarts and middleware is not its only possible client, so it is worth the line.
+        deny_protected_path("zfs_tier_rewrite_job_recover.tier_job_id", dataset_name)
         await self._validate_dataset_writable(dataset_name, "zfs_tier_rewrite_job_recover.tier_job_id")
         async with RewriteClient() as client:
             try:
@@ -589,10 +604,16 @@ class ZfsTierService(GenericConfigService[ZfsTierEntry]):
     )
     async def dataset_set_tier(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """Set the performance tier for a ZFS dataset, optionally migrating existing data."""
+        # As in `rewrite_job_create`, ahead of the "tiering is globally disabled" check. The
+        # property write further down goes through `pool.dataset.update_impl`, which refuses a
+        # managed dataset as well, but it would report against its own schema rather than the field
+        # the caller sent -- and it is not reached until every other validation has passed.
         dataset_name = data["dataset_name"]
+        field = "zfs_tier_dataset_set_tier.dataset_name"
+        deny_protected_path(field, dataset_name)
+
         tier_type = data["tier_type"]
         move_existing_data = data["move_existing_data"]
-        field = "zfs_tier_dataset_set_tier.dataset_name"
 
         config = await self.config()
         if not config.enabled:

--- a/src/middlewared/middlewared/plugins/zfs/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs/utils.py
@@ -5,22 +5,12 @@ from typing import Any, Literal
 
 import truenas_pylibzfs
 
-from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
-
 from .exceptions import ZFSPathNotFoundException, ZFSPathNotProvidedException
 
 __all__ = (
     "get_encryption_info",
     "group_paths_by_parents",
-    "has_internal_path",
     "open_resource",
-)
-
-
-INTERNAL_PATHS = (
-    "ix-apps",
-    "ix-applications",
-    ".system"
 )
 
 
@@ -39,26 +29,6 @@ class EncryptionInfo:
     This property is only set for encrypted datasets which are
     encryption roots. If unspecified, the default is prompt.
     """
-
-
-def has_internal_path(path: str) -> bool:
-    """
-    Check if a ZFS resource path is an internal path.
-
-    Internal paths include:
-    - Boot pools themselves ('boot-pool', 'freenas-boot') and any dataset under them
-    - System datasets directly under a data pool (e.g., 'tank/ix-apps', 'tank/.system')
-
-    Args:
-        path: A ZFS resource relative path string (e.g., 'tank/ix-apps/foo', 'boot-pool/grub')
-
-    Returns:
-        bool: True if the path represents an internal path, False otherwise
-    """
-    components = path.split("/")
-    if components[0] in BOOT_POOL_NAME_VALID:
-        return True
-    return len(components) > 1 and components[1] in INTERNAL_PATHS
 
 
 def get_encryption_info(data: dict[str, dict[str, Any]]) -> EncryptionInfo:

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -32,6 +32,7 @@ from middlewared.utils.zfs.event import (
     ZfsStateChangeEvent,
     ZfsVdevClearEvent,
 )
+from middlewared.utils.zfs.managed_datasets import excluded_from_zfs_events
 
 CACHE_POOLS_STATUSES = 'system.system_health_pools'
 VOLUME_STATUS_ALERTS = 'VolumeStatusAlerts'
@@ -204,7 +205,7 @@ async def zfs_events(middleware, event: ZfsEvent):
         # we need to send events for dataset creation/updating/deletion in case it's done via cli
         event_type = event.history_internal_name
         ds_id = event.history_dsname
-        if await middleware.call('pool.dataset.is_internal_dataset', ds_id):
+        if excluded_from_zfs_events(ds_id):
             # We should not raise any event for system internal datasets
             return
 

--- a/src/middlewared/middlewared/pytest/unit/utils/zfs/test_guard.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/zfs/test_guard.py
@@ -1,0 +1,211 @@
+"""What the mutation guard refuses, and what it lets through.
+
+The guard is the only thing standing between a caller and a dataset middleware manages, so the
+cases that matter are the ones where it could quietly stop refusing: the boot pool root, which is
+the one single-component path that is protected, and the asymmetry between the two guards over a
+snapshot name -- one drops the suffix before asking and the other deliberately does not.
+
+One case runs the other way and is asserted just as hard: the container dataset is let through by
+both guards on purpose, so a well-meant tidy-up that adds it to the mutation membership fails here
+rather than changing product behaviour unnoticed.
+"""
+
+import errno
+
+import pytest
+
+from middlewared.service_exception import ValidationError
+from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
+from middlewared.utils.zfs.managed_datasets import (
+    CONTAINER_DS_NAME,
+    deny_protected_path,
+    deny_protected_snapshot,
+)
+
+SCHEMA = "zfs.resource.snapshot.destroy"
+
+PROTECTED = "tank/.system"
+"""A dataset the system dataset plugin owns."""
+
+USER = "tank/data"
+"""An ordinary dataset."""
+
+MANAGED = ["tank/.system", "tank/ix-apps", "tank/ix-applications"]
+"""Every dataset the guards refuse below a data pool root, one level down where each is created."""
+
+MANAGED_CHILDREN = ["tank/.system/cores", "tank/ix-apps/docker", "tank/ix-applications/releases"]
+"""One level below each of MANAGED, where the data a managed dataset holds actually lives. The
+guards are anchored to the second component, so nothing about being deeper makes a path safe."""
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+def test_protected_path_is_refused_by_default(guard):
+    """The refusal is the default, so a caller that says nothing gets it."""
+    with pytest.raises(ValidationError) as exc:
+        guard(SCHEMA, PROTECTED)
+
+    assert exc.value.attribute == SCHEMA
+    assert exc.value.errmsg == "'tank/.system' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+def test_protected_path_is_refused_when_bypass_is_false(guard):
+    with pytest.raises(ValidationError):
+        guard(SCHEMA, PROTECTED, False)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+def test_owner_may_touch_a_protected_path(guard):
+    guard(SCHEMA, PROTECTED, True)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("bypass", [False, True])
+def test_user_path_passes_either_way(guard, bypass):
+    guard(SCHEMA, USER, bypass)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+def test_data_pool_root_is_not_protected(guard):
+    """Users have to be able to destroy a pool that happens to host the system dataset."""
+    guard(SCHEMA, "tank", False)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("boot_pool", BOOT_POOL_NAME_VALID)
+def test_boot_pool_root_is_protected(guard, boot_pool):
+    """The counterpart to the data pool root: a single-component path is not automatically safe.
+
+    A guard that returned early when the path has no "/" -- the obvious reading of "a pool root is
+    never protected" -- would still pass every other case here while opening the boot pool up.
+    Parametrized over the boot pool names rather than naming one, so that a system upgraded from a
+    FreeNAS-era install is covered by the same assertion as a fresh one.
+    """
+    with pytest.raises(ValidationError) as exc:
+        guard(SCHEMA, boot_pool, False)
+
+    assert exc.value.errmsg == f"'{boot_pool}' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("path", MANAGED)
+def test_managed_dataset_is_refused(guard, path):
+    """Every name the guards refuse below a data pool root, not just the system dataset."""
+    with pytest.raises(ValidationError) as exc:
+        guard(SCHEMA, path, False)
+
+    assert exc.value.errmsg == f"'{path}' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("path", MANAGED_CHILDREN + ["boot-pool/ROOT/default"])
+def test_a_dataset_below_a_managed_one_is_refused(guard, path):
+    """Depth does not earn a path its way out.
+
+    The refusal is what keeps a caller from destroying, renaming or promoting the pieces a managed
+    dataset is actually made of -- which is where the damage is, since the managed dataset itself is
+    usually an empty container.
+    """
+    with pytest.raises(ValidationError) as exc:
+        guard(SCHEMA, path, False)
+
+    assert exc.value.errmsg == f"'{path}' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize(
+    "path",
+    [f"tank/{CONTAINER_DS_NAME}", f"tank/{CONTAINER_DS_NAME}/containers", f"tank/{CONTAINER_DS_NAME}@snap"],
+)
+def test_container_dataset_is_not_protected_from_mutation(guard, path):
+    """The one managed dataset the guards let through, which is deliberate and easy to mistake for a
+    hole.
+
+    It is hidden from ``pool.dataset`` and from nothing else, so ``zfs.resource.destroy`` will
+    destroy it on request while ``pool.dataset.delete`` answers ENOENT -- the lookup behind that one
+    runs through the listing this name is filtered out of. Closing that asymmetry means changing the
+    mutation membership in the registry, deliberately; a guard that quietly starts refusing this
+    name has changed product behaviour instead, and fails here.
+    """
+    guard(SCHEMA, path, False)
+
+
+@pytest.mark.parametrize("boot_pool", BOOT_POOL_NAME_VALID)
+def test_boot_pool_snapshot_is_refused_only_by_the_stripping_guard(boot_pool):
+    """The suffix on "boot-pool@snap" sits on the one component a boot pool is matched by, so the
+    dataset name has to be recovered before the registry recognises it."""
+    deny_protected_path(SCHEMA, f"{boot_pool}@snap", False)
+
+    with pytest.raises(ValidationError) as exc:
+        deny_protected_snapshot(SCHEMA, f"{boot_pool}@snap", False)
+
+    assert exc.value.errmsg == f"'{boot_pool}@snap' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+def test_snapshot_guard_decides_on_the_dataset():
+    """A snapshot of a protected dataset is refused: the suffix is dropped before asking."""
+    with pytest.raises(ValidationError) as exc:
+        deny_protected_snapshot(SCHEMA, "tank/.system@snap")
+
+    assert exc.value.errmsg == "'tank/.system@snap' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+def test_path_guard_lets_a_snapshot_through_when_the_suffix_defeats_the_match():
+    """``zfs.resource.destroy`` has to keep telling the caller to use the snapshot endpoint, so the
+    non-stripping guard must let a snapshot name fall through to that message.
+
+    This is not "the path guard never refuses a snapshot name" -- it refuses plenty; see below. It
+    holds for "tank/.system@snap" because the suffix lands on the very component being compared.
+    """
+    deny_protected_path(SCHEMA, "tank/.system@snap", False)
+
+
+@pytest.mark.parametrize("path", ["boot-pool/ROOT@snap", "freenas-boot/grub@snap", "tank/.system/cores@snap"])
+def test_path_guard_still_refuses_a_snapshot_whose_dataset_it_matches(path):
+    """Not stripping the suffix is not the same as ignoring snapshot names.
+
+    Wherever the compared component sits above the suffix -- the first component for a boot pool,
+    the second for anything below a managed dataset -- the guard matches the name as written and
+    refuses it, so the caller never reaches the "use the snapshot endpoint" hint.
+    """
+    with pytest.raises(ValidationError) as exc:
+        deny_protected_path(SCHEMA, path, False)
+
+    assert exc.value.errmsg == f"'{path}' is a protected path."
+    assert exc.value.errno == errno.EACCES
+
+
+def test_snapshot_guard_still_refuses_a_bare_dataset():
+    with pytest.raises(ValidationError):
+        deny_protected_snapshot(SCHEMA, PROTECTED, False)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("bypass", [1, "yes", ["anything"]])
+def test_any_truthy_bypass_is_permission(guard, bypass):
+    """The guard asks for truth and nothing more, so a stray value permits rather than raising.
+
+    That is deliberate rather than an oversight: reaching any of these entry points already
+    requires an unrestricted credential, so the only thing a stricter reading would catch is a
+    middleware typo, at the cost of a refusal that behaves differently depending on how the value
+    happened to be spelled.
+    """
+    guard(SCHEMA, PROTECTED, bypass)
+
+
+@pytest.mark.parametrize("guard", [deny_protected_path, deny_protected_snapshot])
+@pytest.mark.parametrize("bypass", [0, None, "", []])
+def test_any_falsy_bypass_is_still_a_refusal(guard, bypass):
+    """The other half of the truthiness contract, and the half that has to fail closed.
+
+    A caller that reads its opt-in out of a config dict and gets None back, or that threads an empty
+    collection through, must be refused rather than quietly permitted.
+    """
+    with pytest.raises(ValidationError):
+        guard(SCHEMA, PROTECTED, bypass)

--- a/src/middlewared/middlewared/pytest/unit/utils/zfs/test_managed_datasets.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/zfs/test_managed_datasets.py
@@ -1,0 +1,368 @@
+import pytest
+
+from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
+from middlewared.utils.zfs.managed_datasets import (
+    APPS_DS_NAME,
+    CONTAINER_DS_NAME,
+    LEGACY_APPS_DS_NAME,
+    MANAGED_DATASET_NAMES,
+    blocked_from_mutation,
+    excluded_from_replication,
+    excluded_from_zfs_events,
+    hidden_from_dataset_listing,
+    hidden_from_snapshot_listing,
+    hidden_from_zfs_listing,
+    is_boot_pool_path,
+)
+
+PREDICATES = (
+    hidden_from_zfs_listing,
+    hidden_from_dataset_listing,
+    blocked_from_mutation,
+    excluded_from_zfs_events,
+    excluded_from_replication,
+)
+"""The five predicates, in TRUTH_TABLE column order."""
+
+# path, then one column per predicate, in the order of PREDICATES and of the parametrize below.
+#
+# Disagreements between the columns are real: every predicate matches the same way, so a column
+# that differs from its neighbour differs because the two callers manage a different set of names.
+# A column changing here means a caller's behaviour changed, so a change to this table is only ever
+# deliberate.
+TRUTH_TABLE = [
+    # Boot pools: the pool itself and everything under it, in every view.
+    ("boot-pool", True, True, True, True, True),
+    ("boot-pool/ROOT/default", True, True, True, True, True),
+    ("freenas-boot", True, True, True, True, True),
+    ("freenas-boot/grub", True, True, True, True, True),
+    # The boot pool test compares the first component only, so a snapshot suffix matters exactly
+    # when it lands on that component: "boot-pool@snap" is not a boot pool, while a snapshot
+    # anywhere below the pool root still is. The other views compare the second component instead,
+    # which is why the ".system" rows further down come out the other way round.
+    ("boot-pool@snap", False, False, False, False, False),
+    ("boot-pool/ROOT@snap", True, True, True, True, True),
+    ("freenas-boot@snap", False, False, False, False, False),
+    ("freenas-boot/grub@snap", True, True, True, True, True),
+    # A boot pool name below the pool root is an ordinary dataset -- the boot pool test is anchored
+    # to the first component, and the boot pool names are in no other membership.
+    ("tank/boot-pool", False, False, False, False, False),
+    # A pool whose name merely starts with a boot pool name is an ordinary pool.
+    ("boot-pool-2", False, False, False, False, False),
+    ("boot-pool-2/data", False, False, False, False, False),
+    ("freenas-boot-2", False, False, False, False, False),
+    # Ordinary paths.
+    ("tank", False, False, False, False, False),
+    ("tank/data", False, False, False, False, False),
+    # The system dataset directly under a pool: matched by every view.
+    ("tank/.system", True, True, True, True, True),
+    ("tank/.system/cores", True, True, True, True, True),
+    # A snapshot suffix on the matched component defeats every view, because the component being
+    # compared is then ".system@snap". One position deeper it does not, because the component being
+    # compared is still ".system". The asymmetry is real; it is pinned, not endorsed.
+    ("tank/.system@snap", False, False, False, False, False),
+    ("tank/.system/cores@snap", True, True, True, True, True),
+    # Nested deeper than a pool's top level: a managed name is only managed where the subsystem that
+    # owns it puts it, which is always one level under a pool root.
+    ("tank/foo/.system", False, False, False, False, False),
+    # A name that merely starts with a managed one is a user's dataset, in every view.
+    ("tank/.systembackup", False, False, False, False, False),
+    # The current apps dataset.
+    ("tank/ix-apps", True, True, True, True, False),
+    ("tank/ix-apps/docker", True, True, True, True, False),
+    ("tank/data/ix-apps", False, False, False, False, False),
+    ("tank/ix-apps-data", False, False, False, False, False),
+    ("tank/ix-appsdata", False, False, False, False, False),
+    ("tank/myix-apps", False, False, False, False, False),
+    # The legacy apps dataset, which every view but replication matches, exactly as it matches the
+    # current one.
+    ("tank/ix-applications", True, True, True, True, False),
+    ("tank/ix-applications/releases", True, True, True, True, False),
+    ("tank/a/b/ix-applications", False, False, False, False, False),
+    ("tank/ix-applications-old", False, False, False, False, False),
+    # The container dataset is hidden from the product's dataset listing and nothing else. The event
+    # view in particular has to keep answering False, or destroying one out of band would skip the
+    # encryption-key cleanup that follows a REMOVED event.
+    (f"tank/{CONTAINER_DS_NAME}", False, True, False, False, False),
+    (f"tank/{CONTAINER_DS_NAME}/containers", False, True, False, False, False),
+    (f"tank/a/{CONTAINER_DS_NAME}", False, False, False, False, False),
+    # The container look-alike and a snapshot of the container dataset itself. The look-alike is the
+    # one shape the container name had no row for: the old listing matched "/.truenas_containers"
+    # as a substring, so it hid this user dataset too and left it neither visible nor deletable.
+    (f"tank/{CONTAINER_DS_NAME}-old", False, False, False, False, False),
+    (f"tank/{CONTAINER_DS_NAME}@snap", False, False, False, False, False),
+    # A pool literally named after an entry is not itself managed -- the separator is required.
+    ("ix-apps", False, False, False, False, False),
+    ("ix-apps/child", False, False, False, False, False),
+    ("ix-apps/ix-apps", True, True, True, True, False),
+    # A leading slash makes the first component empty, so what the rest of the table calls the
+    # second component is the first one here and a managed name lands where it is matched. ZFS
+    # rejects these names, so nothing can reach a predicate holding one; they are pinned because the
+    # replication view used to be a regex anchored with "[^/]+", which answered the other way round.
+    ("/.system", True, True, True, True, True),
+    ("/ix-apps", True, True, True, True, False),
+    ("/boot-pool", False, False, False, False, False),
+    # A trailing slash adds an empty component, which changes nothing about the component that gets
+    # compared -- so "tank/" is still a bare data pool root and "tank/.system/" is still matched.
+    ("tank/.system/", True, True, True, True, True),
+    ("tank/", False, False, False, False, False),
+    # Degenerate input must be answered, not raised on.
+    ("", False, False, False, False, False),
+]
+
+
+@pytest.mark.parametrize("path,zfs_listing,dataset_listing,mutation,zfs_events,replication", TRUTH_TABLE)
+def test_predicates(path, zfs_listing, dataset_listing, mutation, zfs_events, replication):
+    assert hidden_from_zfs_listing(path) is zfs_listing
+    assert hidden_from_dataset_listing(path) is dataset_listing
+    assert blocked_from_mutation(path) is mutation
+    assert excluded_from_zfs_events(path) is zfs_events
+    assert excluded_from_replication(path) is replication
+
+
+DATASET_ROWS = [(row[0], row[1]) for row in TRUTH_TABLE if "@" not in row[0]]
+"""TRUTH_TABLE's path and ZFS-listing column, for the rows whose path is a dataset name."""
+
+
+@pytest.mark.parametrize("path,zfs_listing", DATASET_ROWS)
+def test_snapshot_listing_answers_for_the_dataset(path, zfs_listing):
+    """A snapshot is hidden exactly when its dataset is, and never otherwise.
+
+    Derived from TRUTH_TABLE rather than restated, so a row added there is covered here too. The
+    second assertion is the point of the predicate, and the reason it cannot simply be
+    ``hidden_from_zfs_listing``: appending a suffix changes that one's answer for some of these
+    names and not others, so callers handed a name of either shape need a predicate that does not
+    care which they got.
+    """
+    assert hidden_from_snapshot_listing(path) is zfs_listing
+    assert hidden_from_snapshot_listing(f"{path}@snap") is zfs_listing
+
+
+SUFFIX_ON_THE_COMPARED_COMPONENT = [
+    "boot-pool",
+    "freenas-boot",
+    "tank/.system",
+    "tank/ix-apps",
+    "tank/ix-applications",
+    "ix-apps/ix-apps",
+]
+"""Hidden datasets whose managed name is the last component, so a suffix lands on it."""
+
+SUFFIX_BELOW_THE_COMPARED_COMPONENT = [
+    "boot-pool/ROOT/default",
+    "freenas-boot/grub",
+    "tank/.system/cores",
+    "tank/ix-apps/docker",
+    "tank/ix-applications/releases",
+]
+"""Hidden datasets with something below the managed name, so a suffix lands past it."""
+
+
+@pytest.mark.parametrize("path", SUFFIX_ON_THE_COMPARED_COMPONENT)
+def test_zfs_listing_loses_a_hidden_dataset_once_a_suffix_is_appended(path):
+    """Half of why ``hidden_from_snapshot_listing`` exists, named rather than left implicit.
+
+    Most of TRUTH_TABLE answers False before a suffix is appended and False after, so a scan of the
+    rows would suggest "a suffix always defeats the match" while most of the evidence for it is
+    vacuous. It does not always; these are the names where it does.
+    """
+    assert hidden_from_zfs_listing(path) is True
+    assert hidden_from_zfs_listing(f"{path}@snap") is False
+
+
+@pytest.mark.parametrize("path", SUFFIX_BELOW_THE_COMPARED_COMPONENT)
+def test_zfs_listing_keeps_a_hidden_dataset_when_the_suffix_lands_deeper(path):
+    """The other half: the compared component is untouched, so the answer does not move."""
+    assert hidden_from_zfs_listing(path) is True
+    assert hidden_from_zfs_listing(f"{path}@snap") is True
+
+
+@pytest.mark.parametrize(
+    "path,boot_pool",
+    [
+        ("boot-pool", True),
+        ("freenas-boot", True),
+        ("boot-pool/ROOT", True),
+        # A suffix below the pool root leaves the compared component alone, so it still matches.
+        ("freenas-boot/grub@snap", True),
+        # A suffix on the pool root does not: the component being compared is "boot-pool@snap".
+        ("boot-pool@snap", False),
+        ("freenas-boot@snap", False),
+        ("tank/boot-pool", False),
+        ("/boot-pool", False),
+        ("boot-pool-2", False),
+        ("", False),
+    ],
+)
+def test_is_boot_pool_path(path, boot_pool):
+    """The disjunct every predicate carries, and the sole gate on docker's apps-mountpoint check.
+
+    That call site asks this predicate directly rather than through a view, so it is the one place
+    where a regression here would not show up as a changed column in TRUTH_TABLE.
+    """
+    assert is_boot_pool_path(path) is boot_pool
+
+
+ALL_PATHS = [row[0] for row in TRUTH_TABLE]
+"""TRUTH_TABLE's paths, for the laws that relate two columns rather than pin one."""
+
+
+@pytest.mark.parametrize("path", ALL_PATHS)
+def test_event_suppression_is_a_subset_of_the_product_listing(path):
+    """Whatever the ZFS event channel drops, the product's dataset listing must already be hiding.
+
+    Derived from TRUTH_TABLE rather than restated, so a row added there is covered here too. Dropping
+    the event for a path the listing shows means an out-of-band ``zfs destroy`` publishes no REMOVED
+    event, leaves the destroyed dataset's encryption key in the database and leaves a copy of it on
+    the other HA node. The other direction costs nothing -- publishing REMOVED for a name the listing
+    never showed is a no-op -- which is why the relation runs this way round and not both.
+    """
+    if excluded_from_zfs_events(path):
+        assert hidden_from_dataset_listing(path) is True, path
+
+
+@pytest.mark.parametrize("path", ALL_PATHS)
+def test_mutation_refusal_is_a_subset_of_the_zfs_listing(path):
+    """Whatever the mutation guard refuses, ``zfs.resource`` must already be hiding.
+
+    Derived from TRUTH_TABLE rather than restated, so a row added there is covered here too. A name
+    that is listed and then refused is a name the user can see, is told is theirs, and cannot touch;
+    the way that arises in practice is a membership tuple handed to the wrong predicate. The
+    converse is deliberately not asserted -- the container dataset is hidden from the product
+    listing while staying fully mutable.
+    """
+    if blocked_from_mutation(path):
+        assert hidden_from_zfs_listing(path) is True, path
+
+
+@pytest.mark.parametrize("path", ALL_PATHS)
+def test_replication_exclusion_is_a_subset_of_the_mutation_refusal(path):
+    """Whatever replication withholds, the mutation guard must already be refusing.
+
+    Derived from TRUTH_TABLE rather than restated, so a row added there is covered here too.
+    Withholding a mutable dataset from the replication source list is just a dataset the user cannot
+    back up. The converse is deliberately not asserted -- the apps datasets are refused every
+    mutation and still offered to replication, because replication is how they are backed up.
+    """
+    if excluded_from_replication(path):
+        assert blocked_from_mutation(path) is True, path
+
+
+@pytest.mark.parametrize("path", ["tank/.system@snap", "boot-pool@snap", "tank/ix-apps@snap"])
+def test_snapshot_listing_diverges_from_the_zfs_listing_on_a_snapshot_name(path):
+    """The bug this predicate exists to close, pinned from the other direction.
+
+    Three snapshot query and count call sites asked hidden_from_zfs_listing these names and got
+    False for all of them, so the filter and its request-wide opt-out were both inert there.
+    """
+    assert hidden_from_zfs_listing(path) is False
+    assert hidden_from_snapshot_listing(path) is True
+
+
+@pytest.mark.parametrize(
+    "path,hidden",
+    [
+        ("tank/.system@", True),
+        ("tank/.system@a@b", True),
+        ("@snap", False),
+        ("", False),
+        ("tank/data@snap", False),
+    ],
+)
+def test_snapshot_listing_answers_degenerate_input(path, hidden):
+    """ZFS rejects most of these, but a predicate that raises is a predicate a caller has to guard."""
+    assert hidden_from_snapshot_listing(path) is hidden
+
+
+def test_leading_slash_diverges_from_the_replication_regex():
+    """The one known divergence from the behaviour this registry reproduces.
+
+    The replication view used to be a regular expression anchored with ``[^/]+``, which cannot
+    match a path whose first component is empty, so it answered False for "/.system" where the
+    whole-component test answers True. This is unreachable -- ZFS rejects a leading slash in a
+    dataset name,
+    so no such path can exist -- and True is the more defensible of the two answers. It is pinned
+    here so that nobody "corrects" it back on the strength of a diff against the old regex.
+    """
+    assert excluded_from_replication("/.system") is True
+
+
+def test_pool_roots_are_not_blocked_from_mutation():
+    """A *data* pool root must stay mutable even when it hosts the system dataset.
+
+    Boot pool roots are deliberately the other way round; TRUTH_TABLE pins that.
+    """
+    for path in ("tank", "tank/"):
+        assert blocked_from_mutation(path) is False
+
+
+@pytest.mark.parametrize("name", BOOT_POOL_NAME_VALID)
+def test_boot_pools_are_matched_by_every_predicate(name):
+    """No caller may treat a boot pool as an ordinary dataset.
+
+    TRUTH_TABLE pins the two names that exist today; this asserts the same thing for whatever
+    BOOT_POOL_NAME_VALID holds, so a third boot pool name cannot arrive uncovered.
+    """
+    for predicate in PREDICATES:
+        assert predicate(name) is True, predicate.__name__
+        assert predicate(f"{name}/ROOT/default") is True, predicate.__name__
+
+
+@pytest.mark.parametrize("name", MANAGED_DATASET_NAMES)
+def test_every_managed_name_is_matched_by_some_predicate(name):
+    """A name listed as managed but wired into no predicate is managed in name only."""
+    path = name if name in BOOT_POOL_NAME_VALID else f"tank/{name}"
+    assert any(predicate(path) for predicate in PREDICATES), path
+
+
+def test_legacy_apps_dataset_is_matched_by_every_view_that_manages_it():
+    """``<pool>/ix-applications`` used to be creatable and then invisible.
+
+    The creation and event needles carried a trailing slash, so they reached only its descendants
+    while every listing matched the dataset itself -- a user could create it and then neither see
+    nor delete it. The views agree now, so what a user is refused is what a user cannot see.
+    Replication still offers it, because replication is the supported way to back the apps datasets
+    up.
+    """
+    path = f"tank/{LEGACY_APPS_DS_NAME}"
+    assert hidden_from_zfs_listing(path) is True
+    assert hidden_from_dataset_listing(path) is True
+    assert blocked_from_mutation(path) is True
+    assert excluded_from_zfs_events(path) is True
+    assert excluded_from_replication(path) is False
+
+
+def test_container_dataset_is_hidden_from_the_product_listing_only():
+    """A deliberate asymmetry, and the consequences that are easy to trip over.
+
+    The container dataset is hidden from the UI but is an ordinary dataset to every other predicate,
+    so ``zfs.resource.destroy`` will destroy it on request while ``pool.dataset.delete`` answers
+    ENOENT -- the lookup behind that one goes through the listing this name is filtered out of.
+    The event column is the one that must not be "tidied up" to match the listing: destroying a
+    container dataset out of band has to publish REMOVED, or its encryption key is never cleared
+    from the database or from the other HA node.
+    """
+    path = f"tank/{CONTAINER_DS_NAME}"
+    assert hidden_from_dataset_listing(path) is True
+    for predicate in PREDICATES:
+        if predicate is hidden_from_dataset_listing:
+            continue
+        assert predicate(path) is False, predicate.__name__
+
+
+def test_apps_datasets_are_offered_to_replication():
+    """Replication is the supported way to back the apps datasets up, so they must stay listed."""
+    for name in (APPS_DS_NAME, LEGACY_APPS_DS_NAME):
+        assert excluded_from_replication(f"tank/{name}") is False
+
+
+@pytest.mark.parametrize("pool", ["tank", "dozer", "ix-apps"])
+@pytest.mark.parametrize("name", ["ix-apps", "ix-applications"])
+@pytest.mark.parametrize("suffix", ["", "/", "/child", "/a/b"])
+def test_dataset_listing_subsumes_the_apps_alert_skip(pool, name, suffix):
+    """The unencrypted-datasets alert skips the apps datasets by hand while iterating children of
+    an already-filtered dataset listing. Every path that skip covers is one the dataset listing has
+    already removed, so the skip can never fire -- which is what makes it safe to delete rather
+    than convert.
+    """
+    assert hidden_from_dataset_listing(f"{pool}/{name}{suffix}") is True

--- a/src/middlewared/middlewared/pytest/unit/utils/zfs/test_no_second_registry.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/zfs/test_no_second_registry.py
@@ -1,0 +1,316 @@
+"""Guard against a sixth registry of middleware-managed datasets being grown somewhere else.
+
+Five of them existed before ``middlewared.utils.zfs.managed_datasets``, each with its own membership
+list and its own matching algorithm, and they had drifted apart from one another in ways nobody
+noticed because nothing tied them together. What lets that happen again is that spelling a dataset
+name inline is easy and invisible, so this module makes it visible.
+
+Three scans, in decreasing order of how much they catch:
+
+* every string literal that names a managed dataset,
+* every symbol whose name is shaped like a registry,
+* every reference to the registry's own names, which is how a sixth registry would most likely be
+  built -- on top of the fifth rather than beside it, and without spelling a literal that the first
+  scan could see.
+
+Each scan carries a both-directions allowlist: an unexpected hit fails, and so does an allowlist
+entry that no longer matches anything. Every reason is either "owns this dataset" -- the subsystem
+that creates and maintains it, which necessarily knows its name -- or a marker for a spelling that
+has not been converged onto the registry yet. The second kind is the backlog.
+
+One shape is deliberately not caught: a symbol built out of the word "system", such as
+``SYSTEM_DATASETS``. Adding ``system`` to :data:`SYMBOL_RE` flags 25 legitimate symbols across 15
+files -- ``SystemDatasetService``, ``SystemDatasetEntry``, ``system_dataset_path`` and their
+relatives -- so the scan would be noise rather than signal. It is a won't-fix, not an oversight.
+"""
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+from middlewared.utils.zfs import managed_datasets
+from middlewared.utils.zfs.managed_datasets import MANAGED_DATASET_NAMES
+
+MIDDLEWARED_ROOT = pathlib.Path(__file__).resolve().parents[4]
+"""The ``middlewared`` package directory."""
+
+REGISTRY_MODULE = "utils/zfs/managed_datasets.py"
+
+SKIPPED_TREES = ("pytest/", "alembic/")
+"""``pytest/`` holds this file and the registry's own tests, both of which quote dataset names by
+design. ``alembic/`` is generated migration history and is excluded from linting everywhere else."""
+
+
+MANAGED_NAMES = tuple(sorted(set(MANAGED_DATASET_NAMES)))
+"""Read out of the registry rather than copied, or the module whose job is preventing duplicated
+membership lists would be guarded by one: a sixth managed dataset would be added to the registry
+while this scan quietly kept looking for the first five."""
+
+LITERAL_RE = re.compile(
+    r"(?<![^/\\])(?:" + "|".join(re.escape(name) for name in MANAGED_NAMES) + r")(?![A-Za-z0-9_.-])"
+)
+"""Matches a managed dataset name as a whole path component inside a literal -- the old registries
+spelled these as ``'/ix-applications/'``, ``f'{pool}/ix-apps/'`` and ``r'[^/]+/\\.system($|/)'``, so
+an equality test would have missed every one of them.
+
+Both boundaries carry weight, because a name that is merely adjacent to a managed one is a name the
+registry answers *False* for, and flagging it turns this scan into a tax on rewording log lines.
+On the left, only a separator or the start of the literal may precede the name, which is what keeps
+``boot-pool-2`` and ``.ix-apps`` out; a backslash counts as a separator because the replication
+registry spelled its needle as regex source, ``r"[^/]+/\\.system($|/)"``, where the name follows one.
+On the right, ``-`` and ``.`` are excluded along with the identifier characters, which is what keeps
+``tank/ix-apps-data``, ``.truenas_containers-old`` and dotted module paths such as
+``system.system_dataset`` out."""
+
+SYMBOL_RE = re.compile(
+    r"(internal|invalid|excluded?|reserved|hidden|protected|forbidden|banned|skip(?:ped)?|"
+    r"ignored?|restricted|blocked|managed|omit(?:ted)?)_?(path|dataset)s?",
+    re.IGNORECASE,
+)
+"""Matches registry-shaped symbol names. Catches four of the five originals by name alone:
+``INTERNAL_PATHS``, ``has_internal_path``, ``INTERNAL_DATASETS``, ``is_internal_dataset`` and
+``INVALID_DATASETS``. The alternation is wider than what exists today because the cost of a name
+nobody uses is nothing, while the cost of a miss is a sixth registry: ``skip``, in particular, has
+to be spelled with an optional group, or ``skipped?`` reads as ``skippe`` plus an optional ``d`` and
+never matches the bare ``skip_paths`` that a sixth registry is most likely to be called."""
+
+REGISTRY_INTERNALS = (
+    "MANAGED_DATASET_NAMES",
+    "SYSTEM_DS_NAME",
+    "APPS_DS_NAME",
+    "LEGACY_APPS_DS_NAME",
+    "CONTAINER_DS_NAME",
+)
+"""The registry's names, as opposed to its predicates. Callers ask a predicate; anyone reading the
+list or a bare name out of the registry is deriving a second membership set from it, which is how
+the five originals came to disagree -- and the literal scan cannot see it, because no name is
+spelled."""
+
+
+LITERAL_ALLOWLIST = {
+    "plugins/boot/pool_ops.py": "boot: owns the boot pool",
+    "plugins/catalog/utils.py": "apps: owns the ix-apps dataset",
+    "plugins/cloud_sync/rclone.py": "not converged: rclone filter lines, not a membership test",
+    "plugins/docker/state_utils.py": "apps: owns the ix-apps and ix-applications datasets",
+    "plugins/docker/utils.py": "apps: owns the ix-apps and ix-applications datasets",
+    "plugins/pool_/export.py": "not converged: post-export leftover-directory cleanup, should use the registry",
+    "plugins/pool_/import_pool.py": "not converged: names one dataset to skip, should use the registry",
+    "plugins/sysdataset.py": "sysdataset: owns the .system dataset",
+    "plugins/system_dataset/hierarchy.py": "sysdataset: owns the .system dataset",
+    "plugins/system_dataset/mount.py": "sysdataset: owns the .system dataset",
+    "plugins/zettarepl.py": "not converged: builds a zettarepl exclusion string, not a membership test",
+    "utils/boot/pool.py": "boot: owns the boot pool, and defines the names the registry imports",
+}
+
+SYMBOL_ALLOWLIST = {
+    "exclude_internal_datasets": "flag on pool.dataset.query_impl, selects the dataset-listing view",
+    "exclude_internal_paths": "flag on zfs.resource.query, selects the ZFS-listing view",
+    "__should_exclude_internal_paths": (
+        "the auto-opt-out: naming a managed path explicitly turns the filter off for that query"
+    ),
+    "deny_protected_path": "the mutation guard, which asks the registry rather than answering itself",
+}
+"""Symbols that consume a view rather than define one. These are flags and guards, not registries."""
+
+REGISTRY_INTERNALS_ALLOWLIST = {
+    "plugins/container/dataset.py": "containers: owns the container dataset",
+    "plugins/container/utils.py": "containers: owns the container dataset",
+    "plugins/pool_/dataset.py": (
+        "not converged: the post-create mount branch compares a full dataset path against the bare "
+        "component, so it never fires and the container dataset takes the plain-mount path instead"
+    ),
+}
+
+
+def _iter_source_files() -> list[tuple[str, ast.Module]]:
+    """Every parsed module under ``middlewared/`` that a registry could hide in."""
+    found = []
+    for path in sorted(MIDDLEWARED_ROOT.rglob("*.py")):
+        relative = path.relative_to(MIDDLEWARED_ROOT).as_posix()
+        if relative.startswith(SKIPPED_TREES):
+            continue
+        found.append((relative, ast.parse(path.read_text())))
+    return found
+
+
+SOURCE_FILES = _iter_source_files()
+
+
+def _docstring_nodes(tree: ast.Module) -> set[int]:
+    """Identity of every docstring constant, so prose does not count as a spelling."""
+    nodes = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) or not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+            nodes.add(id(first.value))
+    return nodes
+
+
+def _string_literals(tree: ast.Module) -> list[str]:
+    """Every non-docstring string constant, including the pieces of an f-string.
+
+    ``ast.walk`` descends into :class:`ast.JoinedStr`, so the literal halves of ``f"{pool}/ix-apps"``
+    arrive here as ordinary constants -- which is how a registry written with f-strings gets caught.
+    """
+    docstrings = _docstring_nodes(tree)
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) not in docstrings
+    ]
+
+
+def _symbol_names(tree: ast.Module) -> list[str]:
+    """Every name a module defines or refers to."""
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(node.name)
+        elif isinstance(node, ast.Name):
+            names.append(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.append(node.attr)
+        elif isinstance(node, ast.arg):
+            names.append(node.arg)
+        elif isinstance(node, ast.keyword) and node.arg is not None:
+            names.append(node.arg)
+    return names
+
+
+def test_managed_dataset_names_are_only_spelled_by_their_owners():
+    """No module outside the registry names a managed dataset unless it owns it."""
+    offenders = {}
+    for relative, tree in SOURCE_FILES:
+        if relative == REGISTRY_MODULE:
+            continue
+        hits = sorted({literal for literal in _string_literals(tree) if LITERAL_RE.search(literal)})
+        if hits:
+            offenders[relative] = hits
+
+    unexpected = {path: hits for path, hits in offenders.items() if path not in LITERAL_ALLOWLIST}
+    assert not unexpected, (
+        "these modules spell a managed dataset name inline; use a predicate from "
+        f"middlewared.utils.zfs.managed_datasets, or add the module to LITERAL_ALLOWLIST with the "
+        f"reason it owns the dataset: {unexpected}"
+    )
+
+    stale = sorted(set(LITERAL_ALLOWLIST) - set(offenders))
+    assert not stale, f"LITERAL_ALLOWLIST entries no longer match anything and should be dropped: {stale}"
+
+
+def test_no_module_defines_a_registry_shaped_symbol():
+    """No module grows a symbol named like an internal-path list."""
+    offenders = {}
+    for relative, tree in SOURCE_FILES:
+        if relative == REGISTRY_MODULE:
+            continue
+        hits = sorted({name for name in _symbol_names(tree) if SYMBOL_RE.search(name) and name not in SYMBOL_ALLOWLIST})
+        if hits:
+            offenders[relative] = hits
+
+    assert not offenders, (
+        "these symbols look like a second registry of managed datasets; ask "
+        f"middlewared.utils.zfs.managed_datasets instead: {offenders}"
+    )
+
+    seen = {name for _, tree in SOURCE_FILES for name in _symbol_names(tree)}
+    stale = sorted(set(SYMBOL_ALLOWLIST) - seen)
+    assert not stale, f"SYMBOL_ALLOWLIST entries no longer match anything and should be dropped: {stale}"
+
+
+def test_registry_internals_stay_inside_the_registry():
+    """Nobody derives their own membership set from the registry's names."""
+    stale = [name for name in REGISTRY_INTERNALS if not hasattr(managed_datasets, name)]
+    assert not stale, (
+        "REGISTRY_INTERNALS names things the registry no longer has, so this scan is guarding "
+        f"nothing where it thinks it is guarding something: {stale}"
+    )
+
+    offenders = {}
+    for relative, tree in SOURCE_FILES:
+        if relative == REGISTRY_MODULE:
+            continue
+        hits = sorted(set(_symbol_names(tree)).intersection(REGISTRY_INTERNALS))
+        if hits:
+            offenders[relative] = hits
+
+    unexpected = {path: hits for path, hits in offenders.items() if path not in REGISTRY_INTERNALS_ALLOWLIST}
+    assert not unexpected, (
+        "these modules read the registry's names rather than calling one of its predicates, which "
+        "is how a second registry gets built on top of the first; use a predicate, or add the "
+        f"module to REGISTRY_INTERNALS_ALLOWLIST with the reason it owns the dataset: {unexpected}"
+    )
+
+    stale = sorted(set(REGISTRY_INTERNALS_ALLOWLIST) - set(offenders))
+    assert not stale, f"REGISTRY_INTERNALS_ALLOWLIST entries no longer match anything and should be dropped: {stale}"
+
+
+# The old registries, spelled the way they were spelled, so that a scan which has stopped catching
+# them fails here rather than staying silently green. Every entry below was copied off one of the
+# five before they were consolidated.
+ORIGINAL_REGISTRY_SYMBOLS = (
+    "INTERNAL_PATHS",
+    "has_internal_path",
+    "INTERNAL_DATASETS",
+    "is_internal_dataset",
+    "INVALID_DATASETS",
+)
+
+ORIGINAL_REGISTRY_LITERALS = (
+    ".system",
+    "ix-apps",
+    "ix-applications",
+    ".truenas_containers",
+    "/.system",
+    "/ix-apps",
+    "/ix-applications/",
+    "boot-pool/",
+    r"boot-pool($|/)",
+    r"freenas-boot($|/)",
+    r"[^/]+/\.system($|/)",
+)
+"""The last of these is why the lookbehind treats a backslash as a separator: the replication
+registry held a compiled regex, so the name it needed follows an escape rather than a slash."""
+
+UNMANAGED_LOOKALIKES = (
+    "boot-pool-2",
+    "freenas-boot-2",
+    "tank/ix-apps-data",
+    "tank/ix-appsdata",
+    "tank/myix-apps",
+    "tank/ix-applications-old",
+    "tank/.truenas_containers-old",
+    "tank/.systembackup",
+    ".ix-apps",
+    "ix-apps-backup-",
+    "middlewared.plugins.system.system_dataset",
+    "org.freedesktop.systemd1",
+)
+
+
+@pytest.mark.parametrize("name", ORIGINAL_REGISTRY_SYMBOLS)
+def test_symbol_scan_still_catches_the_names_the_originals_used(name):
+    """The regex is only as good as the spellings it matches, and it has been wrong before.
+
+    ``skipped?`` reads as ``skippe`` plus an optional ``d``, so for a while the scan matched neither
+    ``skip_paths`` nor ``SKIP_DATASETS`` -- the two most natural names for a sixth registry -- and
+    nothing said so, because no module happened to be named either.
+    """
+    assert SYMBOL_RE.search(name)
+
+
+@pytest.mark.parametrize("literal", ORIGINAL_REGISTRY_LITERALS)
+def test_literal_scan_still_catches_the_spellings_the_originals_used(literal):
+    assert LITERAL_RE.search(literal)
+
+
+@pytest.mark.parametrize("literal", UNMANAGED_LOOKALIKES)
+def test_literal_scan_ignores_names_the_registry_answers_false_for(literal):
+    """A name adjacent to a managed one belongs to a user, so flagging it is a false positive that
+    makes rewording a log line fail a test about registries."""
+    assert not LITERAL_RE.search(literal)

--- a/src/middlewared/middlewared/utils/libvirt/storage_devices.py
+++ b/src/middlewared/middlewared/utils/libvirt/storage_devices.py
@@ -3,10 +3,10 @@ import os
 from typing import Any
 
 from middlewared.api.current import ZFSResourceQuery
-from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs.zvol_utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.plugins.zfs_.validation_utils import check_zvol_in_boot_pool_using_path
 from middlewared.service_exception import ValidationErrors
+from middlewared.utils.zfs.managed_datasets import blocked_from_mutation
 
 from .delegate import DeviceDelegate
 from .utils import device_uniqueness_check
@@ -85,7 +85,7 @@ class DiskDelegate(StorageDelegate):
             if device['attributes'].get('path'):
                 verrors.add('attributes.path', 'The "path" attribute must not be specified when creating a zvol.')
 
-            if has_internal_path(device['attributes']['zvol_name']):
+            if blocked_from_mutation(device['attributes']['zvol_name']):
                 # before doing anything, let's make sure the zvol
                 # being created isn't within an internal path
                 verrors.add(
@@ -140,7 +140,7 @@ class DiskDelegate(StorageDelegate):
                     )
                 elif zvol[0]['type'] != 'VOLUME':
                     verrors.add('attributes.path', f'Path {path!r} ({zvol_name}) is not a volume.')
-                elif has_internal_path(zvol_name):
+                elif blocked_from_mutation(zvol_name):
                     verrors.add(
                         'attributes.path',
                         'Disk resides in an invalid location and is not supported.'

--- a/src/middlewared/middlewared/utils/zfs/managed_datasets.py
+++ b/src/middlewared/middlewared/utils/zfs/managed_datasets.py
@@ -1,0 +1,182 @@
+"""The datasets middleware maintains for the user, and what callers may do to them.
+
+Those are the boot pools, the per-pool system dataset, the apps datasets and the container dataset.
+There is one predicate per caller decision, because the decisions genuinely differ -- hiding a
+dataset from a listing is not the same call as refusing to destroy it. Each predicate is a single
+line naming the membership it uses and the matching rule it uses; the rules describe themselves.
+``hidden_from_snapshot_listing`` is not another rule: it drops a snapshot suffix and then asks
+``hidden_from_zfs_listing``, because its callers are handed a name that may be either shape.
+
+The predicates never raise. ``deny_protected_path`` and ``deny_protected_snapshot`` turn
+``blocked_from_mutation`` into the standard refusal; callers that accumulate into ``ValidationErrors``
+or want to phrase their own message ask the predicate directly.
+"""
+
+import errno
+
+from middlewared.service_exception import ValidationError
+from middlewared.utils.boot.pool import BOOT_POOL_NAME_VALID
+
+__all__ = (
+    "APPS_DS_NAME",
+    "CONTAINER_DS_NAME",
+    "LEGACY_APPS_DS_NAME",
+    "MANAGED_DATASET_NAMES",
+    "SYSTEM_DS_NAME",
+    "blocked_from_mutation",
+    "deny_protected_path",
+    "deny_protected_snapshot",
+    "excluded_from_replication",
+    "excluded_from_zfs_events",
+    "hidden_from_dataset_listing",
+    "hidden_from_snapshot_listing",
+    "hidden_from_zfs_listing",
+    "is_boot_pool_path",
+)
+
+
+# ------------------------------------------------------------------ names
+
+SYSTEM_DS_NAME = ".system"
+
+APPS_DS_NAME = "ix-apps"
+
+LEGACY_APPS_DS_NAME = "ix-applications"
+"""Name of the per-pool apps dataset used before the current apps implementation. Still managed,
+because a system upgraded from an older release still carries one."""
+
+CONTAINER_DS_NAME = ".truenas_containers"
+
+MANAGED_DATASET_NAMES = (
+    *BOOT_POOL_NAME_VALID,
+    SYSTEM_DS_NAME,
+    APPS_DS_NAME,
+    LEGACY_APPS_DS_NAME,
+    CONTAINER_DS_NAME,
+)
+"""Every name the predicates can match. No predicate reads this; each names its own membership."""
+
+
+# ------------------------------------------------------------ memberships
+
+_BOOT_POOLS = frozenset(BOOT_POOL_NAME_VALID)
+_SYSTEM = (SYSTEM_DS_NAME,)
+_SYSTEM_AND_APPS = (SYSTEM_DS_NAME, APPS_DS_NAME, LEGACY_APPS_DS_NAME)
+_SYSTEM_APPS_AND_CONTAINERS = _SYSTEM_AND_APPS + (CONTAINER_DS_NAME,)
+
+
+# --------------------------------------------------------- matching rules
+
+
+def is_boot_pool_path(path: str) -> bool:
+    """Whether the first component of `path` names a boot pool.
+
+    The bare pool name and everything under it match, while a snapshot of the pool root
+    (``boot-pool@snap``) does not, because the suffix lands on the component being compared.
+    """
+    return path.split("/", 1)[0] in _BOOT_POOLS
+
+
+def _top_level_child_is(path: str, names: tuple[str, ...]) -> bool:
+    """Whether `path` is ``<pool>/<name>`` or below it, for one of `names` compared exactly.
+
+    Anchored one level under the pool root, so ``tank/foo/.system`` does not match, and exact, so
+    ``tank/.systembackup`` does not either. A *data* pool root is never matched, because users have
+    to be able to lock and destroy their own pools even when one hosts the system dataset; a boot
+    pool root is matched by :func:`is_boot_pool_path` instead, which every predicate also asks.
+
+    A snapshot suffix matters exactly when it lands on the compared component:
+    ``tank/.system/cores@snap`` matches while ``tank/.system@snap`` does not.
+    """
+    components = path.split("/")
+    return len(components) > 1 and components[1] in names
+
+
+# ------------------------------------------------------------------ views
+
+
+def hidden_from_zfs_listing(path: str) -> bool:
+    """Whether `path` is omitted from ``zfs.resource`` query results by default."""
+    return is_boot_pool_path(path) or _top_level_child_is(path, _SYSTEM_AND_APPS)
+
+
+def hidden_from_snapshot_listing(path: str) -> bool:
+    """Whether `path` is omitted from ``zfs.resource.snapshot`` query and count results by default.
+
+    `path` may be a dataset or a ``<dataset>@<snapshot>`` name. Snapshot visibility is a property of
+    the dataset in every case -- there is no snapshot that is hidden while its dataset is listed, nor
+    the reverse -- so the suffix is dropped and :func:`hidden_from_zfs_listing` answers. Callers
+    holding a name that is certainly a dataset may ask either predicate; they agree.
+    """
+    return hidden_from_zfs_listing(path.split("@", 1)[0])
+
+
+def hidden_from_dataset_listing(path: str) -> bool:
+    """Whether `path` is omitted from ``pool.dataset`` query results by default.
+
+    The container dataset is matched here and nowhere else: it is hidden from the product listing
+    but is an ordinary dataset to every other question. One consequence is that
+    ``zfs.resource.destroy`` will destroy it on request while ``pool.dataset.delete`` answers ENOENT,
+    because the lookup behind that one goes through this very listing.
+    """
+    return is_boot_pool_path(path) or _top_level_child_is(path, _SYSTEM_APPS_AND_CONTAINERS)
+
+
+def blocked_from_mutation(path: str) -> bool:
+    """Whether `path` may be created, destroyed or changed only by the subsystem that owns it."""
+    return is_boot_pool_path(path) or _top_level_child_is(path, _SYSTEM_AND_APPS)
+
+
+def excluded_from_replication(path: str) -> bool:
+    """Whether `path` is withheld from the dataset list offered when configuring replication.
+
+    The apps datasets are deliberately offered: replication is the supported way to back them up.
+    """
+    return is_boot_pool_path(path) or _top_level_child_is(path, _SYSTEM)
+
+
+def excluded_from_zfs_events(path: str) -> bool:
+    """Whether changes to `path` seen on the ZFS event channel are dropped rather than published as
+    middleware events.
+
+    Suppression has to stay a subset of :func:`hidden_from_dataset_listing`, and the unit tests pin
+    that as a law over the whole truth table. Dropping the event for a path the product listing
+    shows means an out-of-band ``zfs destroy`` publishes no REMOVED event, never clears the
+    dataset's encryption key from the database and never runs the ``dataset.post_delete`` hook that
+    removes that key from the other HA node -- so a destroyed dataset leaves the UI holding a stale
+    entry and its key registered on both nodes and in KMIP. The other direction costs nothing:
+    publishing REMOVED for a name the listing never showed is a no-op.
+
+    The membership is narrower than the listing's on purpose. The container dataset is hidden from
+    the listing, but destroying one still has to be published so that cleanup runs.
+    """
+    return is_boot_pool_path(path) or _top_level_child_is(path, _SYSTEM_AND_APPS)
+
+
+# ----------------------------------------------------------------- guards
+
+
+def deny_protected_path(schema: str, path: str, bypass: bool = False) -> None:
+    """Raise unless `path` may be mutated by this caller. `path` is taken as written.
+
+    `bypass` is set by the subsystem that owns the path, which lifts the refusal.
+    """
+    _deny(schema, path, path, bypass)
+
+
+def deny_protected_snapshot(schema: str, path: str, bypass: bool = False) -> None:
+    """Raise unless the dataset `path` names or is a snapshot of may be mutated by this caller.
+
+    `path` may be either a dataset or a ``<dataset>@<snapshot>`` name; the decision is about the
+    dataset either way, so the snapshot suffix is dropped before asking. Callers that are not about
+    to touch a snapshot want :func:`deny_protected_path`, which does not strip --
+    ``zfs.resource.destroy`` has to keep telling the caller to use
+    ``zfs.resource.snapshot.destroy`` instead.
+    """
+    _deny(schema, path.split("@", 1)[0], path, bypass)
+
+
+def _deny(schema: str, path: str, reported: str, bypass: bool) -> None:
+    """Refuse `path`, quoting `reported` -- what the caller actually passed."""
+    if not bypass and blocked_from_mutation(path):
+        raise ValidationError(schema, f"{reported!r} is a protected path.", errno.EACCES)

--- a/tests/api2/test_internal_dataset_protection.py
+++ b/tests/api2/test_internal_dataset_protection.py
@@ -1,0 +1,499 @@
+"""Public mutators must refuse the datasets middleware manages on the user's behalf.
+
+Every guard is a pure check on the path, run before the resource is looked up, so none of the
+protected paths named here has to exist -- which is what makes covering the whole matrix cheap, and
+what lets the matrix aim at paths that deliberately do not exist. The user-dataset half of the file
+is the control: it proves the guards reject what they are meant to and nothing else.
+"""
+
+import re
+
+import pytest
+from truenas_api_client import ClientException
+from truenas_api_client import ValidationErrors as ClientValidationErrors
+
+from middlewared import service_exception
+from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
+from middlewared.service_exception import (
+    CallError,
+    MatchNotFound,
+    ValidationError,
+    ValidationErrors,
+)
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, pool, ssh
+
+PROTECTED_MESSAGE = "is a protected path."
+SNAP = "protection-test"
+CLONE_DST = f"{pool}/protection-test-clone"
+
+# One representative of each shape the registry matches: the system dataset, the apps dataset,
+# and the boot pool. A bare pool root is deliberately absent -- it is not protected.
+PROTECTED_PREFIXES = [f"{pool}/.system", f"{pool}/ix-apps", "boot-pool/ROOT"]
+
+ABSENT = "protection-test-absent/leaf"
+"""A location under each managed dataset that nothing ever creates.
+
+The matrix fires recursive destroys and renames, so aiming it at the managed datasets themselves
+means a guard that regressed does not fail this file -- it wipes the boot environments and the
+system dataset. Aiming one level down at something absent keeps every refusal meaning the same
+thing while leaving a regressed guard nothing to act on: it gets ENOENT.
+
+Two components rather than one, because with one a regressed rename would *succeed*, leaving a user
+dataset parked inside the system dataset."""
+
+PROTECTED_DATASETS = [f"{prefix}/{ABSENT}" for prefix in PROTECTED_PREFIXES]
+
+LOOKALIKE = f"{pool}/ix-apps-data"
+"""A user dataset whose name merely starts with a managed one.
+
+Nothing about it is managed -- every rule here compares whole components one level under the pool
+root -- so creation and every mutator alike have to treat it as the ordinary dataset it is."""
+
+RESERVED_MESSAGE = "is using system internal managed dataset"
+
+BOOT_POOL_NAMES = ("boot-pool", "freenas-boot")
+"""Every name a boot pool may have. A pool merely named like one -- `boot-pool-2` -- is a user pool
+and has to be listed."""
+
+HIDDEN_TOP_LEVEL_CHILDREN = (
+    ".system",
+    "ix-apps",
+    "ix-applications",
+    ".truenas_containers",
+)
+"""The names that are hidden from the dataset listing when they sit one level under a pool root.
+
+Compared as whole components, so a dataset whose name merely begins with one of these is listed, and
+so is one that carries one of these names at any other depth."""
+
+GRACEFUL_FAILURES = (
+    CallError,
+    MatchNotFound,
+    ValidationError,
+    ValidationErrors,
+    ClientValidationErrors,
+    ZFSPathNotFoundException,
+)
+"""Exception types that mean the service considered the call and declined it.
+
+The raw ZFS exception is one of them because `pool.snapshot.rollback`, `hold`, `release` and
+`clone` call the private implementation directly, past the public `zfs.resource.snapshot.*` method
+that turns a missing path into an ENOENT `ValidationError` -- so an absent snapshot is refused with
+the untranslated exception. That is still a refusal, and translating it is not this file's business.
+
+Anything else -- an unhandled server-side exception surfacing as a bare `ClientException`, a
+transport failure -- means the mutator broke rather than refused, and a control case that "passes"
+on one of those has tested nothing."""
+
+SCHEMA_REJECTION_RE = re.compile(
+    r": (Field required"
+    r"|Extra inputs are not permitted"
+    r"|Input should "
+    r"|Input tag "
+    r"|Unable to extract tag"
+    r"|Value error, "
+    r"|Assertion failed, "
+    r"|Too many arguments)"
+)
+"""Pydantic's own rejection messages, which are a closed set no service produces.
+
+A request model that rejects the payload rejects it before the method body runs, so the guard under
+test was never reached and the case proved nothing. This is the difference between "the mutator let
+this path through" and "this payload was never valid in the first place"."""
+
+# `(method, args)` for every guarded public mutator that takes a dataset path.
+DATASET_MUTATORS = [
+    ("pool.dataset.promote", lambda ds: (ds,)),
+    (
+        "pool.dataset.rename",
+        lambda ds: (ds, {"new_name": f"{pool}/renamed", "force": True}),
+    ),
+    ("pool.dataset.update", lambda ds: (ds, {})),
+    ("pool.dataset.delete", lambda ds: (ds, {"recursive": True})),
+    ("pool.dataset.get_quota", lambda ds: (ds, "DATASET")),
+    (
+        # A real size rather than 0: 0 means "remove" only for a user or group quota, and libzfs
+        # refuses it as a dataset quota, so the control half would fail on the value before the
+        # guard it is here to exercise had said anything.
+        "pool.dataset.set_quota",
+        lambda ds: (
+            ds,
+            [{"quota_type": "DATASET", "id": "QUOTA", "quota_value": 1024**3}],
+        ),
+    ),
+    ("pool.dataset.inherit_parent_encryption_properties", lambda ds: (ds,)),
+    ("pool.snapshot.create", lambda ds: ({"dataset": ds, "name": SNAP},)),
+    ("zfs.resource.destroy", lambda ds: ({"path": ds, "recursive": True},)),
+    ("zfs.resource.snapshot.create", lambda ds: ({"dataset": ds, "name": SNAP},)),
+]
+
+# The same, for mutators that run as jobs: their guard raises inside the job, so the refusal only
+# reaches the caller once the job is waited on.
+JOB_DATASET_MUTATORS = [
+    ("pool.dataset.lock", lambda ds: (ds, {"force_umount": True})),
+    ("pool.dataset.change_key", lambda ds: (ds, {"generate_key": True})),
+]
+
+# `(method, args)` for every guarded public mutator that takes a snapshot path.
+SNAPSHOT_MUTATORS = [
+    ("pool.snapshot.delete", lambda s: (s, {})),
+    ("pool.snapshot.rollback", lambda s: (s, {})),
+    ("pool.snapshot.hold", lambda s: (s, {})),
+    ("pool.snapshot.release", lambda s: (s, {})),
+    ("pool.snapshot.rename", lambda s: (s, {"new_name": f"{s}-new", "force": True})),
+    ("pool.snapshot.clone", lambda s: ({"snapshot": s, "dataset_dst": CLONE_DST},)),
+    ("zfs.resource.snapshot.destroy", lambda s: ({"path": s},)),
+    (
+        "zfs.resource.snapshot.rename",
+        lambda s: ({"current_name": s, "new_name": f"{s}-new"},),
+    ),
+    ("zfs.resource.snapshot.clone", lambda s: ({"snapshot": s, "dataset": CLONE_DST},)),
+    ("zfs.resource.snapshot.hold", lambda s: ({"path": s},)),
+    ("zfs.resource.snapshot.release", lambda s: ({"path": s},)),
+    ("zfs.resource.snapshot.rollback", lambda s: ({"path": s},)),
+]
+
+# Mutators whose *destination* is guarded as well as their source, so that a protected dataset
+# cannot be brought into existence by renaming or cloning onto it.
+DESTINATION_MUTATORS = [
+    (
+        "zfs.resource.snapshot.clone",
+        lambda src, dst: ({"snapshot": src, "dataset": dst},),
+    ),
+    ("pool.snapshot.clone", lambda src, dst: ({"snapshot": src, "dataset_dst": dst},)),
+]
+
+# The methods whose request models carry the `bypass` escape hatch, with payloads that are
+# otherwise valid.
+BYPASS_PAYLOADS = [
+    ("zfs.resource.snapshot.create", {"dataset": f"{pool}/x", "name": "a"}),
+    ("zfs.resource.snapshot.destroy", {"path": f"{pool}/x@a"}),
+    (
+        "zfs.resource.snapshot.rename",
+        {"current_name": f"{pool}/x@a", "new_name": f"{pool}/x@b"},
+    ),
+    ("zfs.resource.snapshot.clone", {"snapshot": f"{pool}/x@a", "dataset": CLONE_DST}),
+    ("zfs.resource.snapshot.hold", {"path": f"{pool}/x@a"}),
+    ("zfs.resource.snapshot.release", {"path": f"{pool}/x@a"}),
+    ("zfs.resource.snapshot.rollback", {"path": f"{pool}/x@a"}),
+]
+
+DATASET_IDS = [m for m, _ in DATASET_MUTATORS]
+JOB_DATASET_IDS = [m for m, _ in JOB_DATASET_MUTATORS]
+SNAPSHOT_IDS = [m for m, _ in SNAPSHOT_MUTATORS]
+DESTINATION_IDS = [m for m, _ in DESTINATION_MUTATORS]
+BYPASS_IDS = [m for m, _ in BYPASS_PAYLOADS]
+
+# Mutators that would really change a user's dataset, so the control test skips them; they get
+# their own round trip further down instead.
+DESTRUCTIVE = {"pool.dataset.rename", "pool.dataset.delete", "zfs.resource.destroy"}
+
+
+def assert_protected(method, args, job=False):
+    with pytest.raises(Exception) as exc_info:
+        call(method, *args, job=job)
+
+    text = str(exc_info.value)
+    assert PROTECTED_MESSAGE in text, text
+    assert "[EACCES]" in text, text
+
+
+def is_a_refusal_that_lost_its_class(exc):
+    """Whether a bare `ClientException` is carrying a refusal rather than a mutator that broke.
+
+    A job's exception does not reach the caller as itself: validation errors are rebuilt, and
+    everything else -- a `CallError` declining the call included -- arrives flattened into a
+    `ClientException` with only the server-side class name left behind in the trace. Reading that
+    back is the one way left to tell the two apart.
+    """
+    raised = getattr(service_exception, (exc.trace or {}).get("class", ""), None)
+    return raised is not None and issubclass(raised, GRACEFUL_FAILURES)
+
+
+def assert_not_protected(method, args, job=False):
+    """The call may fail for its own reasons, but never because the path looked protected -- and it
+    has to have reached the guard at all for its silence to mean anything.
+
+    `ClientValidationErrors` subclasses `ClientException`, so it has to be handled by the first
+    clause or the second one would swallow it.
+    """
+
+    def assert_the_guard_was_not_what_refused(text):
+        assert PROTECTED_MESSAGE not in text, text
+        assert "[EACCES]" not in text, text
+        assert not SCHEMA_REJECTION_RE.search(text), (
+            f"{method}: the request model rejected this payload: {text}"
+        )
+
+    try:
+        call(method, *args, job=job)
+    except GRACEFUL_FAILURES as e:
+        assert_the_guard_was_not_what_refused(str(e))
+    except ClientException as e:
+        if not is_a_refusal_that_lost_its_class(e):
+            raise AssertionError(
+                f"{method}: failed server-side rather than refusing gracefully: {e!r}"
+            ) from e
+        assert_the_guard_was_not_what_refused(str(e))
+    except Exception as e:
+        raise AssertionError(
+            f"{method}: raised {type(e).__name__}, which is not a graceful refusal: {e}"
+        ) from e
+
+
+@pytest.fixture(scope="module", autouse=True)
+def protected_targets_are_absent():
+    """The matrix only stays harmless while its targets do not exist, so check rather than assume.
+
+    The listing filter has to be turned off for this query, or it answers "absent" for every path
+    under a managed dataset and the check is vacuous -- which is also why the prefixes are asserted
+    to be visible first. Turning it off is the private implementation's privilege rather than
+    something a request can ask for, so this goes through `query_impl`.
+    """
+    visible = [
+        ds
+        for ds in PROTECTED_PREFIXES
+        if call("pool.dataset.query_impl", [["id", "=", ds]], {}, False)
+    ]
+    assert visible, (
+        f"none of {PROTECTED_PREFIXES} is visible, so nothing below can be shown to be absent"
+    )
+
+    existing = [
+        ds
+        for ds in PROTECTED_DATASETS
+        if call("pool.dataset.query_impl", [["id", "=", ds]], {}, False)
+    ]
+    assert not existing, (
+        f"the matrix is about to fire destroys and renames at real datasets: {existing}"
+    )
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+@pytest.mark.parametrize("method,build_args", DATASET_MUTATORS, ids=DATASET_IDS)
+def test_dataset_mutator_refuses_protected_dataset(method, build_args, ds):
+    assert_protected(method, build_args(ds))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+@pytest.mark.parametrize("method,build_args", JOB_DATASET_MUTATORS, ids=JOB_DATASET_IDS)
+def test_job_mutator_refuses_protected_dataset(method, build_args, ds):
+    assert_protected(method, build_args(ds), job=True)
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+@pytest.mark.parametrize("method,build_args", SNAPSHOT_MUTATORS, ids=SNAPSHOT_IDS)
+def test_snapshot_mutator_refuses_protected_dataset(method, build_args, ds):
+    assert_protected(method, build_args(f"{ds}@{SNAP}"))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+def test_unload_key_refuses_protected_dataset(ds):
+    """Its own case rather than a row in the matrix, because the matrix has a control half.
+
+    Every other mutator there is aimed at a real user dataset to prove it is let through, and the
+    payload that would need is `force_unmount` against something mounted -- a real unmount of a real
+    dataset, which is not what this file is for.
+    """
+    assert_protected("zfs.resource.unload_key", (ds,))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+def test_update_impl_refuses_protected_dataset(ds):
+    """`pool.dataset.update` carries a guard of its own, so the matrix passes without this one.
+
+    The private implementation is what every in-tree caller that sets a property actually reaches,
+    and it is reachable without going through the public method at all, so its guard needs a case
+    that fails when only it is removed.
+    """
+    assert_protected("pool.dataset.update_impl", ({"name": ds},))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_PREFIXES)
+def test_the_managed_datasets_themselves_are_refused(ds):
+    """The matrix aims one level down, so a shape that narrowed to "descendants only" would leave it
+    entirely green while the managed datasets became mutable. This is the case that would fail.
+
+    Only two mutators, chosen because neither could do damage even with no guard at all: `get_quota`
+    reads, and a managed dataset is never a clone, so `promote` has nothing to promote.
+    """
+    assert_protected("pool.dataset.get_quota", (ds, "DATASET"))
+    assert_protected("pool.dataset.promote", (ds,))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+def test_rename_refuses_a_protected_destination(ds):
+    """Renaming *into* a protected path is how one would otherwise be created."""
+    with dataset("rename-src") as src:
+        assert_protected("pool.dataset.rename", (src, {"new_name": ds, "force": True}))
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+@pytest.mark.parametrize("method,build_args", DESTINATION_MUTATORS, ids=DESTINATION_IDS)
+def test_clone_refuses_a_protected_destination(method, build_args, ds):
+    assert_protected(method, build_args(f"{pool}/x@a", ds))
+
+
+@pytest.mark.parametrize("method,payload", BYPASS_PAYLOADS, ids=BYPASS_IDS)
+def test_bypass_is_rejected(method, payload):
+    """`bypass` is how the subsystem that owns a dataset reaches past these guards, and it is a
+    `Private` field, so a request that supplies it at all is rejected before the guard is reached.
+    """
+    with pytest.raises(Exception) as exc_info:
+        call(method, payload | {"bypass": True})
+
+    text = str(exc_info.value)
+    assert "bypass" in text, text
+    assert "not permitted" in text.lower(), text
+
+
+def test_exclude_internal_paths_is_rejected():
+    """The listing filter is `Private` too, so a caller cannot turn it off over the wire."""
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.query", {"exclude_internal_paths": False})
+
+    text = str(exc_info.value)
+    assert "exclude_internal_paths" in text, text
+    assert "not permitted" in text.lower(), text
+
+
+def test_pool_root_is_not_protected():
+    """A pool root hosting the system dataset stays the user's to manage.
+
+    The read and the promote can be aimed at the real pool because neither can change it. Destroy
+    cannot, so it is aimed at a pool that does not exist: the guard runs before the path is looked
+    up, and the root-filesystem rejection sits after the guard, so reaching that specific message is
+    the proof that the guard let a pool root through.
+    """
+    assert_not_protected("pool.dataset.get_quota", (pool, "DATASET"))
+    assert_not_protected("pool.dataset.promote", (pool,))
+
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.destroy", {"path": "protection-test-absent-pool"})
+
+    assert "Destroying the root filesystem is not allowed." in str(exc_info.value), str(
+        exc_info.value
+    )
+
+
+def test_user_dataset_is_not_protected():
+    """Nothing a user owns is caught by the guards."""
+    with dataset("not-protected") as ds:
+        for method, build_args in DATASET_MUTATORS:
+            if method not in DESTRUCTIVE:
+                assert_not_protected(method, build_args(ds))
+
+        for method, build_args in JOB_DATASET_MUTATORS:
+            assert_not_protected(method, build_args(ds), job=True)
+
+        # A snapshot that does not exist: every one of these fails with ENOENT, which is exactly
+        # what we want -- the call got past the guard without mutating anything.
+        for method, build_args in SNAPSHOT_MUTATORS:
+            assert_not_protected(method, build_args(f"{ds}@no-such-snapshot"))
+
+
+def test_user_dataset_can_still_be_renamed():
+    with dataset("rename-me") as ds:
+        renamed = f"{ds}-renamed"
+        call("pool.dataset.rename", ds, {"new_name": renamed, "force": True})
+        try:
+            assert call("pool.dataset.query", [["id", "=", renamed]])
+        finally:
+            call("pool.dataset.rename", renamed, {"new_name": ds, "force": True})
+
+
+def test_user_dataset_can_still_be_destroyed():
+    ds = f"{pool}/destroy-me"
+    call("pool.dataset.create", {"name": ds})
+    try:
+        call("zfs.resource.destroy", {"path": ds})
+        assert not call("pool.dataset.query", [["id", "=", ds]])
+    finally:
+        # Out of band, because the failure this test exists to catch is `zfs.resource.destroy`
+        # refusing the dataset -- a teardown through it would leak the dataset on exactly that
+        # failure, and every later run would then fail on the name already existing.
+        ssh(f"zfs destroy -r {ds}", check=False)
+
+
+@pytest.fixture
+def lookalike_dataset():
+    """Made out of band so the cases below do not lean on `pool.dataset.create` accepting the name.
+
+    Whether creation accepts it is its own case further down; these ones are about what a user may do
+    to such a dataset once it exists, which has to hold either way -- including on a system where the
+    name was created back when creation refused it.
+    """
+    ssh(f"zfs create {LOOKALIKE}")
+    try:
+        yield LOOKALIKE
+    finally:
+        ssh(f"zfs destroy -r {LOOKALIKE}", check=False)
+
+
+def test_lookalike_dataset_is_listed(lookalike_dataset):
+    assert call("pool.dataset.query", [["id", "=", lookalike_dataset]])
+    assert call("pool.dataset.get_instance", lookalike_dataset)["id"] == LOOKALIKE
+
+
+def test_lookalike_dataset_can_be_updated(lookalike_dataset):
+    updated = call("pool.dataset.update", lookalike_dataset, {"atime": "OFF"})
+    assert updated["atime"]["value"] == "OFF", updated["atime"]
+
+
+def test_lookalike_dataset_can_be_deleted(lookalike_dataset):
+    call("pool.dataset.delete", lookalike_dataset, {"recursive": True})
+    assert not call("pool.dataset.query", [["id", "=", lookalike_dataset]])
+
+
+def test_lookalike_dataset_can_be_created():
+    """Creation asks the same question as every mutator above, so it has to give the same answer.
+
+    Creation used to refuse any component merely starting with a managed name, at any depth. That
+    left a user who asked for this dataset refused outright, while a user who already had one could
+    list, update and delete it freely -- the tests above. One rule now, so the refusal a user gets is
+    exactly the set of datasets a user cannot manage.
+    """
+    call("pool.dataset.create", {"name": LOOKALIKE})
+    try:
+        assert call("pool.dataset.query", [["id", "=", LOOKALIKE]])
+    finally:
+        call("pool.dataset.delete", LOOKALIKE, {"recursive": True})
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        f"{pool}/ix-apps/child",
+        f"{pool}/ix-applications",
+    ],
+)
+def test_creation_is_refused_at_and_under_a_managed_dataset(name):
+    """A managed dataset itself, and anything below one, are both off limits to create.
+
+    The child case is the one that matters: refusing only the managed name would let a user park a
+    dataset inside the apps dataset.
+    """
+    with pytest.raises(Exception) as exc_info:
+        call("pool.dataset.create", {"name": name, "create_ancestors": True})
+
+    assert RESERVED_MESSAGE in str(exc_info.value), str(exc_info.value)
+
+
+def test_internal_datasets_stay_out_of_the_dataset_listing(lookalike_dataset):
+    """The listing hides whole components, not substrings, so it has to hide no more than it must.
+
+    The look-alike is created for this case rather than only asserted against, because "nothing
+    resembling a managed name is listed" and "a user's own dataset is listed" are the same
+    assertion pulling in opposite directions, and only one of them can be right.
+    """
+    listed = [entry["id"] for entry in call("pool.dataset.query")]
+
+    for name in listed:
+        components = name.split("/")
+        assert components[0] not in BOOT_POOL_NAMES, name
+        assert len(components) < 2 or components[1] not in HIDDEN_TOP_LEVEL_CHILDREN, (
+            name
+        )
+
+    assert lookalike_dataset in listed, listed

--- a/tests/api2/test_pool_snapshot_rename.py
+++ b/tests/api2/test_pool_snapshot_rename.py
@@ -1,0 +1,76 @@
+import errno
+
+import pytest
+
+from middlewared.service_exception import ValidationError
+from middlewared.test.integration.assets.pool import dataset, snapshot
+from middlewared.test.integration.utils import call
+
+
+def snapshot_exists(id_):
+    return call("pool.snapshot.query", [["id", "=", id_]], {"count": True}) == 1
+
+
+def test_pool_snapshot_rename():
+    with dataset("test_pool_snap_rename") as ds:
+        with snapshot(ds, "old_name") as snap:
+            call(
+                "pool.snapshot.rename",
+                snap,
+                {"new_name": f"{ds}@new_name", "force": True},
+            )
+
+            try:
+                assert not snapshot_exists(snap)
+                renamed = call(
+                    "pool.snapshot.query",
+                    [["id", "=", f"{ds}@new_name"]],
+                    {"get": True},
+                )
+                assert renamed["snapshot_name"] == "new_name"
+                assert renamed["dataset"] == ds
+            finally:
+                # Restore the original name so the fixture teardown finds the snapshot, otherwise
+                # an assertion failure above is reported alongside a teardown error for it.
+                call(
+                    "pool.snapshot.rename",
+                    f"{ds}@new_name",
+                    {"new_name": snap, "force": True},
+                )
+
+
+def test_pool_snapshot_rename_requires_force():
+    with dataset("test_pool_snap_rename_force") as ds:
+        with snapshot(ds, "snap") as snap:
+            with pytest.raises(ValidationError) as ve:
+                call("pool.snapshot.rename", snap, {"new_name": f"{ds}@renamed"})
+
+            assert ve.value.attribute == "pool.snapshot.rename.force"
+            assert snapshot_exists(snap)
+
+
+def test_pool_snapshot_rename_different_dataset():
+    with dataset("test_pool_snap_rename_src") as src:
+        with dataset("test_pool_snap_rename_dst") as dst:
+            with snapshot(src, "snap") as snap:
+                with pytest.raises(ValidationError) as ve:
+                    call(
+                        "pool.snapshot.rename",
+                        snap,
+                        {"new_name": f"{dst}@snap", "force": True},
+                    )
+
+                assert ve.value.attribute == "pool.snapshot.rename.new_name"
+                assert snapshot_exists(snap)
+
+
+def test_pool_snapshot_rename_nonexistent():
+    with dataset("test_pool_snap_rename_noent") as ds:
+        with pytest.raises(ValidationError) as ve:
+            call(
+                "pool.snapshot.rename",
+                f"{ds}@nonexistent",
+                {"new_name": f"{ds}@renamed", "force": True},
+            )
+
+        assert ve.value.errno == errno.ENOENT

--- a/tests/api2/test_zfs_tier_protected_path.py
+++ b/tests/api2/test_zfs_tier_protected_path.py
@@ -1,0 +1,137 @@
+"""`zfs.tier` must refuse the datasets middleware manages on the user's behalf.
+
+This lives at the top level of `tests/api2/` rather than alongside the other tier tests in
+`tests/api2/zfs_tier/`, whose conftest skips the whole directory unless the system is licensed and
+has a SPECIAL vdev with spare disks. The refusals here are pure path checks that run before
+`zfs.tier` looks at its own configuration, so they are reachable -- and worth asserting -- on any
+system, and none of the paths named below has to exist.
+"""
+
+import re
+
+import pytest
+
+from middlewared.test.integration.utils import call, pool
+
+PROTECTED_MESSAGE = "is a protected path."
+
+# One representative of each shape the registry matches: the system dataset, the apps dataset, and
+# a dataset in the boot pool.
+PROTECTED_PREFIXES = [f"{pool}/.system", f"{pool}/ix-apps", "boot-pool/ROOT"]
+
+ABSENT = "tier-test-absent/leaf"
+"""A location under each managed dataset that nothing ever creates.
+
+`dataset_set_tier` and `rewrite_job_create` queue a full block rewrite of everything they are aimed
+at, so naming the managed datasets themselves means a guard that regressed does not fail this file
+-- it rewrites the boot environments and the system dataset. Aiming one level down at something
+absent keeps every refusal meaning the same thing while leaving a regressed guard nothing to act on:
+it gets ENOENT."""
+
+PROTECTED_DATASETS = [f"{prefix}/{ABSENT}" for prefix in PROTECTED_PREFIXES]
+
+UNMANAGED_ABSENT_DATASET = f"{pool}/no-such-dataset-for-tiering"
+
+SCHEMA_REJECTION_RE = re.compile(
+    r": (Field required"
+    r"|Extra inputs are not permitted"
+    r"|Input should "
+    r"|Input tag "
+    r"|Unable to extract tag"
+    r"|Value error, "
+    r"|Assertion failed, "
+    r"|Too many arguments)"
+)
+"""Pydantic's own rejection messages, which are a closed set no service produces.
+
+A request model that rejects the payload rejects it before the method body runs, so the guard under
+test was never reached and the case proved nothing."""
+
+# A well-formed `dataset_name@job_uuid` needs a uuid half, but no job by this id exists anywhere --
+# the refusal happens before the daemon is ever asked about it.
+JOB_UUID = "00000000-0000-0000-0000-000000000000"
+
+TIER_MUTATORS = [
+    (
+        "zfs.tier.dataset_set_tier",
+        lambda ds: ({"dataset_name": ds, "tier_type": "PERFORMANCE"},),
+    ),
+    ("zfs.tier.rewrite_job_create", lambda ds: ({"dataset_name": ds},)),
+    (
+        "zfs.tier.rewrite_job_recover",
+        lambda ds: ({"tier_job_id": f"{ds}@{JOB_UUID}"},),
+    ),
+]
+
+TIER_IDS = [m for m, _ in TIER_MUTATORS]
+
+
+def assert_protected(method, args):
+    with pytest.raises(Exception) as exc_info:
+        call(method, *args)
+
+    text = str(exc_info.value)
+    assert PROTECTED_MESSAGE in text, text
+    assert "[EACCES]" in text, text
+
+
+@pytest.fixture(scope="module", autouse=True)
+def protected_targets_are_absent():
+    """The targets below only stay harmless while they do not exist, so check rather than assume.
+
+    The listing filter has to be turned off for this query, or it answers "absent" for every path
+    under a managed dataset and the check is vacuous -- which is also why the prefixes are asserted
+    to be visible first. Turning it off is the private implementation's privilege rather than
+    something a request can ask for, so this goes through `query_impl`.
+    """
+    visible = [
+        ds
+        for ds in PROTECTED_PREFIXES
+        if call("pool.dataset.query_impl", [["id", "=", ds]], {}, False)
+    ]
+    assert visible, (
+        f"none of {PROTECTED_PREFIXES} is visible, so nothing below can be shown to be absent"
+    )
+
+    existing = [
+        ds
+        for ds in PROTECTED_DATASETS
+        if call("pool.dataset.query_impl", [["id", "=", ds]], {}, False)
+    ]
+    assert not existing, (
+        f"these tier calls are about to be aimed at real datasets: {existing}"
+    )
+
+    assert not call(
+        "pool.dataset.query_impl", [["id", "=", UNMANAGED_ABSENT_DATASET]], {}, False
+    ), f"{UNMANAGED_ABSENT_DATASET} exists, so the control below would act on it"
+
+
+@pytest.mark.parametrize("ds", PROTECTED_DATASETS)
+@pytest.mark.parametrize("method,build_args", TIER_MUTATORS, ids=TIER_IDS)
+def test_tier_mutator_refuses_protected_dataset(method, build_args, ds):
+    assert_protected(method, build_args(ds))
+
+
+@pytest.mark.parametrize("method,build_args", TIER_MUTATORS, ids=TIER_IDS)
+def test_ordinary_dataset_is_not_refused(method, build_args):
+    """The control: an unmanaged path gets past the check and fails for its own reasons.
+
+    Paired with the test above this is also what proves the check runs first. On a system with
+    tiering switched off -- which is every system the tier suite itself skips on -- these calls
+    stop at "ZFS tiering is globally disabled", while a managed dataset is refused before that.
+
+    Requiring a raise is safe because the target does not exist: every one of these methods either
+    stops at "globally disabled" or at ENOENT from its own dataset lookup. A call that succeeds
+    means the target was real after all, and a request-model rejection means the method body was
+    never entered -- both leave the guard unexercised, which is what this case exists to check.
+    """
+    with pytest.raises(Exception) as exc_info:
+        call(method, *build_args(UNMANAGED_ABSENT_DATASET))
+
+    text = str(exc_info.value)
+    assert PROTECTED_MESSAGE not in text, text
+    assert "[EACCES]" not in text, text
+    assert not SCHEMA_REJECTION_RE.search(text), (
+        f"{method}: the request model rejected this payload: {text}"
+    )


### PR DESCRIPTION
## Problem

Five separate registries answered "is this a dataset middleware manages?", with four different membership sets and no shared matching rule, and they had drifted apart: `<pool>/ix-applications` was creatable and then permanently invisible because one carried a trailing slash the others lacked, and the replication registry did not know about the apps datasets at all. Two of the five matched by substring, which confiscated names the user is entitled to -- `<pool>/ix-apps-data` and `<pool>/.systembackup` were hidden from `pool.dataset.query` forever, and therefore unmanageable, since `get_instance`, `update` and `delete` all run through that listing.

Protection had holes in both directions. `exclude_internal_datasets` was reachable from the wire through `pool.dataset.query`'s free-form `extra` dict, where the model's `extra="forbid"` never reaches, so anyone holding `DATASET_READ` could enumerate the boot pool and the system dataset. And eleven public entry points had no protection at all: `pool.dataset.promote`, `rename`, `set_quota`, `get_quota`, `lock`, `change_key` and `inherit_parent_encryption_properties`, the three `zfs.tier` mutators, and `pool.snapshot.rename` -- which was broken for every valid input in any case, since it passed a snapshot id to a method that rejects any name containing `@`.

## Solution

- **One module, one predicate per question.** `utils/zfs/managed_datasets.py` replaces all five registries. Every predicate matches the same way -- compare the component directly below the pool root against a name, exactly, with the boot pools matched at component zero instead -- so where two of them disagree it is because they manage a different set of names, and that is product policy you can read in one line.
- **The substring reach is gone.** `<pool>/ix-apps-data`, `<pool>/.systembackup` and `<pool>/foo/.system` are visible, creatable, updatable and deletable again, and their destruction publishes an event. That last one was not cosmetic: the suppressed branch is what clears the destroyed dataset's encryption key from the database and removes it from the other HA node, so an out-of-band `zfs destroy` used to leave the key registered on both nodes and in KMIP.
- **The one override a caller could reach is off the wire.** `exclude_internal_datasets` moves onto a new private `pool.dataset.query_impl`, so whether the managed datasets are listed is a property of the caller rather than of the request.
- **Guards live at the chokepoint where there is one** -- inside the `@private` implementation rather than at each public method -- because a missing guard at a public boundary fails open and silently, while a missing owner opt-in fails closed and loudly inside that owner's own workflow. Guarding `update_impl` and `unload_key` took the `bypass=True` call sites from sixteen to thirty-four; the new ones sit on pool import, the system dataset, audit, docker and the container migration. The six operations with no chokepoint to pass through are guarded at the public method instead.
- **Gaps closed.** All eleven unguarded entry points now refuse managed datasets, `rename` refuses a managed *destination* so a dataset can no longer be created at a protected name, `delete` reports `EACCES` rather than a misleading `EINVAL`, and `pool.snapshot.rename` is routed at the snapshot rename endpoint and works. `mount`, `unmount` and `replication.create_dataset` are deliberately left unguarded, with the reasons recorded where they sit.