### PR TITLE
NAS-142191 / 27.0.0-BETA.1 / Don't swallow app upgrade failures in upgrade_impl

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -162,11 +162,14 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
         finally:
             app = context.call_sync2(context.s.app.get_instance, app_name)
             if app.upgrade_available is False or app.custom_app:
-                # Pull may have succeeded but redeploy failed - we early-return here
-                # so that the caller can update alerts based on the refreshed app state
+                # Pull may have succeeded but redeploy failed - refresh the app state here
+                # so that the caller can update alerts based on it either way. Note that this
+                # must not return, as a return inside `finally` discards an in-flight exception.
                 context.middleware.send_event('app.query', 'CHANGED', id=app_name, fields=app.model_dump())
-                job.set_progress(100, 'App successfully upgraded and redeployed')
-                return app
+
+        if app.upgrade_available is False or app.custom_app:
+            job.set_progress(100, 'App successfully upgraded and redeployed')
+            return app
 
     job.set_progress(15, f'Retrieving versions for {app_name!r} app')
     versions_config = context.run_coroutine(get_versions(context, app, options.app_version))

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -161,13 +161,14 @@ def upgrade_impl(context: ServiceContext, job: Job, app_name: str, options: AppU
             )
         finally:
             app = context.call_sync2(context.s.app.get_instance, app_name)
-            if app.upgrade_available is False or app.custom_app:
+            upgrade_completed = app.upgrade_available is False or app.custom_app
+            if upgrade_completed:
                 # Pull may have succeeded but redeploy failed - refresh the app state here
                 # so that the caller can update alerts based on it either way. Note that this
                 # must not return, as a return inside `finally` discards an in-flight exception.
                 context.middleware.send_event('app.query', 'CHANGED', id=app_name, fields=app.model_dump())
 
-        if app.upgrade_available is False or app.custom_app:
+        if upgrade_completed:
             job.set_progress(100, 'App successfully upgraded and redeployed')
             return app
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from middlewared.plugins.apps.upgrade import upgrade_impl
+from middlewared.service import CallError
+
+
+PULL_ERROR = (
+    "Failed 'pull' action for 'custom-app' app. "
+    "Please check /var/log/app_lifecycle.log for more details"
+)
+
+SUCCESS_PROGRESS = (100, 'App successfully upgraded and redeployed')
+
+
+def app_entry(**overrides):
+    """Stands in for a running custom app that has an image update pending."""
+    app = MagicMock()
+    app.state = 'RUNNING'
+    app.upgrade_available = True
+    app.custom_app = True
+    app.metadata = {'name': 'custom-app'}
+    for key, value in overrides.items():
+        setattr(app, key, value)
+    return app
+
+
+@patch('middlewared.plugins.apps.upgrade.assert_app_usable', MagicMock())
+@patch('middlewared.plugins.apps.upgrade.pull_images_internal')
+def test_custom_app_upgrade_surfaces_pull_failure(pull_images_internal):
+    """A failed pull has to fail the job rather than return the app."""
+    pull_images_internal.side_effect = CallError(PULL_ERROR)
+    context = MagicMock()
+    context.call_sync2.return_value = app_entry()
+    job = MagicMock()
+
+    with pytest.raises(CallError, match="Failed 'pull' action"):
+        upgrade_impl(context, job, 'custom-app', MagicMock())
+
+    # The job must not claim the upgrade finished.
+    assert SUCCESS_PROGRESS not in [c.args for c in job.set_progress.call_args_list]
+
+
+@patch('middlewared.plugins.apps.upgrade.assert_app_usable', MagicMock())
+@patch('middlewared.plugins.apps.upgrade.pull_images_internal', MagicMock())
+def test_custom_app_upgrade_returns_app_on_success():
+    """A successful pull and redeploy still short circuits with the refreshed app."""
+    context = MagicMock()
+    app = app_entry()
+    context.call_sync2.return_value = app
+    job = MagicMock()
+
+    assert upgrade_impl(context, job, 'custom-app', MagicMock()) is app
+    job.set_progress.assert_called_with(*SUCCESS_PROGRESS)
+    context.middleware.send_event.assert_called_once()

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
@@ -5,29 +5,25 @@ import pytest
 from middlewared.plugins.apps.upgrade import upgrade_impl
 from middlewared.service import CallError
 
+PULL_ERROR = "Failed 'pull' action for 'custom-app' app. Please check /var/log/app_lifecycle.log for more details"
 
-PULL_ERROR = (
-    "Failed 'pull' action for 'custom-app' app. "
-    "Please check /var/log/app_lifecycle.log for more details"
-)
-
-SUCCESS_PROGRESS = (100, 'App successfully upgraded and redeployed')
+SUCCESS_PROGRESS = (100, "App successfully upgraded and redeployed")
 
 
 def app_entry(**overrides):
     """Stands in for a running custom app that has an image update pending."""
     app = MagicMock()
-    app.state = 'RUNNING'
+    app.state = "RUNNING"
     app.upgrade_available = True
     app.custom_app = True
-    app.metadata = {'name': 'custom-app'}
+    app.metadata = {"name": "custom-app"}
     for key, value in overrides.items():
         setattr(app, key, value)
     return app
 
 
-@patch('middlewared.plugins.apps.upgrade.assert_app_usable', MagicMock())
-@patch('middlewared.plugins.apps.upgrade.pull_images_internal')
+@patch("middlewared.plugins.apps.upgrade.assert_app_usable", MagicMock())
+@patch("middlewared.plugins.apps.upgrade.pull_images_internal")
 def test_custom_app_upgrade_surfaces_pull_failure(pull_images_internal):
     """A failed pull has to fail the job rather than return the app."""
     pull_images_internal.side_effect = CallError(PULL_ERROR)
@@ -36,14 +32,14 @@ def test_custom_app_upgrade_surfaces_pull_failure(pull_images_internal):
     job = MagicMock()
 
     with pytest.raises(CallError, match="Failed 'pull' action"):
-        upgrade_impl(context, job, 'custom-app', MagicMock())
+        upgrade_impl(context, job, "custom-app", MagicMock())
 
     # The job must not claim the upgrade finished.
     assert SUCCESS_PROGRESS not in [c.args for c in job.set_progress.call_args_list]
 
 
-@patch('middlewared.plugins.apps.upgrade.assert_app_usable', MagicMock())
-@patch('middlewared.plugins.apps.upgrade.pull_images_internal', MagicMock())
+@patch("middlewared.plugins.apps.upgrade.assert_app_usable", MagicMock())
+@patch("middlewared.plugins.apps.upgrade.pull_images_internal", MagicMock())
 def test_custom_app_upgrade_returns_app_on_success():
     """A successful pull and redeploy still short circuits with the refreshed app."""
     context = MagicMock()
@@ -51,6 +47,6 @@ def test_custom_app_upgrade_returns_app_on_success():
     context.call_sync2.return_value = app
     job = MagicMock()
 
-    assert upgrade_impl(context, job, 'custom-app', MagicMock()) is app
+    assert upgrade_impl(context, job, "custom-app", MagicMock()) is app
     job.set_progress.assert_called_with(*SUCCESS_PROGRESS)
     context.middleware.send_event.assert_called_once()


### PR DESCRIPTION
## Problem

`upgrade_impl()` returns from inside a `finally` block, which discards any exception raised by `pull_images_internal()`. For custom apps the `or app.custom_app` condition makes that branch unconditional, so a failed `docker compose pull` gets reported to the user as a successful upgrade.

What you see: the Update job finishes in about a second with state SUCCESS and progress "App successfully upgraded and redeployed", then the update badge reappears. The real error only lands in `/var/log/app_lifecycle.log`.

The wrong status also hides two steps that get skipped when the pull raises, both sitting after `compose_action()` in `pull_images_internal()`: the `clear_update_flag_for_tag` loop and `app.redeploy`. So the app isn't recreated and the update flag stays set, which is why the badge comes back.

## Solution

Clearing a stale alert after a partial pull is still worth doing, so this keeps the state refresh in the `finally` and moves only the early return and its progress update out. The success path behaves exactly as before.

Adds unit tests for both the failure and the success path.

## Reproduction

Hit this on 25.10.6 with a custom app that mixes a locally built image with registry images. The pull fails because `compose_action()` runs `docker compose pull --policy always` across the whole project, so one unpullable image interrupts the rest. Full write up and logs in [NAS-142191](https://ixsystems.atlassian.net/browse/NAS-142191).

## Affected branches

The same block is present on `release/25.10.7` and `stable/26` in the pre-typesafe `AppService.upgrade()` shape, so all three active trains are affected, not just master.

One thing to note for the backport: on those branches the `finally` also calls `app.update_app_upgrade_alert()`, which master no longer does. So it wants the same hoist applied to that shape rather than a straight cherry-pick of this diff. Happy to open the companion PRs if that's easier than running it through your tooling.
