### PR TITLE
Use relative redirects

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -184,6 +184,8 @@ http {
         '' close;
     }
 
+    allow_redirect off;
+
     map $http_origin $allow_origin {
         ~^${str(tn_connect_config.tnc_base_url).rstrip("/")}$ $http_origin;
 % if str(tn_connect_config.account_service_base_url).split('.')[1] in ('dev', 'staging'):

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -184,7 +184,7 @@ http {
         '' close;
     }
 
-    allow_redirect off;
+    absolute_redirect off;
 
     map $http_origin $allow_origin {
         ~^${str(tn_connect_config.tnc_base_url).rstrip("/")}$ $http_origin;


### PR DESCRIPTION
For example, when running TrueNAS behind a reverse proxy,, nginx uses absolute paths including the port for redirects (e.g. https://truenasdomain/ui or https://truenasdomain/api/docs), making the reverse proxy fail. Adding the option `absolute_redirect off;` resolves this by forcing relative paths instead.