### PR TITLE
NAS-142115 / 26.0.0-RC.1 / Add RAW data type for TDB databases (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -19,22 +19,23 @@ from struct import pack
 from .constants import SAMBA_BOOTENV_DIR
 
 LOCAL_SHARE_INFO_FILE = os.path.join(SAMBA_BOOTENV_DIR, 'share_info.tdb')
-SHARE_INFO_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
-SHARE_INFO_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.BYTES, True)
+SHARE_INFO_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.RAW)
+SHARE_INFO_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.RAW, True)
 SHARE_INFO_VERSION_KEY = 'INFO/version'
-SHARE_INFO_VERSION_DATA = b64encode(pack('<I', 3))
+SHARE_INFO_SD_PREFIX = 'SECDESC/'
+SHARE_INFO_VERSION_DATA = pack('<I', 3)
 TDB_SHARE_INFO_CONFIG = (LOCAL_SHARE_INFO_FILE, SHARE_INFO_TDB_OPTIONS)
 CTDB_SHARE_INFO_CONFIG = ('share_info.tdb', SHARE_INFO_CTDB_OPTIONS)
 
 
-def _share_info_db_config(cluster: bool) -> TDBOptions:
+def _share_info_db_config(cluster: bool) -> tuple[str, TDBOptions]:
     return CTDB_SHARE_INFO_CONFIG if cluster else TDB_SHARE_INFO_CONFIG
 
 
-def fetch_share_acl(share_name: str, cluster: bool) -> str:
-    """ fetch base64-encoded NT ACL for SMB share """
+def fetch_share_acl(share_name: str, cluster: bool) -> bytes:
+    """ fetch packed NT security descriptor for SMB share """
     with get_tdb_handle(*_share_info_db_config(cluster)) as hdl:
-        return hdl.get(f'SECDESC/{share_name.lower()}')
+        return hdl.get(f'{SHARE_INFO_SD_PREFIX}{share_name.lower()}')
 
 
 def set_version_share_info(cluster: bool):
@@ -42,8 +43,8 @@ def set_version_share_info(cluster: bool):
         hdl.store(SHARE_INFO_VERSION_KEY, SHARE_INFO_VERSION_DATA)
 
 
-def store_share_acl(share_name: str, val: str, cluster: bool) -> None:
-    """ write base64-encoded NT ACL for SMB share to server running configuration """
+def store_share_acl(share_name: str, val: bytes, cluster: bool) -> None:
+    """ write packed NT security descriptor for SMB share to server running configuration """
     if cluster:
         set_version_key = True
     else:
@@ -53,14 +54,14 @@ def store_share_acl(share_name: str, val: str, cluster: bool) -> None:
         if set_version_key:
             hdl.store(SHARE_INFO_VERSION_KEY, SHARE_INFO_VERSION_DATA)
 
-        hdl.store(f'SECDESC/{share_name.lower()}', val)
+        hdl.store(f'{SHARE_INFO_SD_PREFIX}{share_name.lower()}', val)
         hdl.flush()
 
 
 def remove_share_acl(share_name: str, cluster: bool) -> None:
     """ remove ACL from share causing default entry of S-1-1-0 FULL_CONTROL """
     with get_tdb_handle(*_share_info_db_config(cluster)) as hdl:
-        hdl.delete(f'SECDESC/{share_name.lower()}')
+        hdl.delete(f'{SHARE_INFO_SD_PREFIX}{share_name.lower()}')
         hdl.flush()
 
 
@@ -76,9 +77,13 @@ class ShareSec(Service):
         cluster = self.middleware.call_sync('datastore.config', 'services.cifs')['cifs_srv_stateful_failover']
         try:
             with get_tdb_handle(*_share_info_db_config(cluster)) as hdl:
+                # Security descriptors are base64-encoded here rather than in the database
+                # because this is where they leave middleware. Both API consumers and the
+                # backup copy in the share config require a string.
                 return filter_list(
-                    hdl.entries(),
-                    filters + [['key', '^', 'SECDESC/']],
+                    ({'key': entry['key'], 'value': b64encode(entry['value']).decode()}
+                     for entry in hdl.entries(key_prefix=SHARE_INFO_SD_PREFIX)),
+                    filters,
                     options
                 )
         except FileNotFoundError:
@@ -108,8 +113,14 @@ class ShareSec(Service):
             set_version_share_info(False)
 
         try:
-            share_sd_bytes = b64decode(fetch_share_acl(share_name, cluster))
-            share_acl = sd_bytes_to_share_acl(share_sd_bytes)
+            if not (sd_bytes := fetch_share_acl(share_name, cluster)):
+                # An entry that samba cannot unmarshall gets the same treatment as a
+                # missing one so that we report what samba enforces. A zero-length
+                # value is also how ctdb represents a deleted key until it vacuums
+                # the tombstone.
+                raise MatchNotFound(share_name)
+
+            share_acl = sd_bytes_to_share_acl(sd_bytes)
         except MatchNotFound:
             # Non-exist share ACL is treated as granting world FULL permissions
             share_acl = [{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]
@@ -146,12 +157,12 @@ class ShareSec(Service):
         except MatchNotFound as exc:
             raise CallError(f'{data["share_name"]}: share does not exist') from exc
 
-        share_sd_bytes = b64encode(share_acl_to_sd_bytes(data['share_acl'])).decode()
+        share_sd_bytes = share_acl_to_sd_bytes(data['share_acl'])
         store_share_acl(data['share_name'], share_sd_bytes, cluster)
 
         self.middleware.call_sync(
             'datastore.update', 'sharing.cifs_share', config_share['id'],
-            {'cifs_share_acl': share_sd_bytes}
+            {'cifs_share_acl': b64encode(share_sd_bytes).decode()}
         )
 
     def flush_share_info(self):
@@ -164,10 +175,23 @@ class ShareSec(Service):
         for share in shares:
             share_name = 'HOMES' if share['home'] else share['name']
             if share['share_acl'] and share['share_acl'].startswith('S-1-'):
+                # Legacy configurations hold the share ACL as a space-delimited string
+                # rather than a packed security descriptor.
                 sd_bytes = legacy_share_acl_string_to_sd_bytes(share['share_acl'])
-                store_share_acl(share_name, sd_bytes, cluster)
             elif share['share_acl']:
-                store_share_acl(share_name, share['share_acl'], cluster)
+                sd_bytes = b64decode(share['share_acl'])
+            else:
+                # Nothing to flush. Drop any entry samba cannot unmarshall so that it
+                # applies its own default rather than reporting an empty ACL.
+                try:
+                    if not fetch_share_acl(share_name, cluster):
+                        remove_share_acl(share_name, cluster)
+                except MatchNotFound:
+                    pass
+
+                continue
+
+            store_share_acl(share_name, sd_bytes, cluster)
 
     @periodic(3600, run_on_start=False)
     def check_share_info_tdb(self):
@@ -197,7 +221,7 @@ class ShareSec(Service):
         shares = await self.middleware.call('datastore.query', 'sharing.cifs_share', [], {'prefix': 'cifs_'})
         for s in shares:
             share_name = s['name'] if not s['home'] else 'homes'
-            if not (share_acl := filter_list(entries, [['key', '=', f'SECDESC/{share_name.lower()}']])):
+            if not (share_acl := filter_list(entries, [['key', '=', f'{SHARE_INFO_SD_PREFIX}{share_name.lower()}']])):
                 continue
 
             if share_acl[0]['value'] != s['share_acl']:

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -1,6 +1,6 @@
 # Utilities that wrap around samba's group_mapping.tdb file
 #
-# test coverage provided by src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
+# test coverage provided by tests/unit/test_groupmap.py
 # sample tdb contents (via tdbdump)
 #
 # {
@@ -50,7 +50,6 @@
 
 import enum
 
-from base64 import b64decode, b64encode
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from socket import htonl, ntohl
@@ -71,8 +70,8 @@ from middlewared.utils.tdb import (
 UNIX_GROUP_KEY_PREFIX = 'UNIXGROUP/'
 MEMBEROF_PREFIX = 'MEMBEROF/'
 
-GROUP_MAPPING_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
-GROUP_MAPPING_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.BYTES, clustered=True)
+GROUP_MAPPING_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.RAW)
+GROUP_MAPPING_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.RAW, clustered=True)
 
 
 class GroupmapEntryType(enum.Enum):
@@ -108,7 +107,7 @@ def _groupmap_file_to_options(gm: GroupmapFile) -> TDBOptions:
     return GROUP_MAPPING_TDB_OPTIONS
 
 
-def _parse_unixgroup(tdb_key: str, tdb_val: str) -> SMBGroupMap:
+def _parse_unixgroup(tdb_key: str, tdb_val: bytes) -> SMBGroupMap:
     """
     parsing function to convert TDB key/value pair into SMBGroupMap
 
@@ -126,18 +125,17 @@ def _parse_unixgroup(tdb_key: str, tdb_val: str) -> SMBGroupMap:
     the TDB value.
     """
     sid = tdb_key[len(UNIX_GROUP_KEY_PREFIX):]
-    data = b64decode(tdb_val)
 
     # unix groups are written into tdb file via tdb_pack
-    gid = htonl(int.from_bytes(data[0:4]))
-    sid_type = lsa_sidtype(htonl(int.from_bytes(data[4:8])))
+    gid = htonl(int.from_bytes(tdb_val[0:4]))
+    sid_type = lsa_sidtype(htonl(int.from_bytes(tdb_val[4:8])))
 
     # remaining bytes are two null-terminated strings
-    bname, bcomment = data[8:-1].split(b'\x00')
+    bname, bcomment = tdb_val[8:-1].split(b'\x00')
     return SMBGroupMap(sid, gid, sid_type, bname.decode(), bcomment.decode())
 
 
-def _parse_memberof(tdb_key: str, tdb_val: str) -> SMBGroupMembership:
+def _parse_memberof(tdb_key: str, tdb_val: bytes) -> SMBGroupMembership:
     """
     parsing function to convert TDB key/value pair into SMBGroupMembership
 
@@ -155,13 +153,12 @@ def _parse_memberof(tdb_key: str, tdb_val: str) -> SMBGroupMembership:
     specified in TDB value (groups of which _this_ sid is a member of).
     """
     sid = tdb_key[len(MEMBEROF_PREFIX):]
-    data = b64decode(tdb_val)
 
-    groups = tuple(data[:-1].decode().split())
+    groups = tuple(tdb_val[:-1].decode().split())
     return SMBGroupMembership(sid, groups)
 
 
-def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, str]:
+def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, bytes]:
     """ convert a SMBGroupMap object to TDB key-value pair for insertion into TDB file """
     tdb_key = f'{UNIX_GROUP_KEY_PREFIX}{group_map.sid}'
     gid = ntohl(group_map.gid).to_bytes(4)
@@ -170,14 +167,14 @@ def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, str]:
     comment = group_map.comment.encode()
 
     data = gid + sid_type + name + b'\x00' + comment + b'\x00'
-    return (tdb_key, b64encode(data))
+    return (tdb_key, data)
 
 
-def _groupmem_to_tdb_key_val(group_mem: SMBGroupMembership) -> tuple[str, str]:
+def _groupmem_to_tdb_key_val(group_mem: SMBGroupMembership) -> tuple[str, bytes]:
     """ convert a SMBGroupMembership object to TDB key-value pair for insertion into TDB file """
     tdb_key = f'{MEMBEROF_PREFIX}{group_mem.sid}'
     data = ' '.join(set(group_mem.groups)).encode() + b'\x00'
-    return (tdb_key, b64encode(data))
+    return (tdb_key, data)
 
 
 def groupmap_entries(

--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -1,6 +1,6 @@
 # Utilities that wrap around samba's passdb.tdb file
 #
-# test coverage provided by src/middlewared/middlewared/pytest/unit/utils/test_passdb.py
+# test coverage provided by tests/unit/test_passdb.py
 # sample tdb contents (via tdbdump)
 #
 # {
@@ -27,7 +27,6 @@
 import enum
 import os
 
-from base64 import b64decode, b64encode
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from middlewared.plugins.idmap_.idmap_constants import IDType
@@ -50,9 +49,9 @@ from .constants import SMBPath
 # Major and minor versions must be written to the passdb.tdb file
 # Major version identifies version of struct samu.
 MINOR_VERSION_KEY = 'INFO/minor_version'
-MINOR_VERSION_VAL = b64encode(pack('<I', 0))
+MINOR_VERSION_VAL = pack('<I', 0)
 MAJOR_VERSION_KEY = 'INFO/version'
-MAJOR_VERSION_VAL = b64encode(pack('<I', 4))
+MAJOR_VERSION_VAL = pack('<I', 4)
 
 NTHASH_LEN = 16
 
@@ -65,8 +64,8 @@ UNKNOWN_6 = 0x000004ec  # unknown value in samba struct samu
 USER_PREFIX = 'USER_'
 RID_PREFIX = 'RID_'
 
-PASSDB_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
-PASSDB_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.BYTES, True)
+PASSDB_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.RAW)
+PASSDB_CTDB_OPTIONS = TDBOptions(TDBPathType.PERSISTENT, TDBDataType.RAW, True)
 PASSDB_PATH = f'{SMBPath.PASSDB_DIR.path}/passdb.tdb'
 PASSDB_TIME_T_MAX = 2085923199  # observed in recent samba versions. Should be output of get_time_t_max()
 PASSDB_TDB_CONFIG = (PASSDB_PATH, PASSDB_TDB_OPTIONS)
@@ -280,23 +279,21 @@ def _pack_pdb_entry(entry: PDBEntry) -> bytes:
     return data
 
 
-def _parse_passdb_entry(hdl: TDBHandle, tdb_key: str, tdb_val: str) -> PDBEntry:
+def _parse_passdb_entry(hdl: TDBHandle, tdb_key: str, tdb_val: bytes) -> PDBEntry:
     """
     Retrieve SAMU data based on passdb RID entry and parse bytes into a PDBEntry
     object.
 
 
     """
-    key = f'{USER_PREFIX}{b64decode(tdb_val)[:-1].decode()}'
+    key = f'{USER_PREFIX}{tdb_val[:-1].decode()}'
     try:
-        if (pdb_bytes := hdl.get(f'{USER_PREFIX}{b64decode(tdb_val)[:-1].decode()}')) is None:
-            # malformed passdb entry. Shouldn't happen we'll return None to force
-            # rewrite
-            raise PassdbMustReinit(f'{key}: passdb.tdb lacks expected key')
+        pdb_bytes = hdl.get(key)
     except MatchNotFound:
+        # malformed passdb entry, caller rewrites the file
         raise PassdbMustReinit(f'{key}: passdb.tdb lacks expected key') from None
 
-    return _unpack_pdb_bytes(b64decode(pdb_bytes))
+    return _unpack_pdb_bytes(pdb_bytes)
 
 
 def passdb_entries(as_dict: bool = False, clustered=False) -> Iterable[PDBEntry, dict]:
@@ -383,12 +380,12 @@ def insert_passdb_entries(entries: list[PDBEntry], clustered=False) -> None:
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{USER_PREFIX}{entry.username.lower()}',
-                value=b64encode(samu_data)
+                value=samu_data
             ),
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{RID_PREFIX}{entry.user_rid:08x}',
-                value=b64encode(entry.username.lower().encode() + b'\x00')
+                value=entry.username.lower().encode() + b'\x00'
             )
         ])
 
@@ -448,7 +445,7 @@ def update_passdb_entry(entry: PDBEntry, clustered=False) -> None:
     with get_tdb_handle(*_get_pdb_config(clustered)) as hdl:
         batch_ops = []
         try:
-            current_username = b64decode(hdl.get(f'{RID_PREFIX}{entry.user_rid:08x}'))[:-1].decode()
+            current_username = hdl.get(f'{RID_PREFIX}{entry.user_rid:08x}')[:-1].decode()
         except MatchNotFound:
             pass
         else:
@@ -467,12 +464,12 @@ def update_passdb_entry(entry: PDBEntry, clustered=False) -> None:
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{USER_PREFIX}{entry.username.lower()}',
-                value=b64encode(samu_data)
+                value=samu_data
             ),
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{RID_PREFIX}{entry.user_rid:08x}',
-                value=b64encode(entry.username.lower().encode() + b'\x00')
+                value=entry.username.lower().encode() + b'\x00'
             )
         ])
         hdl.batch_op(batch_ops)

--- a/src/middlewared/middlewared/utils/gencache.py
+++ b/src/middlewared/middlewared/utils/gencache.py
@@ -23,7 +23,7 @@ class IDMAPCacheType(enum.Enum):
     NAME2SID = 'NAME2SID'
 
 
-def fetch_gencache_entry(key: str) -> dict[str, Any] | str:
+def fetch_gencache_entry(key: str) -> dict[str, Any] | str | bytes:
     with get_tdb_handle(GENCACHE_FILE, GENCACHE_TDB_OPTIONS) as hdl:
         return hdl.get(key)
 

--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -1,3 +1,4 @@
+import binascii
 import os
 import tdb
 import enum
@@ -48,13 +49,19 @@ class TDBDataType(enum.Enum):
     """
     Types of data to encode in TDB file
 
+    RAW - binary data submitted and returned as python bytes. This is the appropriate
+    type for interacting with TDB files used by 3rd party applications from within
+    middleware.
+
     BYTES - binary data. API consumer submits as b64encoded string that is decoded before insertion.
-    This is particularly relevant when interacting with TDB files used by 3rd party applications.
+    Prefer RAW unless the value is read or written by an API consumer, since base64 is a
+    transport encoding rather than a property of the database.
 
     JSON - submit as python dictionary and converted into JSON before insertion
 
     STRING - submit as python string and inserted as-is
     """
+    RAW = enum.auto()
     BYTES = enum.auto()
     JSON = enum.auto()
     STRING = enum.auto()
@@ -95,7 +102,7 @@ class TDBBatchOperation:
     """
     action: TDBBatchAction
     key: str
-    value: str | dict[str, Any] | None = None
+    value: str | bytes | dict[str, Any] | None = None
 
 
 @dataclass(slots=True, frozen=True)
@@ -126,7 +133,7 @@ def keys_are_null_terminated(name: str, data_type: TDBDataType) -> bool:
         case _:
             # Most samba tdb files use NULL-terminated string keys; middleware-owned
             # databases that store JSON/STRING values do not.
-            return data_type is TDBDataType.BYTES
+            return data_type in (TDBDataType.RAW, TDBDataType.BYTES)
 
 
 class TDBHandle:
@@ -168,8 +175,12 @@ class TDBHandle:
         # if file has been renamed or deleted from under us, readlink will show different path
         return os.readlink(f'/proc/self/fd/{self.hdl.fd}') == self.full_path
 
-    def parse_value(self, tdb_val: bytes) -> dict[str, Any] | str:
+    def parse_value(self, tdb_val: bytes) -> dict[str, Any] | str | bytes:
+        out: dict[str, Any] | str | bytes
+
         match self.data_type:
+            case TDBDataType.RAW:
+                out = tdb_val
             case TDBDataType.BYTES:
                 out = b64encode(tdb_val).decode()
             case TDBDataType.JSON:
@@ -185,13 +196,14 @@ class TDBHandle:
         """ Ensure sync of file to disk """
         os.fdatasync(self.hdl.fd)
 
-    def get(self, key: str) -> dict[str, Any] | str:
+    def get(self, key: str) -> dict[str, Any] | str | bytes:
         """
         Retrieve the specified key
 
         Returns:
-            dict if TDBDatatype is JSON
-            str if TDBDatatype is BYTES or STRING
+            bytes if TDBDataType is RAW
+            dict if TDBDataType is JSON
+            str if TDBDataType is BYTES or STRING
 
         Raises:
             MatchNotFound
@@ -211,29 +223,62 @@ class TDBHandle:
 
         return self.parse_value(tdb_val)
 
+    def encode_value(self, value: str | dict[str, Any] | bytes) -> bytes:
+        """
+        Convert `value` into the bytes to be written for this database's data type.
+
+        The type a caller must supply follows from `data_type` rather than from any
+        signature, and so cannot be expressed to a type checker. It is checked here to
+        keep a mismatch from reaching the database: b64decode() is asked to validate
+        because it otherwise discards everything outside its alphabet before checking
+        padding, and stores a truncated record instead of failing.
+
+        Raises:
+            TypeError
+            ValueError
+        """
+        match self.data_type:
+            case TDBDataType.RAW:
+                if not isinstance(value, bytes):
+                    raise TypeError(f'{type(value).__name__}: RAW values must be bytes')
+
+                return value
+            case TDBDataType.BYTES:
+                # bytes are accepted because b64encode() output is not decoded by most callers
+                if not isinstance(value, (str, bytes)):
+                    raise TypeError(f'{type(value).__name__}: BYTES values must be base64-encoded')
+
+                try:
+                    return b64decode(value, validate=True)
+                except binascii.Error as exc:
+                    raise ValueError(f'BYTES values must be base64-encoded: {exc}') from exc
+            case TDBDataType.JSON:
+                if not isinstance(value, dict):
+                    raise TypeError(f'{type(value).__name__}: JSON values must be a dict')
+
+                return json.dumps(value).encode()
+            case TDBDataType.STRING:
+                if not isinstance(value, str):
+                    raise TypeError(f'{type(value).__name__}: STRING values must be a str')
+
+                return value.encode()
+            case _:
+                raise ValueError(f'{self.data_type}: unknown data type')
+
     def store(self, key: str, value: str | dict[str, Any] | bytes) -> None:
         """
         Set the specified `key` to the specified `value`.
 
         Raises:
             RuntimeError
+            TypeError
             ValueError
         """
         tdb_key = key.encode()
         if self.keys_null_terminated:
             tdb_key += b'\x00'
 
-        match self.data_type:
-            case TDBDataType.BYTES:
-                tdb_val = b64decode(value)  # type: ignore[arg-type]
-            case TDBDataType.JSON:
-                tdb_val = json.dumps(value).encode()
-            case TDBDataType.STRING:
-                tdb_val = value.encode()  # type: ignore[union-attr]
-            case _:
-                raise ValueError(f'{self.data_type}: unknown data type')
-
-        self.ops.store(tdb_key, tdb_val)
+        self.ops.store(tdb_key, self.encode_value(value))
 
     def delete(self, key: str) -> None:
         """
@@ -262,10 +307,12 @@ class TDBHandle:
 
     @overload
     def entries(self, include_keys: Literal[False] = ..., key_prefix: str | None = None) -> (
-        Iterable[dict[str, Any] | str]
+        Iterable[dict[str, Any] | str | bytes]
     ): ...
 
-    def entries(self, include_keys: bool = True, key_prefix: str | None = None) -> Iterable[dict[str, Any] | str]:
+    def entries(
+        self, include_keys: bool = True, key_prefix: str | None = None
+    ) -> Iterable[dict[str, Any] | str | bytes]:
         """
         Iterate entries in TDB file:
 
@@ -318,7 +365,10 @@ class TDBHandle:
             for op in ops:
                 match op.action:
                     case TDBBatchAction.SET:
-                        self.store(op.key, op.value)  # type: ignore[arg-type]
+                        if op.value is None:
+                            raise ValueError(f'{op.key}: SET operation requires a value')
+
+                        self.store(op.key, op.value)
                     case TDBBatchAction.DEL:
                         self.delete(op.key)
                     case TDBBatchAction.GET:
@@ -409,12 +459,18 @@ class CTDBHandle(TDBHandle):
 
     @overload
     def entries(self, include_keys: Literal[False] = ..., key_prefix: str | None = None) -> (
-        Iterable[dict[str, Any] | str]
+        Iterable[dict[str, Any] | str | bytes]
     ): ...
 
-    def entries(self, include_keys: bool = True, key_prefix: str | None = None) -> Iterable[dict[str, Any] | str]:
+    def entries(
+        self, include_keys: bool = True, key_prefix: str | None = None
+    ) -> Iterable[dict[str, Any] | str | bytes]:
         for ctdb_key, ctdb_val in self.hdl.iter():
             key = ctdb_key.decode()
+            # Must match TDBHandle.entries(); batch_op() and store() add this terminator
+            if self.keys_null_terminated:
+                key = key[:-1]
+
             if key_prefix and not key.startswith(key_prefix):
                 continue
 
@@ -445,18 +501,13 @@ class CTDBHandle(TDBHandle):
 
             match op.action:
                 case TDBBatchAction.GET:
-                    batch_ops.append(pyctdb.BatchOp('GET', tdb_key, None))
+                    # pyctdb.BatchOp is a struct sequence and so takes a single tuple
+                    batch_ops.append(pyctdb.BatchOp(('GET', tdb_key, None)))
                 case TDBBatchAction.SET:
-                    match self.data_type:
-                        case TDBDataType.BYTES:
-                            tdb_val = b64decode(op.value)  # type: ignore[arg-type]
-                        case TDBDataType.JSON:
-                            tdb_val = json.dumps(op.value).encode()
-                        case TDBDataType.STRING:
-                            tdb_val = op.value.encode()  # type: ignore[union-attr]
-                        case _:
-                            raise ValueError(f'{self.data_type}: unknown data type')
-                    batch_ops.append(pyctdb.BatchOp(('SET', tdb_key, tdb_val)))
+                    if op.value is None:
+                        raise ValueError(f'{op.key}: SET operation requires a value')
+
+                    batch_ops.append(pyctdb.BatchOp(('SET', tdb_key, self.encode_value(op.value))))
                 case TDBBatchAction.DEL:
                     batch_ops.append(pyctdb.BatchOp(('DEL', tdb_key, None)))
                 case _:

--- a/tests/api2/test_430_smb_sharesec.py
+++ b/tests/api2/test_430_smb_sharesec.py
@@ -231,3 +231,85 @@ def test_restore_via_synchronize(setup_smb_share):
         # Verify we got it back
         acl = call('sharing.smb.getacl', {'share_name': setup_smb_share['name']})
         assert acl['share_acl'][0]['ae_who_sid'] == sid
+
+
+@pytest.fixture(scope="module")
+def legacy_acl_share():
+    with dataset(
+        "smb-sharesec-legacy",
+        {'share_type': 'SMB'},
+    ) as ds:
+        with smb_share(f'/mnt/{ds}', "my_sharesec_legacy") as share:
+            yield share
+
+
+def set_legacy_share_acl(share, aclstr):
+    """ Write a TrueNAS CORE format share ACL directly into the config database """
+    call(
+        'datastore.update', 'sharing.cifs_share', share['id'],
+        {'cifs_share_acl': aclstr}
+    )
+
+
+@pytest.mark.parametrize('aclstr,expected', [
+    # A security descriptor for a single well-known SID packs into a short byte string
+    # that contains no base64 alphabet characters, so an encoding mismatch on it yields
+    # an empty value rather than an error.
+    (
+        'S-1-1-0:ALLOWED/0x0/FULL',
+        [{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}],
+    ),
+    (
+        'S-1-5-32-544:ALLOWED/0x0/FULL',
+        [{'ae_who_sid': 'S-1-5-32-544', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}],
+    ),
+    (
+        'S-1-5-32-544:ALLOWED/0x0/FULL S-1-5-32-545:ALLOWED/0x0/READ',
+        [
+            {'ae_who_sid': 'S-1-5-32-544', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'},
+            {'ae_who_sid': 'S-1-5-32-545', 'ae_perm': 'READ', 'ae_type': 'ALLOWED'},
+        ],
+    ),
+])
+def test_flush_legacy_share_acl(legacy_acl_share, aclstr, expected):
+    """ Share ACLs migrated from TrueNAS CORE are stored as a space-delimited string
+    rather than a packed security descriptor and must be converted on flush. """
+    set_legacy_share_acl(legacy_acl_share, aclstr)
+
+    call('smb.sharesec.flush_share_info')
+
+    entry = call(
+        'smb.sharesec.entries',
+        [['key', '=', f'SECDESC/{legacy_acl_share["name"].lower()}']],
+        {'get': True}
+    )
+    assert entry['value'] != ''
+
+    acl = call('sharing.smb.getacl', {'share_name': legacy_acl_share['name']})
+    assert len(acl['share_acl']) == len(expected)
+    for idx, ace in enumerate(expected):
+        assert acl['share_acl'][idx]['ae_who_sid'] == ace['ae_who_sid']
+        assert acl['share_acl'][idx]['ae_perm'] == ace['ae_perm']
+        assert acl['share_acl'][idx]['ae_type'] == ace['ae_type']
+
+
+def test_legacy_share_acl_converted_in_config(legacy_acl_share):
+    """ Once flushed, the legacy string in the config database is replaced by the
+    packed security descriptor read back out of share_info.tdb. """
+    set_legacy_share_acl(legacy_acl_share, 'S-1-5-32-544:ALLOWED/0x0/CHANGE')
+
+    call('smb.sharesec.flush_share_info')
+    call('smb.sharesec.synchronize_acls')
+
+    stored = call(
+        'datastore.query', 'sharing.cifs_share',
+        [['id', '=', legacy_acl_share['id']]],
+        {'get': True}
+    )['cifs_share_acl']
+
+    assert stored != ''
+    assert not stored.startswith('S-1-')
+
+    acl = call('sharing.smb.getacl', {'share_name': legacy_acl_share['name']})
+    assert acl['share_acl'][0]['ae_who_sid'] == 'S-1-5-32-544'
+    assert acl['share_acl'][0]['ae_perm'] == 'CHANGE'

--- a/tests/unit/test_directoryservices_secrets.py
+++ b/tests/unit/test_directoryservices_secrets.py
@@ -316,6 +316,11 @@ def test__ipa_cred_version_absent_reads_as_zero(secrets_tdb):
     ('group_mapping_rejects.tdb', TDBDataType.BYTES, True),
     ('passdb.tdb', TDBDataType.BYTES, True),
     ('share_info.tdb', TDBDataType.BYTES, True),       # default: BYTES -> terminated
+    # RAW is the type these four are actually opened with
+    ('group_mapping.tdb', TDBDataType.RAW, True),
+    ('group_mapping_rejects.tdb', TDBDataType.RAW, True),
+    ('passdb.tdb', TDBDataType.RAW, True),
+    ('share_info.tdb', TDBDataType.RAW, True),         # default: RAW -> terminated
     ('winbindd_cache.tdb', TDBDataType.BYTES, True),   # default: BYTES -> terminated
     ('middleware_cache', TDBDataType.JSON, False),     # middleware-owned JSON -> not
 ])

--- a/tests/unit/test_groupmap.py
+++ b/tests/unit/test_groupmap.py
@@ -1,7 +1,13 @@
 import os
 import pytest
 
+from struct import pack
+
 from middlewared.plugins.smb_.util_groupmap import (
+    _groupmap_to_tdb_key_val,
+    _groupmem_to_tdb_key_val,
+    _parse_memberof,
+    _parse_unixgroup,
     insert_groupmap_entries,
     delete_groupmap_entry,
     list_foreign_group_memberships,
@@ -175,3 +181,41 @@ def test__insert_group_membership(groupmap_dir, local_sid):
     ], {})
 
     assert len(entries) == 0, str(entries)
+
+
+def test__groupmap_tdb_value_layout():
+    """
+    Test the packed layout of a group mapping entry.
+
+    add_mapping_entry() in source3/groupdb/mapping_tdb.c writes these with
+    tdb_pack(..., "ddff", map->gid, map->sid_name_use, map->nt_name, map->comment).
+    "d" is a little-endian uint32 (IVAL) and "f" a NUL-terminated string, so comparing
+    bytes rather than only round-tripping is what pins the encoding to samba's.
+    """
+    group_map = SMBGroupMap(
+        sid='S-1-5-21-1137207236-3870220311-645177593-200042',
+        gid=3000,
+        sid_type=lsa_sidtype.ALIAS,
+        name='smbgroup',
+        comment='comment'
+    )
+
+    tdb_key, tdb_val = _groupmap_to_tdb_key_val(group_map)
+
+    assert tdb_key == f'UNIXGROUP/{group_map.sid}'
+    assert tdb_val == pack('<I', 3000) + pack('<I', lsa_sidtype.ALIAS) + b'smbgroup\x00comment\x00'
+    assert _parse_unixgroup(tdb_key, tdb_val) == group_map
+
+
+def test__memberof_tdb_value_layout():
+    """ Test that a membership entry is a NUL-terminated space-delimited list of SIDs """
+    group_mem = SMBGroupMembership(
+        sid='S-1-5-21-1137207236-3870220311-645177593-200042',
+        groups=('S-1-5-32-544',)
+    )
+
+    tdb_key, tdb_val = _groupmem_to_tdb_key_val(group_mem)
+
+    assert tdb_key == f'MEMBEROF/{group_mem.sid}'
+    assert tdb_val == b'S-1-5-32-544\x00'
+    assert _parse_memberof(tdb_key, tdb_val) == group_mem

--- a/tests/unit/test_passdb.py
+++ b/tests/unit/test_passdb.py
@@ -5,6 +5,7 @@ import string
 import subprocess
 
 from dataclasses import asdict
+from struct import pack
 from middlewared.plugins.smb_ import util_passdb
 from middlewared.plugins.smb_.util_account_policy import (
     SMBAccountPolicy, sync_account_policy, get_account_policy
@@ -283,3 +284,56 @@ def test__invalid_smb_hash(nthash_str, error):
             util_passdb.user_entry_to_passdb_entry(PDB_DOMAIN, user)
     else:
         util_passdb.user_entry_to_passdb_entry(PDB_DOMAIN, user)
+
+
+def test__passdb_constants_match_samba():
+    """
+    Test the version keys and values written to a new passdb.tdb.
+
+    source3/passdb/pdb_tdb.c defines TDBSAM_VERSION 4, TDBSAM_MINOR_VERSION 0,
+    TDBSAM_VERSION_STRING "INFO/version", TDBSAM_MINOR_VERSION_STRING
+    "INFO/minor_version", USERPREFIX "USER_" and RIDPREFIX "RID_".
+    """
+    assert util_passdb.MAJOR_VERSION_KEY == 'INFO/version'
+    assert util_passdb.MINOR_VERSION_KEY == 'INFO/minor_version'
+    assert util_passdb.MAJOR_VERSION_VAL == pack('<I', 4)
+    assert util_passdb.MINOR_VERSION_VAL == pack('<I', 0)
+    assert util_passdb.USER_PREFIX == 'USER_'
+    assert util_passdb.RID_PREFIX == 'RID_'
+
+
+def test__pdb_entry_buffer_layout(pdb_times):
+    """
+    Test the leading fields of a packed samu buffer.
+
+    init_samu_from_buffer_v3() in source3/passdb/passdb.c reads SAMU_BUFFER_FORMAT_V3
+    as seven "d" timestamps followed by "B" fields in the order username, domain,
+    nt_username, fullname. "d" is a little-endian uint32 and "B" a little-endian uint32
+    length followed by that many bytes, the length of a string field counting its NUL.
+    """
+    entry = util_passdb.PDBEntry(**(PDB_DICT_DEFAULTS | {
+        'username': 'pdbuser',
+        'full_name': 'pdbuser_name',
+        'user_rid': 20070,
+        'nt_pw': SAMPLE_USER['smbhash'],
+        'times': pdb_times,
+    }))
+
+    data = util_passdb._pack_pdb_entry(entry)
+
+    assert data[0:28] == pack(
+        '<iiiiiii',
+        pdb_times.logon,
+        pdb_times.logoff,
+        pdb_times.kickoff,
+        pdb_times.bad_password,
+        pdb_times.pass_last_set,
+        pdb_times.pass_can_change,
+        pdb_times.pass_must_change,
+    )
+    assert data[28:].startswith(pack('<I', len('pdbuser') + 1) + b'pdbuser\x00')
+
+    # the NT hash is packed as 16 raw bytes, not as a NUL-terminated string
+    assert pack('<I', 16) + bytes.fromhex(SAMPLE_USER['smbhash']) in data
+
+    assert util_passdb._unpack_pdb_bytes(data) == entry

--- a/tests/unit/test_sharesec.py
+++ b/tests/unit/test_sharesec.py
@@ -1,0 +1,112 @@
+from base64 import b64encode
+from unittest.mock import Mock
+
+import pytest
+
+from middlewared.plugins.smb_ import sharesec
+from middlewared.service_exception import MatchNotFound
+from middlewared.utils.security_descriptor import sd_bytes_to_share_acl, share_acl_to_sd_bytes
+from middlewared.utils.tdb import get_tdb_handle
+
+SAMPLE_DOM_SID = "S-1-5-21-3510196835-1033636670-2319939847-200108"
+SAMPLE_BUILTIN_SID = "S-1-5-32-544"
+WORLD_SID = "S-1-1-0"
+SHARE_NAME = "sharesec_share"
+
+
+@pytest.fixture
+def share_info_tdb(tmp_path, monkeypatch):
+    """Redirect share_info.tdb reads and writes into a temporary file."""
+    path = str(tmp_path / "share_info.tdb")
+    monkeypatch.setattr(sharesec, "LOCAL_SHARE_INFO_FILE", path)
+    monkeypatch.setattr(sharesec, "TDB_SHARE_INFO_CONFIG", (path, sharesec.SHARE_INFO_TDB_OPTIONS))
+    return path
+
+
+def share_sec_service(stored_acl):
+    """Build a ShareSec service backed by a single share holding `stored_acl` in the config database."""
+
+    def call_sync(method, *args, **kwargs):
+        match method:
+            case "datastore.config":
+                return {"cifs_srv_stateful_failover": False}
+            case "datastore.query":
+                return [{"name": SHARE_NAME, "home": False, "share_acl": stored_acl}]
+            case _:
+                raise AssertionError(f"{method}: unexpected middleware call")
+
+    middleware = Mock()
+    middleware.call_sync = call_sync
+    return sharesec.ShareSec(middleware)
+
+
+@pytest.mark.parametrize(
+    "legacy,expected",
+    [
+        # Descriptors for a single well-known SID are short enough to contain no base64
+        # alphabet characters at all, so an encoding mismatch on them yields an empty
+        # value rather than an error.
+        (
+            f"{WORLD_SID}:ALLOWED/0x0/FULL",
+            [{"ae_who_sid": WORLD_SID, "ae_perm": "FULL", "ae_type": "ALLOWED"}],
+        ),
+        (
+            f"{SAMPLE_BUILTIN_SID}:ALLOWED/0x0/FULL",
+            [{"ae_who_sid": SAMPLE_BUILTIN_SID, "ae_perm": "FULL", "ae_type": "ALLOWED"}],
+        ),
+        (
+            f"{SAMPLE_DOM_SID}:ALLOWED/0x0/READ",
+            [{"ae_who_sid": SAMPLE_DOM_SID, "ae_perm": "READ", "ae_type": "ALLOWED"}],
+        ),
+        (
+            f"{SAMPLE_BUILTIN_SID}:ALLOWED/0x0/FULL {SAMPLE_DOM_SID}:DENIED/0x0/CHANGE",
+            [
+                {"ae_who_sid": SAMPLE_BUILTIN_SID, "ae_perm": "FULL", "ae_type": "ALLOWED"},
+                {"ae_who_sid": SAMPLE_DOM_SID, "ae_perm": "CHANGE", "ae_type": "DENIED"},
+            ],
+        ),
+    ],
+)
+def test__flush_legacy_share_acl(share_info_tdb, legacy, expected):
+    """Test that a legacy share ACL string is flushed as a packed security descriptor."""
+    share_sec_service(legacy).flush_share_info()
+
+    stored = sharesec.fetch_share_acl(SHARE_NAME, False)
+    assert stored != b""
+    assert sd_bytes_to_share_acl(stored) == expected
+
+
+def test__flush_share_acl(share_info_tdb):
+    """Test that a base64-encoded share ACL is decoded before being flushed."""
+    sd_bytes = share_acl_to_sd_bytes(
+        [
+            {"ae_who_sid": SAMPLE_DOM_SID, "ae_perm": "CHANGE", "ae_type": "ALLOWED"},
+        ]
+    )
+
+    share_sec_service(b64encode(sd_bytes).decode()).flush_share_info()
+
+    assert sharesec.fetch_share_acl(SHARE_NAME, False) == sd_bytes
+
+
+def test__flush_share_without_acl(share_info_tdb):
+    """Test that a share with no stored ACL is skipped so that samba applies its default."""
+    share_sec_service("").flush_share_info()
+
+    with pytest.raises(MatchNotFound):
+        sharesec.fetch_share_acl(SHARE_NAME, False)
+
+
+def test__flush_removes_unusable_record(share_info_tdb):
+    """Test that a zero-length record is dropped on flush.
+
+    Such a record cannot be unmarshalled, so samba applies its S-1-1-0 FULL default
+    while getacl would otherwise report an empty ACL. Removing it makes the two agree.
+    """
+    with get_tdb_handle(share_info_tdb, sharesec.SHARE_INFO_TDB_OPTIONS) as hdl:
+        hdl.store(f"{sharesec.SHARE_INFO_SD_PREFIX}{SHARE_NAME}", b"")
+
+    share_sec_service("").flush_share_info()
+
+    with pytest.raises(MatchNotFound):
+        sharesec.fetch_share_acl(SHARE_NAME, False)

--- a/tests/unit/test_tdb.py
+++ b/tests/unit/test_tdb.py
@@ -30,6 +30,8 @@ def basic_tdb_ops(hdl: TDBHandle, datatype: TDBDataType):
     match datatype:
         case TDBDataType.JSON:
             data = {'foo': 'bar'}
+        case TDBDataType.RAW:
+            data = b'foobar_raw'
         case TDBDataType.BYTES:
             data = b64encode(b'foobar_bytes').decode()
         case TDBDataType.STRING:
@@ -57,6 +59,10 @@ def batched_tdb_ops(hdl: TDBHandle, datatype: TDBDataType):
             data1 = {'foo1': 'bar1'}
             data2 = {'foo2': 'bar2'}
             data3 = {'foo3': 'bar3'}
+        case TDBDataType.RAW:
+            data1 = b'foobar_raw1'
+            data2 = b'foobar_raw2'
+            data3 = b'foobar_raw3'
         case TDBDataType.BYTES:
             data1 = b64encode(b'foobar_bytes1').decode()
             data2 = b64encode(b'foobar_bytes2').decode()
@@ -208,3 +214,36 @@ def test__tdb_handle_invalidated_by_rename():
 
         # intentionally close so that our final count is correct
         hdl.close()
+
+
+@pytest.mark.parametrize('datatype,value,message', [
+    (TDBDataType.RAW, b64encode(b'canary').decode(), 'RAW values must be bytes'),
+    (TDBDataType.BYTES, 12345, 'BYTES values must be base64-encoded'),
+    (TDBDataType.JSON, 'canary', 'JSON values must be a dict'),
+    (TDBDataType.STRING, b'canary', 'STRING values must be a str'),
+])
+def test__store_rejects_mismatched_value_type(tmpdir, datatype, value, message):
+    """
+    The type a caller must supply follows from the data type the database was opened
+    with rather than from the signature of store(), so it cannot be checked statically.
+    """
+    custom_file = os.path.join(tmpdir, 'mismatch.tdb')
+    tdb_options = TDBOptions(TDBPathType.CUSTOM, datatype)
+
+    with closing(TDBHandle(custom_file, tdb_options)) as handle:
+        with pytest.raises(TypeError, match=message):
+            handle.store('test_key', value)
+
+
+def test__store_rejects_non_base64_bytes(tmpdir):
+    """
+    Packed bytes handed to a BYTES database must be rejected rather than truncated:
+    b64decode() discards everything outside its alphabet before checking padding, so
+    a short descriptor containing none of it would otherwise store as an empty record.
+    """
+    custom_file = os.path.join(tmpdir, 'notb64.tdb')
+    tdb_options = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
+
+    with closing(TDBHandle(custom_file, tdb_options)) as handle:
+        with pytest.raises(ValueError, match='must be base64-encoded'):
+            handle.store('test_key', b'\x01\x00\x04\x80\x00\x00\x00\x00')


### PR DESCRIPTION
The TDB data types were added for early clustered SCALE, where the contents had to be JSON serializable, and so binary values are base64-encoded on insertion and decoded on read. We now call into the native tdb tables directly and no longer need that intermediate step except where a value still leaves middleware as JSON.

Add TDBDataType.RAW, which reads and writes bytes directly. The conversion moves into a shared encode_value() so the local and clustered write paths cannot disagree about it, and it now checks the value against the data type. Together these remove a category of bug where the encode and decode of a pair do not match.

Extend the tdb, passdb and group_mapping unit tests for the new data type and the on-disk formats.

Original PR: https://github.com/truenas/middleware/pull/19490
