### PR TITLE
NAS-142006 / 27.0.0-BETA.1 / Refresh the recorded NVIDIA GPU UUID when a card is replaced

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -139,9 +139,16 @@ async def normalize_gpu_configuration(
     if all(gpu['vendor'] == 'NVIDIA' for gpu in gpu_choices.values()):
         value['use_all_gpus'] = False
 
-    for nvidia_gpu_pci_slot in list(value['nvidia_gpu_selection']):
+    for nvidia_gpu_pci_slot, gpu_config in list(value['nvidia_gpu_selection'].items()):
         if nvidia_gpu_pci_slot not in gpu_choices or gpu_choices[nvidia_gpu_pci_slot]['vendor'] != 'NVIDIA':
             value['nvidia_gpu_selection'].pop(nvidia_gpu_pci_slot)
+        elif isinstance(gpu_config, dict) and (
+            gpu_uuid := gpu_choices[nvidia_gpu_pci_slot]['vendor_specific_config'].get('uuid')
+        ):
+            # The PCI slot is what identifies the selection, so the recorded UUID must track whichever
+            # card currently occupies that slot - otherwise replacing a GPU leaves the app configured
+            # with a UUID which no longer exists and the container runtime fails to start it
+            gpu_config['uuid'] = gpu_uuid
 
     return value
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_gpu_options.py
@@ -126,6 +126,45 @@ from middlewared.service import ServiceContext
             'nvidia_gpu_selection': {}
         }
 
+    ),
+    (
+        # GPU in slot 0000:02:00.0 has been swapped out for a different card, so the UUID
+        # recorded against that slot must be refreshed to the one currently reported
+        [
+            {
+                'pci_slot': '0000:02:00.0',
+                'description': 'NVIDIA GeForce RTX 3060 Ti',
+                'vendor': 'NVIDIA',
+                'vendor_specific_config': {'uuid': 'GPU-899dd4a1-ac45-57c5-019a-08b06c7172d3'},
+                'available_to_host': True,
+                'error': None,
+            },
+            {
+                'pci_slot': '0000:03:00.0',
+                'description': 'NVIDIA GeForce RTX 3080',
+                'vendor': 'NVIDIA',
+                'vendor_specific_config': {'uuid': 'GPU-11111111-2222-3333-4444-555555555555'},
+                'available_to_host': True,
+                'error': None,
+            },
+        ],
+        {
+            'use_all_gpus': False,
+            'kfd_device_exists': False,
+            'nvidia_gpu_selection': {
+                '0000:02:00.0': {'use_gpu': True, 'uuid': 'GPU-00ef4f92-c70a-446a-8248-d61c7fac9f07'},
+                '0000:03:00.0': {'use_gpu': False, 'uuid': 'GPU-11111111-2222-3333-4444-555555555555'},
+            }
+        },
+        {
+            'use_all_gpus': False,
+            'kfd_device_exists': False,
+            'nvidia_gpu_selection': {
+                '0000:02:00.0': {'use_gpu': True, 'uuid': 'GPU-899dd4a1-ac45-57c5-019a-08b06c7172d3'},
+                '0000:03:00.0': {'use_gpu': False, 'uuid': 'GPU-11111111-2222-3333-4444-555555555555'},
+            }
+        }
+
     )
 ])
 @patch('middlewared.plugins.apps.schema_normalization.kfd_exists', return_value=False)


### PR DESCRIPTION
## Problem
An app's GPU selection is keyed by PCI slot but carries the card's NVML UUID alongside it. Normalization only ever dropped a selection when its slot disappeared or stopped being NVIDIA, so swapping a card into the same slot left the app configured with a UUID which no longer exists, and the container runtime then refused to start it.

## Solution
For a slot that is retained, refresh the stored UUID from the live GPU choices so the recorded value tracks whichever card currently occupies that slot. This means the app has to be updated or redeployed to pick up the corrected value - starting it on its own reuses the compose files rendered before the swap.