### PR TITLE
NAS-142250 / 27.0.0-BETA.1 / Stop in-flight TNC cert and registration flows from re-configuring TNC

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/acme.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/acme.py
@@ -73,6 +73,10 @@ class TNCACMEService(Service):
             logger.error('Failed to complete certificate generation for TNC', exc_info=True)
             await set_status(self.context, Status.CERT_GENERATION_FAILED.name)
         else:
+            if not (await self.call2(self.s.tn_connect.config)).enabled:
+                logger.debug('TNC was disabled while certificate was being generated, discarding it')
+                return
+
             cert_id = await self.middleware.call(
                 'datastore.insert',
                 'system.certificate', {
@@ -114,6 +118,10 @@ class TNCACMEService(Service):
             logger.error('Failed to renew certificate for TNC', exc_info=True)
             await set_status(self.context, Status.CERT_RENEWAL_FAILURE.name)
         else:
+            if not (await self.call2(self.s.tn_connect.config)).enabled:
+                logger.debug('TNC was disabled while certificate was being renewed, discarding it')
+                return
+
             logger.debug('TNC certificate renewed successfully, updating database')
             # renewal_job.wait(raise_error=True) above guarantees a successful result.
             assert renewal_job.result is not None

--- a/src/middlewared/middlewared/plugins/truenas_connect/finalize_registration.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/finalize_registration.py
@@ -64,6 +64,10 @@ async def finalize_registration_impl(context: ServiceContext) -> None:
             try_num += 1
 
         if result is FinalizeResult.SUCCESS:
+            if not (await context.call2(context.s.tn_connect.config)).enabled:
+                logger.debug('TNC was disabled while registration was being finalized, discarding token')
+                return
+
             token = poll_status['response']['token']
             try:
                 decoded_token = decode_and_validate_token(token)

--- a/src/middlewared/middlewared/plugins/truenas_connect/internal.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/internal.py
@@ -35,6 +35,11 @@ async def set_status(
 ) -> None:
     assert new_status in Status.__members__
     entry = await context.call2(context.s.tn_connect.config)
+    if not entry.enabled and new_status != Status.DISABLED.name:
+        # Cert generation/renewal or registration finalization may finish after TNC was disabled
+        logger.warning("TNC is disabled, ignoring status transition to %r", new_status)
+        return
+
     await context.middleware.call(
         "datastore.update",
         DATASTORE,

--- a/src/middlewared/middlewared/plugins/truenas_connect/internal.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/internal.py
@@ -35,7 +35,9 @@ async def set_status(
 ) -> None:
     assert new_status in Status.__members__
     entry = await context.call2(context.s.tn_connect.config)
-    if not entry.enabled and new_status != Status.DISABLED.name:
+    # db_payload may itself be enabling TNC (post-install bootstrap), so it takes precedence over the persisted value
+    will_be_enabled = (db_payload or {}).get("enabled", entry.enabled)
+    if not will_be_enabled and new_status != Status.DISABLED.name:
         # Cert generation/renewal or registration finalization may finish after TNC was disabled
         logger.warning("TNC is disabled, ignoring status transition to %r", new_status)
         return

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -914,3 +914,57 @@ async def test_handle_heartbeat_response_202_pending_without_pem_is_quiet():
 
     install.assert_not_called()
     warn.assert_not_called()
+
+
+# --- Disable while a background flow is in flight -----------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_status_ignored_when_disabled():
+    """A background flow finishing after TNC was disabled must not write a configured status."""
+    from middlewared.plugins.truenas_connect import internal
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock()
+    ctx.middleware.send_event = MagicMock()
+    ctx.call2 = AsyncMock(return_value=make_tnc_entry(enabled=False, status=Status.DISABLED.name))
+
+    await internal.set_status(ctx, Status.CONFIGURED.name, {'certificate': 2})
+
+    ctx.middleware.call.assert_not_awaited()
+    ctx.middleware.send_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_status_writes_when_enabled():
+    from middlewared.plugins.truenas_connect import internal
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock()
+    ctx.middleware.send_event = MagicMock()
+    ctx.call2 = AsyncMock(return_value=make_tnc_entry(status=Status.CERT_GENERATION_SUCCESS.name))
+
+    await internal.set_status(ctx, Status.CONFIGURED.name)
+
+    ctx.middleware.call.assert_awaited_once_with(
+        'datastore.update', 'truenas_connect', 1, {'status': Status.CONFIGURED.name},
+    )
+    ctx.middleware.send_event.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cert_generation_discarded_when_disabled_midway():
+    """Disabling TNC while the cert job runs must not insert the cert or flip status back to configured."""
+    from middlewared.plugins.truenas_connect.acme import TNCACMEService
+
+    service = TNCACMEService(MagicMock())
+    service.initiate_cert_generation_impl = AsyncMock(return_value={'cert': 'c', 'private_key': 'k', 'csr': 's'})
+    service.update_ui = AsyncMock()
+    service.middleware.call = AsyncMock()
+    service.call2 = AsyncMock(return_value=make_tnc_entry(enabled=False, status=Status.DISABLED.name))
+
+    await service.initiate_cert_generation()
+
+    service.middleware.call.assert_not_awaited()
+    service.update_ui.assert_not_awaited()

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -954,6 +954,26 @@ async def test_set_status_writes_when_enabled():
 
 
 @pytest.mark.asyncio
+async def test_set_status_writes_when_payload_enables():
+    """Post-install bootstrap enables TNC through the payload while the row is still disabled."""
+    from middlewared.plugins.truenas_connect import internal
+
+    ctx = MagicMock()
+    ctx.middleware = MagicMock()
+    ctx.middleware.call = AsyncMock()
+    ctx.middleware.send_event = MagicMock()
+    ctx.call2 = AsyncMock(return_value=make_tnc_entry(enabled=False, status=Status.DISABLED.name))
+
+    await internal.set_status(ctx, Status.CONFIGURED.name, {'enabled': True, 'certificate': 2})
+
+    ctx.middleware.call.assert_awaited_once_with(
+        'datastore.update', 'truenas_connect', 1,
+        {'status': Status.CONFIGURED.name, 'enabled': True, 'certificate': 2},
+    )
+    ctx.middleware.send_event.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_cert_generation_discarded_when_disabled_midway():
     """Disabling TNC while the cert job runs must not insert the cert or flip status back to configured."""
     from middlewared.plugins.truenas_connect.acme import TNCACMEService


### PR DESCRIPTION
Disabling TrueNAS Connect while certificate generation, certificate renewal, or registration finalization was still running let that background task write its success state back after the disable. The row ended up with enabled=false and empty registration details but status=CONFIGURED and a certificate attached. Every boot then started the heartbeat and every interface address change re-ran the IP sync, both failing with "TrueNAS Connect is not enabled or not configured properly" and no way to recover without re-enabling and disabling again.

- set_status refuses any transition other than to DISABLED while TNC is disabled
- Cert generation and renewal re-check enabled after the job returns and discard the result instead of inserting or updating the certificate
- Registration finalization discards a token that arrives after TNC was disabled
- Unit tests for the status guard and the cert generation path

Reproduce by enabling TNC, then calling tn_connect.update with enabled: false while status is CERT_GENERATION_IN_PROGRESS.