### PR TITLE
NAS-142943 / 26.0.0-RC.1 / Adapt `AuthLoginExResult` to legacy API (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/auth.py
+++ b/src/middlewared/middlewared/api/v26_0_0/auth.py
@@ -331,6 +331,13 @@ class AuthLoginExResult(BaseModel):
         description="Authentication response indicating success, failure, or additional steps required.",
     )
 
+    @classmethod
+    def to_previous(cls, value: Any) -> Any:
+        if value["result"]["response_type"] in ["SCRAM_RESPONSE", "DENIED"]:
+            return {"result": {"response_type": "AUTH_ERR"}}
+
+        return value
+
 
 class AuthLoginExContinueArgs(BaseModel):
     login_data: AuthOTPToken = Field(description="OTP token data to continue two-factor authentication flow.")


### PR DESCRIPTION
`AuthRespScram` and `AuthRespDenied` were added in 26.0. They fail serialization under 25.10 API, and might not be supported by 25.10 clients.

Original PR: https://github.com/truenas/middleware/pull/19569
