### PR TITLE
NAS-142117 / 26.0.0-RC.1 / Force ACL application on app-owned ix-volume paths (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import PurePath
 
 from .utils import IX_APPS_MOUNT_PATH
 
@@ -33,6 +34,24 @@ def get_app_parent_volume_path() -> str:
 
 def get_app_volume_path(app_name: str) -> str:
     return os.path.join(get_app_parent_volume_path(), app_name)
+
+
+def is_app_volume_path(path: str, app_name: str) -> bool:
+    """Whether `path` is the app's ix-volume directory or lives inside it.
+
+    The comparison is purely lexical - `..` segments are collapsed but symlinks are not resolved, so
+    this stays cheap enough to call from the event loop.
+    """
+    return PurePath(os.path.normpath(path)).is_relative_to(get_app_volume_path(app_name))
+
+
+def is_app_mounts_path(path: str) -> bool:
+    """Whether `path` is the directory holding every app's ix-volumes or lives inside it.
+
+    The comparison is purely lexical - `..` segments are collapsed but symlinks are not resolved, so
+    this stays cheap enough to call from the event loop.
+    """
+    return PurePath(os.path.normpath(path)).is_relative_to(get_app_parent_volume_path())
 
 
 def get_installed_app_path(app_name: str) -> str:

--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 
 from middlewared.service import Service
 
-from .ix_apps.path import get_app_volume_path
+from .ix_apps.path import get_app_volume_path, is_app_volume_path
 from .schema_construction_utils import RESERVED_NAMES
 
 
@@ -152,6 +152,16 @@ class AppSchemaService(Service):
 
         if acl_dict:
             acl_dict['path'] = host_path
+            if is_app_volume_path(host_path, context['app']['name']):
+                # An ix volume is created and owned by middleware, so applying an ACL to one can never clobber data
+                # the user deliberately placed there, and the schema we serve already reflects that by hiding `force`
+                # and defaulting it to true. Clients can still submit an explicit false though, and older configs may
+                # have one persisted, which trips the "path contains existing data" guard as soon as the app writes
+                # anything into its volume. The containment check is not redundant: `dataset_name` is not validated
+                # as a path anywhere, so an absolute or `..`-laden one lands `host_path` outside the app's own tree,
+                # and forcing there would be forcing over somebody else's data. Since this is the same dict which
+                # gets written back to the app config, a stored false heals itself on the next update.
+                acl_dict.setdefault('options', {})['force'] = True
             await self.normalize_acl({'schema': {'type': 'dict'}}, acl_dict, complete_config, context)
         return value
 

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from middlewared.service import Service
 from middlewared.utils.filter_list import filter_list
 
+from .ix_apps.path import is_app_mounts_path
 from .schema_construction_utils import construct_schema, NOT_PROVIDED, RESERVED_NAMES
 
 
@@ -99,13 +100,24 @@ class AppSchemaService(Service):
             verrors.extend(sub_verrors)
 
     def validate_acl_entries(self, verrors, value, question, schema_name, app_data):
+        path = value.get('path')
+        if not path or value.get('options', {}).get('force'):
+            return
+
+        if is_app_mounts_path(path):
+            # Everything under the app mounts directory is created and owned by middleware, so whether it holds
+            # data is not middleware's call to refuse a save over - a stored `force: false` on an ix volume would
+            # otherwise make the config permanently unsavable once the app has written anything into its volume.
+            # Skipping only drops the pre-flight message: filesystem.add_to_acl still refuses an unforced apply
+            # over a populated path, and `force` is written in exactly one place - normalize_ix_volume - which
+            # only ever sets it for the requesting app's own volume.
+            return
+
         try:
-            if value.get('path') and not value.get('options', {}).get('force') and next(
-                Path(value['path']).iterdir(), None
-            ):
-                verrors.add(schema_name, f'{value["path"]}: path contains existing data and `force` was not specified')
+            if next(Path(path).iterdir(), None):
+                verrors.add(schema_name, f'{path}: path contains existing data and `force` was not specified')
         except FileNotFoundError:
-            verrors.add(schema_name, f'{value["path"]}: path does not exist')
+            verrors.add(schema_name, f'{path}: path does not exist')
 
     async def validate_port_available_on_node(self, verrors, value, question, schema_name, app_data):
         for port_entry in (app_data['active_workloads']['used_ports'] if app_data else []):

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_volume_path.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_app_volume_path.py
@@ -1,0 +1,59 @@
+import pytest
+
+from middlewared.plugins.apps.ix_apps.path import (
+    get_app_parent_volume_path,
+    get_app_volume_path,
+    is_app_mounts_path,
+    is_app_volume_path,
+)
+
+
+@pytest.mark.parametrize(
+    "path, app_name, should_match",
+    [
+        (get_app_volume_path("plex"), "plex", True),
+        (f"{get_app_volume_path('plex')}/data", "plex", True),
+        (f"{get_app_volume_path('plex')}/data/nested/deeper", "plex", True),
+        (f"{get_app_volume_path('plex')}/", "plex", True),
+        (f"{get_app_volume_path('plex')}//data", "plex", True),
+        (f"{get_app_volume_path('plex')}/data/../config", "plex", True),
+        (get_app_volume_path("sonarr"), "plex", False),
+        # These share a name prefix with the app but are separate directories
+        (get_app_volume_path("plex-extra"), "plex", False),
+        (f"{get_app_volume_path('plex2')}/data", "plex", False),
+        # Traversal out of the volume directory has to be caught even though nothing is resolved on disk
+        (f"{get_app_volume_path('plex')}/../sonarr/data", "plex", False),
+        (f"{get_app_volume_path('plex')}/../../../../mnt/tank/data", "plex", False),
+        ("/mnt/tank/data", "plex", False),
+        ("", "plex", False),
+        ("data", "plex", False),
+    ],
+)
+def test_is_app_volume_path(path, app_name, should_match):
+    assert is_app_volume_path(path, app_name) is should_match
+
+
+@pytest.mark.parametrize(
+    "path, should_match",
+    [
+        (get_app_parent_volume_path(), True),
+        (f"{get_app_parent_volume_path()}/", True),
+        # Any app's volume directory is under the shared root, no app identity involved
+        (get_app_volume_path("plex"), True),
+        (f"{get_app_volume_path('plex')}/data/nested/deeper", True),
+        (get_app_volume_path("sonarr"), True),
+        (f"{get_app_parent_volume_path()}//plex", True),
+        (f"{get_app_volume_path('plex')}/data/../config", True),
+        # A sibling directory sharing the root's name prefix is not inside it
+        (f"{get_app_parent_volume_path()}-old/plex", False),
+        # Traversal out of the root has to be caught even though nothing is resolved on disk
+        (f"{get_app_volume_path('plex')}/../../../../mnt/tank/data", False),
+        (f"{get_app_parent_volume_path()}/../app_configs/plex", False),
+        ("/mnt/.ix-apps/app_configs/plex", False),
+        ("/mnt/tank/data", False),
+        ("", False),
+        ("data", False),
+    ],
+)
+def test_is_app_mounts_path(path, should_match):
+    assert is_app_mounts_path(path) is should_match

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_ix_volumes.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_normalize_ix_volumes.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.plugins.apps.ix_apps.path import get_app_volume_path
 from middlewared.plugins.apps.schema_normalization import AppSchemaService
 from middlewared.pytest.unit.middleware import Middleware
 
@@ -108,3 +109,70 @@ async def test_normalize_ix_volumes(attr, value, complete_config, context):
     assert len(context['actions']) > 0
     assert value['dataset_name'] in [v['name'] for v in context['actions'][0]['args'][-1]]
     assert result == value
+
+    acl_action = next((a for a in context['actions'] if a['method'] == 'apply_acls'), None)
+    if value['acl_entries']['entries']:
+        # The path here is stamped by normalization and always points inside the app's own volume
+        # directory, so the ACL apply which gets queued for it has to come out forced
+        assert acl_action is not None
+        assert acl_action['args'][0][value['acl_entries']['path']]['options']['force'] is True
+    else:
+        assert acl_action is None
+
+
+@pytest.mark.parametrize('options', [
+    # An explicitly disabled force flag on the app's own volume is overridden rather than
+    # allowed to block the ACL apply
+    {'force': False},
+    {'force': True},
+    # An absent options key has to be created so the flag can be recorded at all
+    None,
+])
+@pytest.mark.asyncio
+async def test_normalize_ix_volume_forces_acl_on_own_volume(options):
+    app_schema_obj = AppSchemaService(Middleware())
+    acl_entries = {'entries': [{'type': 'ALLOW', 'permissions': 'read'}], 'path': ''}
+    if options is not None:
+        acl_entries['options'] = options
+    value = {'dataset_name': 'data', 'acl_entries': acl_entries}
+    context = {'actions': [], 'app': {'name': 'test_app'}}
+
+    await app_schema_obj.normalize_ix_volume({'schema': {'type': 'dict'}}, value, {'ix_volumes': {}}, context)
+
+    host_path = f'{get_app_volume_path("test_app")}/data'
+    assert acl_entries['path'] == host_path
+    assert acl_entries['options'] == {'force': True}
+    acl_action = next(a for a in context['actions'] if a['method'] == 'apply_acls')
+    # The queued action has to hold the very same dict which gets persisted, otherwise the stored
+    # config and the ACL which was actually applied would disagree
+    assert acl_action['args'][0][host_path] is acl_entries
+
+
+# `dataset_name` is not validated as a path anywhere, so an absolute or `..`-laden one steers the volume
+# host path out of the app's own tree. Forcing there would be forcing over data which is not the app's, so
+# the flag has to be left exactly as it was submitted and the escaped path queued unforced. Note that the
+# host path is built with os.path.join, which does not collapse `..`, so the queued path is the literal
+# un-collapsed string even though the containment check itself normalizes before comparing.
+@pytest.mark.parametrize('dataset_name, escaped_path', [
+    ('/mnt/tank/data', '/mnt/tank/data'),
+    ('../other-app/media', f'{get_app_volume_path("test_app")}/../other-app/media'),
+])
+@pytest.mark.asyncio
+async def test_normalize_ix_volume_does_not_force_escaped_dataset_name(dataset_name, escaped_path):
+    app_schema_obj = AppSchemaService(Middleware())
+    acl_entries = {
+        'entries': [{'type': 'ALLOW', 'permissions': 'read'}],
+        # The path carried in a stored config points at the app's own volume directory
+        'path': f'{get_app_volume_path("test_app")}/data',
+        'options': {'force': False},
+    }
+    value = {'dataset_name': dataset_name, 'acl_entries': acl_entries}
+    context = {'actions': [], 'app': {'name': 'test_app'}}
+
+    await app_schema_obj.normalize_ix_volume({'schema': {'type': 'dict'}}, value, {'ix_volumes': {}}, context)
+
+    assert acl_entries['path'] == escaped_path
+    assert acl_entries['options']['force'] is False
+    acl_action = next(a for a in context['actions'] if a['method'] == 'apply_acls')
+    assert acl_action['args'][0][escaped_path] is acl_entries
+    assert all(queued['options']['force'] is False for queued in acl_action['args'][0].values())


### PR DESCRIPTION
## Problem
The served schema hides `force` for ix-volumes and defaults it to true, but clients submit an explicit false and middleware honours it, so applying an ACL fails with `path contains existing data` as soon as the app has written to its own volume. Once that false is persisted, validation rejects the config before normalization can correct it.

The bad value comes from the UI, which honours `hidden` only on the field carrying it: for an ix-volume the whole `options` block is hidden, so the form still builds a `force` control, seeds it with its own boolean default of false rather than the schema's true, and submits that for a system managed dataset.

## Solution
ix-volumes are system managed, so anything in them is managed bys - confirmed with Stavros that `force` should always be true for them when an ACL is wanted.

`normalize_ix_volume` stamps `force` to true in place once it has computed the volume's host path, gated on a containment check since `dataset_name` is not validated as a path anywhere. `validate_acl_entries` skips its existing-data probe for anything under `/mnt/.ix-apps/app_mounts` - that tree is ours, and `filesystem.add_to_acl` still refuses an unforced apply over a populated path.

Host path ACLs keep their guard and their false default. The cost is that a host path typed under `app_mounts` now fails from `add_to_acl` rather than validation, so it fails later, after `update_volumes` has created datasets and any sibling ACLs have been applied.

Jenkins: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/10169/

Original PR: https://github.com/truenas/middleware/pull/19539
