### PR TITLE
NAS-142768 / 27.0.0-BETA.1 / Check API key user roles through privilege API

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/api_key.py
+++ b/src/middlewared/middlewared/api/v26_0_0/api_key.py
@@ -42,7 +42,9 @@ class ApiKeyEntry(BaseModel):
         default=None,
         description="Expiration timestamp for the API key or `null` for no expiration.",
     )
-    local: bool = Field(description="Whether this API key is for local system use only.")
+    local: bool = Field(
+        description="Whether the API key belongs to a local user account rather than a directory services one.",
+    )
     revoked: bool = Field(description="Whether the API key has been revoked and is no longer valid.")
     revoked_reason: str | None = Field(description="Reason for API key revocation or `null` if not revoked.")
 

--- a/src/middlewared/middlewared/api/v27_0_0/api_key.py
+++ b/src/middlewared/middlewared/api/v27_0_0/api_key.py
@@ -43,7 +43,9 @@ class ApiKeyEntry(BaseModel):
         default=None,
         description="Expiration timestamp for the API key or `null` for no expiration.",
     )
-    local: bool = Field(description="Whether this API key is for local system use only.")
+    local: bool = Field(
+        description="Whether the API key belongs to a local user account rather than a directory services one.",
+    )
     revoked: bool = Field(description="Whether the API key has been revoked and is no longer valid.")
     revoked_reason: str | None = Field(description="Reason for API key revocation or `null` if not revoked.")
 

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -402,6 +402,37 @@ class PrivilegeService(CRUDService):
         return compose
 
     @private
+    async def roles_for_user(self, username):
+        """
+        Return the roles currently granted to `username` by evaluating its
+        group membership as reported by NSS.
+
+        Directory services cache entries are not authoritative for privilege
+        determination. They carry no group membership, because populating it
+        while enumerating the domain would require a group lookup per account
+        and overload the domain controller, and so `user.query` reports an
+        empty `roles` list for every directory services account. Anything that
+        determines privilege must go directly through NSS the way that
+        authentication does.
+        """
+        try:
+            user_obj = await self.middleware.call('user.get_user_obj', {
+                'username': username, 'get_groups': True
+            })
+        except KeyError:
+            return []
+
+        privileges = await self.privileges_for_groups(
+            'local_groups' if user_obj['local'] else 'ds_groups',
+            # synthetic accounts (container root) have no group list
+            user_obj['grouplist'] or []
+        )
+        if not privileges:
+            return []
+
+        return sorted((await self.compose_privilege(privileges))['roles'])
+
+    @private
     async def full_privilege(self):
         return {
             'roles': {'FULL_ADMIN'},

--- a/src/middlewared/middlewared/plugins/api_key/crud.py
+++ b/src/middlewared/middlewared/plugins/api_key/crud.py
@@ -14,6 +14,7 @@ from middlewared.api.current import (
     ApiKeyScramData,
     ApiKeyUpdate,
 )
+from middlewared.plugins.idmap_.idmap_constants import BASE_SYNTHETIC_DATASTORE_ID
 from middlewared.service import CallError, CRUDServicePart, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.auth import LEGACY_API_KEY_USERNAME
@@ -78,6 +79,7 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
         return {
             "by_id": by_id,
             "by_sid": {},
+            "by_uid": {},
             "now": utc_now(naive=False),
             "root_name": root_name,
         }
@@ -111,11 +113,29 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
             # If we can't resolve the ID then the account was probably deleted
             # and we didn't quite get to clean up yet.
             data["user_identifier"] = int(user_identifier)
-            data["username"] = context["by_id"].get(data["user_identifier"])
+            if data["user_identifier"] >= BASE_SYNTHETIC_DATASTORE_ID:
+                # Directory services account that has no SID (plain LDAP). Its
+                # `user.query` id is synthesized from the UID.
+                data["local"] = False
+                uid = data["user_identifier"] - BASE_SYNTHETIC_DATASTORE_ID
+                if uid not in context["by_uid"]:
+                    # Feed the account we looked up back into our extend context
+                    # because there may be multiple keys for the same UID value.
+                    try:
+                        pwdobj = await self.middleware.call("user.get_user_obj", {"uid": uid})
+                    except KeyError:
+                        context["by_uid"][uid] = None
+                    else:
+                        context["by_uid"][uid] = pwdobj["pw_name"]
+
+                data["username"] = context["by_uid"][uid]
+            else:
+                data["username"] = context["by_id"].get(data["user_identifier"])
         elif user_identifier == LEGACY_API_KEY_USERNAME:
             # This may be magic string designating a migrated API key
             data["username"] = context["root_name"]
         elif sid_is_valid(user_identifier):
+            data["local"] = False
             if (username := context["by_sid"].get(user_identifier)) is None:
                 resp = await self.middleware.call("idmap.convert_sids", [user_identifier])
                 if entry := resp["mapped"].get(user_identifier):
@@ -194,7 +214,9 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
         )
         if not users:
             verrors.add("api_key_create", "User does not exist.")
-        elif not users[0]["roles"]:
+        elif not await self.middleware.call("privilege.roles_for_user", data.username):
+            # The directory services cache holds no group membership and so is
+            # not authoritative for roles; this goes directly through NSS.
             verrors.add("api_key_create", "User lacks privilege role membership.")
 
         verrors.check()

--- a/src/middlewared/middlewared/plugins/api_key/crud.py
+++ b/src/middlewared/middlewared/plugins/api_key/crud.py
@@ -215,8 +215,8 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
         if not users:
             verrors.add("api_key_create", "User does not exist.")
         elif not await self.middleware.call("privilege.roles_for_user", data.username):
-            # The directory services cache holds no group membership and so is
-            # not authoritative for roles; this goes directly through NSS.
+            # We cannot use user[0]['roles'] as a fast check because it is not populated
+            # for directory services users via cache.
             verrors.add("api_key_create", "User lacks privilege role membership.")
 
         verrors.check()

--- a/src/middlewared/middlewared/plugins/api_key/crud.py
+++ b/src/middlewared/middlewared/plugins/api_key/crud.py
@@ -68,7 +68,28 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
         # need here (e.g. 2FA status), so query the table directly.
         users = await self.middleware.call("datastore.query", "account.bsdusers", [], {"prefix": "bsdusr_"})
 
-        by_id: dict[int, str] = {x["id"]: x["username"] for x in users}
+        by_id: dict[int, str | None] = {x["id"]: x["username"] for x in users}
+
+        # Keys for directory services accounts that have no SID (plain LDAP)
+        # are stored by the `user.query` id synthesized from the account's UID,
+        # which the local user table cannot resolve. Look each distinct one up
+        # through NSS once per query.
+        for row in rows:
+            if not row["user_identifier"].isdigit():
+                continue
+
+            synthetic_id = int(row["user_identifier"])
+            if synthetic_id < BASE_SYNTHETIC_DATASTORE_ID or synthetic_id in by_id:
+                continue
+
+            try:
+                pwdobj = await self.middleware.call(
+                    "user.get_user_obj", {"uid": synthetic_id - BASE_SYNTHETIC_DATASTORE_ID}
+                )
+            except KeyError:
+                by_id[synthetic_id] = None
+            else:
+                by_id[synthetic_id] = pwdobj["pw_name"]
 
         # Convert legacy keys into the appropriate local administrator account.
         if result := _tf.tnfilter(users, filters=_ADMIN_UID_FILTER, options=_ADMIN_UID_GET_OPTS):
@@ -79,7 +100,6 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
         return {
             "by_id": by_id,
             "by_sid": {},
-            "by_uid": {},
             "now": utc_now(naive=False),
             "root_name": root_name,
         }
@@ -113,24 +133,9 @@ class ApiKeyServicePart(CRUDServicePart[ApiKeyEntry]):
             # If we can't resolve the ID then the account was probably deleted
             # and we didn't quite get to clean up yet.
             data["user_identifier"] = int(user_identifier)
-            if data["user_identifier"] >= BASE_SYNTHETIC_DATASTORE_ID:
-                # Directory services account that has no SID (plain LDAP). Its
-                # `user.query` id is synthesized from the UID.
-                data["local"] = False
-                uid = data["user_identifier"] - BASE_SYNTHETIC_DATASTORE_ID
-                if uid not in context["by_uid"]:
-                    # Feed the account we looked up back into our extend context
-                    # because there may be multiple keys for the same UID value.
-                    try:
-                        pwdobj = await self.middleware.call("user.get_user_obj", {"uid": uid})
-                    except KeyError:
-                        context["by_uid"][uid] = None
-                    else:
-                        context["by_uid"][uid] = pwdobj["pw_name"]
-
-                data["username"] = context["by_uid"][uid]
-            else:
-                data["username"] = context["by_id"].get(data["user_identifier"])
+            # Ids at or above the synthetic base belong to directory services accounts.
+            data["local"] = data["user_identifier"] < BASE_SYNTHETIC_DATASTORE_ID
+            data["username"] = context["by_id"].get(data["user_identifier"])
         elif user_identifier == LEGACY_API_KEY_USERNAME:
             # This may be magic string designating a migrated API key
             data["username"] = context["root_name"]

--- a/tests/directory_services/test_directory_services_basic.py
+++ b/tests/directory_services/test_directory_services_basic.py
@@ -1,6 +1,8 @@
 import pytest
 
+from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.assets.directory_service import directoryservice
+from middlewared.test.integration.assets.privilege import privilege
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.utils.audit import expect_audit_method_calls
 from middlewared.test.integration.utils.legacy_functions import SSH_TEST
@@ -69,3 +71,33 @@ def test_directory_services_network_domain(service_type):
     # Final test: restore default (if necessary)
     if service_type == 'LDAP':
         call('network.configuration.update', {'domain': DEFAULT_NETWORK_DOMAIN})
+
+
+@pytest.mark.parametrize('service_type', ['ACTIVEDIRECTORY', 'IPA', 'LDAP'])
+def test_directory_services_api_key(service_type):
+    """
+    API keys may only be created for accounts that have roles granted to them by
+    a privilege. Directory services cache entries carry no group membership and
+    so `user.query` reports no roles for them, which means the check has to
+    evaluate the group membership of the account through NSS.
+    """
+    with directoryservice(service_type) as ds:
+        username = ds['account'].user_obj['pw_name']
+
+        with pytest.raises(Exception, match='User lacks privilege role membership'):
+            with api_key(username):
+                pass
+
+        with privilege({
+            'name': f'DS API key privilege ({service_type})',
+            'local_groups': [],
+            'ds_groups': [ds['account'].user_obj['pw_gid']],
+            'roles': ['READONLY_ADMIN'],
+            'web_shell': False,
+        }):
+            assert 'READONLY_ADMIN' in call('privilege.roles_for_user', username)
+
+            with api_key(username):
+                key_info = call('api_key.query', [['username', '=', username]], {'get': True})
+                assert key_info['local'] is False
+                assert key_info['revoked'] is False, key_info['revoked_reason']


### PR DESCRIPTION
Directory services cache entries are not authoritative for privilege determination. They carry no group membership, because populating it while enumerating the domain would require a group lookup per account and overload the domain controller, so user.query reports an empty roles list for every directory services account. api_key.create read that list and rejected every directory services user.

Add privilege.roles_for_user(), which goes directly through NSS and evaluates the account's group membership the same way authentication does, and use it in do_create().

That makes two gaps in extend() reachable. A directory services account with no SID (plain LDAP) is stored by its synthesized user.query id, which never matched the local-only by_id map, so the key read back as revoked with "User does not exist" and was dropped from the PAM configuration. Resolve those ids through user.get_user_obj() instead, memoizing the lookup the way the SID branch already does.

`local` was initialized True and never cleared, so keys owned by directory services accounts claimed to be local and defeated the filter in user.user_extend_context(). Set it on both directory services paths and correct the field description.