### PR TITLE
NAS-141684 / 27.0.0-BETA.1 / Extend TNC heartbeat retry window to one week

### DIFF
--- a/src/middlewared/middlewared/alert/source/truenas_connect.py
+++ b/src/middlewared/middlewared/alert/source/truenas_connect.py
@@ -6,7 +6,7 @@ class TNCHeartbeatConnectionFailureAlert(OneShotAlertClass):
         category=AlertCategory.TRUENAS_CONNECT,
         level=AlertLevel.ERROR,
         title='Unable to connect to TrueNAS Connect Heartbeat Service',
-        text='Failed to connect to TrueNAS Connect Heartbeat Service in the last 48 hours',
+        text='Failed to connect to TrueNAS Connect Heartbeat Service in the last 7 days',
         deleted_automatically=False,
         keys=[],
     )

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -18,6 +18,7 @@ from .request import Mode, auth_headers, tnc_request
 from .utils import (
     CONFIGURED_TNC_STATES,
     HEARTBEAT_INTERVAL,
+    HEARTBEAT_MAX_ELAPSED_DAYS,
     calculate_sleep,
     decode_and_validate_token,
 )
@@ -191,11 +192,12 @@ async def heartbeat_start_impl(context: ServiceContext) -> None:
 
             sleep_secs = calculate_sleep(last_failure, HEARTBEAT_INTERVAL)
             if sleep_secs is None:
-                # This means that either we have a time mismatch or it's been 48 hours and we have
-                # not been able to establish contact with TNC, so an alert should be raised
+                # This means that either we have a time mismatch or we have exhausted the retry
+                # window without establishing contact with TNC, so an alert should be raised
                 logger.debug(
-                    'TNC Heartbeat: Unable to calculate sleep time, raising alert as it has likely been 48 hours '
-                    'since the last successful heartbeat (last failure: %s)', last_failure,
+                    'TNC Heartbeat: Unable to calculate sleep time, raising alert as it has likely been %d days '
+                    'since the last successful heartbeat (last failure: %s)',
+                    HEARTBEAT_MAX_ELAPSED_DAYS, last_failure,
                 )
                 await context.call2(context.s.alert.oneshot_create, TNCHeartbeatConnectionFailureAlert())
                 break

--- a/src/middlewared/middlewared/plugins/truenas_connect/utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/utils.py
@@ -17,6 +17,9 @@ CONFIGURED_TNC_STATES = (
     Status.CERT_RENEWAL_FAILURE.name,
 )
 HEARTBEAT_INTERVAL = 120
+# How long the heartbeat keeps retrying after the first failure in a streak before it gives up and
+# alerts. The alert text states this figure in prose, so keep the two in step.
+HEARTBEAT_MAX_ELAPSED_DAYS = 7
 TNC_CERT_PREFIX = 'truenas_connect_'
 TNC_IPS_CACHE_KEY = 'truenas_connect_sync_ips'
 
@@ -51,7 +54,8 @@ def calculate_sleep(failure_dt_str: str | None, base_sleep: int = 60) -> int | N
     Behavior:
       - If no failure datetime is provided, returns base_sleep (default 60 seconds).
       - If the provided datetime is in the future, returns None.
-      - If more than 48 hours have elapsed since the failure datetime, returns None.
+      - If more than HEARTBEAT_MAX_ELAPSED_DAYS days have elapsed since the failure datetime,
+        returns None.
       - Otherwise, uses an exponential backoff schedule:
           * First 3 attempts use a sleep time of base_sleep seconds.
           * Next 3 attempts use a sleep time of base_sleep × 2 seconds.
@@ -88,9 +92,9 @@ def calculate_sleep(failure_dt_str: str | None, base_sleep: int = 60) -> int | N
         return None
 
     elapsed = (now - first_failure).total_seconds()
-    max_elapsed = 48 * 3600  # maximum elapsed time threshold: 48 hours
+    max_elapsed = HEARTBEAT_MAX_ELAPSED_DAYS * 24 * 3600
 
-    # If more than 48 hours have passed, no sleep is required.
+    # Past the retry window the caller gives up, so there is nothing left to sleep for.
     if elapsed > max_elapsed:
         return None
 


### PR DESCRIPTION
This commit adds changes to extend the TrueNAS Connect heartbeat retry window from 48 hours to one week, so an outage or transient backend problem lasting longer than two days no longer stops heartbeats permanently. The threshold is now a named constant that the docstring and the give-up log line derive from, and the alert text has been corrected to match since it also stated the old figure.