### PR TITLE
NAS-142191 / 26.0.0-RC.1 / Don't swallow app upgrade failures in upgrade_impl

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -113,12 +113,16 @@ class AppService(Service):
                 self.middleware.call_sync('app.pull_images_internal', app_name, app, {'redeploy': True})
             finally:
                 app = self.middleware.call_sync('app.get_instance', app_name)
-                if app['upgrade_available'] is False or app['custom_app']:
-                    # Pull may have succeeded but redeploy failed - we early-return here
-                    # so that the caller can update alerts based on the refreshed app state
+                upgrade_completed = app['upgrade_available'] is False or app['custom_app']
+                if upgrade_completed:
+                    # Pull may have succeeded but redeploy failed - refresh the app state here
+                    # so that the caller can update alerts based on it either way. Note that this
+                    # must not return, as a return inside `finally` discards an in-flight exception.
                     self.middleware.send_event('app.query', 'CHANGED', id=app_name, fields=app)
-                    job.set_progress(100, 'App successfully upgraded and redeployed')
-                    return app
+
+            if upgrade_completed:
+                job.set_progress(100, 'App successfully upgraded and redeployed')
+                return app
 
         job.set_progress(15, f'Retrieving versions for {app_name!r} app')
         versions_config = self.middleware.call_sync('app.get_versions', app, options)

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_pull_failure.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from middlewared.plugins.apps.upgrade import AppService
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service import CallError
+
+PULL_ERROR = "Failed 'pull' action for 'custom-app' app. Please check /var/log/app_lifecycle.log for more details"
+
+SUCCESS_PROGRESS = (100, "App successfully upgraded and redeployed")
+
+
+def app_entry(**overrides):
+    """Stands in for a running custom app that has an image update pending."""
+    return {
+        "state": "RUNNING",
+        "upgrade_available": True,
+        "custom_app": True,
+        "metadata": {"name": "custom-app"},
+    } | overrides
+
+
+def test_custom_app_upgrade_surfaces_pull_failure():
+    """A failed pull has to fail the job rather than return the app."""
+    middleware = Middleware()
+    middleware["app.get_instance"] = Mock(return_value=app_entry())
+    middleware["app.pull_images_internal"] = Mock(side_effect=CallError(PULL_ERROR))
+    job = MagicMock()
+
+    with pytest.raises(CallError, match="Failed 'pull' action"):
+        AppService(middleware).upgrade_impl(job, "custom-app", {})
+
+    # The job must not claim the upgrade finished.
+    assert SUCCESS_PROGRESS not in [c.args for c in job.set_progress.call_args_list]
+
+
+def test_custom_app_upgrade_returns_app_on_success():
+    """A successful pull and redeploy still short circuits with the refreshed app."""
+    middleware = Middleware()
+    app = app_entry()
+    middleware["app.get_instance"] = Mock(return_value=app)
+    middleware["app.pull_images_internal"] = Mock()
+    job = MagicMock()
+
+    assert AppService(middleware).upgrade_impl(job, "custom-app", {}) is app
+    job.set_progress.assert_called_with(*SUCCESS_PROGRESS)
+    middleware.send_event.assert_called_once()


### PR DESCRIPTION
## Problem
`upgrade_impl()` returns from inside a `finally` block, which discards any exception raised by `app.pull_images_internal`. The `or app['custom_app']` condition makes that branch unconditional for custom apps, so a failed `docker compose pull` is reported to the user as a successful upgrade: the job ends in SUCCESS with "App successfully upgraded and redeployed" while the real error only lands in /var/log/app_lifecycle.log.

The wrong status also hides the two steps that get skipped when the pull raises, both sitting after `compose_action()` in `pull_images_internal()`: the `clear_update_flag_for_tag` loop and `app.redeploy`. So the app isn't recreated and the update flag stays set, which is why the badge comes back.

## Solution
Clearing a stale alert after a partial pull is still worth doing, so the state refresh stays in the `finally` and only the early return and its progress update move out. The success path behaves exactly as before.

Adds unit tests for both the failure and the success path.

Backport of https://github.com/truenas/middleware/pull/19506