### PR TITLE
NAS-142234 / 27.0.0-BETA.1 / Use `configparser` to generate rclone configs

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync/__init__.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/__init__.py
@@ -51,7 +51,7 @@ from .directory import list_buckets as list_buckets_impl
 from .directory import list_directory as list_directory_impl
 from .directory import providers as providers_impl
 from .lock import FsLockManager
-from .rclone import RcloneConfig, RcloneVerboseLogCutter, lsjson_error_excerpt
+from .rclone import RcloneConfig, RcloneVerboseLogCutter, lsjson_error_excerpt, serialize_rclone_config
 from .sync import do_abort, do_restore, do_sync, do_sync_onetime
 
 if TYPE_CHECKING:
@@ -70,6 +70,7 @@ __all__ = (
     "RcloneConfig",
     "RcloneVerboseLogCutter",
     "lsjson_error_excerpt",
+    "serialize_rclone_config",
 )
 
 

--- a/src/middlewared/middlewared/plugins/cloud_sync/__init__.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/__init__.py
@@ -51,7 +51,7 @@ from .directory import list_buckets as list_buckets_impl
 from .directory import list_directory as list_directory_impl
 from .directory import providers as providers_impl
 from .lock import FsLockManager
-from .rclone import RcloneConfig, RcloneVerboseLogCutter, lsjson_error_excerpt, serialize_rclone_config
+from .rclone import RcloneConfig, RcloneVerboseLogCutter, lsjson_error_excerpt, rclone_config_section
 from .sync import do_abort, do_restore, do_sync, do_sync_onetime
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ __all__ = (
     "RcloneConfig",
     "RcloneVerboseLogCutter",
     "lsjson_error_excerpt",
-    "serialize_rclone_config",
+    "rclone_config_section",
 )
 
 

--- a/src/middlewared/middlewared/plugins/cloud_sync/rclone.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/rclone.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import collections
 import configparser
+import io
 import itertools
 import json
 import logging
@@ -45,6 +46,28 @@ RE_CHECKS = re.compile(r"Checks:\s*(?P<checks>[0-9 /]+)(, (?P<progress>[0-9]+)%)
 RcloneConfigTuple = collections.namedtuple("RcloneConfigTuple", ["config_path", "remote_path", "extra_args"])
 
 
+def serialize_rclone_config(sections: dict[str, dict[str, Any]]) -> str:
+    parser = configparser.RawConfigParser()
+    # rclone config keys are case-sensitive; keep them verbatim instead of lower-casing them.
+    parser.optionxform = str  # type: ignore[method-assign,assignment]
+    for section, items in sections.items():
+        parser.add_section(section)
+        for key, value in items.items():
+            if isinstance(value, bool):
+                value = json.dumps(value)
+            else:
+                value = str(value)
+
+            key = key.replace("\r", "").replace("\n", "")
+            value = value.replace("\r", "").replace("\n", "")
+
+            parser.set(section, key, value)
+
+    buf = io.StringIO()
+    parser.write(buf)
+    return buf.getvalue()
+
+
 class RcloneConfig:
     def __init__(
         self,
@@ -74,6 +97,7 @@ class RcloneConfig:
 
         remote_path = None
         extra_args = []
+        sections: dict[str, dict[str, Any]] = {}
 
         if self.task is not None:
             raw_attributes = self.task.attributes.model_dump(expose_secrets=True)
@@ -91,15 +115,14 @@ class RcloneConfig:
             if self.task.encryption:
                 encryption_password = self.task.encryption_password.get_secret_value()
                 encryption_salt = self.task.encryption_salt.get_secret_value()
-                self.tmp_file.write("[encrypted]\n")
-                self.tmp_file.write("type = crypt\n")
-                self.tmp_file.write(f"remote = {remote_path}\n")
-                self.tmp_file.write(
-                    "filename_encryption = {}\n".format("standard" if self.task.filename_encryption else "off")
-                )
-                self.tmp_file.write("password = {}\n".format(rclone_encrypt_password(encryption_password)))
+                sections["encrypted"] = {
+                    "type": "crypt",
+                    "remote": remote_path,
+                    "filename_encryption": "standard" if self.task.filename_encryption else "off",
+                    "password": rclone_encrypt_password(encryption_password),
+                }
                 if encryption_salt:
-                    self.tmp_file.write("password2 = {}\n".format(rclone_encrypt_password(encryption_salt)))
+                    sections["encrypted"]["password2"] = rclone_encrypt_password(encryption_salt)
 
                 remote_path = "encrypted:/"
 
@@ -132,11 +155,9 @@ class RcloneConfig:
             self.tmp_file_filter.flush()
             extra_args.extend(["--filter-from", self.tmp_file_filter.name])
 
-        self.tmp_file.write("[remote]\n")
-        for k, v in config.items():
-            if isinstance(v, bool):
-                v = json.dumps(v)
-            self.tmp_file.write(f"{k} = {v}\n")
+        sections["remote"] = config
+
+        self.tmp_file.write(serialize_rclone_config(sections))
 
         self.tmp_file.flush()
 

--- a/src/middlewared/middlewared/plugins/cloud_sync/rclone.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync/rclone.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import collections
 import configparser
-import io
 import itertools
 import json
 import logging
@@ -46,26 +45,32 @@ RE_CHECKS = re.compile(r"Checks:\s*(?P<checks>[0-9 /]+)(, (?P<progress>[0-9]+)%)
 RcloneConfigTuple = collections.namedtuple("RcloneConfigTuple", ["config_path", "remote_path", "extra_args"])
 
 
-def serialize_rclone_config(sections: dict[str, dict[str, Any]]) -> str:
-    parser = configparser.RawConfigParser()
-    # rclone config keys are case-sensitive; keep them verbatim instead of lower-casing them.
-    parser.optionxform = str  # type: ignore[method-assign,assignment]
-    for section, items in sections.items():
-        parser.add_section(section)
-        for key, value in items.items():
-            if isinstance(value, bool):
-                value = json.dumps(value)
-            else:
-                value = str(value)
+def rclone_config_section(name: str, items: dict[str, Any]) -> str:
+    """
+    Serialize one section of an rclone config file.
 
-            key = key.replace("\r", "").replace("\n", "")
-            value = value.replace("\r", "").replace("\n", "")
+    rclone parses its config with goconfig, which has no continuation lines or escaping: a line break inside a value
+    ends it and the remainder is parsed as the next key (or fails the parse), so CR/LF are stripped. This keeps a
+    pasted multi-line JSON token or service account file a valid single-line value.
 
-            parser.set(section, key, value)
-
-    buf = io.StringIO()
-    parser.write(buf)
-    return buf.getvalue()
+    goconfig trims whitespace around a value before treating one that starts with a backtick or a triple double-quote
+    as quoted, either truncating it at the last matching quote or rejecting the whole file. Wrapping such values (and
+    values with leading/trailing whitespace, which would otherwise be silently trimmed) in goconfig's own triple
+    double-quotes makes them read back verbatim: goconfig closes the quote at the last triple double-quote on the
+    line, so any newline-free value round-trips exactly.
+    """
+    out = f"[{name}]\n"
+    for key, value in items.items():
+        if isinstance(value, bool):
+            value = json.dumps(value)
+        else:
+            value = str(value)
+        value = value.replace("\r", "").replace("\n", "")
+        stripped = value.strip()
+        if value != stripped or stripped.startswith(("`", '"""')):
+            value = f'"""{value}"""'
+        out += f"{key} = {value}\n"
+    return out
 
 
 class RcloneConfig:
@@ -97,7 +102,6 @@ class RcloneConfig:
 
         remote_path = None
         extra_args = []
-        sections: dict[str, dict[str, Any]] = {}
 
         if self.task is not None:
             raw_attributes = self.task.attributes.model_dump(expose_secrets=True)
@@ -115,14 +119,15 @@ class RcloneConfig:
             if self.task.encryption:
                 encryption_password = self.task.encryption_password.get_secret_value()
                 encryption_salt = self.task.encryption_salt.get_secret_value()
-                sections["encrypted"] = {
+                encrypted_section = {
                     "type": "crypt",
                     "remote": remote_path,
                     "filename_encryption": "standard" if self.task.filename_encryption else "off",
                     "password": rclone_encrypt_password(encryption_password),
                 }
                 if encryption_salt:
-                    sections["encrypted"]["password2"] = rclone_encrypt_password(encryption_salt)
+                    encrypted_section["password2"] = rclone_encrypt_password(encryption_salt)
+                self.tmp_file.write(rclone_config_section("encrypted", encrypted_section))
 
                 remote_path = "encrypted:/"
 
@@ -155,9 +160,7 @@ class RcloneConfig:
             self.tmp_file_filter.flush()
             extra_args.extend(["--filter-from", self.tmp_file_filter.name])
 
-        sections["remote"] = config
-
-        self.tmp_file.write(serialize_rclone_config(sections))
+        self.tmp_file.write(rclone_config_section("remote", config))
 
         self.tmp_file.flush()
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -103,10 +103,11 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
 
 
 @pytest.mark.parametrize("value,written", [
-    # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
-    # rejects the whole file, with a closing quote it takes everything through the last matching quote.
+    # goconfig treats a value opening with a backtick (2+ chars) or a triple double-quote (6+ chars) as quoted: with
+    # no closing quote it rejects the whole file, with a closing quote it takes everything through the last matching
+    # quote.
     ("`x", '"""`x"""'),
-    ('"""x', '""""""x"""'),
+    ('"""xyz', '""""""xyz"""'),
     # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
     # still triggers quoting, and an unquoted padded value would be silently trimmed. the serializer is deliberately
     # triple-quoting it so that goconfig reads it literally rather than interpreting the leading backtick
@@ -115,6 +116,17 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
     ("\tpadded", '"""\tpadded"""'),
 ])
 def test__rclone_config_section_quotes_values_goconfig_would_mangle(value, written):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {written}\n"
+
+
+@pytest.mark.parametrize("value,written", [
+    # these fall under goconfig's quote-detection length gates (2 chars for a backtick, 6 for a triple double-quote)
+    # and would parse literally even unquoted; the serializer quotes them anyway, and they read back identically.
+    ("`", '"""`"""'),
+    ('"""x', '""""""x"""'),
+])
+def test__rclone_config_section_quoting_below_goconfig_length_gates_is_harmless(value, written):
     out = rclone_config_section("remote", {"pass": value})
     assert out == f"[remote]\npass = {written}\n"
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter
+from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, serialize_rclone_config
 
 
 @pytest.mark.parametrize("error,excerpt", [
@@ -79,3 +79,44 @@ def test__RcloneVerboseLogCutter(input, output):
         out += result
 
     assert out == output
+
+
+def test__serialize_rclone_config_basic():
+    out = serialize_rclone_config({"remote": {"type": "sftp", "host": "h", "user": "u"}})
+    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n\n"
+
+
+def test__serialize_rclone_config_preserves_key_case():
+    out = serialize_rclone_config({"remote": {"Mixed_Case_Key": "v"}})
+    assert out == "[remote]\nMixed_Case_Key = v\n\n"
+
+
+def test__serialize_rclone_config_bool_rendered_lowercase():
+    out = serialize_rclone_config({"remote": {"fast_list": True, "skip_region": False}})
+    assert out == "[remote]\nfast_list = true\nskip_region = false\n\n"
+
+
+def test__serialize_rclone_config_stringifies_non_str_values():
+    out = serialize_rclone_config({"remote": {"port": 22, "empty": None}})
+    assert out == "[remote]\nport = 22\nempty = None\n\n"
+
+
+def test__serialize_rclone_config_does_not_interpolate_percent():
+    out = serialize_rclone_config({"remote": {"pass": "ab%2Fcd%s"}})
+    assert out == "[remote]\npass = ab%2Fcd%s\n\n"
+
+
+def test__serialize_rclone_config_preserves_section_order():
+    out = serialize_rclone_config({"encrypted": {"type": "crypt"}, "remote": {"type": "sftp"}})
+    assert out == "[encrypted]\ntype = crypt\n\n[remote]\ntype = sftp\n\n"
+
+
+@pytest.mark.parametrize("payload", ["x\ntype = local", "x\r\ntype = local", "x\rtype = local"])
+def test__serialize_rclone_config_strips_line_breaks_from_value(payload):
+    out = serialize_rclone_config({"remote": {"type": "sftp", "host": payload}})
+    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n\n"
+
+
+def test__serialize_rclone_config_strips_line_breaks_from_key():
+    out = serialize_rclone_config({"remote": {"ho\nst": "v"}})
+    assert out == "[remote]\nhost = v\n\n"

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, serialize_rclone_config
+from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, rclone_config_section
 
 
 @pytest.mark.parametrize("error,excerpt", [
@@ -81,42 +81,50 @@ def test__RcloneVerboseLogCutter(input, output):
     assert out == output
 
 
-def test__serialize_rclone_config_basic():
-    out = serialize_rclone_config({"remote": {"type": "sftp", "host": "h", "user": "u"}})
-    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n\n"
+def test__rclone_config_section_basic():
+    out = rclone_config_section("remote", {"type": "sftp", "host": "h", "user": "u"})
+    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n"
 
 
-def test__serialize_rclone_config_preserves_key_case():
-    out = serialize_rclone_config({"remote": {"Mixed_Case_Key": "v"}})
-    assert out == "[remote]\nMixed_Case_Key = v\n\n"
+def test__rclone_config_section_bool_rendered_lowercase():
+    out = rclone_config_section("remote", {"fast_list": True, "skip_region": False})
+    assert out == "[remote]\nfast_list = true\nskip_region = false\n"
 
 
-def test__serialize_rclone_config_bool_rendered_lowercase():
-    out = serialize_rclone_config({"remote": {"fast_list": True, "skip_region": False}})
-    assert out == "[remote]\nfast_list = true\nskip_region = false\n\n"
-
-
-def test__serialize_rclone_config_stringifies_non_str_values():
-    out = serialize_rclone_config({"remote": {"port": 22, "empty": None}})
-    assert out == "[remote]\nport = 22\nempty = None\n\n"
-
-
-def test__serialize_rclone_config_does_not_interpolate_percent():
-    out = serialize_rclone_config({"remote": {"pass": "ab%2Fcd%s"}})
-    assert out == "[remote]\npass = ab%2Fcd%s\n\n"
-
-
-def test__serialize_rclone_config_preserves_section_order():
-    out = serialize_rclone_config({"encrypted": {"type": "crypt"}, "remote": {"type": "sftp"}})
-    assert out == "[encrypted]\ntype = crypt\n\n[remote]\ntype = sftp\n\n"
+def test__rclone_config_section_stringifies_non_str_values():
+    out = rclone_config_section("remote", {"port": 22})
+    assert out == "[remote]\nport = 22\n"
 
 
 @pytest.mark.parametrize("payload", ["x\ntype = local", "x\r\ntype = local", "x\rtype = local"])
-def test__serialize_rclone_config_strips_line_breaks_from_value(payload):
-    out = serialize_rclone_config({"remote": {"type": "sftp", "host": payload}})
-    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n\n"
+def test__rclone_config_section_strips_line_breaks_from_value(payload):
+    out = rclone_config_section("remote", {"type": "sftp", "host": payload})
+    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n"
 
 
-def test__serialize_rclone_config_strips_line_breaks_from_key():
-    out = serialize_rclone_config({"remote": {"ho\nst": "v"}})
-    assert out == "[remote]\nhost = v\n\n"
+@pytest.mark.parametrize("value,written", [
+    # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
+    # rejects the whole file, with one it truncates the value at the last matching quote.
+    ("`x", '"""`x"""'),
+    ('"""x', '""""""x"""'),
+    # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
+    # still triggers quoting, and an unquoted padded value would be silently trimmed.
+    (" `x", '""" `x"""'),
+    (" padded ", '""" padded """'),
+    ("\tpadded", '"""\tpadded"""'),
+])
+def test__rclone_config_section_quotes_values_goconfig_would_mangle(value, written):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {written}\n"
+
+
+@pytest.mark.parametrize("value", [
+    "a`b",           # backtick not at the start is literal
+    'a"""b',         # triple quote not at the start is literal
+    '"x"',           # single double-quotes are only special for keys, not values
+    "ab%2Fcd%s",     # no interpolation layer
+    "",
+])
+def test__rclone_config_section_leaves_safe_values_verbatim(value):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {value}\n"

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -104,11 +104,12 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
 
 @pytest.mark.parametrize("value,written", [
     # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
-    # rejects the whole file, with one it truncates the value at the last matching quote.
+    # rejects the whole file, with a closing quote it takes everything through the last matching quote.
     ("`x", '"""`x"""'),
     ('"""x', '""""""x"""'),
     # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
-    # still triggers quoting, and an unquoted padded value would be silently trimmed.
+    # still triggers quoting, and an unquoted padded value would be silently trimmed. the serializer is deliberately
+    # triple-quoting it so that goconfig reads it literally rather than interpreting the leading backtick
     (" `x", '""" `x"""'),
     (" padded ", '""" padded """'),
     ("\tpadded", '"""\tpadded"""'),


### PR DESCRIPTION
This prevents us from generating invalid ini files by escaping invalid characters.