### PR TITLE
NAS-142099 / 27.0.0-BETA.1 / Remove unreferenced private methods from disk plugins

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info.py
@@ -211,10 +211,6 @@ class DiskService(Service):
         return f'disk/by-partuuid/{part}'
 
     @private
-    async def get_efi_part_type(self):
-        return 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
-
-    @private
     async def get_zfs_part_type(self):
         return '6a898cc3-1dd2-11b2-99a6-080020736631'
 

--- a/src/middlewared/middlewared/plugins/disk_/identify.py
+++ b/src/middlewared/middlewared/plugins/disk_/identify.py
@@ -1,11 +1,8 @@
-import re
-
 from middlewared.service import Service, private
 from middlewared.utils.disks import get_disks_with_identifiers
 
 
 class DiskService(Service):
-    RE_IDENTIFIER = re.compile(r'^\{(?P<type>.+?)\}(?P<value>.+)$')
 
     @private
     def device_to_identifier(self, name: str, disks: dict):
@@ -17,7 +14,6 @@ class DiskService(Service):
           - serial_lunid - for disk serial concatenated with the lunid
           - serial - disk serial
           - uuid - uuid of a ZFS GPT partition
-          - label - label name from geom label
           - devicename - name of the device if any other could not be used/found
 
         `disks` is value returned by `device.get_disks`. This can be passed to avoid collecting system
@@ -26,29 +22,3 @@ class DiskService(Service):
             str - identifier
         """
         return get_disks_with_identifiers([name], disks).get(name, '')
-
-    @private
-    async def identifier_to_device(self, ident, disks):
-        if not ident:
-            return None
-
-        search = self.RE_IDENTIFIER.search(ident)
-        if not search:
-            return None
-
-        tp = search.group('type')
-        value = search.group('value')
-        mapping = {'uuid': 'uuid', 'devicename': 'name', 'serial_lunid': 'serial_lunid', 'serial': 'serial'}
-        if tp not in mapping:
-            return None
-        elif tp == 'uuid':
-            partition = await self.middleware.call('disk.list_all_partitions', [['partition_uuid', '=', value]])
-            if partition:
-                return partition[0]['disk']
-        else:
-            disk = next(
-                (b for b in (
-                    disks or await self.middleware.call('device.get_disks')
-                ).values() if b[mapping[tp]] == value), None
-            )
-            return disk['name'] if disk else None

--- a/src/middlewared/middlewared/plugins/disk_/info.py
+++ b/src/middlewared/middlewared/plugins/disk_/info.py
@@ -27,12 +27,3 @@ class DiskService(Service):
             None
         )
         return part
-
-    @private
-    async def get_partition_uuid_from_name(self, part_type_name):
-        mapping = {
-            'freebsd-zfs': '516e7cba-6ecf-11d6-8ff8-00022d09712b',
-            'freebsd-swap': '516e7cb5-6ecf-11d6-8ff8-00022d09712b',
-            'freebsd-boot': '83bd6b9d-7f41-11dc-be0b-001560b84f0f',
-        }
-        return mapping.get(part_type_name)

--- a/src/middlewared/middlewared/plugins/disk_/retaste.py
+++ b/src/middlewared/middlewared/plugins/disk_/retaste.py
@@ -55,16 +55,6 @@ def retaste_disks_impl(disk_serials: set = None):
 class DiskService(Service):
 
     @private
-    def update_partition_table_quick(self, devnode):
-        """
-        Call the BLKRRPATH ioctl to update the partition table on a single dev node
-        Used by 'wipe'
-        """
-        errors = {}
-        taste_it(devnode, errors)
-        return errors
-
-    @private
     @job(lock='disk_retaste', lock_queue_size=1)
     def retaste(self, job, disks_serials: list[str] | None = None):
         job.set_progress(85, 'Retasting disks')


### PR DESCRIPTION
Removes four `@private` methods in the `disk` namespace that have no callers left in middleware, the test suites, or webui.

`disk.identifier_to_device` lost its last caller in June 2022 when `disk.sync_all` was optimized ([NAS-116484](https://ixsystems.atlassian.net/browse/NAS-116484)); an equivalent lookup lives in `disk_/sync.py` and is the one actually used. The other three are older leftovers: `disk.get_partition_uuid_from_name` maps FreeBSD partition-type names to GUIDs, `disk.get_efi_part_type` returns a constant nothing reads, and `disk.update_partition_table_quick` still documents itself as "Used by 'wipe'" although `wipe.py` no longer calls it.

Also drops the `label` identifier type from the `disk.device_to_identifier` docstring.
