### PR TITLE
NAS-142117 / 27.0.0-BETA.1 / Force ACL application on app-owned ix-volume paths

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import PurePath
 
 from middlewared.plugins.docker.state_utils import IX_APPS_MOUNT_PATH
 
@@ -33,6 +34,24 @@ def get_app_parent_volume_path() -> str:
 
 def get_app_volume_path(app_name: str) -> str:
     return os.path.join(get_app_parent_volume_path(), app_name)
+
+
+def is_app_volume_path(path: str, app_name: str) -> bool:
+    """Whether `path` is the app's ix-volume directory or lives inside it.
+
+    The comparison is purely lexical - `..` segments are collapsed but symlinks are not resolved, so
+    this stays cheap enough to call from the event loop.
+    """
+    return PurePath(os.path.normpath(path)).is_relative_to(get_app_volume_path(app_name))
+
+
+def is_app_mounts_path(path: str) -> bool:
+    """Whether `path` is the directory holding every app's ix-volumes or lives inside it.
+
+    The comparison is purely lexical - `..` segments are collapsed but symlinks are not resolved, so
+    this stays cheap enough to call from the event loop.
+    """
+    return PurePath(os.path.normpath(path)).is_relative_to(get_app_parent_volume_path())
 
 
 def get_installed_app_path(app_name: str) -> str:

--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -7,7 +7,7 @@ from typing import Any
 from middlewared.api.current import AppEntry
 from middlewared.service import ServiceContext
 
-from .ix_apps.path import get_app_volume_path
+from .ix_apps.path import get_app_volume_path, is_app_volume_path
 from .resources import gpu_choices_internal
 from .schema_action_context import apply_acls, update_volumes
 from .schema_construction_utils import RESERVED_NAMES
@@ -25,11 +25,12 @@ async def normalize_and_validate_values(
     context: ServiceContext, item_details: dict[str, Any], values: dict[str, Any], update: bool,
     app_dir: str, app_data: AppEntry | None = None, perform_actions: bool = True,
 ) -> dict[str, Any]:
+    app_name = app_dir.split('/')[-1]
     new_values = await validate_values(context, item_details, values, update, app_data)
     new_values, normalization_context = await normalize_values(
         context, item_details['schema']['questions'], new_values, update, {
             'app': {
-                'name': app_dir.split('/')[-1],
+                'name': app_name,
                 'path': app_dir,
             },
             'actions': [],
@@ -188,6 +189,16 @@ async def normalize_ix_volume(
 
     if acl_dict:
         acl_dict['path'] = host_path
+        if is_app_volume_path(host_path, normalization_context['app']['name']):
+            # An ix volume is created and owned by middleware, so applying an ACL to one can never clobber data
+            # the user deliberately placed there, and the schema we serve already reflects that by hiding `force`
+            # and defaulting it to true. Clients can still submit an explicit false though, and older configs may
+            # have one persisted, which trips the "path contains existing data" guard as soon as the app writes
+            # anything into its volume. The containment check is not redundant: `dataset_name` is not validated
+            # as a path anywhere, so an absolute or `..`-laden one lands `host_path` outside the app's own tree,
+            # and forcing there would be forcing over somebody else's data. Since this is the same dict which
+            # gets written back to the app config, a stored false heals itself on the next update.
+            acl_dict.setdefault('options', {})['force'] = True
         await normalize_acl(context, {'schema': {'type': 'dict'}}, acl_dict, complete_config, normalization_context)
     return value
 

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -6,6 +6,7 @@ from typing import Any
 from middlewared.api.current import AppEntry
 from middlewared.service import ServiceContext, ValidationErrors
 
+from .ix_apps.path import is_app_mounts_path
 from .resources import certificate_choices, used_ports
 from .schema_construction_utils import NOT_PROVIDED, RESERVED_NAMES, USER_VALUES, construct_schema
 
@@ -120,6 +121,15 @@ async def validate_acl_entries(
 ) -> None:
     path = value.get('path')
     if not path or value.get('options', {}).get('force'):
+        return
+
+    if is_app_mounts_path(path):
+        # Everything under the app mounts directory is created and owned by middleware, so whether it holds
+        # data is not middleware's call to refuse a save over - a stored `force: false` on an ix volume would
+        # otherwise make the config permanently unsavable once the app has written anything into its volume.
+        # Skipping only drops the pre-flight message: filesystem.add_to_acl still refuses an unforced apply
+        # over a populated path, and `force` is written in exactly one place - normalize_ix_volume - which
+        # only ever sets it for the requesting app's own volume.
         return
     try:
         if await context.to_thread(_acl_path_has_data, path):

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_volume_path.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_volume_path.py
@@ -1,0 +1,59 @@
+import pytest
+
+from middlewared.plugins.apps.ix_apps.path import (
+    get_app_parent_volume_path,
+    get_app_volume_path,
+    is_app_mounts_path,
+    is_app_volume_path,
+)
+
+
+@pytest.mark.parametrize(
+    "path, app_name, should_match",
+    [
+        (get_app_volume_path("plex"), "plex", True),
+        (f"{get_app_volume_path('plex')}/data", "plex", True),
+        (f"{get_app_volume_path('plex')}/data/nested/deeper", "plex", True),
+        (f"{get_app_volume_path('plex')}/", "plex", True),
+        (f"{get_app_volume_path('plex')}//data", "plex", True),
+        (f"{get_app_volume_path('plex')}/data/../config", "plex", True),
+        (get_app_volume_path("sonarr"), "plex", False),
+        # These share a name prefix with the app but are separate directories
+        (get_app_volume_path("plex-extra"), "plex", False),
+        (f"{get_app_volume_path('plex2')}/data", "plex", False),
+        # Traversal out of the volume directory has to be caught even though nothing is resolved on disk
+        (f"{get_app_volume_path('plex')}/../sonarr/data", "plex", False),
+        (f"{get_app_volume_path('plex')}/../../../../mnt/tank/data", "plex", False),
+        ("/mnt/tank/data", "plex", False),
+        ("", "plex", False),
+        ("data", "plex", False),
+    ],
+)
+def test_is_app_volume_path(path, app_name, should_match):
+    assert is_app_volume_path(path, app_name) is should_match
+
+
+@pytest.mark.parametrize(
+    "path, should_match",
+    [
+        (get_app_parent_volume_path(), True),
+        (f"{get_app_parent_volume_path()}/", True),
+        # Any app's volume directory is under the shared root, no app identity involved
+        (get_app_volume_path("plex"), True),
+        (f"{get_app_volume_path('plex')}/data/nested/deeper", True),
+        (get_app_volume_path("sonarr"), True),
+        (f"{get_app_parent_volume_path()}//plex", True),
+        (f"{get_app_volume_path('plex')}/data/../config", True),
+        # A sibling directory sharing the root's name prefix is not inside it
+        (f"{get_app_parent_volume_path()}-old/plex", False),
+        # Traversal out of the root has to be caught even though nothing is resolved on disk
+        (f"{get_app_volume_path('plex')}/../../../../mnt/tank/data", False),
+        (f"{get_app_parent_volume_path()}/../app_configs/plex", False),
+        ("/mnt/.ix-apps/app_configs/plex", False),
+        ("/mnt/tank/data", False),
+        ("", False),
+        ("data", False),
+    ],
+)
+def test_is_app_mounts_path(path, should_match):
+    assert is_app_mounts_path(path) is should_match

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_ix_volumes.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_ix_volumes.py
@@ -2,7 +2,8 @@ import logging
 
 import pytest
 
-from middlewared.plugins.apps.schema_normalization import normalize_ix_volume
+from middlewared.plugins.apps.ix_apps.path import get_app_volume_path
+from middlewared.plugins.apps.schema_normalization import normalize_ix_volume, normalize_question
 from middlewared.pytest.unit.middleware import Middleware
 from middlewared.service import ServiceContext
 
@@ -110,3 +111,80 @@ async def test_normalize_ix_volumes(attr, value, complete_config, normalization_
     assert len(normalization_context['actions']) > 0
     assert value['dataset_name'] in [v['name'] for v in normalization_context['actions'][0]['args'][-1]]
     assert result == value
+
+    acl_action = next((a for a in normalization_context['actions'] if a['method'] == 'apply_acls'), None)
+    if value['acl_entries']['entries']:
+        # The path here is stamped by normalization and always points inside the app's own volume
+        # directory, so the ACL apply which gets queued for it has to come out forced
+        assert acl_action is not None
+        assert acl_action['args'][0][value['acl_entries']['path']]['options']['force'] is True
+    else:
+        assert acl_action is None
+
+
+@pytest.mark.parametrize('options', [
+    # An explicitly disabled force flag on the app's own volume is overridden rather than
+    # allowed to block the ACL apply
+    {'force': False},
+    {'force': True},
+    # An absent options key has to be created so the flag can be recorded at all
+    None,
+])
+@pytest.mark.asyncio
+async def test_normalize_ix_volume_forces_acl_on_own_volume(options):
+    ctx = ServiceContext(Middleware(), logging.getLogger('test'))
+    acl_entries = {'entries': [{'type': 'ALLOW', 'permissions': 'read'}], 'path': ''}
+    if options is not None:
+        acl_entries['options'] = options
+    value = {'dataset_name': 'data', 'acl_entries': acl_entries}
+    normalization_context = {'actions': [], 'app': {'name': 'test-app'}}
+
+    await normalize_ix_volume(
+        ctx, {'schema': {'type': 'dict'}}, value, {'ix_volumes': {}}, normalization_context,
+    )
+
+    host_path = f'{get_app_volume_path("test-app")}/data'
+    assert acl_entries['path'] == host_path
+    assert acl_entries['options'] == {'force': True}
+    acl_action = next(a for a in normalization_context['actions'] if a['method'] == 'apply_acls')
+    # The queued action has to hold the very same dict which gets persisted, otherwise the stored
+    # config and the ACL which was actually applied would disagree
+    assert acl_action['args'][0][host_path] is acl_entries
+
+
+# `dataset_name` is not validated as a path anywhere, so an absolute or `..`-laden one steers the volume
+# host path out of the app's own tree. Normalizing through the full question walk is what matters here: an
+# `acl_entries` attr carrying its own `normalize/acl` ref is normalized while descending, before the parent
+# ix volume ref has re-pointed its path, so a decision taken on the path seen at that point would outlive
+# the re-point and end up forcing an ACL over data which is not the app's.
+@pytest.mark.parametrize('dataset_name, escaped_path', [
+    ('/mnt/tank/data', '/mnt/tank/data'),
+    ('../other-app/media', f'{get_app_volume_path("test-app")}/../other-app/media'),
+])
+@pytest.mark.asyncio
+async def test_normalize_ix_volume_does_not_force_escaped_dataset_name(dataset_name, escaped_path):
+    ctx = ServiceContext(Middleware(), logging.getLogger('test'))
+    attr = {
+        'variable': 'ix_volume_config',
+        'schema': {
+            'type': 'dict',
+            '$ref': ['normalize/ix_volume'],
+            'attrs': [{'variable': 'acl_entries', 'schema': {'type': 'dict', '$ref': ['normalize/acl']}}],
+        },
+    }
+    acl_entries = {
+        'entries': [{'type': 'ALLOW', 'permissions': 'read'}],
+        # The path carried in a stored config points at the app's own volume directory
+        'path': f'{get_app_volume_path("test-app")}/data',
+        'options': {'force': False},
+    }
+    value = {'dataset_name': dataset_name, 'acl_entries': acl_entries}
+    normalization_context = {'actions': [], 'app': {'name': 'test-app'}}
+
+    await normalize_question(ctx, attr, value, True, {'ix_volumes': {}}, normalization_context)
+
+    assert acl_entries['path'] == escaped_path
+    assert acl_entries['options']['force'] is False
+    acl_action = next(a for a in normalization_context['actions'] if a['method'] == 'apply_acls')
+    assert acl_action['args'][0][escaped_path] is acl_entries
+    assert all(queued['options']['force'] is False for queued in acl_action['args'][0].values())

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_validate_acl_entries.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_validate_acl_entries.py
@@ -1,0 +1,113 @@
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+from middlewared.plugins.apps.ix_apps.path import get_app_volume_path
+from middlewared.plugins.apps.schema_validation import validate_acl_entries
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service import ServiceContext, ValidationErrors
+
+APP_VOLUME_PATH = get_app_volume_path("plex")
+SCHEMA_NAME = "app_update.values.storage.data.acl_entries"
+ENTRIES = [{"id_type": "USER", "id": 568, "access": "FULL_CONTROL"}]
+
+
+@pytest.mark.parametrize(
+    "value, expected_error, probe_called",
+    [
+        (
+            {"path": "", "entries": ENTRIES, "options": {"force": False}},
+            None,
+            False,
+        ),
+        (
+            {"path": "/mnt/tank/data", "entries": ENTRIES, "options": {"force": True}},
+            None,
+            False,
+        ),
+        # A host path belongs to the user, so the existing data guard still has to fire for it
+        (
+            {"path": "/mnt/tank/data", "entries": ENTRIES, "options": {"force": False}},
+            "path contains existing data",
+            True,
+        ),
+        (
+            {"path": APP_VOLUME_PATH, "entries": ENTRIES, "options": {"force": False}},
+            None,
+            False,
+        ),
+        # Everything below sits under the app mounts directory, which middleware owns in its entirety, so the
+        # pre-flight probe is skipped for all of it - including another app's volume, an app whose name merely
+        # shares a prefix with ours, and a host path which was typed under a volume directory. None of these
+        # gain the ability to write an ACL: `force` is only ever stamped onto the requesting app's own volume,
+        # so add_to_acl still refuses them at apply time, just with a later and less well scoped error
+        (
+            {"path": f"{APP_VOLUME_PATH}/nested/dir", "entries": ENTRIES, "options": {"force": False}},
+            None,
+            False,
+        ),
+        (
+            {"path": f"{get_app_volume_path('sonarr')}/data", "entries": ENTRIES, "options": {"force": False}},
+            None,
+            False,
+        ),
+        (
+            {"path": get_app_volume_path("plex-extra"), "entries": ENTRIES, "options": {"force": False}},
+            None,
+            False,
+        ),
+        # Traversal back out of the app mounts directory lands on the user's own data again
+        (
+            {
+                "path": f"{APP_VOLUME_PATH}/../../../../mnt/tank/data",
+                "entries": ENTRIES,
+                "options": {"force": False},
+            },
+            "path contains existing data",
+            True,
+        ),
+        # An absent options key reads as force not being specified
+        (
+            {"path": "/mnt/tank/data", "entries": ENTRIES},
+            "path contains existing data",
+            True,
+        ),
+        # An ix volume with its ACL turned off still carries a path and whatever force value was
+        # stored with it, so it has to be exempt here as well
+        (
+            {"path": APP_VOLUME_PATH, "entries": [], "options": {"force": False}},
+            None,
+            False,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_validate_acl_entries(value, expected_error, probe_called):
+    ctx = ServiceContext(Middleware(), logging.getLogger("test"))
+    verrors = ValidationErrors()
+    probe = Mock(return_value=True)
+
+    with patch("middlewared.plugins.apps.schema_validation._acl_path_has_data", probe):
+        await validate_acl_entries(ctx, verrors, value, SCHEMA_NAME, None)
+
+    assert probe.called is probe_called
+    if expected_error is None:
+        assert verrors.errors == []
+    else:
+        assert len(verrors.errors) == 1
+        assert verrors.errors[0].attribute == SCHEMA_NAME
+        assert expected_error in verrors.errors[0].errmsg
+
+
+@pytest.mark.asyncio
+async def test_validate_acl_entries_missing_path():
+    ctx = ServiceContext(Middleware(), logging.getLogger("test"))
+    verrors = ValidationErrors()
+    value = {"path": "/mnt/tank/data", "entries": ENTRIES, "options": {"force": False}}
+
+    with patch("middlewared.plugins.apps.schema_validation._acl_path_has_data", Mock(side_effect=FileNotFoundError())):
+        await validate_acl_entries(ctx, verrors, value, SCHEMA_NAME, None)
+
+    assert len(verrors.errors) == 1
+    assert "path does not exist" in verrors.errors[0].errmsg


### PR DESCRIPTION
## Problem
The served schema hides `force` for ix-volumes and defaults it to true, but clients submit an explicit false and middleware honours it, so applying an ACL fails with `path contains existing data` as soon as the app has written to its own volume. Once that false is persisted, validation rejects the config before normalization can correct it.

The bad value comes from the UI, which honours `hidden` only on the field carrying it: for an ix-volume the whole `options` block is hidden, so the form still builds a `force` control, seeds it with its own boolean default of false rather than the schema's true, and submits that for a system managed dataset.

## Solution
ix-volumes are system managed, so anything in them is managed bys - confirmed with Stavros that `force` should always be true for them when an ACL is wanted.

`normalize_ix_volume` stamps `force` to true in place once it has computed the volume's host path, gated on a containment check since `dataset_name` is not validated as a path anywhere. `validate_acl_entries` skips its existing-data probe for anything under `/mnt/.ix-apps/app_mounts` - that tree is ours, and `filesystem.add_to_acl` still refuses an unforced apply over a populated path.

Host path ACLs keep their guard and their false default. The cost is that a host path typed under `app_mounts` now fails from `add_to_acl` rather than validation, so it fails later, after `update_volumes` has created datasets and any sibling ACLs have been applied.

Jenkins: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/10169/