### PR TITLE
NAS-142234 / 26.0.0-RC.1 / Use `configparser` to generate rclone configs

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -2,7 +2,6 @@ import base64
 import collections
 import configparser
 import enum
-import io
 import itertools
 import json
 import logging
@@ -75,26 +74,32 @@ RcloneConfigTuple = collections.namedtuple("RcloneConfigTuple", ["config_path", 
 logger = logging.getLogger(__name__)
 
 
-def serialize_rclone_config(sections: dict[str, dict[str, Any]]) -> str:
-    parser = configparser.RawConfigParser()
-    # rclone config keys are case-sensitive; keep them verbatim instead of lower-casing them.
-    parser.optionxform = str  # type: ignore[method-assign,assignment]
-    for section, items in sections.items():
-        parser.add_section(section)
-        for key, value in items.items():
-            if isinstance(value, bool):
-                value = json.dumps(value)
-            else:
-                value = str(value)
+def rclone_config_section(name: str, items: dict[str, Any]) -> str:
+    """
+    Serialize one section of an rclone config file.
 
-            key = key.replace("\r", "").replace("\n", "")
-            value = value.replace("\r", "").replace("\n", "")
+    rclone parses its config with goconfig, which has no continuation lines or escaping: a line break inside a value
+    ends it and the remainder is parsed as the next key (or fails the parse), so CR/LF are stripped. This keeps a
+    pasted multi-line JSON token or service account file a valid single-line value.
 
-            parser.set(section, key, value)
-
-    buf = io.StringIO()
-    parser.write(buf)
-    return buf.getvalue()
+    goconfig trims whitespace around a value before treating one that starts with a backtick or a triple double-quote
+    as quoted, either truncating it at the last matching quote or rejecting the whole file. Wrapping such values (and
+    values with leading/trailing whitespace, which would otherwise be silently trimmed) in goconfig's own triple
+    double-quotes makes them read back verbatim: goconfig closes the quote at the last triple double-quote on the
+    line, so any newline-free value round-trips exactly.
+    """
+    out = f"[{name}]\n"
+    for key, value in items.items():
+        if isinstance(value, bool):
+            value = json.dumps(value)
+        else:
+            value = str(value)
+        value = value.replace("\r", "").replace("\n", "")
+        stripped = value.strip()
+        if value != stripped or stripped.startswith(("`", '"""')):
+            value = f'"""{value}"""'
+        out += f"{key} = {value}\n"
+    return out
 
 
 class RcloneConfig:
@@ -118,7 +123,6 @@ class RcloneConfig:
 
         remote_path = None
         extra_args = []
-        sections: dict[str, dict[str, Any]] = {}
 
         if "attributes" in self.cloud_sync:
             extra_args = self.provider.get_task_extra_args(self.cloud_sync)
@@ -132,16 +136,17 @@ class RcloneConfig:
             remote_path = f"remote:{remote_path}"
 
             if self.cloud_sync["encryption"]:
-                sections["encrypted"] = {
+                encrypted_section = {
                     "type": "crypt",
                     "remote": remote_path,
                     "filename_encryption": "standard" if self.cloud_sync["filename_encryption"] else "off",
                     "password": rclone_encrypt_password(self.cloud_sync["encryption_password"]),
                 }
                 if self.cloud_sync["encryption_salt"]:
-                    sections["encrypted"]["password2"] = rclone_encrypt_password(
+                    encrypted_section["password2"] = rclone_encrypt_password(
                         self.cloud_sync["encryption_salt"]
                     )
+                self.tmp_file.write(rclone_config_section("encrypted", encrypted_section))
 
                 remote_path = "encrypted:/"
 
@@ -172,9 +177,7 @@ class RcloneConfig:
             self.tmp_file_filter.flush()
             extra_args.extend(["--filter-from", self.tmp_file_filter.name])
 
-        sections["remote"] = config
-
-        self.tmp_file.write(serialize_rclone_config(sections))
+        self.tmp_file.write(rclone_config_section("remote", config))
 
         self.tmp_file.flush()
 

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -2,6 +2,7 @@ import base64
 import collections
 import configparser
 import enum
+import io
 import itertools
 import json
 import logging
@@ -12,6 +13,7 @@ import subprocess
 import tempfile
 import threading
 from contextlib import contextmanager
+from typing import Any
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -73,6 +75,28 @@ RcloneConfigTuple = collections.namedtuple("RcloneConfigTuple", ["config_path", 
 logger = logging.getLogger(__name__)
 
 
+def serialize_rclone_config(sections: dict[str, dict[str, Any]]) -> str:
+    parser = configparser.RawConfigParser()
+    # rclone config keys are case-sensitive; keep them verbatim instead of lower-casing them.
+    parser.optionxform = str  # type: ignore[method-assign,assignment]
+    for section, items in sections.items():
+        parser.add_section(section)
+        for key, value in items.items():
+            if isinstance(value, bool):
+                value = json.dumps(value)
+            else:
+                value = str(value)
+
+            key = key.replace("\r", "").replace("\n", "")
+            value = value.replace("\r", "").replace("\n", "")
+
+            parser.set(section, key, value)
+
+    buf = io.StringIO()
+    parser.write(buf)
+    return buf.getvalue()
+
+
 class RcloneConfig:
     def __init__(self, cloud_sync):
         self.cloud_sync = cloud_sync
@@ -94,6 +118,7 @@ class RcloneConfig:
 
         remote_path = None
         extra_args = []
+        sections: dict[str, dict[str, Any]] = {}
 
         if "attributes" in self.cloud_sync:
             extra_args = self.provider.get_task_extra_args(self.cloud_sync)
@@ -107,16 +132,16 @@ class RcloneConfig:
             remote_path = f"remote:{remote_path}"
 
             if self.cloud_sync["encryption"]:
-                self.tmp_file.write("[encrypted]\n")
-                self.tmp_file.write("type = crypt\n")
-                self.tmp_file.write(f"remote = {remote_path}\n")
-                self.tmp_file.write("filename_encryption = {}\n".format(
-                    "standard" if self.cloud_sync["filename_encryption"] else "off"))
-                self.tmp_file.write("password = {}\n".format(
-                    rclone_encrypt_password(self.cloud_sync["encryption_password"])))
+                sections["encrypted"] = {
+                    "type": "crypt",
+                    "remote": remote_path,
+                    "filename_encryption": "standard" if self.cloud_sync["filename_encryption"] else "off",
+                    "password": rclone_encrypt_password(self.cloud_sync["encryption_password"]),
+                }
                 if self.cloud_sync["encryption_salt"]:
-                    self.tmp_file.write("password2 = {}\n".format(
-                        rclone_encrypt_password(self.cloud_sync["encryption_salt"])))
+                    sections["encrypted"]["password2"] = rclone_encrypt_password(
+                        self.cloud_sync["encryption_salt"]
+                    )
 
                 remote_path = "encrypted:/"
 
@@ -147,11 +172,9 @@ class RcloneConfig:
             self.tmp_file_filter.flush()
             extra_args.extend(["--filter-from", self.tmp_file_filter.name])
 
-        self.tmp_file.write("[remote]\n")
-        for k, v in config.items():
-            if isinstance(v, bool):
-                v = json.dumps(v)
-            self.tmp_file.write(f"{k} = {v}\n")
+        sections["remote"] = config
+
+        self.tmp_file.write(serialize_rclone_config(sections))
 
         self.tmp_file.flush()
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -103,10 +103,11 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
 
 
 @pytest.mark.parametrize("value,written", [
-    # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
-    # rejects the whole file, with a closing quote it takes everything through the last matching quote.
+    # goconfig treats a value opening with a backtick (2+ chars) or a triple double-quote (6+ chars) as quoted: with
+    # no closing quote it rejects the whole file, with a closing quote it takes everything through the last matching
+    # quote.
     ("`x", '"""`x"""'),
-    ('"""x', '""""""x"""'),
+    ('"""xyz', '""""""xyz"""'),
     # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
     # still triggers quoting, and an unquoted padded value would be silently trimmed. the serializer is deliberately
     # triple-quoting it so that goconfig reads it literally rather than interpreting the leading backtick
@@ -115,6 +116,17 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
     ("\tpadded", '"""\tpadded"""'),
 ])
 def test__rclone_config_section_quotes_values_goconfig_would_mangle(value, written):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {written}\n"
+
+
+@pytest.mark.parametrize("value,written", [
+    # these fall under goconfig's quote-detection length gates (2 chars for a backtick, 6 for a triple double-quote)
+    # and would parse literally even unquoted; the serializer quotes them anyway, and they read back identically.
+    ("`", '"""`"""'),
+    ('"""x', '""""""x"""'),
+])
+def test__rclone_config_section_quoting_below_goconfig_length_gates_is_harmless(value, written):
     out = rclone_config_section("remote", {"pass": value})
     assert out == f"[remote]\npass = {written}\n"
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter
+from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, serialize_rclone_config
 
 
 @pytest.mark.parametrize("error,excerpt", [
@@ -79,3 +79,44 @@ def test__RcloneVerboseLogCutter(input, output):
         out += result
 
     assert out == output
+
+
+def test__serialize_rclone_config_basic():
+    out = serialize_rclone_config({"remote": {"type": "sftp", "host": "h", "user": "u"}})
+    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n\n"
+
+
+def test__serialize_rclone_config_preserves_key_case():
+    out = serialize_rclone_config({"remote": {"Mixed_Case_Key": "v"}})
+    assert out == "[remote]\nMixed_Case_Key = v\n\n"
+
+
+def test__serialize_rclone_config_bool_rendered_lowercase():
+    out = serialize_rclone_config({"remote": {"fast_list": True, "skip_region": False}})
+    assert out == "[remote]\nfast_list = true\nskip_region = false\n\n"
+
+
+def test__serialize_rclone_config_stringifies_non_str_values():
+    out = serialize_rclone_config({"remote": {"port": 22, "empty": None}})
+    assert out == "[remote]\nport = 22\nempty = None\n\n"
+
+
+def test__serialize_rclone_config_does_not_interpolate_percent():
+    out = serialize_rclone_config({"remote": {"pass": "ab%2Fcd%s"}})
+    assert out == "[remote]\npass = ab%2Fcd%s\n\n"
+
+
+def test__serialize_rclone_config_preserves_section_order():
+    out = serialize_rclone_config({"encrypted": {"type": "crypt"}, "remote": {"type": "sftp"}})
+    assert out == "[encrypted]\ntype = crypt\n\n[remote]\ntype = sftp\n\n"
+
+
+@pytest.mark.parametrize("payload", ["x\ntype = local", "x\r\ntype = local", "x\rtype = local"])
+def test__serialize_rclone_config_strips_line_breaks_from_value(payload):
+    out = serialize_rclone_config({"remote": {"type": "sftp", "host": payload}})
+    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n\n"
+
+
+def test__serialize_rclone_config_strips_line_breaks_from_key():
+    out = serialize_rclone_config({"remote": {"ho\nst": "v"}})
+    assert out == "[remote]\nhost = v\n\n"

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, serialize_rclone_config
+from middlewared.plugins.cloud_sync import lsjson_error_excerpt, RcloneVerboseLogCutter, rclone_config_section
 
 
 @pytest.mark.parametrize("error,excerpt", [
@@ -81,42 +81,50 @@ def test__RcloneVerboseLogCutter(input, output):
     assert out == output
 
 
-def test__serialize_rclone_config_basic():
-    out = serialize_rclone_config({"remote": {"type": "sftp", "host": "h", "user": "u"}})
-    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n\n"
+def test__rclone_config_section_basic():
+    out = rclone_config_section("remote", {"type": "sftp", "host": "h", "user": "u"})
+    assert out == "[remote]\ntype = sftp\nhost = h\nuser = u\n"
 
 
-def test__serialize_rclone_config_preserves_key_case():
-    out = serialize_rclone_config({"remote": {"Mixed_Case_Key": "v"}})
-    assert out == "[remote]\nMixed_Case_Key = v\n\n"
+def test__rclone_config_section_bool_rendered_lowercase():
+    out = rclone_config_section("remote", {"fast_list": True, "skip_region": False})
+    assert out == "[remote]\nfast_list = true\nskip_region = false\n"
 
 
-def test__serialize_rclone_config_bool_rendered_lowercase():
-    out = serialize_rclone_config({"remote": {"fast_list": True, "skip_region": False}})
-    assert out == "[remote]\nfast_list = true\nskip_region = false\n\n"
-
-
-def test__serialize_rclone_config_stringifies_non_str_values():
-    out = serialize_rclone_config({"remote": {"port": 22, "empty": None}})
-    assert out == "[remote]\nport = 22\nempty = None\n\n"
-
-
-def test__serialize_rclone_config_does_not_interpolate_percent():
-    out = serialize_rclone_config({"remote": {"pass": "ab%2Fcd%s"}})
-    assert out == "[remote]\npass = ab%2Fcd%s\n\n"
-
-
-def test__serialize_rclone_config_preserves_section_order():
-    out = serialize_rclone_config({"encrypted": {"type": "crypt"}, "remote": {"type": "sftp"}})
-    assert out == "[encrypted]\ntype = crypt\n\n[remote]\ntype = sftp\n\n"
+def test__rclone_config_section_stringifies_non_str_values():
+    out = rclone_config_section("remote", {"port": 22})
+    assert out == "[remote]\nport = 22\n"
 
 
 @pytest.mark.parametrize("payload", ["x\ntype = local", "x\r\ntype = local", "x\rtype = local"])
-def test__serialize_rclone_config_strips_line_breaks_from_value(payload):
-    out = serialize_rclone_config({"remote": {"type": "sftp", "host": payload}})
-    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n\n"
+def test__rclone_config_section_strips_line_breaks_from_value(payload):
+    out = rclone_config_section("remote", {"type": "sftp", "host": payload})
+    assert out == "[remote]\ntype = sftp\nhost = xtype = local\n"
 
 
-def test__serialize_rclone_config_strips_line_breaks_from_key():
-    out = serialize_rclone_config({"remote": {"ho\nst": "v"}})
-    assert out == "[remote]\nhost = v\n\n"
+@pytest.mark.parametrize("value,written", [
+    # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
+    # rejects the whole file, with one it truncates the value at the last matching quote.
+    ("`x", '"""`x"""'),
+    ('"""x', '""""""x"""'),
+    # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
+    # still triggers quoting, and an unquoted padded value would be silently trimmed.
+    (" `x", '""" `x"""'),
+    (" padded ", '""" padded """'),
+    ("\tpadded", '"""\tpadded"""'),
+])
+def test__rclone_config_section_quotes_values_goconfig_would_mangle(value, written):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {written}\n"
+
+
+@pytest.mark.parametrize("value", [
+    "a`b",           # backtick not at the start is literal
+    'a"""b',         # triple quote not at the start is literal
+    '"x"',           # single double-quotes are only special for keys, not values
+    "ab%2Fcd%s",     # no interpolation layer
+    "",
+])
+def test__rclone_config_section_leaves_safe_values_verbatim(value):
+    out = rclone_config_section("remote", {"pass": value})
+    assert out == f"[remote]\npass = {value}\n"

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -104,11 +104,12 @@ def test__rclone_config_section_strips_line_breaks_from_value(payload):
 
 @pytest.mark.parametrize("value,written", [
     # goconfig treats a value opening with a backtick or a triple double-quote as quoted: with no closing quote it
-    # rejects the whole file, with one it truncates the value at the last matching quote.
+    # rejects the whole file, with a closing quote it takes everything through the last matching quote.
     ("`x", '"""`x"""'),
     ('"""x', '""""""x"""'),
     # goconfig trims whitespace around a value before quote detection, so a quote char behind leading whitespace
-    # still triggers quoting, and an unquoted padded value would be silently trimmed.
+    # still triggers quoting, and an unquoted padded value would be silently trimmed. the serializer is deliberately
+    # triple-quoting it so that goconfig reads it literally rather than interpreting the leading backtick
     (" `x", '""" `x"""'),
     (" padded ", '""" padded """'),
     ("\tpadded", '"""\tpadded"""'),


### PR DESCRIPTION
This prevents us from generating invalid ini files by escaping invalid characters.