### PR TITLE
NAS-142156 / 27.0.0-BETA.1 / Restore global logging state mutated by the logger tests

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_metadata_generate.py
@@ -120,8 +120,6 @@ def test_broken_app_is_logged(caplog):
     def get_config(name, version):
         raise FileNotFoundError(2, "No such file or directory")
 
-    # Bind to the named logger explicitly: `app_lifecycle` has propagation disabled once
-    # middlewared configures logging for real.
     with caplog.at_level(logging.WARNING, logger="app_lifecycle"):
         with generate(["app-broken"], metadata_map, get_config) as (metadata, config):
             assert sorted(metadata) == ["app-broken"]

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -29,6 +29,28 @@ def remove_logfile(path):
         pass
 
 
+@pytest.fixture(scope='function', autouse=True)
+def preserve_global_logging_state():
+    """ `setup_syslog_handler` attaches a queue handler to its target logger and turns off
+    propagation to root, neither of which it can undo. `tests/run_unit_tests.py` runs the
+    middleware pytest suite in this same interpreter afterwards, and a logger that no longer
+    propagates silently defeats `caplog` there, so unwind those mutations here. """
+    loggers = [logging.getLogger(tnlog.name) for tnlog in ALL_LOG_FILES]
+    propagation = [logger.propagate for logger in loggers]
+
+    try:
+        yield
+    finally:
+        for logger, propagate in zip(loggers, propagation):
+            # Only queue handlers belong to `setup_syslog_handler`. Anything else on the root
+            # logger is pytest's own log capture, and removing it would break log reporting.
+            for handler in logger.handlers[:]:
+                if isinstance(handler, logging.handlers.QueueHandler):
+                    logger.removeHandler(handler)
+
+            logger.propagate = propagate
+
+
 @pytest.fixture(scope='function')
 def current_test_name(request):
     return request.node.name


### PR DESCRIPTION
## Problem
`test_app_metadata_generate::test_broken_app_is_logged` has failed every incremental build since it was added, while passing when its file is run on its own. `run_unit_tests.py` puts both unit test directories through `pytest.main()` in a single interpreter, and `test__middleware_logger_paths` calls `setup_syslog_handler()` for every entry in `ALL_LOG_FILES` — which attaches a queue handler and sets `propagate = False`, neither of which it can undo. By the time the middleware suite runs, `app_lifecycle` no longer propagates to root, which is the only place `caplog` installs its handler, so `caplog.text` comes back empty. `ALL_LOG_FILES` also carries an unnamed entry, so one of those leaked handlers lands on the root logger and every record from the second run was being shipped off to the real middlewared log.

## Solution
Added an autouse fixture to the logger tests that snapshots propagation up front and, on teardown, restores it and strips any queue handler the suite left behind. Filtering by handler class rather than diffing the handler list matters here: one of these loggers is root, and pytest swaps its own capture handlers there between a test's setup and teardown phases.

Also dropped the comment in `test_broken_app_is_logged` claiming the `logger=` keyword binds the handler — `caplog.at_level` only sets levels, and nothing configures middleware logging in a unit test process, so the comment was wrong on both counts.

Unit tests run: http://jenkins.eng.ixsystems.net:8080/job/tests/job/unit_tests/4601/