### PR TITLE
NAS-141754 / 26.0.0-RC.1 / Make ZFS deduplication incompatible with the PERFORMANCE tier (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -87,7 +87,10 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     )
     locked: bool = Field(description="Whether an encrypted dataset is currently locked (key not loaded).")
     tier: TierInfo | None = Field(
-        description="Performance tier. `null` if tiering disabled or if underlying pool does not support tiering.",
+        description=(
+            "Performance tier. `null` if tiering disabled, if underlying pool does not support tiering, or if "
+            "deduplication is enabled on the dataset."
+        ),
     )
     comments: PoolDatasetEntryProperty = Field(
         description="ZFS comments property for storing descriptive text about the dataset.",
@@ -306,6 +309,8 @@ class PoolDatasetCreate(BaseModel):
         default="INHERIT",
         description=(
             "Deduplication setting. 'ON' enables dedup, 'VERIFY' enables with checksum verification, 'OFF' disables."
+            " While ZFS tiering is enabled, cannot be enabled on a dataset in the PERFORMANCE tier (data on the"
+            " SPECIAL vdev) or on one with a PERFORMANCE-tier descendant that would inherit the setting."
         ),
     )
     checksum: Literal[

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
@@ -297,7 +297,10 @@ class ZFSResourceEntry(BaseModel):
     children: list | None = Field(description="The children of this zfs resource.")
     tier: TierInfo | None = Field(
         default=None,
-        description="Tier classification for FILESYSTEM resources. None if not requested or not applicable.",
+        description=(
+            "Tier classification for FILESYSTEM resources. None if not requested, not applicable, or "
+            "deduplication is enabled on the dataset."
+        ),
     )
 
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -35,6 +35,7 @@ from .utils import (
     UpdateImplArgs,
     UpdateImplArgsDataclass,
     validate_dedup_license,
+    validate_dedup_tiering,
     ZFSKeyFormat,
     ZFS_VOLUME_BLOCK_SIZE_CHOICES
 )
@@ -199,6 +200,13 @@ class PoolDatasetService(CRUDService):
         verrors.check()
 
         await validate_dedup_license(self.middleware, verrors, schema, data.get('deduplication'))
+        ssb_ref = cur_dataset or parent
+        special_small_blocks = (ssb_ref.get('special_small_block_size') or {}).get('parsed') or 0
+        await validate_dedup_tiering(
+            self.middleware, verrors, schema, data.get('deduplication'), parent['pool'],
+            data['type'], special_small_blocks, cur_dataset.get('deduplication') if cur_dataset else None,
+            cur_dataset['name'] if cur_dataset else None,
+        )
 
         dataset_pool_is_draid = await self.middleware.call('pool.is_draid_pool', parent['pool'])
         if data['type'] == 'FILESYSTEM':

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -17,6 +17,9 @@ from middlewared.utils.size import MB
 from middlewared.utils.filesystem.directory import directory_is_empty
 
 
+if typing.TYPE_CHECKING:
+    from middlewared.main import Middleware
+
 DATASET_DATABASE_MODEL_NAME = 'storage.encrypteddataset'
 RE_DRAID_DATA_DISKS = re.compile(r':\d*d')
 RE_DRAID_SPARE_DISKS = re.compile(r':\d*s')
@@ -125,6 +128,122 @@ async def validate_dedup_license(middleware, verrors, schema, deduplication):
                 f'{schema}.deduplication',
                 'This system is not licensed to use ZFS deduplication.'
             )
+
+
+async def pool_has_special_vdev(middleware: 'Middleware', pool_name: str) -> bool:
+    """Whether the pool has a SPECIAL allocation class vdev. Returns False when the
+    pool cannot be inspected."""
+    try:
+        pools = await middleware.call(
+            'zpool.query_impl',
+            {'pool_names': [pool_name], 'properties': ['class_special_size']},
+        )
+        if not pools:
+            return False
+        special_size = ((pools[0].get('properties') or {}).get('class_special_size') or {}).get('value')
+    except Exception:
+        middleware.logger.debug('%s: failed to query pool SPECIAL vdev size', pool_name, exc_info=True)
+        return False
+    return isinstance(special_size, int) and special_size > 0
+
+
+async def _dedup_inheriting_performance_descendants(middleware, dataset_name):
+    """Names of FILESYSTEM descendants of ``dataset_name`` whose data placement is on
+    the SPECIAL vdev (effective ``special_small_blocks`` > 0) and whose effective
+    deduplication value would change with a deduplication value set on ``dataset_name``.
+    Returns an empty list when the descendants cannot be inspected."""
+    try:
+        results = await middleware.call(
+            'pool.dataset.query',
+            [('id', '=', dataset_name)],
+            {'extra': {'properties': ['dedup', 'special_small_blocks'], 'retrieve_user_props': False}},
+        )
+    except Exception:
+        middleware.logger.debug('%s: failed to query descendant datasets', dataset_name, exc_info=True)
+        return []
+    if not results:
+        return []
+
+    affected = []
+    stack = list(results[0].get('children') or [])
+    while stack:
+        ds = stack.pop()
+        stack.extend(ds.get('children') or [])
+        if ds.get('type') != 'FILESYSTEM':
+            continue
+        if not ((ds.get('special_small_block_size') or {}).get('parsed') or 0):
+            continue
+        dedup = ds.get('deduplication') or {}
+        source = dedup.get('source')
+        if source in ('DEFAULT', 'NONE'):
+            affected.append(ds['name'])
+        elif source == 'INHERITED':
+            # Only a value inherited from the dataset being changed or one of its
+            # ancestors is masked by the new local value; a value inherited from a
+            # dataset in between keeps masking it.
+            src = dedup.get('source_info')
+            if src is not None and (src == dataset_name or dataset_name.startswith(f'{src}/')):
+                affected.append(ds['name'])
+    return sorted(affected)
+
+
+async def validate_dedup_tiering(
+    middleware, verrors, schema, deduplication, pool_name, dataset_type,
+    special_small_blocks, cur_deduplication=None, dataset_name=None,
+):
+    """Reject enabling ZFS deduplication where data sits (or would sit) on the SPECIAL vdev.
+
+    Only PERFORMANCE placement (``special_small_blocks`` > 0, so the dataset's data lives
+    on the SPECIAL vdev) conflicts with deduplication. REGULAR datasets keep their data on
+    the normal vdev and may be deduplicated freely; only FILESYSTEM datasets can be tiered,
+    so volumes are never restricted. Datasets that already have deduplication in effect are
+    left alone so no-op resubmissions and ON<->VERIFY changes keep working.
+
+    ``dataset_name`` names an existing dataset being updated (None on creation). Because
+    deduplication is inherited, enabling it also enables it on every descendant without
+    its own deduplication setting, so a PERFORMANCE-placed descendant that would inherit
+    the new value blocks the change as well.
+    """
+    if dataset_type != 'FILESYSTEM':
+        return
+
+    if deduplication not in ('ON', 'VERIFY'):
+        return
+
+    if cur_deduplication is not None and cur_deduplication.get('value') not in (None, 'OFF'):
+        # Deduplication is already in effect on this dataset.
+        return
+
+    if not special_small_blocks and dataset_name is None:
+        # Creating a dataset with REGULAR placement: its data goes to the normal vdev
+        # and it has no descendants yet, safe to deduplicate.
+        return
+
+    if not (await middleware.call('zfs.tier.config')).enabled:
+        return
+
+    if not await pool_has_special_vdev(middleware, pool_name):
+        # Data cannot land on a SPECIAL vdev regardless of placement.
+        return
+
+    if special_small_blocks:
+        verrors.add(
+            f'{schema}.deduplication',
+            'ZFS deduplication is incompatible with tiering and cannot be enabled on a dataset '
+            'assigned to the PERFORMANCE tier (its data is placed on the SPECIAL vdev); switch it '
+            'to the REGULAR tier first.'
+        )
+        return
+
+    affected = await _dedup_inheriting_performance_descendants(middleware, dataset_name)
+    if affected:
+        others = f' (and {len(affected) - 1} more)' if len(affected) > 1 else ''
+        verrors.add(
+            f'{schema}.deduplication',
+            'ZFS deduplication is incompatible with tiering and cannot be enabled here: descendant '
+            f'dataset {affected[0]!r}{others} is assigned to the PERFORMANCE tier (its data is placed '
+            'on the SPECIAL vdev) and would inherit deduplication; switch it to the REGULAR tier first.'
+        )
 
 
 def none_normalize(x):

--- a/src/middlewared/middlewared/plugins/zfs/tier.py
+++ b/src/middlewared/middlewared/plugins/zfs/tier.py
@@ -51,7 +51,7 @@ from middlewared.api.current import (
     ZfsTierUpdateResult,
 )
 from middlewared.event import EventSource
-from middlewared.plugins.pool_.utils import UpdateImplArgs
+from middlewared.plugins.pool_.utils import UpdateImplArgs, pool_has_special_vdev
 from middlewared.plugins.tunables import zfs_parameter_value
 from middlewared.service import CallError, ConfigService, ConfigServicePart, ValidationError, private
 from middlewared.service.decorators import pass_thread_local_storage
@@ -194,6 +194,8 @@ def get_dataset_tier_info_cached(
     """
     Returns TierInfo for a single dataset using a caller-maintained pool cache.
     pool_special_cache is mutated: {pool_name -> has_special_vdevs}.
+    Returns None when the pool has no SPECIAL vdev or the dataset has
+    deduplication enabled.
     Does not check license or enabled flag — caller must do that.
     """
     pool_name = hdl.name.split("/")[0]
@@ -217,8 +219,13 @@ def get_dataset_tier_info_cached(
             properties={
                 truenas_pylibzfs.ZFSProperty.SPECIAL_SMALL_BLOCKS,
                 truenas_pylibzfs.ZFSProperty.RECORDSIZE,
+                truenas_pylibzfs.ZFSProperty.DEDUP,
             }
         )
+        dedup_slot = dprops.dedup
+        if dedup_slot is not None and dedup_slot.value not in (None, "off"):
+            # Deduplicated datasets are excluded from tiering.
+            return None
         ssb_slot = dprops.special_small_blocks
         ssb_value = ssb_slot.value if ssb_slot is not None else 0
         rs_slot = dprops.recordsize
@@ -406,6 +413,15 @@ class ZfsTierService(ConfigService[ZfsTierEntry]):
             raise ValidationError(field, f"{dataset_name!r}: dataset not found", errno.ENOENT)
 
         if current_info is None:
+            if (
+                await pool_has_special_vdev(self.middleware, dataset_name.split("/")[0])
+                and await self._dataset_dedup_enabled(dataset_name)
+            ):
+                raise ValidationError(
+                    field,
+                    f"{dataset_name!r}: tiering is not supported (ZFS deduplication is enabled on this dataset)",
+                    errno.EINVAL,
+                )
             raise ValidationError(
                 field,
                 f"{dataset_name!r}: tiering is not supported (pool has no SPECIAL vdev)",
@@ -536,6 +552,21 @@ class ZfsTierService(ConfigService[ZfsTierEntry]):
             raise ValidationError(field, f"{dataset_name!r}: dataset is read-only", errno.EROFS)
 
     @private
+    async def _dataset_dedup_enabled(self, dataset_name: str) -> bool:
+        """Return True when the dataset has an effective deduplication value other than off."""
+        try:
+            results = await self.call2(
+                self.s.zfs.resource.query_impl,
+                ZFSResourceQuery(paths=[dataset_name], properties=["dedup"]),
+            )
+        except Exception:
+            return False
+        if not results:
+            return False
+        dedup = (results[0]["properties"] or {}).get("dedup") or {}
+        return dedup.get("raw") not in (None, "off")
+
+    @private
     def _validate_tier_space(
         self,
         field: str,
@@ -580,7 +611,11 @@ class ZfsTierService(ConfigService[ZfsTierEntry]):
         audit_extended=lambda data: f"{data['dataset_name']} -> {data['tier_type']}",
     )
     async def dataset_set_tier(self, data: dict[str, typing.Any]) -> dict[str, typing.Any]:
-        """Set the performance tier for a ZFS dataset, optionally migrating existing data."""
+        """
+        Set the performance tier for a ZFS dataset, optionally migrating existing data.
+
+        Datasets with ZFS deduplication enabled cannot be assigned a tier.
+        """
         dataset_name = data["dataset_name"]
         tier_type = data["tier_type"]
         move_existing_data = data["move_existing_data"]
@@ -597,6 +632,15 @@ class ZfsTierService(ConfigService[ZfsTierEntry]):
             raise ValidationError(field, f"{dataset_name!r}: dataset not found", errno.ENOENT)
 
         if current_info is None:
+            if (
+                await pool_has_special_vdev(self.middleware, dataset_name.split("/")[0])
+                and await self._dataset_dedup_enabled(dataset_name)
+            ):
+                raise ValidationError(
+                    "zfs_tier_dataset_set_tier",
+                    f"{dataset_name!r}: tiering is not supported (ZFS deduplication is enabled on this dataset)",
+                    errno.EINVAL,
+                )
             raise ValidationError(
                 "zfs_tier_dataset_set_tier",
                 f"{dataset_name!r}: tiering is not supported (pool has no SPECIAL vdev)",

--- a/tests/api2/zfs_tier/conftest.py
+++ b/tests/api2/zfs_tier/conftest.py
@@ -17,6 +17,13 @@ from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.system import reset_systemd_svcs
 
+# Daemon test hook: while this file exists, rewrite jobs wait the number of
+# milliseconds it contains after each regular file. The daemon reads it once
+# per job start, and the wait is interruptible by cancellation. It lives in
+# the daemon's runtime directory, so a reboot clears it.
+SLOW_REWRITE_SENTINEL = "/var/run/truenas_zfstierd/slow_rewrite"
+SLOW_REWRITE_DELAY_MS = 100
+
 
 @pytest.fixture(scope="module")
 def tier_pool():
@@ -72,6 +79,57 @@ def tier_pool():
 
 
 @pytest.fixture()
+def slow_rewrite(tier_pool):
+    """Slow rewrite jobs down to SLOW_REWRITE_DELAY_MS per file for this test.
+
+    Gives a job on an N-file dataset a lifetime of at least N * delay, so
+    tests can observe QUEUED/RUNNING, event-source polls, and cancellation
+    mid-run without staging gigabytes of data. The daemon reads the sentinel
+    when a job starts, so it must be active before the job is created;
+    cancellation interrupts the per-file wait promptly."""
+    ssh(
+        f"mkdir -p {SLOW_REWRITE_SENTINEL.rsplit('/', 1)[0]} && "
+        f"echo {SLOW_REWRITE_DELAY_MS} > {SLOW_REWRITE_SENTINEL}"
+    )
+    try:
+        yield
+    finally:
+        ssh(f"rm -f {SLOW_REWRITE_SENTINEL}")
+
+
+def _cancel_active_jobs(ds_name):
+    """Cancel any QUEUED/RUNNING rewrite job on ``ds_name``. The daemon's
+    cancel waits (bounded) for the walker to stop, so on return the dataset
+    is normally no longer held open by a rewrite job."""
+    for job in call("zfs.tier.rewrite_job_query", {}):
+        if job["dataset_name"] == ds_name and job["status"] in (
+            "QUEUED",
+            "RUNNING",
+        ):
+            try:
+                call(
+                    "zfs.tier.rewrite_job_cancel",
+                    {"tier_job_id": job["tier_job_id"]},
+                )
+            except Exception:
+                pass
+
+
+def _delete_dataset(ds_name, attempts=5, delay=2):
+    """pool.dataset.delete with retries on a busy unmount. The daemon's
+    abort wait is bounded, so a just-cancelled job's walker can still be
+    draining (holding fds inside the dataset) when the first delete lands."""
+    for attempt in range(attempts):
+        try:
+            call("pool.dataset.delete", ds_name, {"recursive": True})
+            return
+        except Exception as e:
+            if attempt == attempts - 1 or "busy" not in str(e).lower():
+                raise
+        time.sleep(delay)
+
+
+@pytest.fixture()
 def tier_ds(tier_pool):
     """A fresh dataset on the tier pool, cleaned up after each test.
 
@@ -82,19 +140,29 @@ def tier_ds(tier_pool):
     try:
         yield ds_name
     finally:
-        for job in call("zfs.tier.rewrite_job_query", {}):
-            if job["dataset_name"] == ds_name and job["status"] in (
-                "QUEUED",
-                "RUNNING",
-            ):
-                try:
-                    call(
-                        "zfs.tier.rewrite_job_cancel",
-                        {"tier_job_id": job["tier_job_id"]},
-                    )
-                except Exception:
-                    pass
-        call("pool.dataset.delete", ds_name, {"recursive": True})
+        _cancel_active_jobs(ds_name)
+        _delete_dataset(ds_name)
+
+
+@pytest.fixture()
+def make_tier_ds(tier_pool):
+    """Factory for additional datasets on the tier pool, with the same
+    cancel-active-jobs-then-delete cleanup as ``tier_ds``. For tests that
+    need more than one dataset at a time."""
+    created = []
+
+    def _make(prefix):
+        ds_name = f"{tier_pool['name']}/{prefix}_{time.monotonic_ns()}"
+        call("pool.dataset.create", {"name": ds_name})
+        created.append(ds_name)
+        return ds_name
+
+    try:
+        yield _make
+    finally:
+        for ds_name in reversed(created):
+            _cancel_active_jobs(ds_name)
+            _delete_dataset(ds_name)
 
 
 @pytest.fixture()
@@ -117,16 +185,13 @@ def tier_ds_regular(tier_ds):
     return tier_ds
 
 
-def _write_many_small_files(ds, n=5000, size_mb=1):
+def _write_many_small_files(ds, n=200, size_mb=1):
     """Create `n` separate `size_mb`-MiB files so the rewrite walker visits
     `n` inodes AND has actual blocks to move between vdev classes.
 
-    The daemon's reporting_callback_interval=1 means the per-file callback
-    fires after every iterated object, and (with the default
-    stats_flush_interval=1s) at least one LMDB flush happens for every
-    second the walker is busy. We need the walker busy long enough for
-    tests to observe state transitions, which is why each file is big
-    enough that moving its recordsize-sized blocks is real work."""
+    With the slow-rewrite sentinel active, `n` files also put a floor of
+    `n * SLOW_REWRITE_DELAY_MS` on the job's lifetime, so the total staged
+    data can stay small enough not to pressure the pool's space thresholds."""
     ssh(
         f"cd /mnt/{ds} && seq 1 {n} | "
         f"xargs -P 16 -I X dd if=/dev/urandom of=fX bs=1M count={size_mb} 2>/dev/null"
@@ -134,16 +199,19 @@ def _write_many_small_files(ds, n=5000, size_mb=1):
 
 
 @pytest.fixture()
-def tier_ds_with_work(tier_ds):
-    """A dataset pre-staged so the next rewrite_job has real work to do.
+def tier_ds_with_work(tier_ds, slow_rewrite):
+    """A dataset pre-staged so the next rewrite job has real work to do and
+    stays observable while doing it.
 
     Workflow: set tier=PERFORMANCE (special_small_blocks=16M, so writes
-    land on SPECIAL), create many MiB-sized files, then flip tier=REGULAR
+    land on SPECIAL), create MiB-sized files, then flip tier=REGULAR
     (special_small_blocks=0). Every block is now physically on SPECIAL
     but should be on NORMAL — the rewrite walker has to visit each file
-    and move its blocks, keeping the job alive long enough for per-file
-    callbacks to flush LMDB state. Active-job cancellation on teardown
-    is handled by the nested ``tier_ds`` fixture."""
+    and move its blocks, and the slow-rewrite sentinel holds the job at
+    SLOW_REWRITE_DELAY_MS per file (>= 20 s lifetime at the defaults) so
+    per-file callbacks flush LMDB state and tests can observe the job
+    before it completes. Active-job cancellation on teardown is handled
+    by the nested ``tier_ds`` fixture."""
     call(
         "zfs.tier.dataset_set_tier",
         {"dataset_name": tier_ds, "tier_type": "PERFORMANCE"},

--- a/tests/api2/zfs_tier/test_dedup_interaction.py
+++ b/tests/api2/zfs_tier/test_dedup_interaction.py
@@ -1,0 +1,260 @@
+"""Deduplication conflicts with PERFORMANCE-tier placement, not tiering as such.
+
+A dataset is excluded from tiering (reports ``tier: None`` in every query path)
+whenever its effective deduplication value is other than off. Enabling
+deduplication is refused only when dedup'd data would land on the SPECIAL
+vdev: the dataset itself is (or inherits) the PERFORMANCE tier
+(special_small_blocks > 0), or a descendant that would inherit the new
+deduplication value is. REGULAR datasets (data on the normal vdev), volumes,
+and datasets on pools without a SPECIAL vdev may be deduplicated freely.
+
+Implementation under test:
+  - src/middlewared/middlewared/plugins/zfs/tier.py
+    (get_dataset_tier_info_cached dedup gate, _dataset_dedup_enabled,
+    dataset_set_tier / rewrite_job_create rejection messages)
+  - src/middlewared/middlewared/plugins/pool_/utils.py (validate_dedup_tiering,
+    _dedup_inheriting_performance_descendants, pool_has_special_vdev)
+"""
+
+import contextlib
+import errno
+import time
+
+import pytest
+
+from middlewared.service_exception import ValidationError, ValidationErrors
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+
+INCOMPATIBLE_MSG = "incompatible with tiering"
+
+
+def _child(parent, suffix):
+    return f"{parent}/{suffix}_{time.monotonic_ns()}"
+
+
+@contextlib.contextmanager
+def _dedup_dataset(tier_pool, suffix):
+    """A dedup'd REGULAR dataset on the tier pool. REGULAR datasets keep their
+    data on the normal vdev, so they may be deduplicated with tiering enabled."""
+    ds = _child(tier_pool["name"], suffix)
+    call("pool.dataset.create", {"name": ds, "deduplication": "ON"})
+    try:
+        yield ds
+    finally:
+        call("pool.dataset.delete", ds, {"recursive": True})
+
+
+# ----------------------------------------------------------------------------
+# Display: dedup'd datasets report tier=None in every query path.
+# ----------------------------------------------------------------------------
+
+
+def test_dedup_dataset_tier_is_none_in_queries(tier_pool):
+    with _dedup_dataset(tier_pool, "dedup_disp") as ds:
+        row = call("pool.dataset.query", [["name", "=", ds]], {"get": True})
+        assert row.get("tier") is None
+
+        rows = call("zfs.resource.query", {"paths": [ds], "get_tier": True})
+        assert rows
+        assert rows[0].get("tier") is None
+
+        # Control: a sibling without dedup on the same pool reports a tier.
+        control = _child(tier_pool["name"], "dedup_disp_control")
+        call("pool.dataset.create", {"name": control})
+        try:
+            row = call("pool.dataset.query", [["name", "=", control]], {"get": True})
+            assert row["tier"] is not None
+        finally:
+            call("pool.dataset.delete", control, {"recursive": True})
+
+
+def test_inherited_dedup_child_tier_is_none(tier_pool):
+    """The tier display keys off the effective deduplication value: a child
+    inheriting dedup from its parent is excluded from tiering too, and creating
+    such a child (deduplication left at INHERIT) is allowed."""
+    with _dedup_dataset(tier_pool, "dedup_parent") as parent:
+        child = _child(parent, "inherit_child")
+        call("pool.dataset.create", {"name": child})
+        row = call("pool.dataset.query", [["name", "=", child]], {"get": True})
+        assert row["deduplication"]["value"] == "ON"
+        assert row.get("tier") is None
+
+
+# ----------------------------------------------------------------------------
+# pool.dataset create/update: dedup is allowed on REGULAR placement, refused on
+# PERFORMANCE placement (data on the SPECIAL vdev).
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dedup", ["ON", "VERIFY"])
+def test_create_dedup_allowed_under_regular_parent(tier_pool, dedup):
+    """A new dataset with REGULAR placement (the default; data on the normal
+    vdev) may be created with deduplication enabled while tiering is on. It then
+    drops out of tiering (tier=None)."""
+    ds = _child(tier_pool["name"], "dedup_regular_create")
+    call("pool.dataset.create", {"name": ds, "deduplication": dedup})
+    try:
+        row = call("pool.dataset.query", [["name", "=", ds]], {"get": True})
+        assert row["deduplication"]["value"] == dedup
+        assert row.get("tier") is None
+    finally:
+        call("pool.dataset.delete", ds, {"recursive": True})
+
+
+@pytest.mark.parametrize("dedup", ["ON", "VERIFY"])
+def test_create_dedup_rejected_under_performance_parent(tier_ds_performance, dedup):
+    """A new child inheriting PERFORMANCE placement (data on the SPECIAL vdev)
+    cannot be created with deduplication enabled."""
+    child = _child(tier_ds_performance, "dedup_child")
+    with pytest.raises(ValidationErrors) as ve:
+        call("pool.dataset.create", {"name": child, "deduplication": dedup})
+    error = ve.value.errors[0]
+    assert error.attribute == "pool_dataset_create.deduplication"
+    assert INCOMPATIBLE_MSG in error.errmsg
+    assert call("pool.dataset.query", [["name", "=", child]]) == []
+
+
+def test_update_enabling_dedup_allowed_on_regular_dataset(tier_ds):
+    """A REGULAR dataset (data on the normal vdev) may have dedup enabled while
+    tiering is on; it then drops out of tiering (tier=None)."""
+    call("pool.dataset.update", tier_ds, {"deduplication": "ON"})
+    row = call("pool.dataset.query", [["name", "=", tier_ds]], {"get": True})
+    assert row["deduplication"]["value"] == "ON"
+    assert row.get("tier") is None
+
+
+def test_update_enabling_dedup_rejected_on_performance_dataset(tier_ds_performance):
+    """A PERFORMANCE dataset (data on the SPECIAL vdev) cannot have dedup
+    enabled."""
+    with pytest.raises(ValidationErrors) as ve:
+        call("pool.dataset.update", tier_ds_performance, {"deduplication": "ON"})
+    error = ve.value.errors[0]
+    assert error.attribute == "pool_dataset_update.deduplication"
+    assert INCOMPATIBLE_MSG in error.errmsg
+
+
+def test_update_enabling_dedup_rejected_with_performance_descendant(tier_ds):
+    """Deduplication is inherited: enabling it on a REGULAR dataset is refused
+    when a descendant without its own deduplication setting is assigned to the
+    PERFORMANCE tier (the change would land dedup'd data on the SPECIAL vdev)."""
+    mid = _child(tier_ds, "mid")
+    grandchild = _child(mid, "perf_grandchild")
+    call("pool.dataset.create", {"name": mid})
+    call("pool.dataset.create", {"name": grandchild})
+    call(
+        "zfs.tier.dataset_set_tier",
+        {"dataset_name": grandchild, "tier_type": "PERFORMANCE"},
+    )
+
+    with pytest.raises(ValidationErrors) as ve:
+        call("pool.dataset.update", tier_ds, {"deduplication": "ON"})
+    error = ve.value.errors[0]
+    assert error.attribute == "pool_dataset_update.deduplication"
+    assert INCOMPATIBLE_MSG in error.errmsg
+    assert grandchild in error.errmsg
+
+
+def test_update_enabling_dedup_allowed_when_performance_descendant_masked(tier_ds):
+    """A PERFORMANCE descendant with its own local deduplication=OFF is not
+    affected by the ancestor's change, so it neither blocks enabling dedup nor
+    loses its tier."""
+    child = _child(tier_ds, "perf_child_masked")
+    call("pool.dataset.create", {"name": child, "deduplication": "OFF"})
+    call(
+        "zfs.tier.dataset_set_tier",
+        {"dataset_name": child, "tier_type": "PERFORMANCE"},
+    )
+
+    call("pool.dataset.update", tier_ds, {"deduplication": "ON"})
+    row = call("pool.dataset.query", [["name", "=", child]], {"get": True})
+    assert row["deduplication"]["value"] == "OFF"
+    assert row["tier"] is not None
+
+
+def test_dedup_toggles_freely_on_regular_dataset(tier_pool):
+    """A REGULAR dataset's data is on the normal vdev, so deduplication can be
+    switched, disabled, and re-enabled freely with tiering on."""
+    with _dedup_dataset(tier_pool, "dedup_toggle") as ds:
+        call("pool.dataset.update", ds, {"deduplication": "VERIFY"})
+        call("pool.dataset.update", ds, {"deduplication": "OFF"})
+        call("pool.dataset.update", ds, {"deduplication": "ON"})
+
+
+def test_dedup_allowed_on_pool_without_special_vdev(tier_pool):
+    """Tiering globally enabled, but the primary pool has no SPECIAL vdev:
+    deduplication stays usable there, and such datasets keep reporting
+    tier=None like any dataset on a pool that does not support tiering."""
+    with dataset("dedup_no_special", {"deduplication": "ON"}) as ds:
+        call("pool.dataset.update", ds, {"deduplication": "VERIFY"})
+        row = call("pool.dataset.query", [["name", "=", ds]], {"get": True})
+        assert row.get("tier") is None
+
+
+def test_dedup_allowed_on_zvol_on_tiered_pool(tier_pool):
+    """Volumes are never tiered, so deduplication is allowed on a ZVOL even on a
+    SPECIAL-vdev pool with tiering enabled (create and update), and the volume
+    carries no tier."""
+    zvol = _child(tier_pool["name"], "dedup_zvol")
+    call(
+        "pool.dataset.create",
+        {
+            "name": zvol,
+            "type": "VOLUME",
+            "volsize": 1048576,
+            "sparse": True,
+            "deduplication": "ON",
+        },
+    )
+    try:
+        row = call("pool.dataset.query", [["name", "=", zvol]], {"get": True})
+        assert row["deduplication"]["value"] == "ON"
+        assert row.get("tier") is None
+        # The update path is exempt for volumes too.
+        call("pool.dataset.update", zvol, {"deduplication": "VERIFY"})
+    finally:
+        call("pool.dataset.delete", zvol, {"recursive": True})
+
+
+# ----------------------------------------------------------------------------
+# zfs.tier.dataset_set_tier / rewrite_job_create refuse dedup'd datasets.
+# ----------------------------------------------------------------------------
+
+
+def test_set_tier_rejected_on_dedup_dataset(tier_pool):
+    with _dedup_dataset(tier_pool, "dedup_settier") as ds:
+        with pytest.raises(ValidationError) as ve:
+            call(
+                "zfs.tier.dataset_set_tier",
+                {"dataset_name": ds, "tier_type": "PERFORMANCE"},
+            )
+        assert ve.value.errno == errno.EINVAL
+        assert "deduplication" in ve.value.errmsg
+
+
+def test_rewrite_job_create_rejected_on_dedup_dataset(tier_pool):
+    with _dedup_dataset(tier_pool, "dedup_rw") as ds:
+        with pytest.raises(ValidationError) as ve:
+            call("zfs.tier.rewrite_job_create", {"dataset_name": ds})
+        assert ve.value.errno == errno.EINVAL
+        assert "deduplication" in ve.value.errmsg
+
+
+def test_tier_errors_prefer_pool_reason_without_special_vdev(tier_pool):
+    """On a pool without a SPECIAL vdev the tier APIs report the pool as the
+    reason even when the dataset is deduplicated — disabling deduplication
+    would not make such a dataset tierable."""
+    with dataset("dedup_no_special_msg", {"deduplication": "ON"}) as ds:
+        with pytest.raises(ValidationError) as ve:
+            call(
+                "zfs.tier.dataset_set_tier",
+                {"dataset_name": ds, "tier_type": "PERFORMANCE"},
+            )
+        assert ve.value.errno == errno.EINVAL
+        assert "pool has no SPECIAL vdev" in ve.value.errmsg
+
+        with pytest.raises(ValidationError) as ve:
+            call("zfs.tier.rewrite_job_create", {"dataset_name": ds})
+        assert ve.value.errno == errno.EINVAL
+        assert "pool has no SPECIAL vdev" in ve.value.errmsg

--- a/tests/api2/zfs_tier/test_jobs_extended.py
+++ b/tests/api2/zfs_tier/test_jobs_extended.py
@@ -24,17 +24,18 @@ _FAKE_JOB_ID = "tank/nonexistent@00000000-0000-0000-0000-000000000000"
 
 
 def _stage_pending_rewrite(ds):
-    """Set tier=PERFORMANCE, create 5000 1MiB files (blocks land on SPECIAL),
+    """Set tier=PERFORMANCE, create 200 1MiB files (blocks land on SPECIAL),
     then flip tier=REGULAR (special_small_blocks=0). Every block is now on
-    SPECIAL but policy says NORMAL — a rewrite must walk all 5000 inodes
-    and move every block. Per-file callbacks flush LMDB state on the
-    daemon's 1s stats_flush_interval cadence."""
+    SPECIAL but policy says NORMAL — a rewrite must walk all 200 inodes and
+    move every block. With the slow-rewrite sentinel active the job stays
+    alive for at least 200 * SLOW_REWRITE_DELAY_MS, and the staged data is
+    small enough not to pressure the pool's space thresholds."""
     call(
         "zfs.tier.dataset_set_tier",
         {"dataset_name": ds, "tier_type": "PERFORMANCE"},
     )
     ssh(
-        f"cd /mnt/{ds} && seq 1 5000 | "
+        f"cd /mnt/{ds} && seq 1 200 | "
         "xargs -P 16 -I X dd if=/dev/urandom of=fX bs=1M count=1 2>/dev/null"
     )
     call(
@@ -113,93 +114,77 @@ def test_rewrite_job_cancel_invalid_id_format_raises_callerror():
 
 
 def test_rewrite_job_query_multiple_status_filter_includes_active(
-    tier_pool, wait_for_job_status
+    make_tier_ds, slow_rewrite, wait_for_job_status
 ):
     """Filtering with a list of statuses (including the active job's actual
     status) should include the active job."""
-    ds1 = f"{tier_pool['name']}/jq_multi1_{time.monotonic_ns()}"
-    ds2 = f"{tier_pool['name']}/jq_multi2_{time.monotonic_ns()}"
-    call("pool.dataset.create", {"name": ds1})
-    call("pool.dataset.create", {"name": ds2})
-    try:
-        _stage_pending_rewrite(ds1)
-        _stage_pending_rewrite(ds2)
-        e1 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds1})
-        e2 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds2})
+    ds1 = make_tier_ds("jq_multi1")
+    ds2 = make_tier_ds("jq_multi2")
+    _stage_pending_rewrite(ds1)
+    _stage_pending_rewrite(ds2)
+    e1 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds1})
+    e2 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds2})
 
-        # Wait until the daemon has written initial LMDB state for both.
-        all_statuses = {
-            "QUEUED",
-            "RUNNING",
-            "COMPLETE",
-            "CANCELLED",
-            "STOPPED",
-            "ERROR",
-        }
-        wait_for_job_status(e1["tier_job_id"], all_statuses, timeout=30)
-        wait_for_job_status(e2["tier_job_id"], all_statuses, timeout=30)
+    # Wait until the daemon has written initial LMDB state for both.
+    all_statuses = {
+        "QUEUED",
+        "RUNNING",
+        "COMPLETE",
+        "CANCELLED",
+        "STOPPED",
+        "ERROR",
+    }
+    wait_for_job_status(e1["tier_job_id"], all_statuses, timeout=30)
+    wait_for_job_status(e2["tier_job_id"], all_statuses, timeout=30)
 
-        active = call(
-            "zfs.tier.rewrite_job_query",
-            {"status": ["QUEUED", "RUNNING", "COMPLETE"]},
-        )
-        ids = {j["tier_job_id"] for j in active}
-        assert e1["tier_job_id"] in ids
-        assert e2["tier_job_id"] in ids
+    active = call(
+        "zfs.tier.rewrite_job_query",
+        {"status": ["QUEUED", "RUNNING", "COMPLETE"]},
+    )
+    ids = {j["tier_job_id"] for j in active}
+    assert e1["tier_job_id"] in ids
+    assert e2["tier_job_id"] in ids
 
-        cancelled_only = call("zfs.tier.rewrite_job_query", {"status": ["CANCELLED"]})
-        cancelled_ids = {j["tier_job_id"] for j in cancelled_only}
-        assert e1["tier_job_id"] not in cancelled_ids
-        assert e2["tier_job_id"] not in cancelled_ids
-    finally:
-        for ds in (ds1, ds2):
-            try:
-                call("pool.dataset.delete", ds, {"recursive": True})
-            except Exception:
-                pass
+    cancelled_only = call("zfs.tier.rewrite_job_query", {"status": ["CANCELLED"]})
+    cancelled_ids = {j["tier_job_id"] for j in cancelled_only}
+    assert e1["tier_job_id"] not in cancelled_ids
+    assert e2["tier_job_id"] not in cancelled_ids
 
 
-def test_rewrite_job_query_pagination_via_query_options(tier_pool, wait_for_job_status):
+def test_rewrite_job_query_pagination_via_query_options(
+    make_tier_ds, slow_rewrite, wait_for_job_status
+):
     """rewrite_job_query honors the standard query-options pagination."""
-    ds1 = f"{tier_pool['name']}/jq_page1_{time.monotonic_ns()}"
-    ds2 = f"{tier_pool['name']}/jq_page2_{time.monotonic_ns()}"
-    call("pool.dataset.create", {"name": ds1})
-    call("pool.dataset.create", {"name": ds2})
-    try:
-        _stage_pending_rewrite(ds1)
-        _stage_pending_rewrite(ds2)
-        e1 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds1})
-        e2 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds2})
-        all_statuses = {
-            "QUEUED",
-            "RUNNING",
-            "COMPLETE",
-            "CANCELLED",
-            "STOPPED",
-            "ERROR",
-        }
-        wait_for_job_status(e1["tier_job_id"], all_statuses, timeout=30)
-        wait_for_job_status(e2["tier_job_id"], all_statuses, timeout=30)
+    ds1 = make_tier_ds("jq_page1")
+    ds2 = make_tier_ds("jq_page2")
+    _stage_pending_rewrite(ds1)
+    _stage_pending_rewrite(ds2)
+    e1 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds1})
+    e2 = call("zfs.tier.rewrite_job_create", {"dataset_name": ds2})
+    all_statuses = {
+        "QUEUED",
+        "RUNNING",
+        "COMPLETE",
+        "CANCELLED",
+        "STOPPED",
+        "ERROR",
+    }
+    wait_for_job_status(e1["tier_job_id"], all_statuses, timeout=30)
+    wait_for_job_status(e2["tier_job_id"], all_statuses, timeout=30)
 
-        page_one = call(
-            "zfs.tier.rewrite_job_query",
-            {"query-options": {"limit": 1, "offset": 0}},
-        )
-        assert len(page_one) <= 1
+    page_one = call(
+        "zfs.tier.rewrite_job_query",
+        {"query-options": {"limit": 1, "offset": 0}},
+    )
+    assert len(page_one) <= 1
 
-        all_jobs = call("zfs.tier.rewrite_job_query", {})
-        # Sanity: with limit unspecified, both should show
-        ids = {j["tier_job_id"] for j in all_jobs}
-        # The two we created should both be present
-        # (we don't assert on count because other jobs may exist)
-        # but limit=1 should have given us at most 1 row.
-        assert len(ids) >= 2
-    finally:
-        for ds in (ds1, ds2):
-            try:
-                call("pool.dataset.delete", ds, {"recursive": True})
-            except Exception:
-                pass
+    all_jobs = call("zfs.tier.rewrite_job_query", {})
+    # Sanity: with limit unspecified, both should show
+    ids = {j["tier_job_id"] for j in all_jobs}
+    # The two we created should both be present
+    # (we don't assert on count because other jobs may exist)
+    # but limit=1 should have given us at most 1 row.
+    assert len(ids) >= 2
 
 
 # ----------------------------------------------------------------------------

--- a/tests/api2/zfs_tier/test_set_tier_errors.py
+++ b/tests/api2/zfs_tier/test_set_tier_errors.py
@@ -66,13 +66,19 @@ def test_dataset_set_tier_readonly_rejected_with_erofs(tier_ds):
         call("pool.dataset.update", tier_ds, {"readonly": "OFF"})
 
 
-def test_dataset_set_tier_with_active_job_returns_ebusy(tier_ds_with_work):
+def test_dataset_set_tier_with_active_job_returns_ebusy(
+    tier_ds_with_work, wait_for_job_status
+):
     """If a tier job is already RUNNING or QUEUED for the dataset, set_tier
-    refuses with EBUSY (tier.py:576-584). tier_ds_with_work guarantees the
-    rewrite has real cross-class block movement to perform."""
+    refuses with EBUSY. tier_ds_with_work guarantees the rewrite has real
+    cross-class block movement to perform and stays active long enough."""
     entry = call("zfs.tier.rewrite_job_create", {"dataset_name": tier_ds_with_work})
 
     try:
+        # The EBUSY guard reads job state from LMDB, which the daemon only
+        # writes shortly after rewrite_job_create returns; wait until the
+        # job is visibly active before asserting the guard trips.
+        wait_for_job_status(entry["tier_job_id"], {"QUEUED", "RUNNING"}, timeout=30)
         with pytest.raises(ValidationError) as ve:
             call(
                 "zfs.tier.dataset_set_tier",

--- a/tests/api2/zfs_tier/test_smoke.py
+++ b/tests/api2/zfs_tier/test_smoke.py
@@ -92,12 +92,12 @@ def test_dataset_set_tier_regular(tier_ds):
     assert props[0]["properties"]["special_small_blocks"]["value"] == 0
 
 
-def test_dataset_set_tier_with_migration(tier_ds):
-    # Many MiB-sized files keep the rewrite walker busy long enough for
-    # the event source's 5s poll cycle to fire and for per-file callbacks
-    # to flush LMDB state.
+def test_dataset_set_tier_with_migration(tier_ds, slow_rewrite):
+    # The slow-rewrite sentinel keeps the migration job alive long enough
+    # for the event source's 5s poll cycle to fire and for per-file
+    # callbacks to flush LMDB state; the files give it real work.
     ssh(
-        f"cd /mnt/{tier_ds} && seq 1 5000 | "
+        f"cd /mnt/{tier_ds} && seq 1 200 | "
         "xargs -P 16 -I X dd if=/dev/urandom of=fX bs=1M count=1 2>/dev/null"
     )
 


### PR DESCRIPTION
Deduplicated datasets are excluded from tiering: they report a null tier, and dataset_set_tier and rewrite_job_create reject them.

Enabling dedup (ON/VERIFY) is refused only when a dataset's data is on the SPECIAL vdev, i.e. the PERFORMANCE tier (special_small_blocks > 0). REGULAR datasets, volumes, and pools without a SPECIAL vdev may be deduplicated freely.

Original PR: https://github.com/truenas/middleware/pull/19336
