### PR TITLE
NAS-140259 / 25.10.7 / Fix KeyError in alertservice.test error handler (by ixhamza) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/alert/service/snmp_trap.py
+++ b/src/middlewared/middlewared/alert/service/snmp_trap.py
@@ -1,5 +1,6 @@
 import pysnmp.hlapi
 import pysnmp.smi
+import pysnmp.smi.compiler
 
 from middlewared.alert.base import ThreadedAlertService
 
@@ -51,9 +52,11 @@ class SNMPTrapAlertService(ThreadedAlertService):
             self.context_data = pysnmp.hlapi.ContextData()
 
             mib_builder = pysnmp.smi.builder.MibBuilder()
-            mib_sources = mib_builder.getMibSources() + (
-                pysnmp.smi.builder.DirMibSource("/usr/local/share/pysnmp/mibs"),)
-            mib_builder.setMibSources(*mib_sources)
+            # Use pySMI compiler to compile the ASN.1 .txt MIB on-the-fly into Python format
+            pysnmp.smi.compiler.addMibCompiler(
+                mib_builder,
+                sources=['/usr/local/share/snmp/mibs/'] + pysnmp.smi.compiler.defaultSources,
+            )
             mib_builder.loadModules("TRUENAS-MIB")
             self.snmp_alert_level_type = mib_builder.importSymbols("TRUENAS-MIB", "AlertLevelType")[0]
             mib_view_controller = pysnmp.smi.view.MibViewController(mib_builder)

--- a/src/middlewared/middlewared/alert/service/snmp_trap.py
+++ b/src/middlewared/middlewared/alert/service/snmp_trap.py
@@ -1,6 +1,5 @@
 import pysnmp.hlapi
 import pysnmp.smi
-import pysnmp.smi.compiler
 
 from middlewared.alert.base import ThreadedAlertService
 
@@ -52,11 +51,9 @@ class SNMPTrapAlertService(ThreadedAlertService):
             self.context_data = pysnmp.hlapi.ContextData()
 
             mib_builder = pysnmp.smi.builder.MibBuilder()
-            # Use pySMI compiler to compile the ASN.1 .txt MIB on-the-fly into Python format
-            pysnmp.smi.compiler.addMibCompiler(
-                mib_builder,
-                sources=['/usr/local/share/snmp/mibs/'] + pysnmp.smi.compiler.defaultSources,
-            )
+            mib_sources = mib_builder.getMibSources() + (
+                pysnmp.smi.builder.DirMibSource("/usr/local/share/pysnmp/mibs"),)
+            mib_builder.setMibSources(*mib_sources)
             mib_builder.loadModules("TRUENAS-MIB")
             self.snmp_alert_level_type = mib_builder.importSymbols("TRUENAS-MIB", "AlertLevelType")[0]
             mib_view_controller = pysnmp.smi.view.MibViewController(mib_builder)

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -1145,7 +1145,7 @@ class AlertServiceService(CRUDService):
         try:
             await alert_service.send([test_alert], [], [test_alert])
         except Exception:
-            self.logger.error("Error in alert service %r", data["type"], exc_info=True)
+            self.logger.error("Error in alert service %r", data["attributes"]["type"], exc_info=True)
             return False
 
         return True


### PR DESCRIPTION
This is a partial backport of the original PR.

- Fix `KeyError` in `alertservice.test` error handler where `data["type"]` should be `data["attributes"]["type"]`, which masked the real exception on `send()` failures.

Original PR: https://github.com/truenas/middleware/pull/18449
Original PR: https://github.com/truenas/middleware/pull/18451
