### PR TITLE
NAS-141762 / 27.0.0-BETA.1 / Permit allow_any_host to be toggled

### DIFF
--- a/src/middlewared/middlewared/utils/nvmet/kernel.py
+++ b/src/middlewared/middlewared/utils/nvmet/kernel.py
@@ -389,6 +389,19 @@ class NvmetSubsysConfig(NvmetConfig):
     query = 'nvmet.subsys.query'
     query_key = 'subnqn'
 
+    def update_attrs(self, path: pathlib.Path, attrs: dict, render_ctx: dict):
+        # The kernel will not allow attr_allow_any_host to be set to 1 while
+        # explicit per-host symlinks still exist under allowed_hosts.  Those
+        # symlinks are normally removed later by NvmetHostSubsysConfig, so
+        # if we are transitioning 0 -> 1 we must remove them here first,
+        # before writing the attribute below.
+        if attrs.get('allow_any_host'):
+            allow_any_host_path = pathlib.Path(path, 'attr_allow_any_host')
+            if allow_any_host_path.read_text().strip() == '0':
+                for host_link in pathlib.Path(path, 'allowed_hosts').iterdir():
+                    host_link.unlink()
+        super().update_attrs(path, attrs, render_ctx)
+
     def pre_delete(self, path: pathlib.Path, render_ctx: dict):
         # If we are force deleting a subsystem, then namespaces
         # will have been deleted from the config, but not yet
@@ -581,6 +594,9 @@ class NvmetHostSubsysConfig(NvmetLinkConfig):
 
     def dst_name(self, entry):
         return f'{entry[self.dst_query_keys[0]][self.dst_query_keys[1]]}'
+
+    def create_links(self, entry: dict, render_ctx: dict):
+        return not entry['subsys']['allow_any_host']
 
 
 class NvmetPortSubsysConfig(NvmetLinkConfig):

--- a/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
+++ b/tests/sharing_protocols/nvmet/test_nvmet_tcp.py
@@ -4,10 +4,13 @@ import json
 import random
 import string
 import time
+import uuid
 from collections import defaultdict
 from functools import cache
 
 import pytest
+from nvmeof_client import NVMeoFClient, NVMeoFConnectionError
+
 from assets.websocket.pool import zvol
 from assets.websocket.service import ensure_service_enabled, ensure_service_started
 from auto_config import ha, pool_name
@@ -2300,3 +2303,93 @@ class TestManySubsystems:
             # One extra for the discovery target.
             res = nc.discover()
             assert len(res['records']) == self.SUBSYS_COUNT + 1
+
+
+class TestAllowAnyHostToggle(NVMeRunning):
+    """
+    Regression test for toggling allow_any_host while a host_subsys link
+    to a specific host is still active.
+
+    Previously (see kernel.py NvmetSubsysConfig), flipping allow_any_host
+    False -> True wrote the subsys attribute before the now-superfluous
+    allowed_hosts symlink had been removed, which the kernel target
+    rejected. This test flips allow_any_host in both directions while a
+    host_subsys link remains active throughout, and uses NVMeoFClient
+    directly (rather than the loopback nvme CLI) so that each connection
+    attempt can present an arbitrary host NQN without touching any system
+    state on the loopback client.
+    """
+
+    @pytest.fixture(scope='class')
+    def fixture_port(self, fixture_nvmet_running):
+        assert truenas_server.ip in call('nvmet.port.transport_address_choices', 'TCP')
+        with nvmet_port(truenas_server.ip) as port:
+            yield port
+
+    def _client(self, subsys_nqn, host_nqn):
+        return NVMeoFClient(
+            truenas_server.ip,
+            subsys_nqn,
+            NVME_DEFAULT_TCP_PORT,
+            timeout=10.0,
+            host_nqn=host_nqn,
+        )
+
+    def _assert_can_connect(self, subsys_nqn, host_nqn, namespace_count):
+        client = self._client(subsys_nqn, host_nqn)
+        client.connect()
+        try:
+            assert len(client.list_namespaces()) == namespace_count
+        finally:
+            client.disconnect()
+
+    def _assert_cannot_connect(self, subsys_nqn, host_nqn):
+        client = self._client(subsys_nqn, host_nqn)
+        with pytest.raises(NVMeoFConnectionError):
+            client.connect()
+
+    def test__allow_any_host_toggle_with_active_host_link(
+        self, fixture_port, zvol1
+    ):
+        """
+        Verify that toggling allow_any_host in either direction succeeds,
+        and takes effect correctly, even while a specific host_subsys link
+        remains active throughout.
+        """
+        permitted_nqn = f'nqn.2014-08.org.nvmexpress:uuid:{uuid.uuid4()}'
+        other_nqn = f'nqn.2014-08.org.nvmexpress:uuid:{uuid.uuid4()}'
+
+        subsys_nqn = f'{basenqn()}:{SUBSYS_NAME1}'
+        with nvmet_subsys(SUBSYS_NAME1, allow_any_host=False) as subsys:
+            subsys_id = subsys['id']
+            with nvmet_port_subsys(subsys_id, fixture_port['id']):
+                with nvmet_namespace(subsys_id, f'zvol/{zvol1["name"]}'):
+                    with nvmet_host(permitted_nqn) as host:
+                        with nvmet_host_subsys(host['id'], subsys_id):
+                            # Sanity check pre-toggle behavior.
+                            self._assert_can_connect(subsys_nqn, permitted_nqn, 1)
+                            self._assert_cannot_connect(subsys_nqn, other_nqn)
+
+                            # The regression case: this must succeed even
+                            # though the allowed_hosts link for permitted_nqn
+                            # is still present at the time of the toggle.
+                            call(
+                                'nvmet.subsys.update',
+                                subsys_id,
+                                {'allow_any_host': True},
+                            )
+
+                            # Now ANY host should be able to connect.
+                            self._assert_can_connect(subsys_nqn, permitted_nqn, 1)
+                            self._assert_can_connect(subsys_nqn, other_nqn, 1)
+
+                            # Toggle back while the link is still active.
+                            call(
+                                'nvmet.subsys.update',
+                                subsys_id,
+                                {'allow_any_host': False},
+                            )
+
+                            # Only the permitted host should be allowed again.
+                            self._assert_can_connect(subsys_nqn, permitted_nqn, 1)
+                            self._assert_cannot_connect(subsys_nqn, other_nqn)


### PR DESCRIPTION
- Permit `allow_any_host` to be toggled off for a NVMe-oF subsystem
- Add unit test `TestAllowAnyHostToggle::test__allow_any_host_toggle_with_active_host_link`.

----
Passing CI [here](http://jenkins-eng-ci.cmb1.ixsystems.net:8080/job/master/job/sharing_protocols_tests/175/).