### PR TITLE
NAS-142198 / 27.0.0-BETA.1 / Compare scrub pause time against UTC instead of local time (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/alert/source/scrub_paused.py
+++ b/src/middlewared/middlewared/alert/source/scrub_paused.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from middlewared.alert.base import (
@@ -10,6 +10,7 @@ from middlewared.alert.base import (
     AlertSource,
     NonDataclassAlertClass,
 )
+from middlewared.utils.time_utils import utc_now
 
 
 class ScrubPausedAlert(NonDataclassAlertClass[str], AlertClass):
@@ -29,6 +30,6 @@ class ScrubPausedAlertSource(AlertSource):
         for pool in await self.middleware.call("pool.query"):
             if pool["scan"] is not None:
                 if pool["scan"]["pause"] is not None:
-                    if pool["scan"]["pause"] < datetime.now() - timedelta(hours=8):
+                    if pool["scan"]["pause"] < utc_now() - timedelta(hours=8):
                         alerts.append(Alert(ScrubPausedAlert(pool["name"])))
         return alerts


### PR DESCRIPTION
`scan["pause"]` comes from libzfs as a naive UTC timestamp but was compared against local `datetime.now()`, so the alert's real threshold was 8 hours minus the system's UTC offset.

On the reporting user's UTC+8 system that made it zero, and the alert fired 19 seconds after they paused the scrub.


Original PR: https://github.com/truenas/middleware/pull/19509
