### PR TITLE
NAS-142152 / 26.0.0-RC.1 / Tolerate transient NTB blips before calling dlm.reset_active (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -418,6 +418,14 @@ class DistributedLockManagerService(Service):
                     self.logger.info('remote_down: remote middleware reconnected, skipping reset_active')
                     return
 
+            if await self.middleware.call('failover.status') != 'MASTER':
+                self.logger.info('remote_down: no longer ACTIVE, skipping reset_active')
+                return
+
+            if not await self.middleware.call('iscsi.global.using_dlm'):
+                self.logger.info('remote_down: no longer DLM, skipping reset_active')
+                return
+
             self.logger.info('remote_down: peer unreachable for 60s; calling reset_active')
             await self.middleware.call('dlm.reset_active')
         finally:

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -22,6 +22,7 @@ class DistributedLockManagerService(Service):
         namespace = 'dlm'
 
     resetting = False
+    polling_remote_down = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -320,6 +321,18 @@ class DistributedLockManagerService(Service):
             # await self.middleware.call('dlm.kernel.comms_remove_node', nodeid)
 
     @private
+    async def dlm_port_reachable(self, peer_ip):
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(peer_ip, DLM_PORT), timeout=3
+            )
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except Exception:
+            return False
+
+    @private
     async def remote_down(self):
         """
         Handle the HA remote node going down.
@@ -332,6 +345,13 @@ class DistributedLockManagerService(Service):
           restarted; skip to avoid unnecessarily tearing down iSCSI sessions.
         - If we have logged-in extents, we are in standby or mid-transition to
           master; the failover event is already handling cleanup.
+
+        This is invoked synchronously from the HA connection thread's disconnect
+        handler (via call_sync), so it must return quickly. If the peer's DLM port
+        is unreachable, the up-to-60-second poll that decides whether to call
+        reset_active runs as a background task rather than being awaited here,
+        so it doesn't block reconnection attempts or other disconnect callbacks
+        (e.g. failover status updates).
         """
         if await self.middleware.call('failover.status') != 'MASTER':
             return
@@ -347,20 +367,13 @@ class DistributedLockManagerService(Service):
             self.logger.warning('remote_down: peer IP unknown, skipping reset_active')
             return
 
-        try:
-            _, writer = await asyncio.wait_for(
-                asyncio.open_connection(peer_ip, DLM_PORT), timeout=3
-            )
-            writer.close()
-            await writer.wait_closed()
+        if await self.dlm_port_reachable(peer_ip):
             self.logger.info(
                 'remote_down: DLM port reachable on %s; '
                 'remote middleware restarted, skipping reset_active',
                 peer_ip,
             )
             return
-        except Exception:
-            pass
 
         if await self.middleware.call('iscsi.extent.logged_in_extents'):
             self.logger.info(
@@ -368,28 +381,36 @@ class DistributedLockManagerService(Service):
             )
             return
 
-        # Poll for up to 60 seconds before declaring node dead
+        if DistributedLockManagerService.polling_remote_down:
+            self.logger.debug('remote_down: already polling peer, skipping duplicate poll')
+            return
+
         self.logger.info(
             'remote_down: DLM port unreachable on %s; checking whether transient',
             peer_ip,
         )
-        deadline = time.monotonic() + 60
-        while time.monotonic() < deadline:
-            await asyncio.sleep(5)
-            try:
-                _, writer = await asyncio.wait_for(
-                    asyncio.open_connection(peer_ip, DLM_PORT), timeout=3
-                )
-                writer.close()
-                await writer.wait_closed()
-                # Port is back — peer recovered, skip reset_active
-                self.logger.info('remote_down: DLM port recovered, skipping reset_active')
-                return
-            except Exception:
-                pass  # still unreachable, keep waiting
+        self.middleware.create_task(self.poll_remote_down(peer_ip))
 
-        self.logger.info('remote_down: DLM port unreachable for 60s; calling reset_active')
-        await self.middleware.call('dlm.reset_active')
+    @private
+    async def poll_remote_down(self, peer_ip):
+        """
+        Poll the peer's DLM port for up to 60 seconds; call reset_active if it stays
+        down the whole time. Runs as a background task kicked off from remote_down.
+        """
+        DistributedLockManagerService.polling_remote_down = True
+        try:
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
+                await asyncio.sleep(5)
+                if await self.dlm_port_reachable(peer_ip):
+                    # Port is back — peer recovered, skip reset_active
+                    self.logger.info('remote_down: DLM port recovered, skipping reset_active')
+                    return
+
+            self.logger.info('remote_down: DLM port unreachable for 60s; calling reset_active')
+            await self.middleware.call('dlm.reset_active')
+        finally:
+            DistributedLockManagerService.polling_remote_down = False
 
     @private
     async def local_remove_peer(self, lockspace_name):

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from middlewared.service import Service, job, private
 
@@ -367,10 +368,27 @@ class DistributedLockManagerService(Service):
             )
             return
 
+        # Poll for up to 60 seconds before declaring node dead
         self.logger.info(
-            'remote_down: DLM port unreachable on %s; calling reset_active',
+            'remote_down: DLM port unreachable on %s; checking whether transient',
             peer_ip,
         )
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            await asyncio.sleep(5)
+            try:
+                _, writer = await asyncio.wait_for(
+                    asyncio.open_connection(peer_ip, DLM_PORT), timeout=3
+                )
+                writer.close()
+                await writer.wait_closed()
+                # Port is back — peer recovered, skip reset_active
+                self.logger.info('remote_down: DLM port recovered, skipping reset_active')
+                return
+            except Exception:
+                pass  # still unreachable, keep waiting
+
+        self.logger.info('remote_down: DLM port unreachable for 60s; calling reset_active')
         await self.middleware.call('dlm.reset_active')
 
     @private

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -394,8 +394,14 @@ class DistributedLockManagerService(Service):
     @private
     async def poll_remote_down(self, peer_ip):
         """
-        Poll the peer's DLM port for up to 60 seconds; call reset_active if it stays
-        down the whole time. Runs as a background task kicked off from remote_down.
+        Poll for up to 60 seconds for any sign the peer is still alive (its DLM port
+        or its middleware coming back); call reset_active only if neither recovers
+        the whole time. Runs as a background task kicked off from remote_down.
+
+        If the peer is only transiently unreachable, no action is needed — it will
+        recover on its own. If it has truly died, it will call reset_active on us
+        itself once it reboots and comes back up. So this is a last resort for the
+        case where the peer never comes back, and any sign of life should cancel it.
         """
         DistributedLockManagerService.polling_remote_down = True
         try:
@@ -407,7 +413,12 @@ class DistributedLockManagerService(Service):
                     self.logger.info('remote_down: DLM port recovered, skipping reset_active')
                     return
 
-            self.logger.info('remote_down: DLM port unreachable for 60s; calling reset_active')
+                if await self.middleware.call('failover.remote_connected'):
+                    # Middleware is back — peer recovered, skip reset_active
+                    self.logger.info('remote_down: remote middleware reconnected, skipping reset_active')
+                    return
+
+            self.logger.info('remote_down: peer unreachable for 60s; calling reset_active')
             await self.middleware.call('dlm.reset_active')
         finally:
             DistributedLockManagerService.polling_remote_down = False

--- a/src/middlewared/middlewared/plugins/dlm_/kernel.py
+++ b/src/middlewared/middlewared/plugins/dlm_/kernel.py
@@ -48,6 +48,7 @@ class KernelDistributedLockManagerService(Service):
     SPACES_DIR = CLUSTER_DIR + '/spaces'
     COMMS_DIR = CLUSTER_DIR + '/comms'
     CLUSTER_NAME = "HA"
+    SCAN_SECS = "30"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -68,6 +69,8 @@ class KernelDistributedLockManagerService(Service):
                 if d == KernelDistributedLockManagerService.CLUSTER_DIR:
                     with open(f'{d}/cluster_name', 'w') as f:
                         f.write(name)
+                    with open(f'{d}/scan_secs', 'w') as f:
+                        f.write(KernelDistributedLockManagerService.SCAN_SECS)
 
     def comms_add_node(self, nodeid, addr, local, port=0, mark=None):
         # Create comms directory for this node if necessary


### PR DESCRIPTION
remote_down now polls the DLM port for up to 60 seconds before ejecting the peer, so short NTB packet loss events don't trigger a spurious reset_active

Also raise scan_secs from the default 5 to 30 so the kernel DLM itself doesn't start FORCEUNLOCK recovery during ~20s NTB blips.

Original PR: https://github.com/truenas/middleware/pull/19495
