### PR TITLE
NAS-142825 / 27.0.0-BETA.1 / Guard change_route in route.sync against NetlinkError

### DIFF
--- a/src/middlewared/middlewared/plugins/network_routes/route_sync.py
+++ b/src/middlewared/middlewared/plugins/network_routes/route_sync.py
@@ -83,7 +83,14 @@ def _sync_ip4_impl(ctx: ServiceContext, sock: socket.socket, dbgw: str | None) -
                 cur_gw.gateway,
                 dbgw,
             )
-            change_route(sock, gateway=dbgw)
+            try:
+                change_route(sock, gateway=dbgw)
+            except NetlinkError as e:
+                # same class of failure as add_route() above: the
+                # gateway may be unreachable (e.g. the db value
+                # predates a move to a different network). Log it
+                # instead of aborting the rest of the sync.
+                ctx.logger.error("Failed changing default gateway to %s: %r", dbgw, e)
     elif cur_gw:
         # there is no gateway in the database but there is
         # one installed in the OS so we'll remove it


### PR DESCRIPTION
Jira: https://ixsystems.atlassian.net/browse/NAS-142825

In `_sync_ip4_impl()` (`plugins/network_routes/route_sync.py`) the "add" branch wraps `add_route()` in a `try/except NetlinkError` — the comment there explains the gateway can be unreachable when the DB/lease value is stale or DHCP hasn't bound yet. The "change" branch directly below calls `change_route()` with no guard, so the same condition (e.g. a gateway still stored in the DB after the machine moved to a different subnet) raises out of `route.sync`, skips the IPv6 default-route handling that follows, and surfaces as a failure from `network.configuration.update` (and the HA `failover.call_remote('route.sync')` step).

This wraps `change_route()` in the same `try/except NetlinkError` and logs the error. No behavior change on the success path; no API/schema change.

The same hunk applies unchanged to `stable/26` at `plugins/network_/route_sync.py:86` (only the directory name differs).
