### PR TITLE
NAS-142227 / 26.0.0-RC.1 / Drop kernel address refresh re-announcements in netlink monitor (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/netlink_events.py
+++ b/src/middlewared/middlewared/plugins/device_/netlink_events.py
@@ -9,6 +9,9 @@ from middlewared.plugins.service_.services.dbus_router import system_dbus
 from middlewared.utils.threading import start_daemon_thread
 
 IX_VEND_LOCK = asyncio.Lock()
+# True while a restart is waiting on the lock. Requests arriving in that
+# window are covered by the waiter, so at most one restart is ever queued.
+_restart_queued = False
 
 # Netlink constants
 AF_NETLINK = 16
@@ -51,6 +54,7 @@ IFA_ADDRESS = 1
 IFA_LOCAL = 2
 IFA_LABEL = 3
 IFA_BROADCAST = 4
+IFA_CACHEINFO = 6
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
@@ -313,6 +317,29 @@ def create_address_event(sock, msg_type, ifa_msg, ip_addr, if_name):
     return event_data
 
 
+def is_address_refresh(msg_type, ifa_msg):
+    """Return True when the kernel re-announced an already existing address.
+
+    The kernel emits RTM_NEWADDR not only when an address is added but also
+    every time an address lifetime is refreshed, for example by the periodic
+    router advertisements that renew SLAAC addresses. IFA_CACHEINFO carries
+    the creation and last update timestamps. They are equal for a brand new
+    address and differ on a re-announcement, so each message classifies
+    itself and no state needs to be tracked. Messages without cacheinfo are
+    treated as real changes.
+    """
+    if msg_type != RTM_NEWADDR:
+        return False
+
+    cacheinfo = ifa_msg.attributes.get(IFA_CACHEINFO)
+    if cacheinfo is None or len(cacheinfo) < 16:
+        return False
+
+    # struct ifa_cacheinfo is four u32s (prefered, valid, cstamp, tstamp)
+    cstamp, tstamp = struct.unpack("II", cacheinfo[8:16])
+    return tstamp != cstamp
+
+
 def process_netlink_data(sock, data):
     """Process netlink data and yield IP address change events"""
     offset = 0
@@ -324,30 +351,35 @@ def process_netlink_data(sock, data):
             if msg.type in (RTM_NEWADDR, RTM_DELADDR):
                 ifa_msg = parse_ifaddr_message(msg.payload)
 
-                # Get interface name from IFA_LABEL attribute or fallback to netlink query
-                if_name = None
-                if IFA_LABEL in ifa_msg.attributes:
-                    if_name = (
-                        ifa_msg.attributes[IFA_LABEL].rstrip(b"\x00").decode("utf-8")
-                    )
+                if is_address_refresh(msg.type, ifa_msg):
+                    # Nothing changed, so emitting an event would only make
+                    # subscribers do pointless work
+                    pass
                 else:
-                    if_name = get_interface_name(sock, ifa_msg.index)
+                    # Get interface name from IFA_LABEL attribute or fallback to netlink query
+                    if_name = None
+                    if IFA_LABEL in ifa_msg.attributes:
+                        if_name = (
+                            ifa_msg.attributes[IFA_LABEL].rstrip(b"\x00").decode("utf-8")
+                        )
+                    else:
+                        if_name = get_interface_name(sock, ifa_msg.index)
 
-                # Get address
-                local_addr = ifa_msg.attributes.get(IFA_LOCAL)
-                addr = ifa_msg.attributes.get(IFA_ADDRESS)
+                    # Get address
+                    local_addr = ifa_msg.attributes.get(IFA_LOCAL)
+                    addr = ifa_msg.attributes.get(IFA_ADDRESS)
 
-                # Use LOCAL if available, otherwise ADDRESS
-                ip_addr = None
-                if local_addr:
-                    ip_addr = format_address(ifa_msg.family, local_addr)
-                elif addr:
-                    ip_addr = format_address(ifa_msg.family, addr)
+                    # Use LOCAL if available, otherwise ADDRESS
+                    ip_addr = None
+                    if local_addr:
+                        ip_addr = format_address(ifa_msg.family, local_addr)
+                    elif addr:
+                        ip_addr = format_address(ifa_msg.family, addr)
 
-                if ip_addr:
-                    yield create_address_event(
-                        sock, msg.type, ifa_msg, ip_addr, if_name
-                    )
+                    if ip_addr:
+                        yield create_address_event(
+                            sock, msg.type, ifa_msg, ip_addr, if_name
+                        )
 
             # Move to next message
             offset += (msg.length + 3) & ~3  # Align to 4 bytes
@@ -419,11 +451,16 @@ def netlink_events(middleware):
 
 
 async def _systemctl_restart_ixvendor(middleware):
-    if IX_VEND_LOCK.locked():
-        # A restart is already in progress; skip to avoid piling up
+    global _restart_queued
+
+    if _restart_queued:
+        # The queued restart has not started yet, so it will already pick
+        # up whatever change produced this request
         return
 
+    _restart_queued = True
     async with IX_VEND_LOCK:
+        _restart_queued = False
         if await middleware.call("system.vendor.is_vendored"):
             await system_dbus.call_unit_action_and_wait("ix-vendor.service", "Restart")
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
@@ -1,0 +1,173 @@
+import asyncio
+import socket
+import struct
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from middlewared.plugins.device_ import netlink_events
+from middlewared.plugins.device_.netlink_events import (
+    IFA_ADDRESS,
+    IFA_CACHEINFO,
+    IFA_LABEL,
+    RTM_DELADDR,
+    RTM_NEWADDR,
+    is_address_refresh,
+    parse_ifaddr_message,
+    process_netlink_data,
+)
+
+
+def rtattr(attr_type: int, payload: bytes) -> bytes:
+    header = struct.pack("HH", 4 + len(payload), attr_type)
+    padding = b"\x00" * ((4 - len(payload) % 4) % 4)
+    return header + payload + padding
+
+
+def addr_msg(
+    msg_type: int = RTM_NEWADDR,
+    address: str = "2001:db8::1",
+    prefixlen: int = 64,
+    index: int = 2,
+    label: str = "enp1s0",
+    cacheinfo: tuple[int, int, int, int] | None = None,
+) -> bytes:
+    """Build a binary netlink address message as the kernel would send it.
+
+    cacheinfo is (prefered, valid, cstamp, tstamp) or None to omit the
+    IFA_CACHEINFO attribute entirely.
+    """
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    attrs = rtattr(IFA_ADDRESS, socket.inet_pton(family, address))
+    attrs += rtattr(IFA_LABEL, label.encode() + b"\x00")
+    if cacheinfo is not None:
+        attrs += rtattr(IFA_CACHEINFO, struct.pack("IIII", *cacheinfo))
+    payload = struct.pack("BBBBI", family, prefixlen, 0, 0, index) + attrs
+    header = struct.pack("IHHII", 16 + len(payload), msg_type, 0, 0, 0)
+    return header + payload
+
+
+def failing_sock() -> MagicMock:
+    """A netlink socket stand in whose queries fail.
+
+    get_interface_addresses swallows the error and returns an empty list,
+    keeping the generator under test synchronous and hermetic.
+    """
+    sock = MagicMock()
+    sock.recv.side_effect = OSError("no kernel in unit tests")
+    return sock
+
+
+def events_from(*messages: bytes) -> list[dict]:
+    return list(process_netlink_data(failing_sock(), b"".join(messages)))
+
+
+class TestAddressRefreshFilter:
+    def test_new_address_yields_event(self):
+        """Equal creation and update stamps mean a genuinely new address."""
+        events = events_from(addr_msg(cacheinfo=(300, 300, 1000, 1000)))
+        assert len(events) == 1
+        assert events[0]["event"] == "add"
+        assert events[0]["ip"] == "2001:db8::1/64"
+
+    def test_lifetime_refresh_is_dropped(self):
+        """An update stamp ahead of the creation stamp is an RA refresh."""
+        assert events_from(addr_msg(cacheinfo=(300, 300, 1000, 2500))) == []
+
+    def test_missing_cacheinfo_fails_open(self):
+        assert len(events_from(addr_msg(cacheinfo=None))) == 1
+
+    def test_short_cacheinfo_fails_open(self):
+        truncated = rtattr(IFA_CACHEINFO, struct.pack("II", 300, 300))
+        payload = struct.pack("BBBBI", socket.AF_INET6, 64, 0, 0, 2)
+        payload += rtattr(IFA_ADDRESS, socket.inet_pton(socket.AF_INET6, "2001:db8::1"))
+        payload += rtattr(IFA_LABEL, b"enp1s0\x00") + truncated
+        msg = struct.pack("IHHII", 16 + len(payload), RTM_NEWADDR, 0, 0, 0) + payload
+        assert len(events_from(msg)) == 1
+
+    def test_deladdr_is_never_filtered(self):
+        """Removal of a previously refreshed address is a real change."""
+        events = events_from(addr_msg(msg_type=RTM_DELADDR, cacheinfo=(300, 300, 1000, 9000)))
+        assert len(events) == 1
+        assert events[0]["event"] == "remove"
+
+    def test_ipv4_refresh_is_dropped(self):
+        """A DHCP renewal of the same lease re-announces the same address."""
+        assert events_from(addr_msg(address="10.0.0.5", prefixlen=24, cacheinfo=(600, 600, 50, 4000))) == []
+
+    def test_mixed_batch_only_yields_real_changes(self):
+        """One recv can carry several messages and only real changes surface."""
+        events = events_from(
+            addr_msg(cacheinfo=(300, 300, 1000, 2000)),
+            addr_msg(address="10.0.0.5", prefixlen=24, cacheinfo=(600, 600, 3000, 3000)),
+            addr_msg(cacheinfo=(300, 300, 1000, 2500)),
+        )
+        assert [e["ip"] for e in events] == ["10.0.0.5/24"]
+
+    def test_predicate_direct(self):
+        refreshed = parse_ifaddr_message(addr_msg(cacheinfo=(300, 300, 1, 2))[16:])
+        brand_new = parse_ifaddr_message(addr_msg(cacheinfo=(300, 300, 7, 7))[16:])
+        assert is_address_refresh(RTM_NEWADDR, refreshed) is True
+        assert is_address_refresh(RTM_NEWADDR, brand_new) is False
+        assert is_address_refresh(RTM_DELADDR, refreshed) is False
+
+
+class TestVendorRestartCoalescing:
+    @pytest.fixture
+    def dbus_env(self, monkeypatch):
+        monkeypatch.setattr(netlink_events, "IX_VEND_LOCK", asyncio.Lock())
+        monkeypatch.setattr(netlink_events, "_restart_queued", False)
+        dbus_mock = MagicMock()
+        monkeypatch.setattr(netlink_events, "system_dbus", dbus_mock)
+        middleware = MagicMock()
+        middleware.call2 = AsyncMock(return_value=True)
+        return middleware, dbus_mock
+
+    @pytest.mark.asyncio
+    async def test_requests_during_restart_collapse_into_one_waiter(self, dbus_env):
+        """Requests made while a restart runs produce one queued restart, never a pileup."""
+        middleware, dbus_mock = dbus_env
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def dbus_action(unit, action):
+            if dbus_mock.call_unit_action_and_wait.await_count == 1:
+                first_started.set()
+                await release_first.wait()
+
+        dbus_mock.call_unit_action_and_wait = AsyncMock(side_effect=dbus_action)
+
+        task1 = asyncio.ensure_future(netlink_events._systemctl_restart_ixvendor(middleware))
+        await first_started.wait()
+
+        # Five requests while the restart is blocked mid run
+        extra = [asyncio.ensure_future(netlink_events._systemctl_restart_ixvendor(middleware)) for _ in range(5)]
+        await asyncio.sleep(0)
+        assert dbus_mock.call_unit_action_and_wait.await_count == 1
+
+        release_first.set()
+        await asyncio.gather(task1, *extra)
+        # They collapsed into exactly one follow up restart
+        assert dbus_mock.call_unit_action_and_wait.await_count == 2
+        assert netlink_events._restart_queued is False
+        assert not netlink_events.IX_VEND_LOCK.locked()
+
+    @pytest.mark.asyncio
+    async def test_sequential_requests_each_restart(self, dbus_env):
+        middleware, dbus_mock = dbus_env
+        dbus_mock.call_unit_action_and_wait = AsyncMock()
+        await netlink_events._systemctl_restart_ixvendor(middleware)
+        await netlink_events._systemctl_restart_ixvendor(middleware)
+        assert dbus_mock.call_unit_action_and_wait.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_restart_leaves_clean_state(self, dbus_env):
+        """A restart failure releases the lock and clears the queued flag."""
+        middleware, dbus_mock = dbus_env
+        dbus_mock.call_unit_action_and_wait = AsyncMock(side_effect=[RuntimeError("dbus down"), None])
+        with pytest.raises(RuntimeError):
+            await netlink_events._systemctl_restart_ixvendor(middleware)
+        assert netlink_events._restart_queued is False
+        assert not netlink_events.IX_VEND_LOCK.locked()
+        await netlink_events._systemctl_restart_ixvendor(middleware)
+        assert dbus_mock.call_unit_action_and_wait.await_count == 2

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_netlink_vendor_restart.py
@@ -120,7 +120,7 @@ class TestVendorRestartCoalescing:
         dbus_mock = MagicMock()
         monkeypatch.setattr(netlink_events, "system_dbus", dbus_mock)
         middleware = MagicMock()
-        middleware.call2 = AsyncMock(return_value=True)
+        middleware.call = AsyncMock(return_value=True)
         return middleware, dbus_mock
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The kernel re-emits RTM_NEWADDR every time a router advertisement refreshes an address lifetime. Each refresh became an ipaddress.change event that restarted ix-vendor.service, every few seconds behind routers with aggressive RA timers.

IFA_CACHEINFO carries creation and update timestamps that are equal only for a brand new address, so refreshes are dropped at parse time with no state tracking needed. Messages without cacheinfo pass through and RTM_DELADDR is never filtered.

Restarts now allow a single waiter on the lock instead of silently skipping, so the latest address state is always applied without piling up. Verified against a live kernel on real hardware.

This was pointed out in https://ixsystems.atlassian.net/browse/NAS-141358 and a fix was proposed in https://github.com/truenas/middleware/pull/19401. This fix supersedes that one.

Original PR: https://github.com/truenas/middleware/pull/19510
