### PR TITLE
NAS-142109 / 26.0.0-RC.1 / Protect the container dataset from user deletion

### DIFF
--- a/src/middlewared/middlewared/plugins/container/dataset.py
+++ b/src/middlewared/middlewared/plugins/container/dataset.py
@@ -1,8 +1,8 @@
-import os
+import errno
 
 from middlewared.api.current import ZFSResourceQuery
 from middlewared.service import CallError, private, Service
-from middlewared.plugins.pool_.utils import CreateImplArgs
+from middlewared.plugins.pool_.utils import CreateImplArgs, UpdateImplArgs
 from middlewared.utils.filesystem.perms import enforce_dir_perms
 
 from .utils import CONTAINER_DS_NAME, container_dataset, container_dataset_mountpoint
@@ -17,6 +17,64 @@ class ContainerService(Service):
         role_prefix = 'CONTAINER'
 
     @private
+    async def ensure_pool_mountpoint(self, pool):
+        """Repair the container dataset's custom mountpoint on `pool`.
+
+        The dataset is deliberately mounted outside the pool's own tree so it cannot be shared over
+        SMB, NFS, etc. by accident. That gets lost whenever the pool's mountpoints are reset: a pool
+        foreign to this system, a rollback to a release without containers, or someone running
+        `zfs inherit -r mountpoint`.
+
+        Nothing reads the rootfs location back out of ZFS, so the drift does not fail loudly. The
+        container simply comes up on an empty directory.
+
+        Returns whether the mountpoint property was rewritten.
+        """
+        main_dataset = container_dataset(pool)
+        # `container_dataset_mountpoint` returns the value without the pool's `/mnt` altroot, while
+        # the value ZFS reports back has it. Both forms are needed.
+        expected_prop = container_dataset_mountpoint(pool)
+        expected_path = f'/mnt{expected_prop}'
+
+        # Naming the dataset explicitly is load-bearing: it is an internal path, and `query_impl`
+        # only returns those when the caller asks for them by name.
+        resources = await self.call2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(paths=[main_dataset], properties=['mountpoint'])
+        )
+        if not resources:
+            return False
+
+        current = resources[0]['properties']['mountpoint']['value']
+        if current == expected_path:
+            return False
+
+        # Something may already be mounted where this dataset is about to move. Setting the
+        # mountpoint would stack ours on top and silently hide theirs, so refuse instead.
+        try:
+            statfs = await self.middleware.call('filesystem.statfs', expected_path)
+        except CallError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            # Path does not exist yet. ZFS creates it on mount.
+        else:
+            if statfs['dest'] == expected_path and statfs['source'] != main_dataset:
+                self.logger.error(
+                    '%s: not repairing mountpoint, %r is already the mountpoint of %r',
+                    main_dataset, expected_path, statfs['source'],
+                )
+                return False
+
+        await self.middleware.call(
+            'pool.dataset.update_impl',
+            UpdateImplArgs(name=main_dataset, zprops={'mountpoint': expected_prop})
+        )
+        self.logger.info(
+            '%s: reset mountpoint from %r to %r', main_dataset, current, expected_path
+        )
+        return True
+
+    @private
     async def ensure_datasets(self, pool):
         main_dataset = container_dataset(pool)
         main_dataset_mountpoint = container_dataset_mountpoint(pool)
@@ -26,20 +84,15 @@ class ContainerService(Service):
         existing_datasets = set()
         for dataset in await self.call2(
             self.s.zfs.resource.query_impl,
-            ZFSResourceQuery(paths=[main_dataset] + datasets, properties=['mountpoint'])
+            ZFSResourceQuery(paths=[main_dataset] + datasets, properties=None)
         ):
             if dataset['type'] != 'FILESYSTEM':
                 raise CallError(f'Expected dataset {dataset["name"]!r} to be FILESYSTEM, but it is {dataset["type"]}')
 
-            if dataset['name'] == main_dataset:
-                main_dataset_mountpoint_value = f'/mnt{main_dataset_mountpoint}'
-                if dataset['properties']['mountpoint']['value'] != main_dataset_mountpoint_value:
-                    raise CallError(
-                        f'Expected dataset {dataset["name"]} to have mountpoint of {main_dataset_mountpoint_value!r}, '
-                        f'but it is {dataset["properties"]["mountpoint"]["value"]!r}.'
-                    )
-
             existing_datasets.add(dataset['name'])
+
+        # Repair drifted mountpoints so the mount below lands in the right place.
+        await self.ensure_pool_mountpoint(pool)
 
         if main_dataset not in existing_datasets:
             await self.middleware.call(
@@ -56,8 +109,7 @@ class ContainerService(Service):
                 )
             )
 
-        if not await self.middleware.run_in_thread(os.path.ismount, f'/mnt{main_dataset_mountpoint}'):
-            await self.call2(self.s.zfs.resource.mount, main_dataset)
+        await self.call2(self.s.zfs.resource.mount, main_dataset)
 
         for dataset in datasets:
             if dataset not in existing_datasets:

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -98,7 +98,33 @@ class ContainerService(Service):
         start containers without ever migrating them.
         """
         await self.middleware.call('container.maybe_migrate_legacy')
+        await self.middleware.call('container.repair_pool_mountpoints')
         await self.middleware.call('container.start_on_boot')
+
+    @private
+    async def repair_pool_mountpoints(self):
+        """Repair the container dataset mountpoint on every pool hosting containers.
+
+        ``pool.import_pool`` and ``pool.reimport`` do this for the pool they import, but
+        ``pool.import_on_boot`` and the failover import never reset mountpoints at all, so on those
+        paths a drifted mountpoint goes unnoticed and the container starts on an empty directory.
+
+        Every pool with containers is covered, not just the autostart ones, so a later manual
+        ``container.start`` is safe too.
+        """
+        pools = {
+            container['dataset'].split('/')[0]
+            for container in await self.middleware.call('container.query')
+        }
+        for pool in sorted(pools):
+            try:
+                # A pool that is not imported simply has no container dataset to look at, so the
+                # query inside `ensure_pool_mountpoint` comes back empty and it does nothing.
+                await self.middleware.call('container.ensure_pool_mountpoint', pool)
+            except Exception:
+                self.logger.error(
+                    'Failed to repair container dataset mountpoint on %r', pool, exc_info=True
+                )
 
     @private
     async def start_on_boot(self):

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -9,7 +9,6 @@ from middlewared.api.current import (
     PoolReimportArgs, PoolReimportResult,
     ZFSResourceQuery,
 )
-from middlewared.plugins.container.utils import container_dataset, container_dataset_mountpoint
 from middlewared.plugins.pool_.utils import UpdateImplArgs
 from middlewared.service import CallError, InstanceNotFound, Service, ValidationError, job, private
 from middlewared.utils.filesystem import attrs as fs_attrs
@@ -32,8 +31,6 @@ class PoolService(Service):
         property. This usually happens when a zpool is foreign to
         TrueNAS or someone has unintentionally changed this property."""
         to_inherit = list()
-        container_mnt = container_dataset_mountpoint(pool_name)
-        container_ds = container_dataset(pool_name)
         for i in await self.call2(
             self.s.zfs.resource.query_impl,
             ZFSResourceQuery(paths=[pool_name], properties=['mountpoint'], max_depth=1, get_source=True)
@@ -63,21 +60,7 @@ class PoolService(Service):
                 # cause PVC's to not mount because "mountpoint=legacy" is expected.
                 continue
 
-            if i['name'] == container_ds:
-                if container_mnt != mntpnt.removeprefix('/mnt'):
-                    # TODO: fix the "removeprefix('/mnt')" logic. /mnt is altroot
-                    # set at the zpool but the container_dataset_mountpoint function
-                    # returns the mountpoint without it. Makes using it confusing
-                    # and non-obvious.
-                    # This dataset gets a custom mountpoint so user cannot
-                    # unintentionally share it via SMB, NFS, etc.
-                    await self.middleware.call(
-                        'pool.dataset.update_impl',
-                        UpdateImplArgs(name=i['name'], zprops={'mountpoint': container_mnt})
-                    )
-
-                # We do not do anything if the mountpoint is already correct
-            elif mntpnt != f'/mnt/{i["name"]}':
+            if mntpnt != f'/mnt/{i["name"]}':
                 to_inherit.append(i["name"])
 
         if to_inherit:
@@ -97,6 +80,16 @@ class PoolService(Service):
                     )
                 except Exception:
                     self.logger.exception('Failed inheriting mountpoint property for %r', i.name)
+
+        # The container dataset keeps a custom mountpoint and is an internal path, so neither the
+        # first-level query nor the inherit walk above ever sees it. Repair it by name instead.
+        # Nothing here may escape: the caller is midway through an import, and an exception would
+        # abort it after the pool is already imported at the ZFS layer but before it is recorded
+        # in the database.
+        try:
+            await self.middleware.call('container.ensure_pool_mountpoint', pool_name)
+        except Exception:
+            self.logger.exception('Failed repairing container dataset mountpoint for %r', pool_name)
 
     @api_method(PoolImportFindArgs, PoolImportFindResult, roles=['POOL_READ'])
     @job()

--- a/src/middlewared/middlewared/plugins/zfs/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs/utils.py
@@ -21,6 +21,10 @@ INTERNAL_PATHS = (
     "ix-apps",
     "ix-applications",
     ".system",
+    # Kept in sync with `middlewared.plugins.container.utils.CONTAINER_DS_NAME` by a unit test
+    # rather than imported: this module sits on the zfs query hot path and the zfs layer should
+    # not reach into a plugin package ("ix-apps" is likewise a literal here).
+    ".truenas_containers",
 )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/container/test_ensure_pool_mountpoint.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container/test_ensure_pool_mountpoint.py
@@ -1,0 +1,123 @@
+import errno
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from middlewared.plugins.container.dataset import ContainerService
+from middlewared.pytest.unit.helpers import create_service
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service_exception import CallError
+
+
+POOL = "tank"
+DATASET = f"{POOL}/.truenas_containers"
+# The property is stored without the pool's /mnt altroot; ZFS reports it back with.
+EXPECTED_PROP = f"/.truenas_containers/{POOL}"
+EXPECTED_PATH = f"/mnt{EXPECTED_PROP}"
+DRIFTED_PATH = f"/mnt/{POOL}/.truenas_containers"
+
+
+def resource(mountpoint):
+    return {
+        "name": DATASET,
+        "type": "FILESYSTEM",
+        "properties": {"mountpoint": {"value": mountpoint}},
+    }
+
+
+def make_service(*, resources, statfs=None):
+    m = Middleware()
+    m.services.zfs.resource.query_impl = Mock(return_value=resources)
+    if isinstance(statfs, Exception):
+        m["filesystem.statfs"] = AsyncMock(side_effect=statfs)
+    else:
+        m["filesystem.statfs"] = AsyncMock(return_value=statfs)
+    m["pool.dataset.update_impl"] = AsyncMock()
+    return create_service(m, ContainerService), m
+
+
+@pytest.mark.asyncio
+async def test_noop_when_dataset_absent():
+    svc, m = make_service(resources=[])
+
+    assert await svc.ensure_pool_mountpoint(POOL) is False
+    m["pool.dataset.update_impl"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_mountpoint_correct():
+    svc, m = make_service(resources=[resource(EXPECTED_PATH)])
+
+    assert await svc.ensure_pool_mountpoint(POOL) is False
+    m["pool.dataset.update_impl"].assert_not_called()
+    m["filesystem.statfs"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repairs_drifted_mountpoint():
+    svc, m = make_service(
+        resources=[resource(DRIFTED_PATH)],
+        statfs=CallError("Path not found.", errno.ENOENT),
+    )
+
+    assert await svc.ensure_pool_mountpoint(POOL) is True
+    m["pool.dataset.update_impl"].assert_called_once_with({"name": DATASET, "zprops": {"mountpoint": EXPECTED_PROP}})
+
+
+@pytest.mark.asyncio
+async def test_repairs_when_expected_path_is_not_a_mount_root():
+    # statfs described the filesystem *containing* the path, not a mount at it.
+    svc, m = make_service(
+        resources=[resource(DRIFTED_PATH)],
+        statfs={"dest": "/mnt", "source": POOL},
+    )
+
+    assert await svc.ensure_pool_mountpoint(POOL) is True
+    m["pool.dataset.update_impl"].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_repairs_when_already_mounted_by_us():
+    svc, m = make_service(
+        resources=[resource(DRIFTED_PATH)],
+        statfs={"dest": EXPECTED_PATH, "source": DATASET},
+    )
+
+    assert await svc.ensure_pool_mountpoint(POOL) is True
+    m["pool.dataset.update_impl"].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refuses_to_overmount_foreign_dataset():
+    svc, m = make_service(
+        resources=[resource(DRIFTED_PATH)],
+        statfs={"dest": EXPECTED_PATH, "source": "dozer/.truenas_containers"},
+    )
+
+    assert await svc.ensure_pool_mountpoint(POOL) is False
+    m["pool.dataset.update_impl"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_statfs_error_other_than_enoent_propagates():
+    svc, m = make_service(
+        resources=[resource(DRIFTED_PATH)],
+        statfs=CallError("Permission denied.", errno.EACCES),
+    )
+
+    with pytest.raises(CallError):
+        await svc.ensure_pool_mountpoint(POOL)
+
+    m["pool.dataset.update_impl"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_queries_by_explicit_container_path():
+    # The container dataset is an internal path, so query_impl only returns it when it is named
+    # explicitly. Querying the pool instead would silently disable the whole repair.
+    svc, m = make_service(resources=[resource(EXPECTED_PATH)])
+
+    await svc.ensure_pool_mountpoint(POOL)
+
+    query = m.services.zfs.resource.query_impl.call_args.args[0]
+    assert query.paths == [DATASET]

--- a/src/middlewared/middlewared/pytest/unit/plugins/container/test_repair_pool_mountpoints.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container/test_repair_pool_mountpoints.py
@@ -1,0 +1,61 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from middlewared.plugins.container.lifecycle import ContainerService
+from middlewared.pytest.unit.helpers import create_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+def container(dataset, id_=1):
+    return {"id": id_, "name": f"c{id_}", "dataset": dataset}
+
+
+def make_service(containers, ensure_side_effect=None):
+    m = Middleware()
+    m["container.query"] = AsyncMock(return_value=containers)
+    m["container.ensure_pool_mountpoint"] = AsyncMock(side_effect=ensure_side_effect)
+    return create_service(m, ContainerService), m
+
+
+def repaired_pools(m):
+    return [call.args[0] for call in m["container.ensure_pool_mountpoint"].call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_derives_distinct_pools():
+    svc, m = make_service(
+        [
+            container("tank/.truenas_containers/containers/a", 1),
+            container("tank/.truenas_containers/containers/b", 2),
+            container("dozer/.truenas_containers/containers/c", 3),
+        ]
+    )
+
+    await svc.repair_pool_mountpoints()
+
+    assert repaired_pools(m) == ["dozer", "tank"]
+
+
+@pytest.mark.asyncio
+async def test_one_pool_failure_does_not_stop_the_rest():
+    svc, m = make_service(
+        [
+            container("dozer/.truenas_containers/containers/a", 1),
+            container("tank/.truenas_containers/containers/b", 2),
+        ],
+        ensure_side_effect=[Exception("boom"), None],
+    )
+
+    await svc.repair_pool_mountpoints()
+
+    assert repaired_pools(m) == ["dozer", "tank"]
+
+
+@pytest.mark.asyncio
+async def test_no_containers_is_a_noop():
+    svc, m = make_service([])
+
+    await svc.repair_pool_mountpoints()
+
+    m["container.ensure_pool_mountpoint"].assert_not_called()

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_zfs_internal_paths.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_zfs_internal_paths.py
@@ -1,0 +1,38 @@
+import pytest
+
+from middlewared.plugins.container.utils import CONTAINER_DS_NAME
+from middlewared.plugins.zfs.utils import INTERNAL_PATHS, has_internal_path
+
+
+def test_container_dataset_name_is_internal():
+    # INTERNAL_PATHS spells the container dataset name out rather than importing it, so that the
+    # zfs layer does not depend on a plugin package. This keeps the two from drifting apart.
+    assert CONTAINER_DS_NAME in INTERNAL_PATHS
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tank/.truenas_containers",
+        "tank/.truenas_containers/containers",
+        "tank/.truenas_containers/containers/foo",
+        "tank/.truenas_containers/images/ubuntu:24.04",
+    ],
+)
+def test_container_paths_are_internal(path):
+    assert has_internal_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tank",
+        "tank/.truenas_containers_backup",
+        "tank/data/.truenas_containers",
+        # Legacy incus datasets are the source the container migration renames *from*, so they have to
+        # stay outside the guard.
+        "tank/.ix-virt/containers/foo",
+    ],
+)
+def test_lookalike_paths_are_not_internal(path):
+    assert has_internal_path(path) is False

--- a/tests/api2/test_container_internal_path.py
+++ b/tests/api2/test_container_internal_path.py
@@ -1,0 +1,109 @@
+import pytest
+
+from middlewared.test.integration.assets.container import (
+    ALPINE_IMAGE_NAME,
+    configure_bridge,
+    container,
+    resolve_image,
+)
+from middlewared.test.integration.utils import call, pool, ssh
+
+CONTAINER_DS = f"{pool}/.truenas_containers"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    configure_bridge()
+
+
+@pytest.fixture(scope="module")
+def image():
+    yield resolve_image(ALPINE_IMAGE_NAME)
+
+
+@pytest.fixture(scope="module")
+def alpine_container(image):
+    with container(image) as c:
+        yield c
+
+
+def image_snapshot():
+    # The tree is hidden from the API now, so go around it.
+    out = ssh(f"zfs list -H -o name -t snapshot -r {CONTAINER_DS}/images")
+    return next(line for line in out.splitlines() if line.endswith("@image"))
+
+
+def test_container_dataset_hidden_from_zfs_resource_query(alpine_container):
+    names = [r["name"] for r in call("zfs.resource.query", {"paths": [pool], "get_children": True})]
+
+    assert CONTAINER_DS not in names
+    assert not [name for name in names if name.startswith(f"{CONTAINER_DS}/")]
+
+
+def test_container_dataset_still_visible_when_named_explicitly(alpine_container):
+    """Naming an internal path opts out of the filter.
+
+    The mountpoint repair depends on this, so it has to keep working.
+    """
+    rv = call("zfs.resource.query", {"paths": [CONTAINER_DS], "properties": ["mountpoint"]})
+
+    assert len(rv) == 1
+    assert rv[0]["properties"]["mountpoint"]["value"] == f"/mnt/.truenas_containers/{pool}"
+
+
+@pytest.mark.parametrize("suffix", ["", "/containers", "/images"])
+def test_zfs_resource_destroy_refused(alpine_container, suffix):
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.destroy", {"path": f"{CONTAINER_DS}{suffix}", "recursive": True})
+
+    assert "protected" in str(exc_info.value).lower(), exc_info.value
+
+
+def test_zfs_resource_destroy_of_container_rootfs_refused(alpine_container):
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.destroy", {"path": alpine_container["dataset"], "recursive": True})
+
+    assert "protected" in str(exc_info.value).lower(), exc_info.value
+
+
+@pytest.mark.parametrize("suffix", ["", "/containers"])
+def test_pool_dataset_delete_refused(alpine_container, suffix):
+    with pytest.raises(Exception) as exc_info:
+        call("pool.dataset.delete", f"{CONTAINER_DS}{suffix}", {"recursive": True})
+
+    assert "invalid location" in str(exc_info.value).lower(), exc_info.value
+
+
+def test_image_snapshot_delete_refused(alpine_container):
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.snapshot.destroy", {"path": image_snapshot()})
+
+    assert "protected" in str(exc_info.value).lower(), exc_info.value
+
+
+def test_image_snapshot_delete_with_defer_refused(alpine_container):
+    """`defer` skips the dependent-clone check, so before the guard this one succeeded.
+
+    Every container rootfs is a clone of this snapshot, which is what made the
+    non-deferred destroy fail with EBUSY rather than because it was protected.
+    """
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.snapshot.destroy", {"path": image_snapshot(), "defer": True})
+
+    assert "protected" in str(exc_info.value).lower(), exc_info.value
+
+
+def test_pool_snapshot_delete_refused(alpine_container):
+    with pytest.raises(Exception) as exc_info:
+        call("pool.snapshot.delete", image_snapshot())
+
+    assert "protected" in str(exc_info.value).lower(), exc_info.value
+
+
+def test_container_lifecycle_still_works(image):
+    """The plugin destroys its own datasets and snapshots with `bypass`.
+
+    If any of those lost their bypass, create/delete would start failing with EACCES.
+    """
+    with container(image, name="protected") as c:
+        assert call("container.get_instance", c["id"])["dataset"].startswith(f"{CONTAINER_DS}/")

--- a/tests/api2/test_container_mountpoint_repair.py
+++ b/tests/api2/test_container_mountpoint_repair.py
@@ -1,0 +1,83 @@
+import pytest
+
+from middlewared.test.integration.assets.container import (
+    ALPINE_IMAGE_NAME,
+    configure_bridge,
+    container,
+    resolve_image,
+)
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call, mock, ssh
+
+# A throwaway pool, so exporting and reimporting it can never touch a pool the system needs.
+POOL_NAME = "test_container_mnt"
+CONTAINER_DS = f"{POOL_NAME}/.truenas_containers"
+EXPECTED_MOUNTPOINT = f"/mnt/.truenas_containers/{POOL_NAME}"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bridge():
+    configure_bridge()
+
+
+@pytest.fixture(scope="module")
+def image():
+    yield resolve_image(ALPINE_IMAGE_NAME)
+
+
+def mountpoint():
+    return ssh(f"zfs get -H -o value mountpoint {CONTAINER_DS}").strip()
+
+
+def test_import_repairs_drifted_container_mountpoint(image):
+    """The container dataset is an internal path, so pool import cannot see it in the
+    first-level query any more. It has to be repaired by name instead, and this is the
+    regression test for that: without the repair the container comes back mounted under
+    the pool's own tree and starts on an empty directory.
+    """
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}) as c:
+            assert mountpoint() == EXPECTED_MOUNTPOINT
+
+            # What a foreign pool, or `zfs inherit -r mountpoint`, leaves behind.
+            ssh(f"zfs inherit -r mountpoint {POOL_NAME}")
+            assert mountpoint() == f"/mnt/{POOL_NAME}/.truenas_containers"
+
+            call("pool.export", pool["id"], {"cascade": True, "destroy": False}, job=True)
+            call("pool.import_pool", {"guid": pool["guid"], "name": POOL_NAME}, job=True)
+
+            assert mountpoint() == EXPECTED_MOUNTPOINT
+
+            call("container.start", c["id"])
+            assert call("container.get_instance", c["id"])["status"]["state"] == "RUNNING"
+            call("container.stop", c["id"], {"force": True}, job=True)
+
+
+def test_import_does_not_touch_correct_container_mountpoint(image):
+    """A healthy pool must not have any mountpoint rewritten on import."""
+    with another_pool({"name": POOL_NAME}) as pool:
+        with container(image, options={"pool": POOL_NAME}):
+            call("pool.export", pool["id"], {"cascade": True, "destroy": False}, job=True)
+
+            with mock(
+                "pool.dataset.update_impl",
+                """
+                async def mock(self, *args):
+                    raise Exception("mountpoint was reset on a healthy pool")
+            """,
+            ):
+                call("pool.import_pool", {"guid": pool["guid"], "name": POOL_NAME}, job=True)
+
+            assert mountpoint() == EXPECTED_MOUNTPOINT
+
+
+def test_ensure_datasets_repairs_instead_of_raising(image):
+    """A drifted mountpoint used to be a hard `CallError` with no way forward."""
+    with another_pool({"name": POOL_NAME}):
+        with container(image, options={"pool": POOL_NAME}, name="first"):
+            ssh(f"zfs set mountpoint=/{POOL_NAME}/.truenas_containers {CONTAINER_DS}")
+            assert mountpoint() != EXPECTED_MOUNTPOINT
+
+            # `container.create` calls `container.ensure_datasets`, which used to raise here.
+            with container(image, options={"pool": POOL_NAME}, name="second"):
+                assert mountpoint() == EXPECTED_MOUNTPOINT

--- a/tests/api2/test_pool_dataset_info.py
+++ b/tests/api2/test_pool_dataset_info.py
@@ -6,6 +6,11 @@ from middlewared.test.integration.assets.docker import docker
 from middlewared.test.integration.assets.pool import pool, another_pool, dataset, snapshot
 
 
+# Datasets that are internal to the product and so are never offered as choices. The container
+# dataset lives on every pool, hence the leading slash rather than a pool-qualified name.
+EXCLUDED = f"boot-pool|{pool}/.system|/.truenas_containers"
+
+
 @pytest.fixture(scope='function')
 def pool_dataset_zvol_snapshot_app():
     """ Create a pool, dataset, zvol, snapshot and an app dataset """
@@ -14,7 +19,7 @@ def pool_dataset_zvol_snapshot_app():
     pool_list = [line for line in ssh("zpool list -H -o name | grep -v boot-pool").split()]
 
     try:
-        ds_list = [line for line in ssh(f"zfs list -H -t fs -o name | grep -Ev 'boot-pool|{pool}/.system'").split()]
+        ds_list = [line for line in ssh(f"zfs list -H -t fs -o name | grep -Ev '{EXCLUDED}'").split()]
     except AssertionError:
         ds_list = []
 
@@ -24,7 +29,7 @@ def pool_dataset_zvol_snapshot_app():
         zv_list = []
 
     try:
-        snap_list = [line for line in ssh(f"zfs list -H -t snap -o name | grep -Ev 'boot-pool|{pool}/.system'").split()]
+        snap_list = [line for line in ssh(f"zfs list -H -t snap -o name | grep -Ev '{EXCLUDED}'").split()]
     except AssertionError:
         snap_list = []
 
@@ -62,7 +67,8 @@ def test_recommended_zvol_blocksize():
 
 def test_pool_filesystem_choices(pool_dataset_zvol_snapshot_app):
     """ filesystem_choices returns a list of datasets and pools
-        It should not list boot-pool or the system dataset (.system) """
+        It should not list boot-pool, the system dataset (.system) or the
+        container dataset (.truenas_containers) """
 
     created_items = pool_dataset_zvol_snapshot_app
     assert 'apps' in created_items
@@ -74,6 +80,7 @@ def test_pool_filesystem_choices(pool_dataset_zvol_snapshot_app):
     assert sorted(fc_set_all) == sorted(expected_set)
     assert 'boot-pool' not in fc_set_all
     assert f'{pool}.system' not in fc_set_all
+    assert not [i for i in fc_set_all if '/.truenas_containers' in i]
 
     # Test request for volumes
     fc_vol_list = call('pool.filesystem_choices', ["VOLUME"])


### PR DESCRIPTION
## Problem
`<pool>/.truenas_containers` was destroyable through the public API. The destroy and rollback guards test the second path component against `INTERNAL_PATHS`, and the container dataset was not in that tuple, so a recursive `zfs.resource.destroy` wiped the whole tree, container rootfs snapshots deleted cleanly, and the image snapshot went away with `defer` set. `pool.dataset.delete` only failed by accident and reported a misleading "does not exist".

Adding the entry is not enough on its own. `pool.reset_mountpoint_recursively` reads the container dataset out of a pool-level query, which filters internal paths out, so the custom mountpoint would silently stop being repaired and containers would come up on an empty directory.

## Solution
Move the mountpoint repair into the container plugin as `container.ensure_pool_mountpoint`, which names the dataset explicitly - naming an internal path opts out of the filter, the same thing `docker.fs_manage.ensure_ix_apps_mount_point` relies on for `ix-apps`. It also refuses to overmount, which matters more here than for `ix-apps` because the container dataset exists on every pool and two pools can end up claiming the same path after a rename.

- **`pool.reset_mountpoint_recursively`** delegates to it, after the inherit walk rather than inside the first-level loop.
- **`ensure_datasets`** repairs a drifted mountpoint instead of raising, so it is no longer a dead end.
- **`container.repair_pool_mountpoints`** runs on boot between the legacy migration and autostart, covering `pool.import_on_boot` and the failover import, neither of which resets mountpoints at all.

With that in place `.truenas_containers` joins `INTERNAL_PATHS`. It is spelled out there rather than imported so the zfs layer does not reach into a plugin package, and a unit test keeps the two in sync.

CI Run: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/10008/