### PR TITLE
NAS-142185 / 27.0.0-BETA.1 / Fix stale literalinclude path in docs/database/sqlalchemy.rst

### DIFF
--- a/docs/source/database/sqlalchemy.rst
+++ b/docs/source/database/sqlalchemy.rst
@@ -12,7 +12,7 @@ TrueNAS configuration we only use the following components:
 
 Database tables are defined as classes in corresponding middleware plugins:
 
-.. literalinclude:: /../../src/middlewared/middlewared/plugins/api_key.py
+.. literalinclude:: /../../src/middlewared/middlewared/plugins/api_key/crud.py
     :pyobject: APIKeyModel
     :caption:
 


### PR DESCRIPTION
A prior commit (PR #18854) split plugins/api_key.py into a package (api_key/{__init__,crud,internal}.py), moving APIKeyModel into crud.py. The docs literalinclude still pointed at the old single-file path, which no longer exists, breaking `make html` (SPHINXOPTS=-W treats the resulting warning as fatal).

This does **NOT** need to be backported, as `stable/26` still uses src/middlewared/middlewared/plugins/api_key.py