### PR TITLE
NAS-142256 / 27.0.0-BETA.1 / Alert when VMs or containers fail to autostart at boot

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -244,6 +244,7 @@ class AlertCategory(enum.Enum):
     TASKS = "TASKS"
     TRUENAS_CONNECT = "TRUENAS_CONNECT"
     UPS = "UPS"
+    VIRTUALIZATION = "VIRTUALIZATION"
 
 
 alert_category_names = {
@@ -265,6 +266,7 @@ alert_category_names = {
     AlertCategory.TASKS: "Tasks",
     AlertCategory.TRUENAS_CONNECT: "TrueNAS Connect Service",
     AlertCategory.UPS: "UPS",
+    AlertCategory.VIRTUALIZATION: "Virtualization",
 }
 
 

--- a/src/middlewared/middlewared/alert/source/__init__.py
+++ b/src/middlewared/middlewared/alert/source/__init__.py
@@ -61,6 +61,7 @@ from middlewared.alert.source import (  # noqa: F401
     update,
     ups,
     usb_storage,
+    virtualization,
     vmware_login,
     vmware_snapshot,
     volume_status,

--- a/src/middlewared/middlewared/alert/source/virtualization.py
+++ b/src/middlewared/middlewared/alert/source/virtualization.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from middlewared.alert.base import AlertCategory, AlertClassConfig, AlertLevel, OneShotAlertClass
+
+
+@dataclass(kw_only=True)
+class VMAutostartFailedAlert(OneShotAlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.VIRTUALIZATION,
+        level=AlertLevel.CRITICAL,
+        title="Unable to Automatically Start VMs",
+        text=(
+            "The following VMs are configured to start automatically but failed to start: %(vms)s. "
+            "See /var/log/middlewared.log for the reason each one failed."
+        ),
+        keys=[],
+    )
+
+    vms: str
+
+
+@dataclass(kw_only=True)
+class ContainerAutostartFailedAlert(OneShotAlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.VIRTUALIZATION,
+        level=AlertLevel.CRITICAL,
+        title="Unable to Automatically Start Containers",
+        text=(
+            "The following containers are configured to start automatically but failed to start: %(containers)s. "
+            "See /var/log/middlewared.log for the reason each one failed."
+        ),
+        keys=[],
+    )
+
+    containers: str

--- a/src/middlewared/middlewared/plugins/container/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/container/lifecycle.py
@@ -15,6 +15,7 @@ from truenas_pylibvirt import (
     Time,
 )
 
+from middlewared.alert.source.virtualization import ContainerAutostartFailedAlert
 from middlewared.api.current import ContainerEntry, ContainerStopOptions, QueryOptions, ZFSResourceQuery
 from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID, IDMAP_COUNT
 from middlewared.service import CallError, ServiceContext
@@ -80,6 +81,10 @@ def _build_idmapped_root_acl() -> "truenas_os.POSIXACL":
 
 
 def start_on_boot(context: ServiceContext) -> None:
+    # Clear any alert from the previous pass up front so the alert, if any, always describes
+    # the pass that just ran.
+    context.call_sync2(context.s.alert.oneshot_delete, "ContainerAutostartFailed", None)
+
     # Reap orphaned runtime state under /run/truenas_containers/ before any
     # autostart so a fresh start can't collide with a leaked staged path
     # from a previous unclean shutdown (libvirtd or middlewared crash).
@@ -88,13 +93,20 @@ def start_on_boot(context: ServiceContext) -> None:
     except Exception:
         context.logger.error('Failed to reconcile container runtime state', exc_info=True)
 
+    failures: list[str] = []
     for container in context.call_sync2(
         context.s.container.query, [("autostart", "=", True)], QueryOptions(force_sql_filters=True)
     ):
         try:
             start(context, container.id)
-        except Exception as e:
-            context.logger.error(f"Failed to start {container.name!r} container: {e}")
+        except Exception:
+            context.logger.error("Failed to start %r container", container.name, exc_info=True)
+            failures.append(container.name)
+
+    if failures:
+        context.call_sync2(
+            context.s.alert.oneshot_create, ContainerAutostartFailedAlert(containers=", ".join(failures))
+        )
 
 
 async def _stop_one_container(context: ServiceContext, container: typing.Any) -> None:

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -6,6 +6,7 @@ import typing
 
 from truenas_pylibvirt import Time, VmBootloader, VmCpuMode
 
+from middlewared.alert.source.virtualization import VMAutostartFailedAlert
 from middlewared.api.current import QueryOptions, VMEntry, VMStartOptions, VMStopOptions
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.libvirt.utils import ACTIVE_STATES
@@ -154,11 +155,20 @@ def suspend_vms(context: ServiceContext, vm_ids: list[int]) -> None:
 
 
 async def start_on_boot(context: ServiceContext) -> None:
+    # Clear any alert from the previous pass up front so the alert, if any, always describes
+    # the pass that just ran.
+    await context.call2(context.s.alert.oneshot_delete, 'VMAutostartFailed', None)
+
+    failures: list[str] = []
     for vm in await context.call2(context.s.vm.query, [('autostart', '=', True)], QueryOptions(force_sql_filters=True)):
         try:
             await context.to_thread(start_vm, context, vm.id, VMStartOptions())
-        except Exception as e:
-            context.logger.error(f'Failed to start VM {vm.name}: {e}')
+        except Exception:
+            context.logger.error('Failed to start VM %r', vm.name, exc_info=True)
+            failures.append(vm.name)
+
+    if failures:
+        await context.call2(context.s.alert.oneshot_create, VMAutostartFailedAlert(vms=', '.join(failures)))
 
 
 async def _stop_one_vm(context: ServiceContext, vm: typing.Any) -> None:


### PR DESCRIPTION
## Problem
A VM or container that fails to start during the boot autostart pass is swallowed into a single log line - no alert, no retry, nothing persisted. There is no alert class for VMs or containers anywhere in the tree, so the only signal is `/var/log/middlewared.log`. A user hit this with an autostart VM that failed to come up at boot and stayed down all day simply because nothing told them.

## Solution
- **Two aggregated one-shot alerts**, `VMAutostartFailedAlert` and `ContainerAutostartFailedAlert`, under a new `VIRTUALIZATION` alert category. Both use the `keys=[]` convention already used by the NFS/SMB/GPU aggregate alerts, so ten failed VMs produce one alert listing all ten rather than ten alerts.
- **Cleared at the start of every autostart pass and re-raised at the end** if anything failed, so the alert always describes the pass that just ran: a guest fixed between boots has its alert cleared, a still-broken one gets it re-raised with the current reason. The clear is unconditional, so removing autostart from a broken guest also clears it.
- **The failure reason travels with the alert**, collapsed to one line and truncated at 200 characters per entry, since the common failures are self-diagnosing one-liners and the whole point is to avoid forcing a log dig. The full traceback still goes to the log, which is also why the two error logs here now pass `exc_info=True` like every one of their siblings.

Both HA failover entry points funnel into the same two functions, so they are covered without changes. 