### PR TITLE
NAS-142772 / 27.0.0-BETA.1 / krb5.conf: alias realm case variants and fix domain_realm

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
@@ -345,9 +345,26 @@ class KRB5Conf():
         NOTE: if admin_server, kdc, or kpasswd_server are unspecified, then they will be
         resolved through DNS.
         """
+        # MIT krb5 matches [realms] section names with a case-sensitive comparison, but
+        # some clients ask for the realm using whatever spelling the domain controller
+        # handed them. Samba's `net ads join` is one of these: once the computer account
+        # exists it reconnects as the machine account and kinits as
+        # MACHINE$@<dns_domain_name>, where dns_domain_name comes from
+        # lsa_QueryInfoPolicy2 and is lower case. Because we pin `kdc` entries and set
+        # dns_lookup_kdc = false, a miss here has no DNS fallback and fails outright with
+        # KRB5_REALM_UNKNOWN ("Cannot find KDC for requested realm"). Alias the case
+        # variants onto the same KDCs so that every spelling resolves. An explicitly
+        # configured realm always wins over an alias generated for another one.
         clean_realms = {}
         for realm in realms:
-            clean_realms.update(self.__parse_realm(realm))
+            for name, realm_conf in self.__parse_realm(realm).items():
+                clean_realms[name] = realm_conf
+
+                for alias in (name.lower(), name.upper()):
+                    if alias in clean_realms:
+                        continue
+
+                    clean_realms[alias] = realm_conf.copy()
 
         self.realms = clean_realms
 
@@ -403,17 +420,23 @@ class KRB5Conf():
         kconf = '[realms]\n'
         for realm in list(self.realms.keys()):
             this_realm = self.realms[realm].copy()
-            this_realm.pop('realm')
+            # `realm` here may be a case alias, so default_domain comes from the
+            # canonical realm name rather than the section name.
+            default_domain = this_realm.pop('realm')
 
             kconf += self.__dump_a_parameter(
-                realm, {'default_domain': realm} | this_realm
+                realm, {'default_domain': default_domain} | this_realm
             )
 
         return kconf + '\n'
 
     def __generate_domain_realms(self):
-        kconf = '[domain_realms]\n'
-        for realm in self.realms.keys():
+        # NOTE: the section name MIT krb5 reads is "domain_realm" (singular). Any other
+        # spelling parses without error and is then silently ignored.
+        kconf = '[domain_realm]\n'
+        # self.realms may hold case aliases of the same realm. Map hostnames onto the
+        # canonical name only, otherwise we emit redundant (and conflicting) entries.
+        for realm in dict.fromkeys(r['realm'] for r in self.realms.values()):
             kconf += f'\t{realm.lower()} = {realm}\n'
             kconf += f'\t.{realm.lower()} = {realm}\n'
             kconf += f'\t{realm.upper()} = {realm}\n'

--- a/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_conf.py
@@ -431,8 +431,6 @@ class KRB5Conf():
         return kconf + '\n'
 
     def __generate_domain_realms(self):
-        # NOTE: the section name MIT krb5 reads is "domain_realm" (singular). Any other
-        # spelling parses without error and is then silently ignored.
         kconf = '[domain_realm]\n'
         # self.realms may hold case aliases of the same realm. Map hostnames onto the
         # canonical name only, otherwise we emit redundant (and conflicting) entries.

--- a/tests/unit/test_krb5.py
+++ b/tests/unit/test_krb5.py
@@ -370,9 +370,16 @@ def validate_realms_section(data):
     \t\tkdc = ip1 ip2 ip3\n
     \t\tadmin_server = ip1\n
     \t\tkpasswd_server = ip1 ip2 ip3\n
+
+    Every realm is also emitted under its lower- and upper-case spelling so that
+    clients which learn the realm from the domain controller (samba's `net ads
+    join` kinits as MACHINE$@<lower-case dns domain>) still find the pinned KDCs.
+    Those aliases carry the same settings and the canonical default_domain.
     """
-    def validate_realm(idx, realm):
-        this = REALMS[idx]
+    def validate_realm(section_name, realm):
+        matching = [r for r in REALMS if r['realm'].casefold() == section_name.casefold()]
+        assert len(matching) == 1, f'{section_name}: no matching realm in {REALMS}'
+        this = matching[0]
         lidx = 0
         for line in realm.splitlines():
             if not line.strip():
@@ -380,7 +387,7 @@ def validate_realms_section(data):
 
             match lidx:
                 case 0:
-                    assert line.startswith(f'\t{this["realm"]} =')
+                    assert line.startswith(f'\t{section_name} =')
                 case 1:
                     assert line.strip() == f'default_domain = {this["realm"]}', str(realm)
                 case _:
@@ -399,15 +406,26 @@ def validate_realms_section(data):
 
             lidx += 1
 
-    for idx, realm in enumerate(data.split('}')):
+    seen = []
+    for realm in data.split('}'):
         if not realm.strip():
             continue
 
-        validate_realm(idx, realm)
+        section_name = realm.strip().splitlines()[0].split('=')[0].strip()
+        seen.append(section_name)
+        validate_realm(section_name, realm)
+
+    # each configured realm must appear under both case spellings
+    for entry in REALMS:
+        assert entry['realm'].lower() in seen, seen
+        assert entry['realm'].upper() in seen, seen
 
 
 def validate_domain_realms_section(data):
     """
+    Case aliases in [realms] must not multiply these entries: hostnames map onto
+    the canonical realm name only.
+
     data will consist of approximately following:
 
     \tad02.tn.ixsystems.net = AD02.TN.IXSYSTEMS.NET\n
@@ -457,17 +475,84 @@ def test__krb5conf_realm():
     # Convert our stored kerberos realm configuration into krb5.conf
     # data via `generate()` method and validate it's what we expect.
     for section in kconf.generate().split('\n\n'):
-        if not section.startswith(('[realms]', '[domain_realms]')):
+        if not section.startswith(('[realms]', '[domain_realm]')):
             continue
 
         section_name, data = section.split('\n', 1)
         match section_name:
             case '[realms]':
                 validate_realms_section(data)
-            case '[domain_realms]':
+            case '[domain_realm]':
                 validate_domain_realms_section(data)
             case _:
                 raise ValueError(f'{section_name}: unexpected entry')
+
+
+def realms_section(conf):
+    """
+    Return the lines of the [realms] section of a generated krb5.conf, stripped of
+    leading whitespace (krb5.conf indentation is cosmetic).
+    """
+    lines = conf.splitlines()
+    start = lines.index('[realms]')
+    out = []
+    for line in lines[start + 1:]:
+        if line.startswith('['):
+            break
+        out.append(line.strip())
+
+    return out
+
+
+def test__krb5conf_realm_case_aliases():
+    """
+    MIT krb5 looks up [realms] sections case-sensitively, and we set
+    dns_lookup_kdc = false whenever KDCs are pinned. Clients that learn the realm
+    from the domain controller get the lower-case DNS domain -- samba's
+    `net ads join` kinits as MACHINE$@<dns_domain_name> when it reconnects as the
+    machine account -- so both spellings must resolve to the same KDCs. Otherwise
+    the kinit fails with KRB5_REALM_UNKNOWN and, when NTLM fallback is disabled
+    (`client use kerberos = required`, which the GPOS STIG sets), the join fails.
+    """
+    kconf = krb5_conf.KRB5Conf()
+    kconf.add_realms(REALMS)
+    realms = realms_section(kconf.generate())
+
+    for entry in REALMS:
+        realm = entry['realm']
+        assert f'{realm.upper()} = {{' in realms
+        assert f'{realm.lower()} = {{' in realms
+
+        for kdc in entry['kdc']:
+            # the alias must carry the same pinned KDCs, not fall back to DNS
+            assert realms.count(f'kdc = {kdc}') == 2, realms
+
+    # aliases keep the canonical realm as default_domain
+    for entry in REALMS:
+        assert f'default_domain = {entry["realm"].lower()}' not in realms
+        assert realms.count(f'default_domain = {entry["realm"]}') == 2, realms
+
+
+def test__krb5conf_realm_already_lowercase_not_duplicated():
+    kconf = krb5_conf.KRB5Conf()
+    kconf.add_realms([dict(REALMS[0], realm='acme.test')])
+    realms = realms_section(kconf.generate())
+
+    assert realms.count('acme.test = {') == 1
+    assert realms.count('ACME.TEST = {') == 1
+
+
+def test__krb5conf_domain_realm_section_name():
+    """
+    MIT krb5 reads "domain_realm" (singular). Any other spelling parses without
+    error and is then silently ignored, leaving host -> realm unconfigured.
+    """
+    kconf = krb5_conf.KRB5Conf()
+    kconf.add_realms(REALMS)
+    conf = kconf.generate()
+
+    assert '[domain_realm]\n' in conf
+    assert '[domain_realms]' not in conf
 
 
 def test__krb5conf_libdefaults():


### PR DESCRIPTION
MIT krb5 matches [realms] sections case-sensitively, and we set dns_lookup_kdc = false whenever KDCs are pinned. Samba reconnects as the machine account after creating it, kiniting as MACHINE$@<dns_domain_name>, and that name comes from lsa_QueryInfoPolicy2 in lower case. The lookup misses our upper-case realm section, has no DNS fallback, and fails with KRB5_REALM_UNKNOWN.

SPNEGO normally falls back to NTLMSSP and the join survives. With the GPOS STIG enabled smb.conf carries client use kerberos = required, leaving no other mechanism, so every fresh AD join fails with WERR_GEN_FAILURE.

Emit each realm under both case spellings sharing the same pinned KDCs, and take default_domain from the canonical name.

Also rename [domain_realms] to [domain_realm]. MIT krb5 only reads the singular form, so the section was parsing cleanly and being ignored.