### PR TITLE
NAS-142826 / 27.0.0-BETA.1 / Fall back to a default critical disk temperature when a disk reports none

### DIFF
--- a/src/middlewared/middlewared/alert/source/disk_temp.py
+++ b/src/middlewared/middlewared/alert/source/disk_temp.py
@@ -15,6 +15,21 @@ from middlewared.alert.base import (
     AlertSource,
 )
 
+# Critical thresholds of last resort, in degrees celsius, used only for disks
+# that report no usable critical temperature of their own (hwmon `temp1_crit`),
+# or report a non-positive one. SAS disks are the common case: the only limit
+# they expose on log page 0x0D subpage 0x00 is parameter 0x0001 (REFERENCE
+# TEMPERATURE), which is an "operate continuously" limit and is therefore
+# surfaced by the kernel as `temp1_max`, not `temp1_crit`. Without these
+# fallbacks such disks would have no critical temperature coverage at all now
+# that smartd is no longer shipped.
+FALLBACK_CRIT_ROTATIONAL = 60
+FALLBACK_CRIT_NON_ROTATIONAL = 70
+# The fallback threshold is never allowed to land at or below the temperature
+# the disk itself reports it can run at continuously, otherwise a disk whose
+# recommended maximum is already above the fallback would alert permanently.
+FALLBACK_CRIT_MARGIN = 5
+
 
 @dataclass(kw_only=True)
 class DiskTemperatureTooHotAlert(AlertClass):
@@ -35,17 +50,45 @@ class DiskTemperatureTooHotAlert(AlertClass):
     temp: int
 
 
+@dataclass(kw_only=True)
+class DiskTemperatureAboveDefaultLimitAlert(AlertClass):
+    config = AlertClassConfig(
+        category=AlertCategory.HARDWARE,
+        level=AlertLevel.CRITICAL,
+        title="Disk Temperature Exceeds The Default Critical Limit",
+        text=(
+            "Disk %(device)s (with serial: %(serial)s) does not report a"
+            " critical temperature; its current temp of %(temp)d degrees"
+            " celsius has exceeded the default limit of %(crit_threshold)d"
+            " degrees celsius"
+        ),
+    )
+
+    device: str
+    serial: str
+    crit_threshold: int
+    temp: int
+
+    @classmethod
+    def key_from_args(cls, args: Any) -> Any:
+        # `temp` drifts on every poll. Keying on it would clear and re-raise
+        # the alert (and send mail) every time the disk moves by a degree.
+        return {"device": args["device"]}
+
+
 class DiskTemperatureTooHotAlertSource(AlertSource):
     run_on_backup_node = False
 
     async def check(self) -> list[Alert[Any]] | Alert[Any] | None:
         alerts: list[Alert[Any]] = list()
         disk_map = {i.name: i for i in await self.middleware.call("disk.get_disks")}
-        temp_cache = await self.middleware.call("disk.temperatures", [], True)
-        for disk, (temp, crit) in temp_cache.items():
-            if temp is None or crit is None or crit <= 0:
+        temp_cache = await self.middleware.call("disk.temperature_entries", [])
+        for disk, entry in temp_cache.items():
+            if entry is None:
                 continue
-            elif temp < crit:
+
+            temp, crit, max_ = entry
+            if temp is None:
                 continue
 
             try:
@@ -55,14 +98,48 @@ class DiskTemperatureTooHotAlertSource(AlertSource):
                 # so disk could have gone away by the time
                 # this alert runs
                 continue
+
+            if crit is not None and crit > 0:
+                # The disk reports a critical temperature of its own. Behaviour
+                # here is unchanged: alert with the value the disk reported.
+                if temp >= crit:
+                    alerts.append(
+                        Alert(
+                            DiskTemperatureTooHotAlert(
+                                device=f"/dev/{disk}",
+                                serial=di.serial,
+                                crit_threshold=crit,
+                                temp=temp,
+                            )
+                        )
+                    )
+                continue
+
+            # The disk reports no usable critical temperature. A SAS disk that
+            # implements only log page 0x0D subpage 0x00 is the common case: its
+            # reference temperature is a continuous operating limit, reported as
+            # `temp1_max`, and must not be treated as a failure threshold. Fall
+            # back to an absolute limit for the device class, raised above the
+            # disk's own recommended maximum where it reports one so that a disk
+            # rated to run hotter than the fallback does not alert permanently.
+            if di.rotational is False:
+                crit_threshold = FALLBACK_CRIT_NON_ROTATIONAL
             else:
+                # rotational is None (sysfs did not say) is treated as
+                # rotational on purpose: it is the stricter threshold.
+                crit_threshold = FALLBACK_CRIT_ROTATIONAL
+
+            if max_ is not None and max_ > 0:
+                crit_threshold = max(crit_threshold, max_ + FALLBACK_CRIT_MARGIN)
+
+            if temp >= crit_threshold:
                 alerts.append(
                     Alert(
-                        DiskTemperatureTooHotAlert(
+                        DiskTemperatureAboveDefaultLimitAlert(
                             device=f"/dev/{disk}",
                             serial=di.serial,
-                            crit_threshold=crit,
-                            temp=temp,
+                            crit_threshold=int(crit_threshold),
+                            temp=int(temp),
                         )
                     )
                 )

--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -10,13 +10,34 @@ from middlewared.api.current import (
     DiskTemperaturesArgs,
     DiskTemperaturesResult,
 )
-from middlewared.service import Service
+from middlewared.service import Service, private
 from middlewared.utils.disks_.disk_class import TempEntry
+
+# Alert classes raised per disk by `middlewared.alert.source.disk_temp`.
+TEMPERATURE_ALERT_CLASSES = ("DiskTemperatureTooHot", "DiskTemperatureAboveDefaultLimit")
 
 
 class DiskService(Service):
     temp_cache: dict[str, tuple[TempEntry, float]] = dict()
     temp_cache_age: int = 300  # 5mins
+
+    def __refresh_temp_cache(self):
+        """Refresh `temp_cache` for every disk on the system, returning the
+        names of the disks that were refreshed."""
+        now = time()
+        names = list()
+        for i in self.middleware.call_sync("disk.get_disks"):
+            try:
+                temp, temp_time = self.temp_cache[i.name]
+                if now - temp_time > self.temp_cache_age:
+                    # cache time expired, grab a new temp
+                    self.temp_cache[i.name] = (i.temp(), now)
+            except KeyError:
+                # no cache or disk not in cache
+                self.temp_cache[i.name] = (i.temp(), now)
+
+            names.append(i.name)
+        return names
 
     @api_method(
         DiskTemperaturesArgs,
@@ -31,26 +52,32 @@ class DiskService(Service):
 
             Disk temperatures are not retrieved more than once every 5 minutes.
         """
-        now = time()
         rv = {i: None for i in names}
-        for i in self.middleware.call_sync("disk.get_disks"):
-            try:
-                temp, temp_time = self.temp_cache[i.name]
-                if now - temp_time > self.temp_cache_age:
-                    # cache time expired, grab a new temp
-                    self.temp_cache[i.name] = (i.temp(), now)
-            except KeyError:
-                # no cache or disk not in cache
-                self.temp_cache[i.name] = (i.temp(), now)
-
-            if not names or i.name in names:
+        for name in self.__refresh_temp_cache():
+            if not names or name in names:
                 if include_thresholds:
-                    rv[i.name] = (
-                        self.temp_cache[i.name][0].temp_c,
-                        self.temp_cache[i.name][0].crit,
+                    rv[name] = (
+                        self.temp_cache[name][0].temp_c,
+                        self.temp_cache[name][0].crit,
                     )
                 else:
-                    rv[i.name] = self.temp_cache[i.name][0].temp_c
+                    rv[name] = self.temp_cache[name][0].temp_c
+        return rv
+
+    @private
+    def temperature_entries(self, names):
+        """Same cache and same 5 minute refresh interval as `temperatures`,
+        but returns `(temp_c, crit, max_c)` for each disk.
+
+        This is deliberately not part of the public API: the shape of the
+        `disk.temperatures` result is an untyped dict in every released API
+        version, so widening its tuple would change the wire format for
+        clients pinned to an already frozen version."""
+        rv = {i: None for i in names}
+        for name in self.__refresh_temp_cache():
+            if not names or name in names:
+                entry = self.temp_cache[name][0]
+                rv[name] = (entry.temp_c, entry.crit, entry.max_c)
         return rv
 
     @api_method(
@@ -89,6 +116,6 @@ class DiskService(Service):
         alerts = list()
         names = {f'/dev/{i}' for i in names}
         for i in await self.call2(self.s.alert.list):
-            if i.klass == "DiskTemperatureTooHot" and i.args["device"] in names:
+            if i.klass in TEMPERATURE_ALERT_CLASSES and i.args["device"] in names:
                 alerts.append(i)
         return alerts

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_disk_temp.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_disk_temp.py
@@ -1,0 +1,147 @@
+from types import SimpleNamespace
+
+import pytest
+
+from middlewared.alert.source.disk_temp import (
+    DiskTemperatureAboveDefaultLimitAlert,
+    DiskTemperatureTooHotAlert,
+    DiskTemperatureTooHotAlertSource,
+)
+from middlewared.pytest.unit.middleware import Middleware
+
+
+def _source(rotational, temp, crit, max_):
+    m = Middleware()
+    m["disk.get_disks"] = lambda: [
+        SimpleNamespace(name="sda", serial="AAAABBBBCCCCDDDD", rotational=rotational)
+    ]
+    m["disk.temperature_entries"] = lambda names: {"sda": (temp, crit, max_)}
+    return DiskTemperatureTooHotAlertSource(m)
+
+
+# ---------------------------------------------------------------------------
+# Disks that report a critical temperature of their own: unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_alert_below_reported_crit():
+    assert await _source(True, 35, 70, 55).check() == []
+
+
+@pytest.mark.asyncio
+async def test_reported_crit_alerts_with_the_reported_value():
+    alerts = await _source(True, 71, 70, 55).check()
+    assert len(alerts) == 1
+    assert isinstance(alerts[0].instance, DiskTemperatureTooHotAlert)
+    assert alerts[0].instance.crit_threshold == 70
+
+
+@pytest.mark.asyncio
+async def test_reported_crit_is_inclusive():
+    """The pre-existing comparison is `temp >= crit`, not `>`."""
+    alerts = await _source(True, 70, 70, 55).check()
+    assert len(alerts) == 1
+    assert isinstance(alerts[0].instance, DiskTemperatureTooHotAlert)
+
+
+@pytest.mark.asyncio
+async def test_recommended_maximum_alone_does_not_alert():
+    """Exceeding the disk's own continuous operating maximum is not by itself
+    an alerting condition; only the critical tier alerts."""
+    assert await _source(True, 56, 70, 55).check() == []
+
+
+# ---------------------------------------------------------------------------
+# Disks that report no usable critical temperature: absolute fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rotational,temp,expected_threshold",
+    [
+        (True, 60, 60),
+        (True, 59, None),
+        (False, 60, None),
+        (False, 70, 70),
+        # sysfs did not say: treated as rotational, i.e. the stricter threshold.
+        (None, 60, 60),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fallback_threshold_by_device_class(rotational, temp, expected_threshold):
+    alerts = await _source(rotational, temp, None, None).check()
+    if expected_threshold is None:
+        assert alerts == []
+    else:
+        assert len(alerts) == 1
+        assert isinstance(alerts[0].instance, DiskTemperatureAboveDefaultLimitAlert)
+        assert alerts[0].instance.crit_threshold == expected_threshold
+
+
+@pytest.mark.parametrize("crit", [0, -5])
+@pytest.mark.asyncio
+async def test_non_positive_reported_crit_falls_back(crit):
+    alerts = await _source(True, 61, crit, None).check()
+    assert len(alerts) == 1
+    assert isinstance(alerts[0].instance, DiskTemperatureAboveDefaultLimitAlert)
+    assert alerts[0].instance.crit_threshold == 60
+
+
+@pytest.mark.asyncio
+async def test_fallback_never_lands_below_reported_maximum():
+    """A disk whose reported maximum continuous operating temperature is above
+    the absolute fallback (e.g. the Seagate SAS default of 65C) must not be
+    declared critical at 60C, or it would alert permanently."""
+    assert await _source(True, 62, None, 65).check() == []
+    assert await _source(True, 66, None, 65).check() == []
+
+    alerts = await _source(True, 71, None, 65).check()
+    assert len(alerts) == 1
+    assert isinstance(alerts[0].instance, DiskTemperatureAboveDefaultLimitAlert)
+    assert alerts[0].instance.crit_threshold == 70
+
+
+@pytest.mark.asyncio
+async def test_sas_reference_temperature_does_not_alert():
+    """A NETAPP rebadged Seagate SAS disk reports a reference temperature of
+    40C and idles at 46C. The reference temperature is a continuous operating
+    limit, not a failure threshold, so this must not alert at all."""
+    assert await _source(True, 46, None, 40).check() == []
+
+
+@pytest.mark.asyncio
+async def test_alert_key_ignores_temperature():
+    """The dedup key must not include the temperature, or every degree of
+    drift clears and re-raises the alert (and sends mail)."""
+    a = (await _source(True, 61, None, None).check())[0]
+    b = (await _source(True, 62, None, None).check())[0]
+    assert a.key == b.key
+
+
+# ---------------------------------------------------------------------------
+# Degenerate input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_temperature_no_alert():
+    assert await _source(True, None, None, None).check() == []
+
+
+@pytest.mark.asyncio
+async def test_no_entry_no_alert():
+    m = Middleware()
+    m["disk.get_disks"] = lambda: [
+        SimpleNamespace(name="sda", serial="AAAABBBBCCCCDDDD", rotational=True)
+    ]
+    m["disk.temperature_entries"] = lambda names: {"sda": None}
+    assert await DiskTemperatureTooHotAlertSource(m).check() == []
+
+
+@pytest.mark.asyncio
+async def test_disk_disappeared_from_map():
+    m = Middleware()
+    m["disk.get_disks"] = lambda: []
+    m["disk.temperature_entries"] = lambda names: {"sda": (99, None, None)}
+    assert await DiskTemperatureTooHotAlertSource(m).check() == []

--- a/src/middlewared/middlewared/pytest/unit/utils/test_disk_sysfs_properties.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_disk_sysfs_properties.py
@@ -122,6 +122,22 @@ def test_media_type_hdd_regression(mock_sysfs):
         assert DiskEntry(name="sda", devpath="/dev/sda").media_type == "HDD"
 
 
+@pytest.mark.parametrize("raw,expected", [
+    ("1\n", True),
+    ("0\n", False),
+])
+def test_rotational(mock_sysfs, raw, expected):
+    with mock_sysfs({"sda/queue/rotational": raw}):
+        assert DiskEntry(name="sda", devpath="/dev/sda").rotational is expected
+
+
+def test_rotational_missing_is_none(mock_sysfs):
+    """Unlike media_type, an absent rotational file is not reported as
+    non-rotational."""
+    with mock_sysfs({}):
+        assert DiskEntry(name="sda", devpath="/dev/sda").rotational is None
+
+
 # ---------------------------------------------------------------------------
 # 3. vendor
 # ---------------------------------------------------------------------------
@@ -329,6 +345,44 @@ def test_temp_with_crit(mock_sysfs):
     }):
         result = DiskEntry(name="sda", devpath="/dev/sda").temp()
         assert result == TempEntry(temp_c=35.0, crit=70.0)
+
+
+def test_temp_with_max(mock_sysfs):
+    """SATA: SCT byte 6 (recommended max) is exposed as temp1_max and must
+    not be confused with temp1_crit (SCT byte 7)."""
+    with mock_sysfs({
+        "sda/device/hwmon/hwmon0/name": "drivetemp\n",
+        "sda/device/hwmon/hwmon0/temp1_input": "35000\n",
+        "sda/device/hwmon/hwmon0/temp1_max": "55000\n",
+        "sda/device/hwmon/hwmon0/temp1_crit": "70000\n",
+    }):
+        result = DiskEntry(name="sda", devpath="/dev/sda").temp()
+        assert result == TempEntry(temp_c=35.0, crit=70.0, max_c=55.0)
+
+
+def test_temp_max_without_crit(mock_sysfs):
+    """SAS: a drive that only implements log page 0x0D subpage 0x00 reports
+    its reference temperature as temp1_max and no temp1_crit at all."""
+    with mock_sysfs({
+        "sda/device/hwmon/hwmon0/name": "drivetemp\n",
+        "sda/device/hwmon/hwmon0/temp1_input": "46000\n",
+        "sda/device/hwmon/hwmon0/temp1_max": "40000\n",
+    }):
+        result = DiskEntry(name="sda", devpath="/dev/sda").temp()
+        assert result == TempEntry(temp_c=46.0, crit=None, max_c=40.0)
+
+
+def test_temp_nvme_max_not_read(mock_sysfs):
+    """Reading temp1_max on nvme issues a Get Features admin command, so it
+    is deliberately not read for the nvme driver."""
+    with mock_sysfs({
+        "nvme0n1/device/hwmon0/name": "nvme\n",
+        "nvme0n1/device/hwmon0/temp1_input": "42000\n",
+        "nvme0n1/device/hwmon0/temp1_crit": "84000\n",
+        "nvme0n1/device/hwmon0/temp1_max": "70000\n",
+    }):
+        result = DiskEntry(name="nvme0n1", devpath="/dev/nvme0n1").temp()
+        assert result == TempEntry(temp_c=42.0, crit=84.0, max_c=None)
 
 
 def test_temp_no_hwmon_dir(mock_sysfs):

--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -47,14 +47,18 @@ class TempEntry:
     crit: float | None = None
     """This value is reported as celsius.
 
-    For SCSI drives (as described in SPC-6):
-        The REFERENCE TEMPERATURE field indicates
-        the maximum reported sensor temperature in
-        degrees Celsius at which the SCSI target
-        device is capable of operating continuously
-        without degrading the SCSI target device's
-        operation or reliability beyond manufacturer
-        accepted limits.
+    This is the temperature at which the device is
+    expected to be damaged, throttled or shut down.
+    It is read from hwmon's `temp1_crit`.
+
+    For SCSI drives:
+        Only reported by drives that implement log
+        page 0x0D subpage 0x02 (environmental
+        limits), in which case it is the high
+        critical temperature limit trigger. The
+        REFERENCE TEMPERATURE on subpage 0x00 is an
+        "operate continuously" limit and is reported
+        as `max_c` below, not here.
 
     For NVMe drives (as described in base spec 2.0e)
         The critical composite temperature threshold
@@ -71,6 +75,42 @@ class TempEntry:
         maximum temperature limit. Operating the device
         over this temperature may cause physical damage to
         the device.
+    """
+    max_c: float | None = None
+    """This value is reported as celsius.
+
+    This is the highest temperature at which the device
+    itself claims it can be operated continuously. It is
+    not a failure threshold: exceeding it means the device
+    is running outside the range for which the vendor
+    guarantees operation and reliability, not that damage
+    is imminent. It is read from hwmon's `temp1_max`.
+
+    NOTE: this is only populated for the `drivetemp`
+    driver. For NVMe, reading `temp1_max` issues a Get
+    Features admin command on every read (see
+    nvme_get_temp_thresh() in drivers/nvme/host/hwmon.c),
+    which is too expensive for the rate this is polled at.
+
+    For SCSI drives (as described in SPC-5):
+        Either the high operating temperature limit
+        trigger from log page 0x0D subpage 0x02
+        (environmental limits), or, on drives that do not
+        implement that subpage, the REFERENCE TEMPERATURE
+        field (log page 0x0D, parameter 0x0001): the
+        maximum reported sensor temperature in degrees
+        Celsius at which the SCSI target device is capable
+        of operating continuously without degrading its
+        operation or reliability beyond manufacturer
+        accepted limits. Its ETC bit is 0 ("no threshold
+        comparison is made on this value") and the standard
+        states that no comparison is performed between it
+        and the current temperature in parameter 0x0000.
+
+    For ATA drives (as described in ATA/ATAPI Command Set)
+        The "Max Operating Limit" field (byte 6 of the SCT
+        status response), i.e. the maximum recommended
+        continuous operating temperature.
     """
 
 
@@ -283,6 +323,20 @@ class DiskEntry:
         return "HDD" if fr == "1" else "SSD"
 
     @functools.cached_property
+    def rotational(self) -> bool | None:
+        """Whether the disk is rotational, or None when sysfs does not
+        report it.
+
+        Unlike `media_type`, an unreadable value is not silently reported
+        as non-rotational. Callers that pick a safety threshold based on
+        the device class need to be able to tell "not rotational" from
+        "do not know"."""
+        fr = self.__opener(relative_path="queue/rotational")
+        if fr is None:
+            return None
+        return fr == "1"
+
+    @functools.cached_property
     def identifier(self) -> str:
         """Return, ideally, a unique identifier for the disk.
 
@@ -403,6 +457,7 @@ class DiskEntry:
 
         temp_c: float | None = None
         crit: float | None = None
+        max_c: float | None = None
         try:
             with os.scandir(path) as sdir:
                 for i in filter(
@@ -435,11 +490,26 @@ class DiskEntry:
                     else:
                         # syfs values are stored in millidegrees celsius
                         crit = crit / 1000
+
+                    if name == "drivetemp":
+                        # `temp1_max` is answered from cached driver state
+                        # by drivetemp, but the nvme driver turns it into a
+                        # Get Features admin command on every read, so it is
+                        # only read for drivetemp.
+                        try:
+                            max_c = int(
+                                self.__opener(absolute_path=f"{i.path}/temp1_max")  # type: ignore[arg-type]
+                            )
+                        except Exception:
+                            pass
+                        else:
+                            # sysfs values are stored in millidegrees celsius
+                            max_c = max_c / 1000
         except FileNotFoundError:
             # pmem devices dont have this, for example
             pass
 
-        return TempEntry(temp_c=temp_c, crit=crit)
+        return TempEntry(temp_c=temp_c, crit=crit, max_c=max_c)
 
     def partitions(self, dev_fd: int | None = None) -> tuple[GptPartEntry, ...] | None:
         """Return a tuple of `GptPartEntry` objects for any


### PR DESCRIPTION
Jira: https://ixsystems.atlassian.net/browse/NAS-142826

Companion to the kernel series on the Jira. Once drivetemp reports the SAS reference temperature as `temp1_max` instead of `temp1_crit`, a SAS drive that implements only log page 0Dh subpage 00h exposes no `temp1_crit`, and `alert/source/disk_temp.py` currently skips such disks entirely — leaving them with no temperature alerting now that smartd is gone.

This is strictly additive:

- `DiskTemperatureTooHot` is unmodified (byte-for-byte). Disks that report a critical temperature behave exactly as before.
- One new CRITICAL class, `DiskTemperatureAboveDefaultLimit`, fires only for disks with no usable `temp1_crit`: 60 °C rotational / 70 °C non-rotational, raised to `temp1_max + 5` where the disk reports a higher continuous limit (Seagate documents a 65 °C SAS default, which would otherwise alert permanently at 60). Its text says the disk reported no critical temperature, so an invented threshold is never presented as a device-reported one. Keyed on `device` only so temperature drift does not clear/re-raise.
- `DiskEntry.rotational -> bool | None`; `None` is treated as rotational (the stricter threshold) rather than `media_type`'s "unknown ⇒ SSD".
- `disk.temperatures` and its result shape are untouched (`result: dict` in every released API version). A new `@private disk.temperature_entries` serves `(temp_c, crit, max_c)` from the same cache and refresh interval. No `api/` model changes.
- `temp1_max` is read only for `drivetemp`; the nvme driver answers it with a Get Features admin command per read.

Tests: new `pytest/unit/alert/source/test_disk_temp.py` (15 cases) plus additions to `test_disk_sysfs_properties.py`; 75 pass including the full existing sysfs suite. flake8 introduces no new findings.

Without the kernel change this patch is inert: SAS disks still report the reference temperature as `temp1_crit` and take the unchanged path.
