### PR TITLE
NAS-142542 / 26.0.0-RC.1 / Make ZFS tier alerts normal alerts (by themylogin)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,7 +22,7 @@ jobs:
       id: new-files
       run: |
         git fetch origin "$GITHUB_BASE_REF" --depth=1
-        mapfile -t NEW_PY_FILES < <(git diff --name-only --diff-filter=A FETCH_HEAD HEAD -- '*.py')
+        mapfile -t NEW_PY_FILES < <(git diff --name-only --diff-filter=A FETCH_HEAD HEAD -- '*.py' ':!src/middlewared/middlewared/alembic/**')
         if [ ${#NEW_PY_FILES[@]} -eq 0 ]; then
           echo "✅ No new Python files to check"
           echo "found=false" >> "$GITHUB_OUTPUT"

--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-08-24_12-00_remove_tier_oneshot_alerts.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-08-24_12-00_remove_tier_oneshot_alerts.py
@@ -1,0 +1,26 @@
+"""Bind Tier* alerts to their source (they were one-shot)
+
+Revision ID: b7d4e91c53aa
+Revises: 9c31be47d5a2
+Create Date: 2026-08-24 12:00:00.000000+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7d4e91c53aa'
+down_revision = '9c31be47d5a2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE system_alert SET source = 'TierJob' WHERE klass IN "
+        "('TierJobError', 'TierJobComplete', 'TierSpecialVdevWarning', 'TierSpecialVdevCritical')"
+    )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alert/source/zfs_tier.py
+++ b/src/middlewared/middlewared/alert/source/zfs_tier.py
@@ -8,30 +8,19 @@ from middlewared.alert.base import (
     AlertCategory,
     AlertClass,
     AlertLevel,
-    OneShotAlertClass,
     ThreadedAlertSource,
 )
 from middlewared.plugins.zfs.tier import special_vdev_thresholds
 
-_TERMINAL_STATUSES = (RewriteJobStatus.ERROR, RewriteJobStatus.COMPLETE)
 
-
-class TierJobErrorAlertClass(AlertClass, OneShotAlertClass):
-    deleted_automatically = False
+class TierJobErrorAlertClass(AlertClass):
     category = AlertCategory.TASKS
     level = AlertLevel.CRITICAL
     title = "Tier Migration Job Error"
     text = "Tier migration job %(tier_job_id)s encountered an error: %(error)s"
 
-    async def create(self, args):
-        return Alert(TierJobErrorAlertClass, args, key=args["tier_job_id"])
 
-    async def delete(self, alerts, query):
-        return list(filter(lambda alert: alert.key != str(query), alerts))
-
-
-class TierJobCompleteAlertClass(AlertClass, OneShotAlertClass):
-    deleted_automatically = False
+class TierJobCompleteAlertClass(AlertClass):
     category = AlertCategory.TASKS
     level = AlertLevel.NOTICE
     title = "Tier Migration Job Complete"
@@ -40,15 +29,8 @@ class TierJobCompleteAlertClass(AlertClass, OneShotAlertClass):
         "migrated to %(tier)s for a total of %(size)s bytes of data."
     )
 
-    async def create(self, args):
-        return Alert(TierJobCompleteAlertClass, args, key=args["tier_job_id"])
 
-    async def delete(self, alerts, query):
-        return list(filter(lambda alert: alert.key != str(query), alerts))
-
-
-class TierSpecialVdevCriticalAlertClass(AlertClass, OneShotAlertClass):
-    deleted_automatically = False
+class TierSpecialVdevCriticalAlertClass(AlertClass):
     category = AlertCategory.STORAGE
     level = AlertLevel.CRITICAL
     title = "Special Allocation Class Space Critical"
@@ -58,15 +40,8 @@ class TierSpecialVdevCriticalAlertClass(AlertClass, OneShotAlertClass):
         "writes may overflow into the REGULAR tier."
     )
 
-    async def create(self, args):
-        return Alert(TierSpecialVdevCriticalAlertClass, args, key=args["pool_name"])
 
-    async def delete(self, alerts, query):
-        return list(filter(lambda alert: alert.key != str(query), alerts))
-
-
-class TierSpecialVdevWarningAlertClass(AlertClass, OneShotAlertClass):
-    deleted_automatically = False
+class TierSpecialVdevWarningAlertClass(AlertClass):
     category = AlertCategory.STORAGE
     level = AlertLevel.WARNING
     title = "Special Allocation Class Space Warning"
@@ -75,96 +50,103 @@ class TierSpecialVdevWarningAlertClass(AlertClass, OneShotAlertClass):
         "%(threshold)d%% — within 10 points of the configured critical cap."
     )
 
-    async def create(self, args):
-        return Alert(TierSpecialVdevWarningAlertClass, args, key=args["pool_name"])
 
-    async def delete(self, alerts, query):
-        return list(filter(lambda alert: alert.key != str(query), alerts))
+# Sorted (dataset_name, job_uuid) pairs of the ERROR and COMPLETE jobs seen on
+# a poll — identifies the job set a cached computation belongs to.
+_JobAlertsCacheKey = tuple[tuple[tuple[str, str], ...], tuple[tuple[str, str], ...]]
+
+
+class _JobAlertsCache:
+    """Single-slot memo of the alerts computed for a set of terminal jobs.
+
+    ``get_info()`` and ``bulk_get_tier_info()`` results are stable for a
+    given terminal job, so the previous poll's alerts can be reused while
+    the set of terminal jobs is unchanged. Re-serving the same ``Alert``
+    instances is safe: the framework re-derives their bookkeeping fields
+    (uuid, datetime, dismissed, node) per poll, keyed by alert class and
+    alert key.
+    """
+
+    def __init__(self) -> None:
+        self._key: _JobAlertsCacheKey | None = None
+        self._alerts: list[Alert] = []
+
+    @staticmethod
+    def _key_for(error_jobs: list[Any], complete_jobs: list[Any]) -> _JobAlertsCacheKey:
+        return (
+            tuple(sorted((job.dataset_name, job.job_uuid) for job in error_jobs)),
+            tuple(sorted((job.dataset_name, job.job_uuid) for job in complete_jobs)),
+        )
+
+    def get(self, error_jobs: list[Any], complete_jobs: list[Any]) -> list[Alert] | None:
+        """Return the alerts cached for this job set, or ``None`` on miss."""
+        if self._key != self._key_for(error_jobs, complete_jobs):
+            return None
+        return list(self._alerts)
+
+    def store(self, error_jobs: list[Any], complete_jobs: list[Any], alerts: list[Alert]) -> None:
+        self._key = self._key_for(error_jobs, complete_jobs)
+        self._alerts = list(alerts)
+
+    def clear(self) -> None:
+        self._key = None
+        self._alerts = []
 
 
 class TierJobAlertSource(ThreadedAlertSource):
-    """Single threaded source that drives every Tier* OneShot alert.
+    """Single threaded source that drives every Tier* alert.
 
     Gated at runtime on ``zfs.tier.config.enabled`` — community and
-    licensed-but-disabled boxes both early-exit. The two job alerts
-    (ERROR / COMPLETE) are fired once per terminal-state UUID, tracked
-    in memory so dismissal sticks across polls; the two SPECIAL-vdev
-    alerts are fired/cleared every poll based on the current
-    ``class_special_used / class_special_usable`` ratio per pool.
+    licensed-but-disabled boxes both return no alerts, which clears any
+    previously raised ones. The two job alerts (ERROR / COMPLETE) exist
+    for as long as the corresponding job record sits in that terminal
+    state; the two SPECIAL-vdev alerts reflect the current
+    ``class_special_used / class_special_usable`` ratio per pool. All
+    lifecycle management (dedup by key, dismissal, clearing) is handled
+    by the alert framework.
     """
+
+    run_on_backup_node = False
 
     def __init__(self, middleware: Any) -> None:
         super().__init__(middleware)
-        self._fired_terminal_jobs: set[str] = set()
-        self._fired_special_pools: set[str] = set()
+        self._job_alerts_cache = _JobAlertsCache()
 
-    def check_sync(self) -> list:
-        try:
-            config = self.middleware.call_sync("zfs.tier.config")
-        except Exception:
-            self.middleware.logger.warning("Failed to read zfs.tier.config", exc_info=True)
-            return []
-
+    def check_sync(self) -> list[Alert]:
+        config = self.call_sync2(self.s.zfs.tier.config)
         if not config.enabled:
-            self._clear_all_oneshots()
+            # Drop the cache: tier info baked into cached COMPLETE alerts
+            # (e.g. tier_type) may change while tiering is disabled.
+            self._job_alerts_cache.clear()
             return []
 
         warning_pct, critical_pct = special_vdev_thresholds(config)
+        return self._check_jobs() + self._check_special_vdev_usage(warning_pct, critical_pct)
 
-        try:
-            self._check_jobs()
-        except Exception:
-            self.middleware.logger.warning("Failed to check tier job alerts", exc_info=True)
-
-        try:
-            self._check_special_vdev_usage(warning_pct, critical_pct)
-        except Exception:
-            self.middleware.logger.warning("Failed to check special vdev space alerts", exc_info=True)
-
-        return []
-
-    # ------------------------------------------------------------------
-    # Job ERROR/COMPLETE OneShots
-    # ------------------------------------------------------------------
-
-    def _check_jobs(self) -> None:
-        current_terminal: set[str] = set()
+    def _check_jobs(self) -> list[Alert]:
+        error_jobs = []
+        complete_jobs = []
 
         # Materialize first: enum_jobs() holds an LMDB read transaction open for
-        # the life of the iterator, and _fire_job_alert() -> get_info() below opens
-        # another read transaction on the same thread. LMDB permits one read
-        # transaction per thread, so reading inside the live iterator raises
-        # MDB_BAD_RSLOT.
+        # the life of the iterator, and get_info() below opens another read
+        # transaction on the same thread. LMDB permits one read transaction per
+        # thread, so reading inside the live iterator raises MDB_BAD_RSLOT.
         for job in list(enum_jobs()):
+            if job.status == RewriteJobStatus.ERROR:
+                error_jobs.append(job)
+            elif job.status == RewriteJobStatus.COMPLETE:
+                complete_jobs.append(job)
+
+        cached = self._job_alerts_cache.get(error_jobs, complete_jobs)
+        if cached is not None:
+            return cached
+
+        alerts: list[Alert] = []
+
+        for job in error_jobs:
             tier_job_id = f"{job.dataset_name}@{job.job_uuid}"
-
-            if job.status in _TERMINAL_STATUSES:
-                current_terminal.add(tier_job_id)
-                if tier_job_id in self._fired_terminal_jobs:
-                    continue
-                self._fire_job_alert(job, tier_job_id)
-                self._fired_terminal_jobs.add(tier_job_id)
-            else:
-                if tier_job_id in self._fired_terminal_jobs:
-                    self.middleware.call_sync(
-                        "alert.oneshot_delete",
-                        "TierJobError",
-                        tier_job_id,
-                    )
-                    self.middleware.call_sync(
-                        "alert.oneshot_delete",
-                        "TierJobComplete",
-                        tier_job_id,
-                    )
-                    self._fired_terminal_jobs.discard(tier_job_id)
-
-        self._fired_terminal_jobs &= current_terminal
-
-    def _fire_job_alert(self, job: Any, tier_job_id: str) -> None:
-        if job.status == RewriteJobStatus.ERROR:
             try:
-                info = get_info(job.dataset_name, job.job_uuid)
-                error = info.error or ""
+                error = get_info(job.dataset_name, job.job_uuid).error or ""
             except Exception:
                 self.middleware.logger.debug(
                     "Failed to get info for tier job %s",
@@ -172,54 +154,54 @@ class TierJobAlertSource(ThreadedAlertSource):
                     exc_info=True,
                 )
                 error = ""
-            self.middleware.call_sync(
-                "alert.oneshot_create",
-                "TierJobError",
+            alerts.append(Alert(
+                TierJobErrorAlertClass,
                 {"tier_job_id": tier_job_id, "error": error},
+                key=tier_job_id,
+            ))
+
+        if complete_jobs:
+            tier_map = self.call_sync2(
+                self.s.zfs.tier.bulk_get_tier_info,
+                [job.dataset_name for job in complete_jobs],
             )
-            return
+            for job in complete_jobs:
+                tier_info = tier_map.get(job.dataset_name)
+                if not tier_info:
+                    continue
 
-        try:
-            info = get_info(job.dataset_name, job.job_uuid)
-            stats = info.stats
-        except Exception:
-            self.middleware.logger.debug(
-                "Failed to get info for tier job %s",
-                tier_job_id,
-                exc_info=True,
-            )
-            stats = None
+                tier_job_id = f"{job.dataset_name}@{job.job_uuid}"
+                try:
+                    stats = get_info(job.dataset_name, job.job_uuid).stats
+                except Exception:
+                    self.middleware.logger.debug(
+                        "Failed to get info for tier job %s",
+                        tier_job_id,
+                        exc_info=True,
+                    )
+                    stats = None
 
-        tier_map = self.middleware.call_sync(
-            "zfs.tier.bulk_get_tier_info",
-            [job.dataset_name],
-        )
-        tier_info = tier_map.get(job.dataset_name)
-        if not tier_info:
-            return
+                alerts.append(Alert(
+                    TierJobCompleteAlertClass,
+                    {
+                        "tier_job_id": tier_job_id,
+                        "files": stats.success if stats else 0,
+                        "tier": tier_info["tier_type"],
+                        "size": str(stats.count_bytes if stats else 0),
+                    },
+                    key=tier_job_id,
+                ))
 
-        self.middleware.call_sync(
-            "alert.oneshot_create",
-            "TierJobComplete",
-            {
-                "tier_job_id": tier_job_id,
-                "files": stats.success if stats else 0,
-                "tier": tier_info["tier_type"],
-                "size": str(stats.count_bytes if stats else 0),
-            },
-        )
+        self._job_alerts_cache.store(error_jobs, complete_jobs, alerts)
+        return alerts
 
-    # ------------------------------------------------------------------
-    # SPECIAL-vdev space OneShots
-    # ------------------------------------------------------------------
-
-    def _check_special_vdev_usage(self, warning_pct: int, critical_pct: int) -> None:
+    def _check_special_vdev_usage(self, warning_pct: int, critical_pct: int) -> list[Alert]:
         pools = self.middleware.call_sync(
             "zpool.query_impl",
             {"properties": ["class_special_usable", "class_special_used"]},
         )
 
-        current_pools: set[str] = set()
+        alerts: list[Alert] = []
         for pool in pools:
             props = pool.get("properties") or {}
             usable_prop = props.get("class_special_usable") or {}
@@ -228,91 +210,23 @@ class TierJobAlertSource(ThreadedAlertSource):
             used = used_prop.get("value") if isinstance(used_prop, dict) else None
 
             if not usable or used is None:
+                # Pool has no SPECIAL vdev — skip.
                 continue
 
-            pool_name = pool.get("name")
-            if not pool_name:
-                continue
-
-            current_pools.add(pool_name)
+            pool_name = pool["name"]
             pct = (used / usable) * 100
 
             if pct > critical_pct:
-                self.middleware.call_sync(
-                    "alert.oneshot_create",
-                    "TierSpecialVdevCritical",
+                alerts.append(Alert(
+                    TierSpecialVdevCriticalAlertClass,
                     {"pool_name": pool_name, "threshold": critical_pct},
-                )
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevWarning",
-                    pool_name,
-                )
+                    key=pool_name,
+                ))
             elif pct > warning_pct:
-                self.middleware.call_sync(
-                    "alert.oneshot_create",
-                    "TierSpecialVdevWarning",
+                alerts.append(Alert(
+                    TierSpecialVdevWarningAlertClass,
                     {"pool_name": pool_name, "threshold": warning_pct},
-                )
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevCritical",
-                    pool_name,
-                )
-            else:
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevWarning",
-                    pool_name,
-                )
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevCritical",
-                    pool_name,
-                )
+                    key=pool_name,
+                ))
 
-        for stale in self._fired_special_pools - current_pools:
-            self.middleware.call_sync(
-                "alert.oneshot_delete",
-                "TierSpecialVdevWarning",
-                stale,
-            )
-            self.middleware.call_sync(
-                "alert.oneshot_delete",
-                "TierSpecialVdevCritical",
-                stale,
-            )
-        self._fired_special_pools = current_pools
-
-    def _clear_all_oneshots(self) -> None:
-        for pool_name in self._fired_special_pools:
-            try:
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevWarning",
-                    pool_name,
-                )
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierSpecialVdevCritical",
-                    pool_name,
-                )
-            except Exception:
-                pass
-        self._fired_special_pools.clear()
-
-        for tier_job_id in self._fired_terminal_jobs:
-            try:
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierJobError",
-                    tier_job_id,
-                )
-                self.middleware.call_sync(
-                    "alert.oneshot_delete",
-                    "TierJobComplete",
-                    tier_job_id,
-                )
-            except Exception:
-                pass
-        self._fired_terminal_jobs.clear()
+        return alerts

--- a/src/middlewared/middlewared/plugins/zfs/tier.py
+++ b/src/middlewared/middlewared/plugins/zfs/tier.py
@@ -382,7 +382,10 @@ class ZfsTierService(ConfigService[ZfsTierEntry]):
         await self.middleware.call("etc.generate", "truenas_zfstierd")
         if new.special_class_metadata_reserve_pct != old.special_class_metadata_reserve_pct:
             await self.middleware.run_in_thread(
-                _apply_metadata_reserve_pct, self.middleware, new.special_class_metadata_reserve_pct, True
+                _apply_metadata_reserve_pct,
+                self.middleware,
+                new.special_class_metadata_reserve_pct,
+                await self.middleware.call("failover.licensed"),
             )
         if new.max_concurrent_jobs != old.max_concurrent_jobs:
             verb = "RESTART"

--- a/tests/api2/zfs_tier/test_alerts.py
+++ b/tests/api2/zfs_tier/test_alerts.py
@@ -1,0 +1,324 @@
+"""
+All job-alert assertions are scoped to this module's own dataset names:
+rewrite-job records live in LMDB under ``/var/db/system/truenas_zfstierd``,
+survive dataset deletion and pool export, and therefore accumulate across
+tests and suite runs.
+"""
+
+import time
+
+import pytest
+
+from middlewared.test.integration.utils import call, ssh
+
+# Written by the tier_pool conftest fixture context; used by tests that stage
+# data through the SPECIAL vdev.
+SEED = "/dev/shm/tier_alert_seed"
+
+# Daemon test hook shared with conftest.py: per-file rewrite delay in ms.
+SLOW_REWRITE_SENTINEL = "/var/run/truenas_zfstierd/slow_rewrite"
+
+# Direct daemon job creation, bypassing the middleware validation that
+# (correctly) refuses to create a rewrite job on a read-only dataset. The
+# daemon itself does not check readonly, so the job starts and its walker
+# fails with EROFS on the first file — a deterministic ERROR-state job.
+_DAEMON_CREATE_JOB = """\
+import asyncio
+from truenas_zfstierd_client import RewriteClient
+
+async def main():
+    client = RewriteClient()
+    await client.connect()
+    try:
+        result = await client.create_job({ds!r})
+    finally:
+        await client.close()
+    print(result.job_uuid)
+
+asyncio.run(main())
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def clean_job_db(tier_pool):
+    """Start this module with an empty rewrite-job database.
+
+    Job records survive dataset deletion and pool destruction, so without
+    this, records left by earlier suite runs would appear in every
+    ``alert.run_source`` result. The daemon recreates the state directory
+    on start."""
+    ssh(
+        "systemctl stop truenas_zfstierd && "
+        "rm -rf /var/db/system/truenas_zfstierd/* && "
+        "systemctl start truenas_zfstierd"
+    )
+
+
+def _run_source():
+    return call("alert.run_source", "TierJob")
+
+
+def _job_alerts_for(ds_name):
+    return [alert for alert in _run_source() if alert["args"].get("tier_job_id", "").startswith(f"{ds_name}@")]
+
+
+def _special_vdev_alerts_for(pool_name):
+    return [
+        alert
+        for alert in _run_source()
+        if alert["klass"].startswith("TierSpecialVdev") and alert["args"].get("pool_name") == pool_name
+    ]
+
+
+def _stage_rewrite_work(ds_name, files=5, size_mb=1):
+    """PERFORMANCE -> write -> REGULAR: every block now sits on SPECIAL but
+    belongs on NORMAL, so a rewrite job has real per-file work to do."""
+    call("zfs.tier.dataset_set_tier", {"dataset_name": ds_name, "tier_type": "PERFORMANCE"})
+    ssh(f"cd /mnt/{ds_name} && seq 1 {files} | xargs -I X dd if=/dev/urandom of=fX bs=1M count={size_mb} 2>/dev/null")
+    call("zfs.tier.dataset_set_tier", {"dataset_name": ds_name, "tier_type": "REGULAR"})
+
+
+def _complete_job(ds_name, wait_for_job_status, files=5):
+    _stage_rewrite_work(ds_name, files=files)
+    entry = call("zfs.tier.rewrite_job_create", {"dataset_name": ds_name})
+    status = wait_for_job_status(entry["tier_job_id"], {"COMPLETE", "ERROR"}, timeout=120)
+    assert status == "COMPLETE"
+    return entry["tier_job_id"]
+
+
+def _special_vdev_pct(pool_name):
+    for pool in call(
+        "zpool.query_impl",
+        {"properties": ["class_special_usable", "class_special_used"]},
+    ):
+        if pool["name"] == pool_name:
+            props = pool["properties"]
+            return 100 * props["class_special_used"]["value"] / props["class_special_usable"]["value"]
+    raise AssertionError(f"pool {pool_name!r} not found")
+
+
+# ----------------------------------------------------------------------------
+# Gate: tiering disabled -> the source reports nothing at all.
+# ----------------------------------------------------------------------------
+
+
+def test_disabled_tiering_produces_no_alerts(tier_pool, disabled_tier):
+    assert _run_source() == []
+
+
+# ----------------------------------------------------------------------------
+# COMPLETE job -> NOTICE alert with migration stats.
+# ----------------------------------------------------------------------------
+
+
+def test_complete_job_raises_notice_alert(tier_ds, wait_for_job_status):
+    # The module starts with an empty job database, so the first enabled poll
+    # sees no terminal jobs at all.
+    assert [a for a in _run_source() if a["klass"].startswith("TierJob")] == []
+
+    tier_job_id = _complete_job(tier_ds, wait_for_job_status, files=5)
+
+    alerts = _job_alerts_for(tier_ds)
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert["klass"] == "TierJobComplete"
+    assert alert["args"] == {
+        "tier_job_id": tier_job_id,
+        "files": 5,
+        "tier": "REGULAR",
+        "size": str(5 * 1024 * 1024),
+    }
+
+    # A second poll with an unchanged terminal-job set serves the same alert
+    # (from the source's cache — equal output either way).
+    assert _job_alerts_for(tier_ds) == alerts
+
+
+# ----------------------------------------------------------------------------
+# A job that is still running is not a terminal state -> no alert.
+# ----------------------------------------------------------------------------
+
+
+def test_running_job_raises_no_alert(tier_ds_with_work, wait_for_job_status):
+    entry = call("zfs.tier.rewrite_job_create", {"dataset_name": tier_ds_with_work})
+    wait_for_job_status(entry["tier_job_id"], {"QUEUED", "RUNNING"}, timeout=30)
+
+    alerts = _job_alerts_for(tier_ds_with_work)
+
+    # Guard against the job having completed under the alert query: the
+    # slow-rewrite sentinel gives it a >=20s lifetime, so it must still be
+    # active — which makes the empty-alerts assertion meaningful.
+    status = call("zfs.tier.rewrite_job_status", {"tier_job_id": entry["tier_job_id"]})
+    assert status["status"] in ("QUEUED", "RUNNING")
+    assert alerts == []
+
+
+# ----------------------------------------------------------------------------
+# ERROR job -> CRITICAL alert carrying the daemon's error text.
+# ----------------------------------------------------------------------------
+
+
+def _make_error_job(ds_name, wait_for_job_status):
+    """Drive a rewrite job on ``ds_name`` into the ERROR state.
+
+    Makes the dataset genuinely read-only (the remount is required: setting
+    the property alone does not change an already-mounted filesystem), then
+    creates the job directly against the daemon, whose walker fails with
+    EROFS on the first file. Leaves the dataset writable again on return."""
+    _stage_rewrite_work(ds_name, files=3)
+    ssh(f"zfs set readonly=on {ds_name} && zfs unmount {ds_name} && zfs mount {ds_name}")
+    try:
+        job_uuid = ssh(f"python3 - <<'EOF'\n{_DAEMON_CREATE_JOB.format(ds=ds_name)}EOF").strip()
+        tier_job_id = f"{ds_name}@{job_uuid}"
+        assert wait_for_job_status(tier_job_id, {"COMPLETE", "ERROR"}, timeout=60) == "ERROR"
+    finally:
+        ssh(f"zfs set readonly=off {ds_name}")
+    return tier_job_id
+
+
+def test_error_job_raises_critical_alert(make_tier_ds, wait_for_job_status):
+    ds_name = make_tier_ds("alert_err")
+    tier_job_id = _make_error_job(ds_name, wait_for_job_status)
+
+    alerts = _job_alerts_for(ds_name)
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert["klass"] == "TierJobError"
+    assert alert["args"]["tier_job_id"] == tier_job_id
+    assert "Read-only file system" in alert["args"]["error"]
+
+
+# ----------------------------------------------------------------------------
+# Degraded mode: a job listed in the global index whose per-dataset state DB
+# is lost still gets an alert, with the unavailable details blanked.
+# ----------------------------------------------------------------------------
+
+
+def test_alerts_degrade_when_job_state_db_is_lost(make_tier_ds, wait_for_job_status):
+    """The daemon keeps a global job index (``rewrite_jobs.mdb``) and one
+    state DB per dataset. Deleting a per-dataset state DB leaves its jobs
+    enumerable but unreadable in detail, so the source falls back to an
+    empty error message / zeroed stats instead of dropping the alerts."""
+    ds_complete = make_tier_ds("alert_nodb_c")
+    ds_error = make_tier_ds("alert_nodb_e")
+    complete_id = _complete_job(ds_complete, wait_for_job_status, files=2)
+    error_id = _make_error_job(ds_error, wait_for_job_status)
+
+    for ds_name in (ds_complete, ds_error):
+        ssh(f"rm -rf /var/db/system/truenas_zfstierd/*{ds_name.split('/')[-1]}*")
+
+    # The terminal-job set is unchanged, so the source would keep serving the
+    # cached (fully detailed) alerts; a disable/enable cycle drops the cache
+    # and forces recomputation against the crippled state.
+    call("zfs.tier.update", {"enabled": False})
+    try:
+        assert _run_source() == []
+    finally:
+        call("zfs.tier.update", {"enabled": True})
+
+    complete_alerts = _job_alerts_for(ds_complete)
+    assert len(complete_alerts) == 1
+    assert complete_alerts[0]["klass"] == "TierJobComplete"
+    assert complete_alerts[0]["args"] == {
+        "tier_job_id": complete_id,
+        "files": 0,
+        "tier": "REGULAR",
+        "size": "0",
+    }
+
+    error_alerts = _job_alerts_for(ds_error)
+    assert len(error_alerts) == 1
+    assert error_alerts[0]["klass"] == "TierJobError"
+    assert error_alerts[0]["args"] == {"tier_job_id": error_id, "error": ""}
+
+
+# ----------------------------------------------------------------------------
+# Job-alerts cache: served while the terminal-job set is unchanged, dropped
+# on a disable/enable cycle.
+# ----------------------------------------------------------------------------
+
+
+def test_complete_alert_cached_across_dataset_deletion(tier_pool, wait_for_job_status):
+    """Deleting a completed job's dataset does not change the terminal-job
+    set (LMDB records outlive the dataset), so the cached COMPLETE alert is
+    still served — a recomputation would drop it because the dataset no
+    longer resolves to any tier info. Disabling tiering clears the cache, so
+    after re-enabling, the recomputation does drop the alert."""
+    ds_name = f"{tier_pool['name']}/alert_cache_{time.monotonic_ns()}"
+    call("pool.dataset.create", {"name": ds_name})
+    try:
+        _complete_job(ds_name, wait_for_job_status)
+        assert len(_job_alerts_for(ds_name)) == 1
+
+        call("pool.dataset.delete", ds_name, {"recursive": True})
+        assert len(_job_alerts_for(ds_name)) == 1  # cache hit
+
+        call("zfs.tier.update", {"enabled": False})
+        try:
+            assert _run_source() == []  # gate short-circuits, cache dropped
+        finally:
+            call("zfs.tier.update", {"enabled": True})
+
+        assert _job_alerts_for(ds_name) == []  # recomputed: dataset is gone
+    finally:
+        if call("pool.dataset.query", [["name", "=", ds_name]]):
+            call("pool.dataset.delete", ds_name, {"recursive": True})
+
+
+# ----------------------------------------------------------------------------
+# SPECIAL-vdev usage thresholds. Runs last: it fills the SPECIAL vdev.
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(600)
+def test_special_vdev_warning_and_critical_alerts(tier_pool):
+    """With max_used_percentage=70 (reserve untouched at its default), the
+    thresholds land at warning=60 / critical=70 while the kernel's spill
+    point stays at 75 — so both alert levels are reachable by filling.
+
+    The fill copies an incompressible tmpfs seed file cross-filesystem:
+    an on-pool source would be reflink-cloned by cp (ZFS block cloning)
+    and allocate nothing."""
+    pool_name = tier_pool["name"]
+    original_cap = call("zfs.tier.config")["max_used_percentage"]
+    call("zfs.tier.update", {"max_used_percentage": 70})
+    filler = f"{pool_name}/alert_fill_{time.monotonic_ns()}"
+    call("pool.dataset.create", {"name": filler})
+    call("zfs.tier.dataset_set_tier", {"dataset_name": filler, "tier_type": "PERFORMANCE"})
+    ssh(f"dd if=/dev/urandom of={SEED} bs=1M count=512 2>/dev/null")
+
+    counter = 0
+
+    def fill_to(target_pct, batch):
+        """Copy seed files (2 in parallel per round) until the SPECIAL usage
+        ratio crosses target_pct. Small batches so the overshoot cannot jump
+        the 60–70 warning window."""
+        nonlocal counter
+        deadline = time.monotonic() + 480
+        while _special_vdev_pct(pool_name) < target_pct:
+            assert time.monotonic() < deadline, (
+                f"fill to {target_pct}% too slow, at {_special_vdev_pct(pool_name):.1f}%"
+            )
+            copies = " ".join(f"cp {SEED} /mnt/{filler}/f{counter + i} &" for i in range(batch))
+            counter += batch
+            ssh(f"{copies} wait; zpool sync {pool_name}")
+
+    try:
+        # Below both thresholds: no SPECIAL-vdev alerts for any pool (this
+        # also exercises the skip of pools without a SPECIAL vdev, e.g. the
+        # system's main pool).
+        assert all(not a["klass"].startswith("TierSpecialVdev") for a in _run_source())
+
+        fill_to(61, batch=2)
+        alerts = _special_vdev_alerts_for(pool_name)
+        assert [a["klass"] for a in alerts] == ["TierSpecialVdevWarning"]
+        assert alerts[0]["args"] == {"pool_name": pool_name, "threshold": 60}
+
+        fill_to(71, batch=2)
+        alerts = _special_vdev_alerts_for(pool_name)
+        assert [a["klass"] for a in alerts] == ["TierSpecialVdevCritical"]
+        assert alerts[0]["args"] == {"pool_name": pool_name, "threshold": 70}
+    finally:
+        ssh(f"rm -f {SEED}")
+        call("pool.dataset.delete", filler, {"recursive": True})
+        call("zfs.tier.update", {"max_used_percentage": original_cap})


### PR DESCRIPTION
Creating oneshot alerts in the alert source is not how the rest of TrueNAS alerts work. No other source does that, and it doesn't seem to give us any benefit. I was able to simplify the code by rewriting tiering alerts in a more idiomatic way.

I was also able to replace unit tests with integration tests with 99% coverage.

While I am here, fix the bug that `zfs.tier.update` hardcoded `ha_propagate=True` for reserve-pct changes, so on any licensed non-HA box it failed with `EHOSTUNREACH`.

Original PR: https://github.com/truenas/middleware/pull/19540
