### PR TITLE
NAS-142197 / 25.10.7 / Allow null aggregations in the reporting.get_data result schema

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_5/reporting.py
+++ b/src/middlewared/middlewared/api/v25_10_5/reporting.py
@@ -112,8 +112,8 @@ class ReportingGetDataResponse(BaseModel):
     """Specific instance identifier for the metric. `null` for system-wide metrics."""
     data: list
     """Array of time-series data points for the requested time period."""
-    aggregations: Aggregations
-    """Statistical aggregations of the data over the time period."""
+    aggregations: Aggregations | None
+    """Statistical aggregations of the data over the time period. `null` when `aggregate` was not requested."""
     start: timestamp
     """Actual start timestamp of the returned data."""
     end: timestamp


### PR DESCRIPTION
## Problem
`reporting.get_data` sets `aggregations` to `None` whenever a caller passes `aggregate: false`, but the result model declares the field required and non-nullable. Pydantic then refuses to dump the result, so every such call logs a `Serialization error` warning and silently falls back to returning the verbatim payload.

## Solution
Make `aggregations` nullable in `v25_10_5`, which is what `current.py` loads. 

Essentially a backport of https://github.com/truenas/middleware/pull/16946