### PR TITLE
NAS-142157 / 26.0.0-RC.1 / Fix drift-repair apps test calling a nonexistent method

### DIFF
--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -330,5 +330,5 @@ def test_drift_repair_ix_apps(docker_pool):
     ssh(f"chmod 0755 {IX_APPS_CHOKEPOINT}")
     # start_service is idempotent if docker is already running, but still
     # runs the drift-repair enforce_mountpoint_perms call.
-    call("docker.start_service")
+    call("docker.state.start_service")
     assert _chokepoint_perms(IX_APPS_CHOKEPOINT) == (0o700, 0, 0)


### PR DESCRIPTION
## Problem
`test_drift_repair_ix_apps` calls `docker.start_service`, which doesn't exist on this branch — the method is registered as `docker.state.start_service` on the private `DockerStateService`. The test was brought over from master, where the docker plugin's typesafe conversion collapsed that service into the public `docker` namespace. It has failed with "Method does not exist" on every CI run since it landed, so the drift-repair path it covers has never actually been exercised here, and it leaves `/mnt/.ix-apps` at 0755 because it loosens the perms before the call that would re-tighten them.

## Solution
Point the call at `docker.state.start_service`. Same function and same default `mount_datasets=False` — master's `docker.start_service` just delegates into it.