### PR TITLE
NAS-142192 / 25.10.7 / Don't let one registry failure abort the image update sweep

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/apps_images/update_alerts.py
@@ -35,6 +35,10 @@ class ContainerImagesService(Service, ContainerRegistryClientMixin):
                     await self.check_update_for_image(tag, image)
                 except CallError as e:
                     logger.error(str(e))
+                except Exception:
+                    # A single misbehaving image/registry must not abort the whole sweep
+                    # (and surface as an unretrieved task exception); log and move on.
+                    logger.error('Failed to check for image update for %r', tag, exc_info=True)
 
     async def retrieve_digest(self, reference: str):
         repo_digests = []


### PR DESCRIPTION
## Problem

`ContainerImagesService.check_update()` catches only `CallError`:

```python
for image in images:
    for tag in image['repo_tags']:
        try:
            await self.check_update_for_image(tag, image)
        except CallError as e:
            logger.error(str(e))
```

Anything else raised by the registry client escapes the per-tag handler and aborts the whole sweep, so every image after the failing one keeps whatever flag it already had. `check_update` is launched with `create_task()` and nobody awaits it, so there is no user-visible failure at all, just a `Task exception was never retrieved` entry in `middlewared.log`.

Seen on 25.10.6. `lscr.io` served a certificate with a hostname mismatch, aiohttp raised `ClientConnectorCertificateError`, and the sweep stopped there:

```
Task exception was never retrieved
future: <Task ... exception=ClientConnectorCertificateError(ConnectionKey(host='lscr.io', ...),
  SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
  Hostname mismatch, certificate is not valid for 'lscr.io'."))>
  File ".../plugins/apps_images/update_alerts.py", line 35, in check_update
    await self.check_update_for_image(tag, image)
```

The effect is worse than a missed notification. `ix_apps/query.py` derives `upgrade_available` from `image_updates_available` for custom apps, and `app.upgrade()` raises `No upgrade available` when that is false, so an app whose check never ran can't be upgraded from the UI at all until a later sweep gets past the bad image.

## Solution

Backport of the hardening already on master and `stable/26`, from 160986f01 (NAS-141553), where it came in alongside an unrelated Basic auth change and so never reached the 25.10 line. Same code and same comment as master, adapted to the pre-typesafe shape of this branch.

This only changes error handling. A registry that fails for any reason now logs and the sweep continues to the next tag.

Full write up and the original traceback in [NAS-142192](https://ixsystems.atlassian.net/browse/NAS-142192).

Only the error handling from 160986f01 is backported here. That commit also changed the digest check to pass configured registry credentials, which is a behaviour change rather than a fix, so it is deliberately left out of a point release.
