### PR TITLE
NAS-142601 / 27.0.0-BETA.1 / Tolerate a license SDK that has no top-level expiry (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas/license_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas/license_utils.py
@@ -197,8 +197,12 @@ def get_license_info(lic: LicenseStatus | None = None) -> LicenseInfo | None:
     else:
         contract_type = None
 
-    if lic.expires_at:
-        expires_at: date | None = date.fromisoformat(lic.expires_at)
+    # The license schema replaced the top-level expiry with an issued_at mint date, so
+    # newer builds of the SDK do not define this attribute at all. Expiry now lives on
+    # the support contract.
+    license_expires_at = getattr(lic, "expires_at", None)
+    if license_expires_at:
+        expires_at: date | None = date.fromisoformat(license_expires_at)
     elif support and support.expires_at:
         expires_at = date.fromisoformat(support.expires_at)
     else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_license_utils.py
@@ -14,7 +14,6 @@ def _make_status(features: dict[str, FeatureEntry]) -> LicenseStatus:
         version=1,
         type=LicenseType.ENTERPRISE_HA,
         model="H10",
-        expires_at=None,
         features=features,
         system_id={"serials": ["TEST-000001", "TEST-000002"]},
         enclosures={"E24": {"count": 3}},


### PR DESCRIPTION
This commit fixes an issue where get_license_info() read LicenseStatus.expires_at, which newer builds of the license SDK no longer define. The dataclass is slots=True, so the read raises AttributeError instead of coming back None, and that escapes plugin setup by way of alert.initialize asking for the product type. Nothing catches it, so middlewared never finishes starting and the box sits in a crash loop rather than reporting itself unlicensed. It fires on any license the daemon considers valid, so an existing install breaks on the SDK upgrade alone, with no new license involved.

The read is a getattr now, which works against both the old SDK and the new one where the only expiry a license carries lives on the support contract. The unit fixture drops the same field for the same reason.

Original PR: https://github.com/truenas/middleware/pull/19542
