### PR TITLE
NAS-142104 / 27.0.0-BETA.1 / Reject and normalize non-colon NIC MAC addresses (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-08-06_12-00_normalize_nic_mac.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-08-06_12-00_normalize_nic_mac.py
@@ -1,0 +1,67 @@
+"""Normalize NIC MAC addresses to libvirt's colon-separated form
+
+Revision ID: 9c31be47d5a2
+Revises: 1dc145b1f6fa
+Create Date: 2026-08-06 12:00:00.000000+00:00
+
+"""
+
+import json
+import random
+import re
+
+from alembic import op
+from sqlalchemy import text
+
+from middlewared.utils.pwenc import decrypt, encrypt
+
+
+# revision identifiers, used by Alembic.
+revision = "9c31be47d5a2"
+down_revision = "1dc145b1f6fa"
+branch_labels = None
+depends_on = None
+
+
+def random_mac() -> str:
+    mac_address = [0x00, 0xA0, 0x98, random.randint(0x00, 0x7F), random.randint(0x00, 0xFF), random.randint(0x00, 0xFF)]
+    return ":".join(["%02x" % x for x in mac_address])
+
+
+def normalize_mac(mac) -> str:
+    if not isinstance(mac, str):
+        return random_mac()
+
+    # libvirt's defineXML only parses colon-separated MACs. Older releases stored dash, no-separator,
+    # mixed and uppercase forms; collapse anything that carries a valid 48-bit address to the canonical
+    # lowercase colon form, and regenerate the rare value that isn't a MAC at all.
+    hexed = re.sub(r"[:-]", "", mac).lower()
+    if re.fullmatch(r"[0-9a-f]{12}", hexed):
+        return ":".join(hexed[i : i + 2] for i in range(0, 12, 2))
+    return random_mac()
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for table in ("vm_device", "container_device"):
+        for row in conn.execute(text(f"SELECT * FROM {table}")).mappings().all():
+            if not (decrypted := decrypt(row["attributes"])):
+                continue
+
+            attributes = json.loads(decrypted)
+
+            if attributes.get("dtype") != "NIC" or not attributes.get("mac"):
+                continue
+
+            normalized = normalize_mac(attributes["mac"])
+            if normalized != attributes["mac"]:
+                attributes["mac"] = normalized
+                conn.execute(
+                    text(f"UPDATE {table} SET attributes = :attrs WHERE id = :id"),
+                    {"attrs": encrypt(json.dumps(attributes)), "id": row["id"]},
+                )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-06-16_12-00_normalize_nic_mac.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-06-16_12-00_normalize_nic_mac.py
@@ -5,15 +5,6 @@ Revises: de51ca6f583a
 Create Date: 2026-06-16 12:00:00.000000+00:00
 
 """
-import json
-import random
-import re
-
-from alembic import op
-from sqlalchemy import text
-
-from middlewared.utils.pwenc import decrypt, encrypt
-
 
 # revision identifiers, used by Alembic.
 revision = '4a7e1c9b2f30'
@@ -22,43 +13,11 @@ branch_labels = None
 depends_on = None
 
 
-def random_mac() -> str:
-    mac_address = [
-        0x00, 0xa0, 0x98, random.randint(0x00, 0x7f), random.randint(0x00, 0xff), random.randint(0x00, 0xff)
-    ]
-    return ':'.join(['%02x' % x for x in mac_address])
-
-
-def normalize_mac(mac: str) -> str:
-    # libvirt's defineXML only parses colon-separated MACs. Older releases stored dash, no-separator,
-    # mixed and uppercase forms; collapse anything that carries a valid 48-bit address to the canonical
-    # lowercase colon form, and regenerate the rare value that isn't a MAC at all.
-    hexed = re.sub(r'[:-]', '', mac).lower()
-    if re.fullmatch(r'[0-9a-f]{12}', hexed):
-        return ':'.join(hexed[i:i + 2] for i in range(0, 12, 2))
-    return random_mac()
-
-
 def upgrade():
-    conn = op.get_bind()
-
-    for table in ('vm_device', 'container_device'):
-        for row in conn.execute(text(f"SELECT * FROM {table}")).mappings().all():
-            if not (decrypted := decrypt(row['attributes'])):
-                continue
-
-            attributes = json.loads(decrypted)
-
-            if attributes.get('dtype') != 'NIC' or not attributes.get('mac'):
-                continue
-
-            normalized = normalize_mac(attributes['mac'])
-            if normalized != attributes['mac']:
-                attributes['mac'] = normalized
-                conn.execute(
-                    text(f"UPDATE {table} SET attributes = :attrs WHERE id = :id"),
-                    {"attrs": encrypt(json.dumps(attributes)), "id": row['id']}
-                )
+    # Superseded by revision 9c31be47d5a2, which runs the same normalization and additionally handles
+    # a mac that isn't a string at all. Kept as a no-op so installs that already recorded this revision
+    # keep a valid chain.
+    pass
 
 
 def downgrade():

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-08-11_12-00_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-08-11_12-00_merge.py
@@ -1,0 +1,21 @@
+"""Merge migration for normalizing NIC MAC addresses (revision 9c31be47d5a2)
+
+Revision ID: 8f2a6d1c94b3
+Revises: 74ee5c16e7ff, 9c31be47d5a2
+Create Date: 2026-08-11 12:00:00.000000+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8f2a6d1c94b3"
+down_revision = ("74ee5c16e7ff", "9c31be47d5a2")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -83,10 +83,14 @@ Domain = Annotated[str, AfterValidator(match_validator(
     re.compile(r"^[a-z.\-0-9]*$", re.IGNORECASE),
     "Domain can only contain letters, numbers, periods, and dashes"
 ))]
+# Normalized to lowercase: MAC addresses are case-insensitive and libvirt stores them lowercased, so
+# an uppercase spelling would otherwise be a distinct string to every comparison we make against one
+# (notably the per-instance duplicate check in middlewared.utils.libvirt.utils.device_uniqueness_check)
+# while still being the same address on the wire.
 MACAddress = Annotated[str, AfterValidator(match_validator(
-    re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
+    re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\Z"),
     'MAC address must be a colon-separated hexadecimal value (e.g. 00:a0:99:7e:bb:8a).'
-))]
+)), AfterValidator(str.lower)]
 IPv4Address = Annotated[str, AfterValidator(_validate_ipv4_address)]
 IPv6Address = Annotated[str, AfterValidator(_validate_ipv6_address)]
 IPvAnyAddress = Literal[''] | Annotated[str, AfterValidator(_validate_ipaddr)]

--- a/src/middlewared/middlewared/api/v26_0_0/container_device.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container_device.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    MACAddress,
     NonEmptyString,
     excluded_field,
     single_argument_args,
@@ -57,9 +58,8 @@ class ContainerNICDevice(BaseModel):
         default=None,
         description="Host network interface or bridge to attach to. `null` for no attachment.",
     )
-    mac: str | None = Field(
+    mac: MACAddress | None = Field(
         default=None,
-        pattern='^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$',
         description="MAC address for the virtual network interface. `null` for auto-generation.",
     )
 

--- a/src/middlewared/middlewared/api/v26_0_0/vm_device.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm_device.py
@@ -6,6 +6,7 @@ from middlewared.api.base import (
     BaseModel,
     Excluded,
     ForUpdateMetaclass,
+    MACAddress,
     NonEmptyString,
     excluded_field,
     single_argument_args,
@@ -76,9 +77,8 @@ class VMNICDevice(BaseModel):
         default=None,
         description="Host network interface or bridge to attach to. `null` for no attachment.",
     )
-    mac: str | None = Field(
+    mac: MACAddress | None = Field(
         default=None,
-        pattern='^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$',
         description="MAC address for the virtual network interface. `null` for auto-generation.",
     )
 

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_mac_address.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_mac_address.py
@@ -13,14 +13,15 @@ class MACAddressModel(BaseModel):
 
 
 @pytest.mark.parametrize(
-    "value",
+    "value,expected",
     [
-        "00:a0:99:7e:bb:8a",  # canonical lowercase
-        "00:A0:99:7E:BB:8A",  # uppercase colon (libvirt accepts and lowercases)
+        ("00:a0:99:7e:bb:8a", "00:a0:99:7e:bb:8a"),  # canonical lowercase
+        ("00:A0:99:7E:BB:8A", "00:a0:99:7e:bb:8a"),  # uppercase is accepted, then normalized
+        ("00:A0:99:7e:bb:8A", "00:a0:99:7e:bb:8a"),  # as is mixed case
     ],
 )
-def test_mac_address_accepts_colon(value):
-    assert accept_params(MACAddressModel, [value]) == [value]
+def test_mac_address_accepts_colon_and_normalizes(value, expected):
+    assert accept_params(MACAddressModel, [value]) == [expected]
 
 
 @pytest.mark.parametrize(
@@ -32,6 +33,9 @@ def test_mac_address_accepts_colon(value):
         "00:a0-99:7e-bb:8a",  # mixed separators
         "00:a0:99:7e:bb",  # too short
         "gg:gg:gg:gg:gg:gg",  # colon-separated but non-hex
+        "00:a0:99:7e:bb:8a\n",  # trailing newline ($ in Python re matches before it)
+        "00:a0:99:7e:bb:8a ",  # trailing whitespace
+        " 00:a0:99:7e:bb:8a",  # leading whitespace
     ],
 )
 def test_mac_address_rejects_non_colon(value):
@@ -42,8 +46,9 @@ def test_mac_address_rejects_non_colon(value):
 
 
 @pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
-def test_nic_device_mac_accepts_colon(model):
-    assert model(dtype="NIC", mac="00:a0:99:7e:bb:8a").mac == "00:a0:99:7e:bb:8a"
+@pytest.mark.parametrize("value", ["00:a0:99:7e:bb:8a", "00:A0:99:7E:BB:8A"])
+def test_nic_device_mac_accepts_colon(model, value):
+    assert model(dtype="NIC", mac=value).mac == "00:a0:99:7e:bb:8a"
 
 
 @pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
@@ -52,6 +57,7 @@ def test_nic_device_mac_allows_null(model):
 
 
 @pytest.mark.parametrize("model", [VMNICDevice, ContainerNICDevice])
-def test_nic_device_mac_rejects_dash(model):
+@pytest.mark.parametrize("value", ["10-66-6a-1f-f1-b1", "00:a0:99:7e:bb:8a\n"])
+def test_nic_device_mac_rejects_invalid(model, value):
     with pytest.raises(pydantic.ValidationError):
-        model(dtype="NIC", mac="10-66-6a-1f-f1-b1")
+        model(dtype="NIC", mac=value)

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_libvirt_device_uniqueness.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_libvirt_device_uniqueness.py
@@ -179,6 +179,30 @@ def test_extract_identity_nic_no_mac():
     assert _extract_identity(device) is None
 
 
+@pytest.mark.parametrize('mac', ['00:A0:98:61:F2:A0', '00:a0:98:61:f2:A0'])
+def test_extract_identity_nic_mac_is_case_insensitive(mac):
+    device = {'attributes': {'dtype': 'NIC', 'mac': mac}}
+    assert _extract_identity(device) == '00:a0:98:61:f2:a0'
+
+
+@pytest.mark.parametrize('mac', ['00:A0:98:61:F2:A0', '00:a0:98:61:f2:A0'])
+def test_uppercase_mac_duplicating_existing_fails(mac):
+    """The same address in a different case is still the same address to libvirt."""
+    instance = {
+        'name': 'test_vm',
+        'devices': [{'id': 1, 'attributes': {'dtype': 'NIC', 'mac': '00:a0:98:61:f2:a0'}}],
+    }
+    device = {'attributes': {'dtype': 'NIC', 'mac': mac}}
+
+    assert device_uniqueness_check(device, instance, 'NIC') is False
+
+
+def test_extract_identity_disk_path_keeps_case():
+    """Only NIC identities are case-folded: paths are case-sensitive."""
+    device = {'attributes': {'dtype': 'DISK', 'path': '/mnt/tank/Disk1.img'}}
+    assert _extract_identity(device) == '/mnt/tank/Disk1.img'
+
+
 def test_extract_identity_disk_path():
     device = {'attributes': {'dtype': 'DISK', 'path': '/dev/zvol/tank/disk1'}}
     assert _extract_identity(device) == '/dev/zvol/tank/disk1'

--- a/src/middlewared/middlewared/utils/libvirt/utils.py
+++ b/src/middlewared/middlewared/utils/libvirt/utils.py
@@ -33,7 +33,9 @@ def _extract_identity(device: dict[str, Any]) -> str | None:
         case 'GPU':
             return device['attributes'].get('pci_address')  # type: ignore[no-any-return]
         case 'NIC':
-            return device['attributes'].get('mac')  # type: ignore[no-any-return]
+            # MAC addresses are case-insensitive, so compare them canonically
+            mac = device['attributes'].get('mac')
+            return str(mac).lower() if mac is not None else None
         case 'USB':
             if device['attributes'].get('device'):
                 return device['attributes']['device']  # type: ignore[no-any-return]


### PR DESCRIPTION
## Problem
The NIC `mac` field accepted dash-separated, no-separator and mixed forms, but libvirt's `defineXML` only parses colon-separated MACs — so a VM or container configured that way was accepted by the API and then failed to start with an XML parse error. Existing installs can already have such addresses stored.

## Solution
- **Colon-only validation.** The shared `MACAddress` type now matches colon-separated hex only. It is anchored with `\Z` rather than `$`, because Python's `$` also matches before a trailing newline and would otherwise let through a value libvirt still cannot parse.
- **Lowercase normalization.** MAC addresses are case-insensitive, but every comparison we make against one is a plain string compare, so an uppercase spelling was a distinct value to the per-instance duplicate check. The type now lowercases, and `device_uniqueness_check` case-folds the NIC identity so rows written before this still compare correctly.
- **Migration for stored addresses.** Existing `vm_device` / `container_device` NIC rows are rewritten to the canonical form. Anything not carrying a valid 48-bit address is replaced with a freshly generated MAC — that includes non-string values, which an incus migration can leave behind when PyYAML resolves an unquoted address such as `52:54:00:12:34:56` as a YAML 1.1 base-60 integer.

Frozen API versions keep their original pattern, so a client pinned to 25.10 that sends a dash-separated MAC is now rejected at validation instead of failing later at start.

Original PR: https://github.com/truenas/middleware/pull/19487
