### PR TITLE
NAS-141968 / 27.0.0-BETA.1 / Scan every dataset in a pool for open files, not just the pool root

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -54,13 +54,18 @@ class PoolDatasetService(Service):
         need_restart_services = []
         need_stop_services = []
         midpid = os.getpid()
+        # a service usually owns many of the matched processes (e.g. one smbd per
+        # client), so each one is only worth classifying once
+        restartable = {
+            attachment_delegate.service
+            for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
+        }
+        seen_services = set()
         for process in await processes_using_dataset_tree(self.context, oid):
             service = process.get('service')
-            if service is not None and service not in need_restart_services + need_stop_services:
-                if any(
-                    attachment_delegate.service == service
-                    for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
-                ):
+            if service is not None and service not in seen_services:
+                seen_services.add(service)
+                if service in restartable:
                     need_restart_services.append(service)
                 else:
                     need_stop_services.append(service)
@@ -77,8 +82,7 @@ class PoolDatasetService(Service):
             if not processes:
                 return
 
-            # a service usually owns many of the matched processes (e.g. one smbd per
-            # client), so control it once per pass rather than once per PID
+            # likewise control a service once per pass rather than once per PID
             controlled_services = set()
             for process in processes:
                 if process['pid'] == midpid:
@@ -93,10 +97,7 @@ class PoolDatasetService(Service):
                     if service in controlled_services:
                         continue
                     controlled_services.add(service)
-                    if any(
-                        attachment_delegate.service == service
-                        for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
-                    ):
+                    if service in restartable:
                         self.logger.info('Restarting service %r that holds dataset %r', service, oid)
                         await (await self.call2(self.s.service.control, 'RESTART', service)).wait(raise_error=True)
                     else:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -8,6 +8,7 @@ from middlewared.api.current import PoolDatasetProcessesArgs, PoolDatasetProcess
 from middlewared.plugins.zfs_.utils import zvol_name_to_path
 from middlewared.service import CallError, Service, private
 
+from .dataset_processes_utils import processes_using_dataset_tree
 from .utils import dataset_mountpoint
 
 RE_ZD = re.compile(r'^/dev/zd[0-9]+$')
@@ -53,7 +54,7 @@ class PoolDatasetService(Service):
         need_restart_services = []
         need_stop_services = []
         midpid = os.getpid()
-        for process in await self.middleware.call('pool.dataset.processes', oid):
+        for process in await processes_using_dataset_tree(self.context, oid):
             service = process.get('service')
             if service is not None:
                 if any(
@@ -72,7 +73,7 @@ class PoolDatasetService(Service):
             })
 
         for i in range(max_tries):
-            processes = await self.middleware.call('pool.dataset.processes', oid)
+            processes = await processes_using_dataset_tree(self.context, oid)
             if not processes:
                 return
 
@@ -103,7 +104,7 @@ class PoolDatasetService(Service):
                     except CallError as e:
                         self.logger.warning('Error killing process: %r', e)
 
-        processes = await self.middleware.call('pool.dataset.processes', oid)
+        processes = await processes_using_dataset_tree(self.context, oid)
         if not processes:
             return
 
@@ -126,7 +127,9 @@ class PoolDatasetService(Service):
         These are not included by default.
         """
         exact_matches = set()
-        include_devs = []
+        # A pool-wide scan passes one path per dataset, and this is tested against every open
+        # file descriptor on the system, so keep the lookup O(1)
+        include_devs = set()
         for path in paths:
             if RE_ZD.match(path):
                 exact_matches.add(path)
@@ -140,7 +143,7 @@ class PoolDatasetService(Service):
                         else:
                             exact_matches.add(os.path.realpath(path))
                     else:
-                        include_devs.append(os.stat(path).st_dev)
+                        include_devs.add(os.stat(path).st_dev)
                 except FileNotFoundError:
                     continue
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -56,7 +56,7 @@ class PoolDatasetService(Service):
         midpid = os.getpid()
         for process in await processes_using_dataset_tree(self.context, oid):
             service = process.get('service')
-            if service is not None:
+            if service is not None and service not in need_restart_services + need_stop_services:
                 if any(
                     attachment_delegate.service == service
                     for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
@@ -77,6 +77,9 @@ class PoolDatasetService(Service):
             if not processes:
                 return
 
+            # a service usually owns many of the matched processes (e.g. one smbd per
+            # client), so control it once per pass rather than once per PID
+            controlled_services = set()
             for process in processes:
                 if process['pid'] == midpid:
                     self.logger.warning(
@@ -87,6 +90,9 @@ class PoolDatasetService(Service):
 
                 service = process.get('service')
                 if service is not None:
+                    if service in controlled_services:
+                        continue
+                    controlled_services.add(service)
                     if any(
                         attachment_delegate.service == service
                         for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
@@ -144,7 +150,9 @@ class PoolDatasetService(Service):
                             exact_matches.add(os.path.realpath(path))
                     else:
                         include_devs.add(os.stat(path).st_dev)
-                except FileNotFoundError:
+                except OSError:
+                    # ENOENT for a vanished mountpoint, but also e.g. EIO from a faulted
+                    # pool; skip the path rather than abort the whole scan
                     continue
 
         result = []

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -121,7 +121,7 @@ class PoolDatasetService(Service):
         })
 
     @private
-    def processes_using_paths(self, paths, include_paths=False, include_middleware=False):
+    def processes_using_paths(self, paths, include_paths=False, include_middleware=False, devices=None):
         """
         Find processes using paths supplied via `paths`. Path may be an absolute path for
         a directory (e.g. /var/db/system) or a path in /dev/zvol or /dev/zd*
@@ -131,11 +131,15 @@ class PoolDatasetService(Service):
 
         `include_middleware`: include files opened by the middlewared process in output.
         These are not included by default.
+
+        `devices`: device ids to match directly, for callers that already know them.
+        Preferred over passing a mountpoint, which has to be stat'ed and so resolves
+        whatever is mounted topmost at that path rather than the filesystem intended.
         """
         exact_matches = set()
-        # A pool-wide scan passes one path per dataset, and this is tested against every open
-        # file descriptor on the system, so keep the lookup O(1)
-        include_devs = set()
+        # A pool-wide scan passes one entry per dataset, and this is tested against every
+        # open file descriptor on the system, so keep the lookup O(1)
+        include_devs: set[int] = set(devices or ())
         for path in paths:
             if RE_ZD.match(path):
                 exact_matches.add(path)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -154,9 +154,14 @@ class PoolDatasetService(Service):
                             exact_matches.add(os.path.realpath(path))
                     else:
                         include_devs.add(os.stat(path).st_dev)
+                except FileNotFoundError:
+                    # the path went away while we were looking at it, nothing holds it
+                    continue
                 except OSError:
-                    # ENOENT for a vanished mountpoint, but also e.g. EIO from a faulted
-                    # pool; skip the path rather than abort the whole scan
+                    # e.g. EIO from a faulted pool. Skip the path rather than abort the
+                    # whole scan, but say so: holders on it are now invisible, and the
+                    # caller would otherwise read the result as "nothing is using this"
+                    self.logger.warning('%s: cannot scan path for open files', path, exc_info=True)
                     continue
 
         result = []

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from truenas_os_pyutils.mount import iter_mountinfo
 
+from middlewared.api.current import ZFSResourceQuery
 from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs_.utils import zvol_name_to_path
 from middlewared.service import ServiceContext
@@ -61,13 +62,13 @@ async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[d
     paths = await ctx.to_thread(mounted_pool_paths, name)
 
     # Zvols are block devices rather than mounts, so mountinfo knows nothing about
-    # them and they have to be collected from ZFS itself
-    for ds in await ctx.middleware.call(
-        "pool.dataset.query",
-        [["OR", [["id", "=", name], ["id", "^", f"{name}/"]]]],
-        {"extra": {"properties": ["keystatus"], "retrieve_children": False}},
+    # them and they have to be collected from ZFS itself. Only their names matter,
+    # hence no properties: a zvol with no device node yet is simply never matched.
+    for rsrc in await ctx.call2(
+        ctx.s.zfs.resource.query_impl,
+        ZFSResourceQuery(paths=[name], properties=None, get_children=True),
     ):
-        if ds["type"] == "VOLUME" and not ds["locked"]:
-            paths.append(zvol_name_to_path(ds["name"]))
+        if rsrc["type"] == "VOLUME":
+            paths.append(zvol_name_to_path(rsrc["name"]))
 
     return await ctx.middleware.call("pool.dataset.processes_using_paths", paths)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from truenas_os_pyutils.mount import iter_mountinfo
 
 from middlewared.plugins.zfs.utils import has_internal_path
@@ -9,41 +11,56 @@ from middlewared.service import ServiceContext
 __all__ = ("processes_using_dataset_tree",)
 
 
-def mounted_pool_paths(name: str) -> list[str]:
-    """Mountpoints of everything mounted from `name` or a dataset beneath it.
+def pool_scan_targets(name: str) -> tuple[list[int], list[str]]:
+    """Device ids and paths to scan for open files under `name`.
 
-    Read from mountinfo rather than from the dataset list, because what blocks a
-    teardown is the mount tree, not the datasets. Only mounted filesystems appear
-    here, which is what the caller needs: an unmounted dataset holds no open files,
-    and its mountpoint directory, if one is even left behind, belongs to whichever
-    filesystem it sits on rather than to this pool. Datasets mounted somewhere other
-    than their default location are covered too.
+    The devices come from mountinfo rather than from the dataset list, because what
+    blocks a teardown is the mount tree, not the datasets. Only mounted filesystems
+    appear there, which is what the caller needs: an unmounted dataset holds no open
+    files, and its mountpoint directory, if one is even left behind, belongs to
+    whichever filesystem it sits on rather than to this pool. Datasets mounted
+    somewhere other than their default location are covered too.
+
+    Taking the device id straight from mountinfo also avoids stat'ing the mountpoint,
+    which resolves whatever is mounted topmost at that path. A dataset with a foreign
+    filesystem mounted over it would otherwise report the overmount's device and hide
+    its own holders.
 
     ZFS snapshot automounts under `.zfs/snapshot` are included: they are unmounted
     during a teardown like any other mount, so a process holding one open blocks an
     export just the same.
 
     Args:
-        name: Pool or dataset whose mount tree should be collected
+        name: Pool or dataset whose scan targets should be collected
 
     Returns:
-        Absolute mountpoint paths, excluding internal datasets and their snapshots
+        Device ids of the mounted filesystems, and paths for anything not represented
+        by a mount, excluding internal datasets and their snapshots
     """
     prefixes = (f"{name}/", f"{name}@")
-    paths = []
+    devices = []
     for mnt in iter_mountinfo(include_snapshot_mounts=True):
-        mountpoint, source = mnt["mountpoint"], mnt["mount_source"]
+        source = mnt["mount_source"]
         if (
             mnt["fs_type"] == "zfs"
-            and mountpoint is not None
             and source is not None
             and (source == name or source.startswith(prefixes))
             # strip any @snapshot suffix so snapshots of internal datasets stay excluded
             and not has_internal_path(source.split("@", 1)[0])
         ):
-            paths.append(mountpoint)
+            devices.append(mnt["device_id"]["dev_t"])
 
-    return paths
+    # Zvols are block devices rather than mounts, so mountinfo knows nothing about
+    # them. /dev/zvol mirrors the pool's zvol hierarchy and processes_using_paths
+    # walks a /dev/zvol directory recursively, so this one path covers every zvol
+    # device in the tree, snapshot devices included. Skip it when the pool has no
+    # zvols at all: a path that resolves to nothing still counts as something to
+    # match against, which costs a readlink on every open file descriptor scanned.
+    paths = []
+    if os.path.exists(zvol_path := zvol_name_to_path(name)):
+        paths.append(zvol_path)
+
+    return devices, paths
 
 
 async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[dict]:
@@ -67,13 +84,7 @@ async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[d
     Returns:
         Processes as reported by `pool.dataset.processes_using_paths`
     """
-    paths = await ctx.to_thread(mounted_pool_paths, name)
+    devices, paths = await ctx.to_thread(pool_scan_targets, name)
 
-    # Zvols are block devices rather than mounts, so mountinfo knows nothing about
-    # them. /dev/zvol mirrors the pool's zvol hierarchy and processes_using_paths
-    # walks a /dev/zvol directory recursively, so this one path covers every zvol
-    # device in the tree, snapshot devices included. A zvol with no device node
-    # yet is never matched, but it cannot be held open either.
-    paths.append(zvol_name_to_path(name))
-
-    return await ctx.middleware.call("pool.dataset.processes_using_paths", paths)
+    # positional args are paths, include_paths, include_middleware, devices
+    return await ctx.middleware.call("pool.dataset.processes_using_paths", paths, False, False, devices)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -30,18 +30,20 @@ def mounted_pool_paths(name: str) -> list[str]:
         Absolute mountpoint paths, excluding internal datasets and their snapshots
     """
     prefixes = (f"{name}/", f"{name}@")
-    return [
-        mnt["mountpoint"]
-        for mnt in iter_mountinfo(include_snapshot_mounts=True)
+    paths = []
+    for mnt in iter_mountinfo(include_snapshot_mounts=True):
+        mountpoint, source = mnt["mountpoint"], mnt["mount_source"]
         if (
             mnt["fs_type"] == "zfs"
-            and mnt["mountpoint"] is not None
-            and (source := mnt["mount_source"]) is not None
+            and mountpoint is not None
+            and source is not None
             and (source == name or source.startswith(prefixes))
             # strip any @snapshot suffix so snapshots of internal datasets stay excluded
             and not has_internal_path(source.split("@", 1)[0])
-        )
-    ]
+        ):
+            paths.append(mountpoint)
+
+    return paths
 
 
 async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[dict]:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -1,9 +1,40 @@
 from __future__ import annotations
 
+from truenas_os_pyutils.mount import iter_mountinfo
+
+from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs_.utils import zvol_name_to_path
 from middlewared.service import ServiceContext
 
 __all__ = ("processes_using_dataset_tree",)
+
+
+def mounted_pool_paths(name: str) -> list[str]:
+    """Mountpoints of everything mounted from `name` or a dataset beneath it.
+
+    Read from mountinfo rather than from the dataset list, because what blocks a
+    teardown is the mount tree, not the datasets. Only mounted filesystems appear
+    here, which is what the caller needs: an unmounted dataset holds no open files,
+    and its mountpoint directory, if one is even left behind, belongs to whichever
+    filesystem it sits on rather than to this pool. Datasets mounted somewhere other
+    than their default location are covered too.
+
+    Args:
+        name: Pool or dataset whose mount tree should be collected
+
+    Returns:
+        Absolute mountpoint paths, excluding internal datasets
+    """
+    prefix = f"{name}/"
+    return [
+        mnt["mountpoint"]
+        for mnt in iter_mountinfo()
+        if mnt["fs_type"] == "zfs"
+        and mnt["mountpoint"] is not None
+        and mnt["mount_source"] is not None
+        and (mnt["mount_source"] == name or mnt["mount_source"].startswith(prefix))
+        and not has_internal_path(mnt["mount_source"])
+    ]
 
 
 async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[dict]:
@@ -27,25 +58,16 @@ async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[d
     Returns:
         Processes as reported by `pool.dataset.processes_using_paths`
     """
-    paths = []
+    paths = await ctx.to_thread(mounted_pool_paths, name)
+
+    # Zvols are block devices rather than mounts, so mountinfo knows nothing about
+    # them and they have to be collected from ZFS itself
     for ds in await ctx.middleware.call(
         "pool.dataset.query",
         [["OR", [["id", "=", name], ["id", "^", f"{name}/"]]]],
-        # `keystatus` is what populates `locked`. `mountpoint` is deliberately not
-        # requested: left out, it is reported as the live mount state (`null` when the
-        # dataset is not mounted) rather than as the ZFS property, which still holds a
-        # path. Only the mount state is usable here. An unmounted dataset has no open
-        # files by definition, and stat'ing its leftover mountpoint directory would
-        # report the device id of whichever filesystem that directory sits on -- the
-        # boot environment's /mnt dataset for an unmounted pool root -- so every match
-        # against it would be a process that has nothing to do with this pool.
         {"extra": {"properties": ["keystatus"], "retrieve_children": False}},
     ):
-        if ds["locked"]:
-            continue
-        elif ds["type"] == "VOLUME":
+        if ds["type"] == "VOLUME" and not ds["locked"]:
             paths.append(zvol_name_to_path(ds["name"]))
-        elif ds["mountpoint"]:
-            paths.append(ds["mountpoint"])
 
     return await ctx.middleware.call("pool.dataset.processes_using_paths", paths)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from truenas_os_pyutils.mount import iter_mountinfo
 
-from middlewared.api.current import ZFSResourceQuery
 from middlewared.plugins.zfs.utils import has_internal_path
 from middlewared.plugins.zfs_.utils import zvol_name_to_path
 from middlewared.service import ServiceContext
@@ -20,21 +19,28 @@ def mounted_pool_paths(name: str) -> list[str]:
     filesystem it sits on rather than to this pool. Datasets mounted somewhere other
     than their default location are covered too.
 
+    ZFS snapshot automounts under `.zfs/snapshot` are included: they are unmounted
+    during a teardown like any other mount, so a process holding one open blocks an
+    export just the same.
+
     Args:
         name: Pool or dataset whose mount tree should be collected
 
     Returns:
-        Absolute mountpoint paths, excluding internal datasets
+        Absolute mountpoint paths, excluding internal datasets and their snapshots
     """
-    prefix = f"{name}/"
+    prefixes = (f"{name}/", f"{name}@")
     return [
         mnt["mountpoint"]
-        for mnt in iter_mountinfo()
-        if mnt["fs_type"] == "zfs"
-        and mnt["mountpoint"] is not None
-        and mnt["mount_source"] is not None
-        and (mnt["mount_source"] == name or mnt["mount_source"].startswith(prefix))
-        and not has_internal_path(mnt["mount_source"])
+        for mnt in iter_mountinfo(include_snapshot_mounts=True)
+        if (
+            mnt["fs_type"] == "zfs"
+            and mnt["mountpoint"] is not None
+            and (source := mnt["mount_source"]) is not None
+            and (source == name or source.startswith(prefixes))
+            # strip any @snapshot suffix so snapshots of internal datasets stay excluded
+            and not has_internal_path(source.split("@", 1)[0])
+        )
     ]
 
 
@@ -47,10 +53,10 @@ async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[d
     open is invisible to it. Anything acting on a whole pool has to scan the entire
     tree, otherwise a busy child is missed and the pool fails to export.
 
-    Internal datasets are left out, as they are by any other dataset query. Their
-    consumers are shut down separately (the attachment delegates for apps, the
-    `pool.pre_export` hook for the system dataset), and treating them as ordinary
-    datasets here would mean killing processes that hold the system dataset open.
+    Internal datasets are left out of the mount scan. Their consumers are shut down
+    separately (the attachment delegates for apps, the `pool.pre_export` hook for
+    the system dataset), and treating them as ordinary datasets here would mean
+    killing processes that hold the system dataset open.
 
     Args:
         ctx: Service context
@@ -62,13 +68,10 @@ async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[d
     paths = await ctx.to_thread(mounted_pool_paths, name)
 
     # Zvols are block devices rather than mounts, so mountinfo knows nothing about
-    # them and they have to be collected from ZFS itself. Only their names matter,
-    # hence no properties: a zvol with no device node yet is simply never matched.
-    for rsrc in await ctx.call2(
-        ctx.s.zfs.resource.query_impl,
-        ZFSResourceQuery(paths=[name], properties=None, get_children=True),
-    ):
-        if rsrc["type"] == "VOLUME":
-            paths.append(zvol_name_to_path(rsrc["name"]))
+    # them. /dev/zvol mirrors the pool's zvol hierarchy and processes_using_paths
+    # walks a /dev/zvol directory recursively, so this one path covers every zvol
+    # device in the tree, snapshot devices included. A zvol with no device node
+    # yet is never matched, but it cannot be held open either.
+    paths.append(zvol_name_to_path(name))
 
     return await ctx.middleware.call("pool.dataset.processes_using_paths", paths)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes_utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from middlewared.plugins.zfs_.utils import zvol_name_to_path
+from middlewared.service import ServiceContext
+
+__all__ = ("processes_using_dataset_tree",)
+
+
+async def processes_using_dataset_tree(ctx: ServiceContext, name: str) -> list[dict]:
+    """Find processes with open files on a dataset or on any dataset beneath it.
+
+    `pool.dataset.processes` only covers the single dataset it is given. It matches
+    open files by the device id of the scanned mountpoint, and every ZFS dataset is a
+    separate filesystem with its own device id, so a process holding a child dataset
+    open is invisible to it. Anything acting on a whole pool has to scan the entire
+    tree, otherwise a busy child is missed and the pool fails to export.
+
+    Internal datasets are left out, as they are by any other dataset query. Their
+    consumers are shut down separately (the attachment delegates for apps, the
+    `pool.pre_export` hook for the system dataset), and treating them as ordinary
+    datasets here would mean killing processes that hold the system dataset open.
+
+    Args:
+        ctx: Service context
+        name: Dataset to scan along with all of its descendants
+
+    Returns:
+        Processes as reported by `pool.dataset.processes_using_paths`
+    """
+    paths = []
+    for ds in await ctx.middleware.call(
+        "pool.dataset.query",
+        [["OR", [["id", "=", name], ["id", "^", f"{name}/"]]]],
+        # `keystatus` is what populates `locked`. `mountpoint` is deliberately not
+        # requested: left out, it is reported as the live mount state (`null` when the
+        # dataset is not mounted) rather than as the ZFS property, which still holds a
+        # path. Only the mount state is usable here. An unmounted dataset has no open
+        # files by definition, and stat'ing its leftover mountpoint directory would
+        # report the device id of whichever filesystem that directory sits on -- the
+        # boot environment's /mnt dataset for an unmounted pool root -- so every match
+        # against it would be a process that has nothing to do with this pool.
+        {"extra": {"properties": ["keystatus"], "retrieve_children": False}},
+    ):
+        if ds["locked"]:
+            continue
+        elif ds["type"] == "VOLUME":
+            paths.append(zvol_name_to_path(ds["name"]))
+        elif ds["mountpoint"]:
+            paths.append(ds["mountpoint"])
+
+    return await ctx.middleware.call("pool.dataset.processes_using_paths", paths)

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -4,7 +4,7 @@ import shutil
 
 from middlewared.api import api_method
 from middlewared.api.current import PoolExportArgs, PoolExportResult
-from middlewared.service import CallError, Service, ValidationError, job, private
+from middlewared.service import CallError, Service, job, private
 from middlewared.utils.asyncio_ import asyncio_map
 from middlewared.utils.filesystem import attrs as fs_attrs
 
@@ -139,15 +139,7 @@ class PoolService(Service):
             await self.call2(self.s.keyvalue.delete, enable_on_import_key)
 
         job.set_progress(20, 'Terminating processes that are using this pool')
-        try:
-            await self.middleware.call('pool.dataset.kill_processes', pool['name'],
-                                       options.get('restart_services', False))
-        except ValidationError as e:
-            if e.errno == errno.ENOENT:
-                # Dataset might not exist (e.g. pool is not decrypted), this is not an error
-                pass
-            else:
-                raise
+        await self.middleware.call('pool.dataset.kill_processes', pool['name'], options.get('restart_services', False))
 
         await self.middleware.call('iscsi.global.terminate_luns_for_pool', pool['name'])
 

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -19,6 +19,8 @@ from middlewared.api.current import (
 from middlewared.plugins.zpool import get_zpool_disks_impl, get_zpool_features_impl, is_upgraded_impl
 from middlewared.service import Service, ValidationError, private
 
+from .dataset_processes_utils import processes_using_dataset_tree
+
 
 class PoolService(Service):
 
@@ -73,7 +75,7 @@ class PoolService(Service):
         pool = await self.middleware.call('pool.get_instance', oid)
         processes = []
         try:
-            processes = await self.middleware.call('pool.dataset.processes', pool['name'])
+            processes = await processes_using_dataset_tree(self.context, pool['name'])
         except ValidationError as e:
             if e.errno == errno.ENOENT:
                 # Dataset might not exist (e.g. not online), this is not an error

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -73,17 +73,7 @@ class PoolService(Service):
         Returns a list of running processes using this pool.
         """
         pool = await self.middleware.call('pool.get_instance', oid)
-        processes = []
-        try:
-            processes = await processes_using_dataset_tree(self.context, pool['name'])
-        except ValidationError as e:
-            if e.errno == errno.ENOENT:
-                # Dataset might not exist (e.g. not online), this is not an error
-                pass
-            else:
-                raise
-
-        return processes
+        return await processes_using_dataset_tree(self.context, pool['name'])
 
     @api_method(
         PoolGetDisksArgs,

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -1,5 +1,6 @@
 import contextlib
-import time
+import uuid
+from collections import namedtuple
 
 import pytest
 
@@ -9,6 +10,35 @@ from middlewared.test.integration.assets.pool import another_pool, dataset, pool
 import os
 import sys
 sys.path.append(os.getcwd())
+
+Holder = namedtuple('Holder', ['pid', 'cmdline'])
+
+
+@contextlib.contextmanager
+def file_held_open(path):
+    """Hold `path` open in a background process on the test system.
+
+    Yields the holder's pid and the cmdline it reports through /proc, once the file is
+    confirmed open. Readiness is polled rather than slept on, because interpreter
+    startup on a loaded box can outrun any constant we would pick. The holder sleeps
+    far longer than any caller needs and is killed on the way out, so its own timeout
+    never bounds the test.
+    """
+    marker = f'/tmp/holder_ready_{uuid.uuid4().hex}'
+    script = f'f = open("{path}", "w+"); open("{marker}", "w").close(); import time; time.sleep(600)'
+    out = ssh(
+        f"""python -c '{script}' > /dev/null 2>&1 & pid=$!; """
+        f"""for _ in $(seq 200); do [ -e {marker} ] && break; sleep 0.05; done; """
+        f"""[ -e {marker} ] && echo "$pid ready" || echo "$pid timeout" """
+    ).strip()
+
+    pid, status = out.split()
+    try:
+        assert pid.isdigit(), f'{pid!r} is not a digit'
+        assert status == 'ready', f'holder process never opened {path!r}'
+        yield Holder(pid=int(pid), cmdline=f'python -c {script}')
+    finally:
+        ssh(f'kill -9 {pid}; rm -f {marker}', check=False)
 
 
 @pytest.mark.parametrize("datasets,file_open_path,arg_path", [
@@ -40,47 +70,30 @@ sys.path.append(os.getcwd())
         lambda ssh: f'/dev/zvol/{pool}/test',
     ),
 ])
-def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
+def test__open_path_and_check_proc(datasets, file_open_path, arg_path):
     with contextlib.ExitStack() as stack:
         for name, data in datasets:
             stack.enter_context(dataset(name, data))
 
-        opened = False
-        try:
-            test_file = file_open_path
-            open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""")
-            open_pid = open_pid.strip()
-            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
-            opened = True
-
-            # spinning up python interpreter could take some time on busy system so sleep
-            # for a couple seconds to give it time
-            time.sleep(2)
-
-            # what the cmdline output is formatted to
-            cmdline = f"""python -c import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)"""
-
+        test_file = file_open_path
+        with file_held_open(test_file) as holder:
             # have to use websocket since the method being called is private
             res = call('pool.dataset.processes_using_paths', [arg_path(ssh)])
             assert len(res) == 1
 
             result = res[0]
-            assert result['pid'] == int(open_pid), f'{result["pid"]!r} does not match {open_pid!r}'
-            assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert result['pid'] == holder.pid, f'{result["pid"]!r} does not match {holder.pid!r}'
+            assert result['cmdline'] == holder.cmdline, f'{result["cmdline"]!r} does not match {holder.cmdline!r}'
             assert 'paths' not in result
 
             res = call('pool.dataset.processes_using_paths', [arg_path(ssh)], True)
             assert len(res) == 1
             result = res[0]
-            assert result['pid'] == int(open_pid), f'{result["pid"]!r} does not match {open_pid!r}'
-            assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert result['pid'] == holder.pid, f'{result["pid"]!r} does not match {holder.pid!r}'
+            assert result['cmdline'] == holder.cmdline, f'{result["cmdline"]!r} does not match {holder.cmdline!r}'
             assert 'paths' in result
             assert len(result['paths']) == 1
             assert result['paths'][0] == test_file if test_file.startswith('/mnt') else '/dev/zd0'
-
-        finally:
-            if opened:
-                ssh(f'kill -9 {open_pid}', check=False)
 
 
 @pytest.mark.parametrize("child,data,file_open_path", [
@@ -101,30 +114,17 @@ def test__pool_processes_finds_child_dataset(child, data, file_open_path):
         stack.enter_context(dataset('parent'))
         child_ds = stack.enter_context(dataset(child, data))
 
-        test_file = file_open_path(child_ds)
-        open_pid = None
-        try:
-            open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""").strip()
-            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
-
-            # spinning up python interpreter could take some time on busy system so sleep
-            # for a couple seconds to give it time
-            time.sleep(2)
-
+        with file_held_open(file_open_path(child_ds)) as holder:
             pool_id = call('pool.query', [['name', '=', pool]], {'get': True})['id']
             pool_wide = call('pool.processes', pool_id)
-            assert int(open_pid) in [proc['pid'] for proc in pool_wide], pool_wide
+            assert holder.pid in [proc['pid'] for proc in pool_wide], pool_wide
 
             if data is None:
                 # Scanning the pool root alone cannot see a file open on a child filesystem.
                 # Child zvols are exempt: the root scan resolves `/dev/zvol/<pool>` as a
                 # directory and walks every device node underneath it.
                 root_only = call('pool.dataset.processes', pool)
-                assert int(open_pid) not in [proc['pid'] for proc in root_only], root_only
-
-        finally:
-            if open_pid:
-                ssh(f'kill -9 {open_pid}', check=False)
+                assert holder.pid not in [proc['pid'] for proc in root_only], root_only
 
 
 def test__pool_export_kills_process_holding_child_dataset():
@@ -137,18 +137,5 @@ def test__pool_export_kills_process_holding_child_dataset():
         child = f'{temp_pool["name"]}/child'
         call('pool.dataset.create', {'name': child})
 
-        open_pid = None
-        try:
-            # sleep far longer than the export takes, so the file stays open unless the
-            # export's process scan finds and terminates the holder
-            open_pid = ssh(f"""python -c 'import time; f = open("/mnt/{child}/test_file", "w+"); time.sleep(600)' > /dev/null 2>&1 & echo $!""").strip()
-            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
-
-            # spinning up python interpreter could take some time on busy system so sleep
-            # for a couple seconds to give it time
-            time.sleep(2)
-
+        with file_held_open(f'/mnt/{child}/test_file'):
             call('pool.export', temp_pool['id'], {'destroy': True}, job=True)
-        finally:
-            if open_pid:
-                ssh(f'kill -9 {open_pid}', check=False)

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -32,7 +32,9 @@ def file_held_open(path):
         f"""[ -e {marker} ] && echo "$pid ready" || echo "$pid timeout" """
     ).strip()
 
-    pid, status = out.split()
+    # parse with partition, which cannot raise: the holder must be killed even if the
+    # echoed output is malformed
+    pid, _, status = out.partition(' ')
     try:
         assert pid.isdigit(), f'{pid!r} is not a digit'
         assert status == 'ready', f'holder process never opened {path!r}'
@@ -93,7 +95,10 @@ def test__open_path_and_check_proc(datasets, file_open_path, arg_path):
             assert result['cmdline'] == holder.cmdline, f'{result["cmdline"]!r} does not match {holder.cmdline!r}'
             assert 'paths' in result
             assert len(result['paths']) == 1
-            assert result['paths'][0] == test_file if test_file.startswith('/mnt') else '/dev/zd0'
+            # a zvol is reported by its resolved /dev/zd* device node rather than the
+            # /dev/zvol path it was opened through
+            expected_path = test_file if test_file.startswith('/mnt') else ssh(f'readlink -f {test_file}').strip()
+            assert result['paths'][0] == expected_path, result['paths']
 
 
 @pytest.mark.parametrize("child,data,file_open_path", [

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -81,3 +81,46 @@ def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
         finally:
             if opened:
                 ssh(f'kill -9 {open_pid}', check=False)
+
+
+@pytest.mark.parametrize("child,data,file_open_path", [
+    # A file on a child filesystem
+    ('parent/child', None, lambda ds: f'/mnt/{ds}/test_file'),
+    # A child zvol
+    ('parent/zvol', {'type': 'VOLUME', 'volsize': 1024 * 1024 * 100}, lambda ds: f'/dev/zvol/{ds}'),
+])
+def test__pool_processes_finds_child_dataset(child, data, file_open_path):
+    """
+    A pool-wide scan has to see processes holding a child dataset open.
+
+    Every ZFS dataset is a separate filesystem with its own device id, so scanning only the
+    pool root -- which is all `pool.dataset.processes` does -- never matches an open file on
+    a child filesystem, and `pool.export` then fails to unmount it.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(dataset('parent'))
+        child_ds = stack.enter_context(dataset(child, data))
+
+        test_file = file_open_path(child_ds)
+        open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""")
+        open_pid = open_pid.strip()
+        assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
+
+        try:
+            # spinning up python interpreter could take some time on busy system so sleep
+            # for a couple seconds to give it time
+            time.sleep(2)
+
+            pool_id = call('pool.query', [['name', '=', pool]], {'get': True})['id']
+            pool_wide = call('pool.processes', pool_id)
+            assert int(open_pid) in [proc['pid'] for proc in pool_wide], pool_wide
+
+            if data is None:
+                # Scanning the pool root alone cannot see a file open on a child filesystem.
+                # Child zvols are exempt: the root scan resolves `/dev/zvol/<pool>` as a
+                # directory and walks every device node underneath it.
+                root_only = call('pool.dataset.processes', pool)
+                assert int(open_pid) not in [proc['pid'] for proc in root_only], root_only
+
+        finally:
+            ssh(f'kill -9 {open_pid}', check=False)

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -2,9 +2,9 @@ import contextlib
 import time
 
 import pytest
-from pytest_dependency import depends
+
 from middlewared.test.integration.utils import call, ssh
-from middlewared.test.integration.assets.pool import dataset, pool
+from middlewared.test.integration.assets.pool import another_pool, dataset, pool
 
 import os
 import sys
@@ -102,11 +102,11 @@ def test__pool_processes_finds_child_dataset(child, data, file_open_path):
         child_ds = stack.enter_context(dataset(child, data))
 
         test_file = file_open_path(child_ds)
-        open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""")
-        open_pid = open_pid.strip()
-        assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
-
+        open_pid = None
         try:
+            open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""").strip()
+            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
+
             # spinning up python interpreter could take some time on busy system so sleep
             # for a couple seconds to give it time
             time.sleep(2)
@@ -123,4 +123,32 @@ def test__pool_processes_finds_child_dataset(child, data, file_open_path):
                 assert int(open_pid) not in [proc['pid'] for proc in root_only], root_only
 
         finally:
-            ssh(f'kill -9 {open_pid}', check=False)
+            if open_pid:
+                ssh(f'kill -9 {open_pid}', check=False)
+
+
+def test__pool_export_kills_process_holding_child_dataset():
+    """
+    `pool.export` must terminate a process holding a file open on a child dataset,
+    otherwise the export fails to unmount the child with EBUSY. This exercises the
+    full export path, not just the detection that `pool.processes` reports.
+    """
+    with another_pool() as temp_pool:
+        child = f'{temp_pool["name"]}/child'
+        call('pool.dataset.create', {'name': child})
+
+        open_pid = None
+        try:
+            # sleep far longer than the export takes, so the file stays open unless the
+            # export's process scan finds and terminates the holder
+            open_pid = ssh(f"""python -c 'import time; f = open("/mnt/{child}/test_file", "w+"); time.sleep(600)' > /dev/null 2>&1 & echo $!""").strip()
+            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
+
+            # spinning up python interpreter could take some time on busy system so sleep
+            # for a couple seconds to give it time
+            time.sleep(2)
+
+            call('pool.export', temp_pool['id'], {'destroy': True}, job=True)
+        finally:
+            if open_pid:
+                ssh(f'kill -9 {open_pid}', check=False)


### PR DESCRIPTION
## Problem

`pool.export` only scanned the pool's root dataset for processes with open files. Every ZFS dataset is a separate filesystem, so a process holding a file open on a child dataset was never detected. It was never stopped or restarted, and it never triggered the prompt asking whether services may be controlled, so the export went ahead and failed to unmount the busy child:

```
[EFAULT] cannot unmount '/mnt/<pool>/<child>': pool or dataset is busy
```

Passing `restart_services` did not help, because nothing was ever detected to restart.

This is long standing rather than a regression, and it reproduces on 25.10.x as well. On 26 it was masked until recently by a crash that fired earlier in the export job.

## Fix

The scan now covers every dataset in the pool, filesystems and zvols alike, rather than the root alone. The pool's mount tree is read from mountinfo and open files are matched by the device id each mount reports, rather than by stat'ing mountpoints, so a foreign filesystem mounted over a dataset's mountpoint cannot hide the dataset's own holders. Zvols are covered through the `/dev/zvol/<pool>` hierarchy, which is skipped when the pool has no zvols so that a pool with nothing to scan (e.g. offline) no longer walks every open file descriptor on the system. Paths that cannot be scanned are logged instead of skipped silently, and each service holding the dataset is classified once rather than once per PID. `pool.processes` uses the same scan, so the process list shown before an export is no longer limited to the root dataset either.

`iter_mountinfo()` raises `FileNotFoundError` if a mount is unmounted between `listmount(2)` and `statmount(2)`, and ZFS snapshot automounts expire on a timer, so the scan re-reads the mount table when that happens rather than working from a partial one.
