### PR TITLE
NAS-142457 / 27.0.0-BETA.1 / Fix TTL handling in cache.has_key and get_or_put

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -39,14 +39,17 @@ class KVCache:
         self.time_fn = time_fn
 
     def has_key(self, key: str) -> bool:
-        """Check if given `key` exists in persistent cache."""
-        with get_tdb_handle(self.path, self.tdb_options) as hdl:
-            try:
-                hdl.get(key)
-            except (FileNotFoundError, MatchNotFound):
-                return False
-            else:
-                return True
+        """
+        Check whether `key` is present in the persistent cache and has not expired.
+
+        An expired entry is removed from the cache and reported as absent.
+        """
+        try:
+            self.get(key)
+        except KeyError:
+            return False
+        else:
+            return True
 
     def get(self, key: str) -> Any:
         """
@@ -126,6 +129,8 @@ class KVCache:
         If key exists and is not expired, returns cached value.
         Otherwise, calls method() to generate a new value, caches it, and returns it.
 
+        A `timeout` of 0 means the generated value never expires.
+
         NOTE: This operation is atomic for the local persistent cache, but not for clustered cache.
         More design work will be required if atomicity is needed on clustered database.
         """
@@ -142,7 +147,8 @@ class KVCache:
 
             if call_method:
                 value = method()
-                hdl.store(key, {'timeout': self.time_fn() + timeout, 'value': value})
+                expires_at = self.time_fn() + timeout if timeout != 0 else 0
+                hdl.store(key, {'timeout': expires_at, 'value': value})
             else:
                 value = data['value']
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -57,6 +57,22 @@ def test__volatile_timeout():
             c.call('cache.get', 'timeout_key', 'VOLATILE')
 
 
+def test__volatile_has_key_respects_timeout():
+    """Test that has_key reports an expired key as absent."""
+    with Client(py_exceptions=True) as c:
+        # Put a key with 1 second timeout
+        c.call('cache.put', 'has_key_timeout_key', 'timeout_value', 1, 'VOLATILE')
+
+        # Should exist immediately
+        assert c.call('cache.has_key', 'has_key_timeout_key', 'VOLATILE')
+
+        # Wait for timeout
+        time.sleep(1.5)
+
+        # Should be reported as absent after timeout
+        assert not c.call('cache.has_key', 'has_key_timeout_key', 'VOLATILE')
+
+
 def test__volatile_complex_data():
     """Test storing complex data structures in volatile cache."""
     with Client(py_exceptions=True) as c:


### PR DESCRIPTION
## Problem
`cache.has_key` returned True whenever the TDB record existed and never looked at the stored `timeout`, so it disagreed with `cache.get` — which expires the entry and raises `KeyError` — for any key that had expired but not yet been reaped. The only reaper is a 24h periodic with `run_on_start=False` whose timer is re-armed from scratch on every middlewared start, so on a box that restarts more often than daily it never runs at all and the wrong answer sticks around indefinitely.

Separately, `get_or_put` always stored `now + timeout`, so unlike `put` — where 0 means "never expires" — `get_or_put(key, 0, method)` stored an expiry of now and the entry was already expired on the very next read.

## Solution
`has_key` now delegates to `get()` and maps `KeyError` to False. Delegating rather than repeating the timeout comparison is deliberate: the bug existed because two methods independently decided what "expired" means, and this leaves only one. Expired entries are reaped on access as a side effect, which matters given how unreliable the periodic reaper is.

`get_or_put` stores a literal 0 when `timeout` is 0, matching `put`.

Jenkins: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/10165/