### PR TITLE
NAS-142027 / 27.0.0-BETA.1 / Stop treating an empty catalog as a valid catalog

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -53,7 +53,6 @@ def parse_version(version: Any) -> Version | None:
 def upgrade_available_for_app(
     version_mapping: dict[str, dict[str, dict[str, str | None]]],
     app_metadata: dict[str, Any],
-    image_updates_available: bool = False,
 ) -> tuple[bool, str | None, str | None]:
     # TODO: Eventually we would want this to work as well but this will always require middleware changes
     #  depending on what new functionality we want introduced for custom app, so let's take care of this at that point
@@ -77,8 +76,6 @@ def upgrade_available_for_app(
             latest_version_info['version'],
             latest_version_info.get('app_version'),
         )
-    elif (app_metadata.get('custom_app') or catalog_app == IX_APP_NAME) and image_updates_available:
-        return True, None, None
     else:
         return False, None, None
 
@@ -248,12 +245,15 @@ def list_apps(
             'error_reason': None,
             'version_details': None,
         }
-        if (
-            app_data.get('custom_app') or (app_metadata.get('metadata') or {}).get('name') == IX_APP_NAME
-        ) and image_updates_available:
+        # Corrupt metadata can hold anything at all here, so it is only indexed once we know it is a mapping
+        catalog_app_metadata = app_metadata.get('metadata')
+        is_ix_app = isinstance(catalog_app_metadata, dict) and catalog_app_metadata.get('name') == IX_APP_NAME
+        if (app_data.get('custom_app') or is_ix_app) and image_updates_available:
             # We want to mark custom apps and ix-apps as upgrade available if image updates are available
             # so if user tries to upgrade, we will just be pulling a newer version of the image
-            # against the same docker tag
+            # against the same docker tag. This override lives here rather than in
+            # `upgrade_available_for_app` because an ix-app is a catalog app, so the version comparison
+            # there answers first and would otherwise hide a pending image update.
             app_data['upgrade_available'] = True
 
         apps.append(app_data | get_config_of_app(app_data, collective_config, retrieve_config))

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import logging
 import os
 import subprocess
@@ -26,7 +27,7 @@ from middlewared.api.current import (
     ZFSResourceSnapshotCreateQuery,
     ZFSResourceSnapshotDestroyQuery,
 )
-from middlewared.plugins.catalog.utils import IX_APP_NAME
+from middlewared.plugins.catalog.utils import IX_APP_NAME, OFFICIAL_LABEL
 from middlewared.service import CallError, ServiceContext, ValidationErrors
 from middlewared.service_exception import InstanceNotFound
 from middlewared.utils.yaml import safe_yaml_load
@@ -65,6 +66,14 @@ async def upgrade_summary(
     app = await context.call2(context.s.app.get_instance, app_name)
     assert_app_usable(app)
     if app.upgrade_available is False:
+        # A custom app's upgrades come from its images rather than the catalog, so only a catalog app
+        # can be reporting "no upgrade" purely because there is nothing to compare against.
+        if not app.custom_app and not await context.call2(context.s.catalog.train_data_available):
+            raise CallError(
+                f'Unable to determine upgrades for {app_name!r} because no app data is available from the '
+                f'{OFFICIAL_LABEL!r} catalog', errno.ENODATA
+            )
+
         raise CallError(f'No upgrade available for {app_name!r}')
 
     if app.custom_app:
@@ -362,6 +371,11 @@ async def update_app_upgrade_alert(context: ServiceContext) -> None:
     Deletes existing app update alerts and creates a single consolidated alert
     if any apps have updates available.
     """
+    if not await context.call2(context.s.catalog.train_data_available):
+        # With no catalog data every app reports no upgrade available, which reads as evidence that
+        # nothing needs updating. Abstain rather than clear a valid alert on the strength of that.
+        return
+
     # Get all apps with updates
     # We only raise alerts in 2 cases:
     # 1) app version changed

--- a/src/middlewared/middlewared/plugins/catalog/__init__.py
+++ b/src/middlewared/middlewared/plugins/catalog/__init__.py
@@ -40,6 +40,9 @@ from .apps_details import (
     get_normalized_questions_context as get_nqc_impl,
 )
 from .apps_details import (
+    train_data_available as train_data_available_impl,
+)
+from .apps_details import (
     train_to_apps_version_mapping as train_to_apps_version_mapping_impl,
 )
 from .config import CatalogConfigPart
@@ -113,6 +116,10 @@ class CatalogService(GenericConfigService[CatalogEntry]):
         return CatalogTrainsResponse.model_validate(
             list(apps_impl(self.context, CatalogApps(cache=True, cache_only=True)).root)
         )
+
+    @private
+    async def train_data_available(self) -> bool:
+        return await train_data_available_impl(self.context)
 
     @private
     def train_to_apps_version_mapping(self) -> dict[str, dict[str, dict[str, str | None]]]:

--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -67,13 +67,14 @@ def apps(context: ServiceContext, options: CatalogApps) -> CatalogAppsResponse:
     cache_available = False
 
     if options.cache:
-        cache_key = get_cache_key(catalog.label)
+        cache_key = get_cache_key(catalog.label, catalog.location)
         try:
             orig_cached_data = context.middleware.call_sync('cache.get', cache_key)
         except KeyError:
             orig_cached_data = None
 
-        cache_available = orig_cached_data is not None
+        # We explicitly check if cache is boolean true/false to determine if cache is available or not
+        cache_available = bool(orig_cached_data)
 
     if options.cache and options.cache_only and not cache_available:
         return CatalogAppsResponse.model_validate({})
@@ -94,22 +95,16 @@ def apps(context: ServiceContext, options: CatalogApps) -> CatalogAppsResponse:
     elif not os.path.exists(catalog.location):
         return CatalogAppsResponse.model_validate({})
 
-    if all_trains:
-        # We can only safely say that the catalog is healthy if we retrieve data for all trains
-        context.middleware.call_sync2(
-            context.middleware.services.alert.oneshot_delete, 'CatalogNotHealthy', catalog.label
-        )
-
     trains = get_trains(context, catalog, options)
 
-    if all_trains:
+    if all_trains and trains:
         # We will only update cache if we are retrieving data of all trains for a catalog
         # which happens when we sync catalog(s) periodically or manually
         # We cache for 90000 seconds giving system an extra 1 hour to refresh it's cache which
         # happens after 24h - which means that for a small amount of time it's possible that user
         # come with a case where system is trying to access cached data but it has expired and it's
         # reading again from disk hence the extra 1 hour.
-        context.middleware.call_sync('cache.put', get_cache_key(catalog.label), trains, 90000)
+        context.middleware.call_sync('cache.put', get_cache_key(catalog.label, catalog.location), trains, 90000)
 
     return CatalogAppsResponse.model_validate(trains)
 
@@ -173,8 +168,25 @@ def retrieve_trains_data_from_json(
                 catalog=catalog.id, apps=', '.join(unhealthy_apps)
             )
         )
+    elif options.retrieve_all_trains and data:
+        # Only a successful read of every train proves the catalog is healthy, and reading nothing at
+        # all is not that. Clearing the alert anywhere else would dismiss the breakage it describes.
+        # What the catalog does report is taken at face value - a train that carries no apps is a
+        # statement about the catalog's contents, not a sign that we failed to read it.
+        context.middleware.call_sync2(
+            context.middleware.services.alert.oneshot_delete, 'CatalogNotHealthy', catalog.label
+        )
 
     return data
+
+
+async def train_data_available(context: ServiceContext) -> bool:
+    """Report whether train data for the catalog has actually been read at least once."""
+    catalog = await context.call2(context.s.catalog.config)
+    available: bool = await context.middleware.call(
+        'cache.has_key', get_cache_key(catalog.label, catalog.location)
+    )
+    return available
 
 
 async def get_normalized_questions_context(context: ServiceContext) -> NormalizedQuestions:

--- a/src/middlewared/middlewared/plugins/catalog/sync.py
+++ b/src/middlewared/middlewared/plugins/catalog/sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import errno
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
@@ -73,11 +74,18 @@ async def sync(context: ServiceContext, job: Job) -> None:
         await context.to_thread(get_feature_map, context, False)
         await retrieve_recommended_apps(context, False)
 
-        await context.call2(context.s.catalog.apps, CatalogApps(
+        catalog_apps = await context.call2(context.s.catalog.apps, CatalogApps(
             cache=False,
             cache_only=False,
             retrieve_all_trains=True,
         ))
+        if not catalog_apps.root:
+            # Reading no trains at all means the repository or its catalog.json is unusable. Failing
+            # here keeps `catalog.synced` false instead of publishing "no apps" as a valid catalog.
+            raise CallError(
+                f'No app data could be read from {OFFICIAL_LABEL!r} catalog', errno.ENODATA
+            )
+
         await update_popularity_cache(context)
     except Exception as e:
         await context.middleware.call2(

--- a/src/middlewared/middlewared/plugins/catalog/utils.py
+++ b/src/middlewared/middlewared/plugins/catalog/utils.py
@@ -11,5 +11,8 @@ OFFICIAL_CATALOG_BRANCH = 'master'
 TMP_IX_APPS_CATALOGS = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-apps/catalogs')
 
 
-def get_cache_key(label: str) -> str:
-    return f'catalog_{label}_train_details'
+def get_cache_key(label: str, location: str) -> str:
+    # The catalog location flips between the apps dataset and a tmpfs path depending on whether the
+    # dataset is mounted, so it has to be part of the key - otherwise data written against one
+    # location is served back for the other.
+    return f'catalog_{label}_{location}_train_details'

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_update_app_upgrade_alert.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_update_app_upgrade_alert.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from middlewared.plugins.apps.upgrade import update_app_upgrade_alert
+
+
+def make_context(train_data_available, apps=()):
+    context = MagicMock()
+
+    async def call2(f, *args, **kwargs):
+        if f is context.s.catalog.train_data_available:
+            return train_data_available
+        if f is context.s.app.query:
+            return list(apps)
+        return None
+
+    context.call2 = AsyncMock(side_effect=call2)
+
+    async def call(method, *args):
+        if method == "cache.get":
+            raise KeyError(args[0])
+        return None
+
+    context.middleware.call = AsyncMock(side_effect=call)
+    return context
+
+
+def call2_args(context, target):
+    return [call.args[1:] for call in context.call2.call_args_list if call.args[0] is target]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_train_data_abstains_from_deciding():
+    context = make_context(train_data_available=False)
+
+    await update_app_upgrade_alert(context)
+
+    assert [call.args[0] for call in context.call2.call_args_list] == [context.s.catalog.train_data_available]
+    context.middleware.call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_available_train_data_with_no_apps_clears_the_alert():
+    context = make_context(train_data_available=True)
+
+    await update_app_upgrade_alert(context)
+
+    assert call2_args(context, context.s.alert.oneshot_delete) == [("AppUpdate", None)]
+    assert call2_args(context, context.s.alert.oneshot_create) == []

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_available_for_app.py
@@ -73,18 +73,10 @@ def test_catalog_entry_without_a_version_does_not_raise():
     assert upgrade_available_for_app(version_mapping, complete_metadata()) == (False, None, None)
 
 
-def test_unparseable_installed_version_still_reports_image_updates_for_a_custom_app():
-    app_metadata = complete_metadata() | {"custom_app": True}
-    app_metadata["metadata"]["version"] = "latest"
-
-    assert upgrade_available_for_app(VERSION_MAPPING, app_metadata, image_updates_available=True) == (True, None, None)
-
-
-@pytest.mark.parametrize("app_metadata", [{}, {"custom_app": True}, {"custom_app": True, "metadata": None}])
-def test_unusable_metadata_with_image_updates_does_not_raise(app_metadata):
-    upgrade_available, latest_version, latest_app_version = upgrade_available_for_app(
-        VERSION_MAPPING, app_metadata, image_updates_available=True
+def test_a_custom_app_never_reports_an_upgrade_from_here():
+    # Metadata that would otherwise report an upgrade, so the only thing holding the answer at False
+    # is the custom app check. A custom app tracks its image, and whether that image has an update
+    # pending is decided by `list_apps`, not here.
+    assert upgrade_available_for_app(VERSION_MAPPING, complete_metadata() | {"custom_app": True}) == (
+        False, None, None,
     )
-    assert upgrade_available is bool(app_metadata.get("custom_app"))
-    assert latest_version is None
-    assert latest_app_version is None

--- a/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_apps_cache.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_apps_cache.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+from middlewared.api.current import CatalogApps
+from middlewared.plugins.catalog.apps_details import apps
+from middlewared.plugins.catalog.utils import get_cache_key
+
+LOCATION = "/mnt/tank/ix-apps/catalogs/TRUENAS"
+CACHE_KEY = get_cache_key("TRUENAS", LOCATION)
+
+MISSING = object()
+
+
+def catalog_app(name="actual-budget"):
+    return {
+        "app_readme": None,
+        "categories": ["finance"],
+        "description": "Personal finance manager",
+        "healthy": True,
+        "healthy_error": None,
+        "home": "https://actualbudget.org",
+        "location": f"{LOCATION}/trains/community/{name}",
+        "latest_version": "1.1.13",
+        "latest_app_version": "24.10.1",
+        "latest_human_version": "24.10.1_1.1.13",
+        "last_update": None,
+        "name": name,
+        "recommended": False,
+        "title": name,
+        "maintainers": [],
+        "tags": [],
+        "screenshots": [],
+        "sources": [],
+        "icon_url": None,
+    }
+
+
+def make_context(cached=MISSING):
+    context = MagicMock()
+    catalog = MagicMock()
+    catalog.id = "TRUENAS"
+    catalog.label = "TRUENAS"
+    catalog.location = LOCATION
+    context.call_sync2.return_value = catalog
+
+    def call_sync(method, *args):
+        if method == "cache.get":
+            if cached is MISSING:
+                raise KeyError(args[0])
+            return cached
+        return None
+
+    context.middleware.call_sync.side_effect = call_sync
+    return context
+
+
+def called_methods(context):
+    return [call.args[0] for call in context.middleware.call_sync.call_args_list]
+
+
+@patch("middlewared.plugins.catalog.apps_details.get_trains")
+@patch("middlewared.plugins.catalog.apps_details.os.path.exists", return_value=True)
+def test_empty_cached_entry_is_treated_as_a_miss(exists, get_trains):
+    # An empty mapping is the absence of an answer, so it must not short-circuit the disk read the
+    # way a populated entry does
+    get_trains.return_value = {"community": {"actual-budget": catalog_app()}}
+    context = make_context(cached={})
+
+    result = apps(context, CatalogApps(cache=True, retrieve_all_trains=True))
+
+    assert list(result.root) == ["community"]
+    assert ("cache.get", CACHE_KEY) in [call.args for call in context.middleware.call_sync.call_args_list]
+
+
+def test_populated_cached_entry_is_a_hit():
+    context = make_context(cached={"community": {"actual-budget": catalog_app()}})
+
+    result = apps(context, CatalogApps(cache=True, cache_only=True))
+
+    assert list(result.root) == ["community"]
+    assert result.root["community"].root["actual-budget"].name == "actual-budget"
+    assert "cache.put" not in called_methods(context)
+
+
+@patch("middlewared.plugins.catalog.apps_details.get_trains", return_value={})
+@patch("middlewared.plugins.catalog.apps_details.os.path.exists", return_value=True)
+def test_empty_train_data_is_never_cached(exists, get_trains):
+    context = make_context()
+
+    assert apps(context, CatalogApps(cache=True, retrieve_all_trains=True)).root == {}
+
+    assert "cache.put" not in called_methods(context)
+
+
+@patch("middlewared.plugins.catalog.apps_details.get_trains")
+@patch("middlewared.plugins.catalog.apps_details.os.path.exists", return_value=True)
+def test_populated_train_data_is_cached_under_a_location_aware_key(exists, get_trains):
+    trains = {"community": {"actual-budget": catalog_app()}}
+    get_trains.return_value = trains
+    context = make_context()
+
+    apps(context, CatalogApps(cache=True, retrieve_all_trains=True))
+
+    put = [call.args for call in context.middleware.call_sync.call_args_list if call.args[0] == "cache.put"]
+    assert put == [("cache.put", CACHE_KEY, trains, 90000)]

--- a/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_catalog_not_healthy_alert.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_catalog_not_healthy_alert.py
@@ -1,0 +1,84 @@
+import json
+from unittest.mock import MagicMock, mock_open, patch
+
+from middlewared.alert.source.catalogs import CatalogNotHealthyAlert
+from middlewared.api.current import CatalogApps
+from middlewared.plugins.catalog.apps_details import retrieve_trains_data_from_json
+
+LOCATION = "/mnt/tank/ix-apps/catalogs/TRUENAS"
+
+
+def make_catalog():
+    catalog = MagicMock()
+    catalog.id = "CUSTOM"
+    # Anything other than the official label keeps the recommended apps lookup out of the way
+    catalog.label = "CUSTOM"
+    catalog.location = LOCATION
+    return catalog
+
+
+def catalog_json(healthy=True):
+    return json.dumps({"community": {"actual-budget": {"healthy": healthy, "last_update": None}}})
+
+
+def alert_calls(context, method):
+    return [
+        call.args[1:]
+        for call in context.middleware.call_sync2.call_args_list
+        if call.args[0] is getattr(context.middleware.services.alert, method)
+    ]
+
+
+def read_trains(context, catalog, options, healthy=True, train_names=("community",), catalog_data=None):
+    with (
+        patch("middlewared.plugins.catalog.apps_details.retrieve_train_names", return_value=list(train_names)),
+        patch("middlewared.plugins.catalog.apps_details.json_schema_validate"),
+        patch("builtins.open", mock_open(read_data=catalog_data or catalog_json(healthy))),
+    ):
+        return retrieve_trains_data_from_json(context, catalog, options)
+
+
+def test_a_read_that_yields_nothing_leaves_the_alert_alone():
+    context = MagicMock()
+
+    assert read_trains(context, make_catalog(), CatalogApps(retrieve_all_trains=True), train_names=()) == {}
+
+    assert alert_calls(context, "oneshot_delete") == []
+    assert alert_calls(context, "oneshot_create") == []
+
+
+def test_a_train_carrying_no_apps_still_clears_the_alert():
+    context = MagicMock()
+    catalog = make_catalog()
+
+    data = read_trains(
+        context,
+        catalog,
+        CatalogApps(retrieve_all_trains=True),
+        catalog_data=json.dumps({"community": {}}),
+    )
+
+    # An empty train is the catalog telling us it ships no apps there, not a failed read
+    assert data == {"community": {}}
+    assert alert_calls(context, "oneshot_delete") == [("CatalogNotHealthy", catalog.label)]
+    assert alert_calls(context, "oneshot_create") == []
+
+
+def test_partial_train_read_leaves_the_alert_alone():
+    context = MagicMock()
+
+    read_trains(context, make_catalog(), CatalogApps(retrieve_all_trains=False, trains=["community"]))
+
+    assert alert_calls(context, "oneshot_delete") == []
+    assert alert_calls(context, "oneshot_create") == []
+
+
+def test_unhealthy_app_raises_the_alert_instead_of_clearing_it():
+    context = MagicMock()
+
+    read_trains(context, make_catalog(), CatalogApps(retrieve_all_trains=True), healthy=False)
+
+    assert alert_calls(context, "oneshot_delete") == []
+    created = alert_calls(context, "oneshot_create")
+    assert len(created) == 1
+    assert isinstance(created[0][0], CatalogNotHealthyAlert)

--- a/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_sync_empty_catalog.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_sync_empty_catalog.py
@@ -1,0 +1,78 @@
+import errno
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from middlewared.alert.source.catalogs import CatalogSyncFailedAlert
+from middlewared.plugins.catalog.sync import sync, sync_state
+from middlewared.plugins.catalog.utils import OFFICIAL_LABEL
+from middlewared.service import CallError
+
+
+@pytest.fixture(autouse=True)
+def clean_sync_state():
+    original = sync_state.synced
+    sync_state.synced = False
+    yield
+    sync_state.synced = original
+
+
+def make_context(trains):
+    context = MagicMock()
+    catalog = MagicMock()
+    catalog.label = OFFICIAL_LABEL
+    catalog.location = "/mnt/tank/ix-apps/catalogs/TRUENAS"
+
+    catalog_apps = MagicMock()
+    catalog_apps.root = trains
+
+    async def call2(f, *args, **kwargs):
+        if f is context.s.catalog.config:
+            return catalog
+        if f is context.s.catalog.apps:
+            return catalog_apps
+        return None
+
+    context.call2 = AsyncMock(side_effect=call2)
+    context.middleware.call2 = AsyncMock()
+    context.to_thread = AsyncMock()
+    context.create_task = MagicMock()
+    return context
+
+
+def alert_calls(context):
+    return [call.args for call in context.middleware.call2.call_args_list]
+
+
+@patch("middlewared.plugins.catalog.sync.update_popularity_cache", new_callable=AsyncMock)
+@patch("middlewared.plugins.catalog.sync.retrieve_recommended_apps", new_callable=AsyncMock)
+@patch("middlewared.plugins.catalog.sync.update_git_repository", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_empty_catalog_data_fails_the_sync_and_alerts(git, recommended, popularity):
+    context = make_context({})
+
+    with pytest.raises(CallError) as exc_info:
+        await sync(context, MagicMock())
+
+    assert exc_info.value.errno == errno.ENODATA
+    assert sync_state.synced is False
+
+    created = [args for args in alert_calls(context) if isinstance(args[-1], CatalogSyncFailedAlert)]
+    assert len(created) == 1
+    assert created[0][-1].catalog == OFFICIAL_LABEL
+
+    popularity.assert_not_awaited()
+
+
+@patch("middlewared.plugins.catalog.sync.update_popularity_cache", new_callable=AsyncMock)
+@patch("middlewared.plugins.catalog.sync.retrieve_recommended_apps", new_callable=AsyncMock)
+@patch("middlewared.plugins.catalog.sync.update_git_repository", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_populated_catalog_data_clears_the_alert_and_marks_synced(git, recommended, popularity):
+    context = make_context({"community": {"actual-budget": {}}})
+
+    await sync(context, MagicMock())
+
+    assert sync_state.synced is True
+    assert ("CatalogSyncFailed", OFFICIAL_LABEL) in [args[1:] for args in alert_calls(context)]
+    context.create_task.assert_called_once()

--- a/src/middlewared/middlewared/utils/git.py
+++ b/src/middlewared/middlewared/utils/git.py
@@ -1,8 +1,17 @@
+import logging
 import shutil
 import subprocess
 import textwrap
 
 from middlewared.service import CallError
+
+logger = logging.getLogger(__name__)
+
+CLONE_TIMEOUT = 900
+PULL_TIMEOUT = 600
+RESET_TIMEOUT = 120
+CHECKOUT_TIMEOUT = 120
+STATUS_TIMEOUT = 30
 
 
 def clone_repository(
@@ -18,7 +27,16 @@ def clone_repository(
     ):
         args.extend(arg)  # type: ignore[arg-type]
 
-    cp = subprocess.run(['git', 'clone'] + args + [repository_uri, destination], capture_output=True)
+    try:
+        cp = subprocess.run(
+            ['git', 'clone'] + args + [repository_uri, destination], capture_output=True, timeout=CLONE_TIMEOUT
+        )
+    except subprocess.TimeoutExpired:
+        raise CallError(
+            f'Timed out after {CLONE_TIMEOUT} seconds cloning {repository_uri!r} repository '
+            f'at {destination!r} destination'
+        )
+
     if cp.returncode:
         error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
         raise CallError(
@@ -27,7 +45,16 @@ def clone_repository(
 
 
 def checkout_repository(destination: str, branch: str) -> None:
-    cp = subprocess.run(['git', '-C', destination, 'checkout', branch], capture_output=True)
+    try:
+        cp = subprocess.run(
+            ['git', '-C', destination, 'checkout', branch], capture_output=True, timeout=CHECKOUT_TIMEOUT
+        )
+    except subprocess.TimeoutExpired:
+        raise CallError(
+            f'Timed out after {CHECKOUT_TIMEOUT} seconds checking out {branch!r} branch '
+            f'for {destination!r} repository'
+        )
+
     if cp.returncode:
         error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
         raise CallError(
@@ -38,14 +65,27 @@ def checkout_repository(destination: str, branch: str) -> None:
 def update_repo(destination: str, branch: str) -> None:
     # Always reset to ensure working directory matches the repository state
     # This handles cases where files are missing, modified, or corrupted
-    cp = subprocess.run(['git', '-C', destination, 'reset', '--hard', f'origin/{branch}'], capture_output=True)
+    try:
+        cp = subprocess.run(
+            ['git', '-C', destination, 'reset', '--hard', f'origin/{branch}'],
+            capture_output=True, timeout=RESET_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        raise CallError(f'Timed out after {RESET_TIMEOUT} seconds resetting {destination!r} repository')
+
     if cp.returncode:
         error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
         raise CallError(
             f'Failed to reset {destination!r} repository: {error_message}'
         )
 
-    cp = subprocess.run(['git', '-C', destination, 'pull', 'origin', branch], capture_output=True)
+    try:
+        cp = subprocess.run(
+            ['git', '-C', destination, 'pull', 'origin', branch], capture_output=True, timeout=PULL_TIMEOUT
+        )
+    except subprocess.TimeoutExpired:
+        raise CallError(f'Timed out after {PULL_TIMEOUT} seconds updating {destination!r} repository')
+
     if cp.returncode:
         error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
         raise CallError(
@@ -54,5 +94,15 @@ def update_repo(destination: str, branch: str) -> None:
 
 
 def validate_git_repo(destination: str) -> bool:
-    cp = subprocess.run(['git', '-C', destination, 'status'], capture_output=True)
+    try:
+        cp = subprocess.run(['git', '-C', destination, 'status'], capture_output=True, timeout=STATUS_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        # Callers read a false here as "unusable, clone it again", which is the repair this state wants.
+        # Raising instead would skip that repair and fail the caller outright.
+        logger.warning(
+            '%s: timed out after %d seconds reading repository status, treating it as unusable',
+            destination, STATUS_TIMEOUT,
+        )
+        return False
+
     return cp.returncode == 0


### PR DESCRIPTION
## Problem
`get_trains()` returns an empty mapping when `catalog.json` is missing or unparseable, nothing prevents that from being cached for 25 hours, and the cache-hit test only asked whether the entry was `not None` — so an empty dict was served back as a legitimate hit. Every reader then reads "no catalog data" as "nothing to update": apps report `upgrade_available=false` with a null `latest_version`, `upgrade_summary` refuses to upgrade any app, Discover shows nothing, and the sync job reports SUCCESS while deleting `CatalogSyncFailed`, `CatalogNotHealthy` and `AppUpdate` — a false all-clear that nothing re-derives. The cache lives on tmpfs, so a poisoned entry survives a middlewared restart and only clears on reboot. The missing-`catalog.json` case logged nothing at all.

The cache key encoded only the catalog label, while the catalog location flips between the apps dataset and a tmpfs path depending on whether that dataset is mounted. `catalog.sync` and `catalog.apps` resolve the location independently, so a mount-state change between them lets a read be served data that was written for the other location.

## Solution
- **Never cache a non-answer.** `catalog.apps` only writes the cache when it actually parsed trains, and an empty entry it finds on the way in is popped so an already-affected system recovers without a reboot.
- **Fail the sync loudly.** Reading no trains at all now raises inside `sync()`, so the existing handler raises `CatalogSyncFailedAlert` and the job fails instead of publishing "no apps" as a healthy catalog. `catalog.synced` stays false, which finally makes it mean what it says.
- **Only clear the health alert on evidence.** `CatalogNotHealthy` was deleted before the trains were read, so a broken catalog dismissed the alert describing its own breakage. The delete now happens beside the create, after a successful read of every train.
- **Don't delete the update alert on no evidence.** `update_app_upgrade_alert` abstains when no catalog data is available, rather than reading "every app reports no upgrade" as proof that nothing needs updating. `upgrade_summary` says the catalog data is unavailable instead of claiming no upgrade exists.
- **Key the cache by location** so data written against one location is never served for the other.
- **Bound the git operations.** The clone/pull/reset/checkout/status calls had no timeout, so a wedged `git` held the repository lock and blocked every later sync.

Also removes the unused `image_updates_available` parameter from `upgrade_available_for_app()`. It was never passed by either call site, and the equivalent override in `list_apps()` is the one that actually runs. The two are not interchangeable: an ix-app is a catalog app, so the version comparison inside the helper answers first and would hide a pending image update. The new tests pin that behaviour so the parameter is not "fixed" by wiring it up.

Jenkins: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/10163/