### PR TITLE
NAS-142020 / 27.0.0-BETA.1 / Bound failover.call_remote timeouts in the login and alert paths (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/alert/runtime.py
+++ b/src/middlewared/middlewared/plugins/alert/runtime.py
@@ -292,7 +292,7 @@ async def get_failover_info(context: ServiceContext, state: AlertState) -> Alert
 
         run_failover_related = time.monotonic() > state.blocked_failover_alerts_until
         if run_failover_related:
-            args: tuple[list[Any], dict[str, Any]] = ([], {"connect_timeout": 2})
+            args: tuple[list[Any], dict[str, Any]] = ([], {"timeout": 2, "connect_timeout": 2})
 
             # Do not run on backup if there is a software version mismatch
             try:

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -789,7 +789,8 @@ class AuthService(Service):
             if await self.middleware.call('failover.status') == 'BACKUP':
                 try:
                     rem_status = await self.middleware.call(
-                        'failover.call_remote', 'failover.status', [], {'connect_timeout': 2}
+                        'failover.call_remote', 'failover.status', [],
+                        {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2}
                     )
                     if rem_status == 'MASTER':
                         return {


### PR DESCRIPTION
`auth.login_ex()` checks the peer controller's HA status before authenticating on a BACKUP node, but passes only `connect_timeout` to `failover.call_remote`. That option bounds the wait for the websocket to exist, not the RPC itself, so the call timeout falls back to `CALL_TIMEOUT`, which is 60 seconds.

The peer is normally rebooted during a failover, which leaves the interconnect socket half-open: `RemoteClient.connected` is still set, because `connect_and_wait()` only clears it once `c._closed` fires and that waits on the TCP window to elapse. `connected.wait(2)` therefore returns immediately and the RPC blocks for the full 60 seconds before raising `ETIMEDOUT`. `login_ex()` already catches that and falls through, so the login does succeed, just a minute late and after logging an ERROR traceback.

Passing `timeout` bounds the RPC at 2 seconds, and `raise_connect_error: False` makes `call_remote` return `None` for an expected network failure rather than raising. `None` is not `'MASTER'`, so it reaches the same fall-through as before, without the traceback.

`__get_failover_info()` in `alert.py` is missing `timeout` the same way and stalls the alert loop for 60 seconds per cycle against the same half-open peer. Only `timeout` is added there. Its four call sites read the result inside `except Exception: pass`, and three of them would change behavior on a network error if `raise_connect_error` were also flipped, because `None` compares false where the raised exception left the previous value in place.


Original PR: https://github.com/truenas/middleware/pull/19571
