### PR TITLE
NAS-142994 / 26.0.0-RC.1 / add zfs.resource.create (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import (
     BaseModel,
@@ -14,6 +14,11 @@ from .zfs_tier import TierInfo
 
 __all__ = (
     "ZFSResourceEntry",
+    "ZFSResourceCreateArgsData",
+    "ZFSResourceCreateArgs",
+    "ZFSResourceCreateEncryption",
+    "ZFSResourceCreateProperties",
+    "ZFSResourceCreateResult",
     "ZFSResourceDestroyArgsData",
     "ZFSResourceDestroyArgs",
     "ZFSResourceDestroyResult",
@@ -313,17 +318,17 @@ class ZFSResourceQuery(BaseModel):
             "the requested information is retrieved as efficiently and quickly as possible.\n"
             "\n"
             "Example 1:\n"
-            "    {\"paths\": [\"tank/foo\"]} will query the relevant information for this resource only.\n"
+            '    {"paths": ["tank/foo"]} will query the relevant information for this resource only.\n'
             "Example 2:\n"
-            "    {\"paths\": [\"tank/foo\", \"dozer/test\"]} will query the relevant information for these resources "
+            '    {"paths": ["tank/foo", "dozer/test"]} will query the relevant information for these resources '
             "only.\n"
             "\n"
             "NOTE:\n"
             "    paths must be non-overlapping if `get_children` is True.\n"
             "    (i.e. this won't work and will raise a validation error)\n"
             "        {\n"
-            "            \"paths\": [\"tank/foo1\", \"tank/foo1/foo2\"],\n"
-            "            \"get_children\": True\n"
+            '            "paths": ["tank/foo1", "tank/foo1/foo2"],\n'
+            '            "get_children": True\n'
             "        }"
         ),
     )
@@ -373,11 +378,173 @@ class ZFSResourceQuery(BaseModel):
     )
 
 
+class ZFSResourceCreateEncryption(BaseModel):
+    """Exactly one of `key`, `passphrase`, or `generate_key` must be provided."""
+
+    generate_key: bool = Field(
+        default=False,
+        description="Automatically generate a 64-character hex key for the new encryption root.",
+    )
+    key: Secret[Annotated[str, Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]+$")] | None] = Field(
+        default=None,
+        description="A 64-character hex-encoded key for the new encryption root.",
+    )
+    passphrase: Secret[Annotated[str, Field(min_length=8)] | None] = Field(
+        default=None,
+        description=(
+            "A passphrase (at least 8 characters) for the new encryption root. Passphrases are never stored by the "
+            "system. The resource can only be unlocked by someone who knows it."
+        ),
+    )
+    pbkdf2iters: int = Field(
+        ge=1_300_000,
+        le=10_000_000,
+        default=1_300_000,
+        description=(
+            "Number of PBKDF2 iterations for key derivation from the passphrase. Only meaningful together with "
+            "`passphrase`. Higher values improve resistance to brute force attacks but increase unlock time."
+        ),
+    )
+
+
+class ZFSResourceCreateProperties(BaseModel):
+    """ZFS properties that may be set at creation time.
+
+    Each field is the native ZFS property name and values are handed to ZFS verbatim.
+    A field left as null is simply not sent to ZFS so the property inherits from the parent as usual.
+    """
+
+    aclinherit: str | None = Field(
+        default=None,
+        description="ACL inheritance behavior for new files and directories.",
+    )
+    aclmode: str | None = Field(default=None, description="How ACLs are modified during chmod operations.")
+    acltype: str | None = Field(default=None, description="The type of ACL to use (off, posix, or nfsv4).")
+    atime: str | None = Field(default=None, description="Whether file access times are updated on read.")
+    casesensitivity: str | None = Field(
+        default=None,
+        description="Filename matching sensitivity. Settable at creation time only.",
+    )
+    checksum: str | None = Field(default=None, description="Checksum algorithm used to verify data integrity.")
+    compression: str | None = Field(default=None, description="Compression algorithm for the resource.")
+    copies: str | int | None = Field(default=None, description="Number of copies of data blocks to store.")
+    dedup: str | None = Field(default=None, description="Deduplication setting for the resource.")
+    exec: str | None = Field(default=None, description="Whether programs can be executed from the filesystem.")
+    quota: str | int | None = Field(
+        default=None,
+        description="Maximum space the dataset and its descendants may consume.",
+    )
+    readonly: str | None = Field(default=None, description="Whether the resource can be modified.")
+    recordsize: str | int | None = Field(default=None, description="Suggested block size for files in the filesystem.")
+    refquota: str | int | None = Field(default=None, description="Maximum space the dataset itself may consume.")
+    refreservation: str | int | None = Field(
+        default=None,
+        description="Minimum space reserved for the resource itself. Set to 'none' to create a sparse volume.",
+    )
+    reservation: str | int | None = Field(
+        default=None,
+        description="Minimum space reserved for the dataset and its descendants.",
+    )
+    snapdev: str | None = Field(default=None, description="Snapshot device visibility under /dev/zvol.")
+    snapdir: str | None = Field(default=None, description="Visibility of the .zfs/snapshot directory.")
+    special_small_blocks: str | int | None = Field(
+        default=None,
+        description="Size threshold below which blocks are stored on the SPECIAL vdev.",
+    )
+    sync: str | None = Field(default=None, description="Synchronous write behavior.")
+    volblocksize: str | int | None = Field(
+        default=None,
+        description="Block size of the volume. Settable at creation time only.",
+    )
+    volsize: str | int | None = Field(
+        default=None,
+        description="Logical size of the volume in bytes. Required when creating a VOLUME.",
+    )
+    xattr: str | None = Field(
+        default=None,
+        description="Extended attribute storage mode. Defaults to 'sa' for performance.",
+    )
+
+
+class ZFSResourceCreateArgsData(BaseModel):
+    path: NonEmptyString = Field(
+        description=(
+            "Path of the zfs resource (dataset or volume) to be created. Must be of the form 'pool/name'. It cannot "
+            "be an absolute path or end with '/'. Snapshot paths (containing '@') are not accepted one must use "
+            "`zfs.resource.snapshot.create` instead."
+        ),
+    )
+    type: Literal["FILESYSTEM", "VOLUME"] = Field(
+        default="FILESYSTEM",
+        description=(
+            "The type of ZFS resource to create. A FILESYSTEM is a mountable dataset; a VOLUME (zvol) is a virtual "
+            "block device."
+        ),
+    )
+    properties: ZFSResourceCreateProperties = Field(
+        default_factory=ZFSResourceCreateProperties,
+        description=(
+            "ZFS properties to set at creation time. Values are handed to ZFS verbatim and canonicalized by ZFS "
+            "itself. Read the returned entry for the effective values. A property left as null is simply not sent "
+            "to ZFS and inherits from the parent as usual. Any property not in this model may not be set at "
+            "creation time.\n"
+            "\n"
+            "Creating a VOLUME requires 'volsize'. Volumes are thick-provisioned by default ('refreservation' "
+            "defaults to the volsize, like `zfs create -V`). Set 'refreservation' to 'none' to create a sparse "
+            "(thin) volume.\n"
+            "\n"
+            "A FILESYSTEM defaults 'xattr' to 'sa' (a TrueNAS performance default) unless explicitly specified. An "
+            "explicit 'acltype' also defaults the coupled acl properties. An nfsv4 acltype defaults 'aclinherit' to "
+            "'passthrough' while a posix or off acltype defaults both 'aclmode' and 'aclinherit' to 'discard'.\n"
+            "\n"
+            "Encryption is configured through the `encryption` argument and shares are managed with the "
+            "`sharing.nfs` and `sharing.smb` APIs. Neither may be configured through these properties."
+        ),
+    )
+    user_properties: dict[str, str] = Field(
+        default={},
+        description=(
+            "User properties to set at creation time. Property names must contain a colon (e.g. 'org.truenas:custom')."
+        ),
+    )
+    create_ancestors: bool = Field(
+        default=False,
+        description="Create any missing ancestor filesystems.",
+    )
+    encryption: ZFSResourceCreateEncryption | None = Field(
+        default=None,
+        description=(
+            "Make the new resource its own ZFS encryption root, encrypted (aes-256-gcm) with the given key or "
+            "passphrase. When omitted (the default), the resource simply inherits its parent's encryption state. A "
+            "child of an encrypted parent is encrypted as part of the parent's encryption root, a child of an "
+            "unencrypted parent is unencrypted.\n"
+            "\n"
+            "A key-encrypted root may NOT be created beneath a passphrase-encrypted parent. Such a child could "
+            "not be unlocked while its parent is locked."
+        ),
+    )
+    bypass: Private[bool] = Field(
+        default=False,
+        description=(
+            'If true, will bypass the safety checks that prevent creating zfs resources under "protected" paths.'
+        ),
+    )
+
+
+class ZFSResourceCreateArgs(BaseModel):
+    data: ZFSResourceCreateArgsData = Field(description="Create parameters for creating a ZFS resource.")
+
+
+class ZFSResourceCreateResult(BaseModel):
+    result: ZFSResourceEntry
+
+
 class ZFSResourceDestroyArgsData(BaseModel):
     path: NonEmptyString = Field(
         description=(
-            "Path of the zfs resource (dataset or volume) to be destroyed. Snapshot paths (containing '@') are not "
-            "accepted - use `zfs.resource.snapshot.destroy` instead."
+            "Path of the zfs resource (dataset or volume) to be destroyed. Must be of the form 'pool/name'. It cannot "
+            "be an absolute path or end with '/'. Snapshot paths (containing '@') are not accepted. One must use "
+            "`zfs.resource.snapshot.destroy` instead."
         ),
     )
     recursive: bool = Field(

--- a/src/middlewared/middlewared/plugins/zfs/create_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/create_impl.py
@@ -1,0 +1,128 @@
+import pathlib
+from typing import Any, Literal
+
+import truenas_pylibzfs
+
+from .exceptions import ZFSPathAlreadyExistsException, ZFSPathNotFoundException
+from .mount_unmount_impl import mount_impl
+
+__all__ = (
+    "ZFS_INVALID_INPUT_ERRORS",
+    "ZFS_TYPE_MAP",
+    "create_impl",
+)
+
+ZFS_TYPE_MAP = {
+    "FILESYSTEM": truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+    "VOLUME": truenas_pylibzfs.ZFSType.ZFS_TYPE_VOLUME,
+}
+
+ZFS_INVALID_INPUT_ERRORS = frozenset(
+    {
+        truenas_pylibzfs.ZFSError.EZFS_BADPROP,
+        truenas_pylibzfs.ZFSError.EZFS_BADTYPE,
+        truenas_pylibzfs.ZFSError.EZFS_INVALIDNAME,
+        truenas_pylibzfs.ZFSError.EZFS_NAMETOOLONG,
+        truenas_pylibzfs.ZFSError.EZFS_PROPNONINHERIT,
+        truenas_pylibzfs.ZFSError.EZFS_PROPREADONLY,
+        truenas_pylibzfs.ZFSError.EZFS_PROPSPACE,
+        truenas_pylibzfs.ZFSError.EZFS_PROPTYPE,
+        truenas_pylibzfs.ZFSError.EZFS_VOLTOOBIG,
+    }
+)
+"""ZFSException codes from a create that mean the caller's input was the
+problem (bad property name/value/type, bad name) rather than an
+operational failure."""
+
+
+def _create_one(
+    tls: Any,
+    name: str,
+    ztype: Any,
+    properties: dict[str, str | int] | None = None,
+    user_properties: dict[str, str] | None = None,
+    encrypt: dict[str, Any] | None = None,
+) -> None:
+    kwargs: dict[str, Any] = {"name": name, "type": ztype}
+    if properties:
+        kwargs["properties"] = properties
+    if user_properties:
+        kwargs["user_properties"] = user_properties
+    if encrypt:
+        try:
+            kwargs["crypto"] = tls.lzh.resource_cryptography_config(
+                keyformat=encrypt["keyformat"],
+                key=encrypt["key"],
+                pbkdf2iters=encrypt.get("pbkdf2iters"),
+            )
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Invalid encryption configuration: {e}") from None
+    try:
+        tls.lzh.create_resource(**kwargs)
+    except truenas_pylibzfs.ZFSException as e:
+        if e.code == truenas_pylibzfs.ZFSError.EZFS_EXISTS:
+            raise ZFSPathAlreadyExistsException(name)
+        elif e.code == truenas_pylibzfs.ZFSError.EZFS_NOENT:
+            # the parent is what does not exist
+            raise ZFSPathNotFoundException(name.rsplit("/", 1)[0])
+        raise
+
+
+def _should_mount(properties: dict[str, str | int]) -> bool:
+    return properties.get("mountpoint") not in ("legacy", "none") and properties.get("canmount", "on") == "on"
+
+
+def create_impl(
+    tls: Any,
+    path: str,
+    type_: Literal["FILESYSTEM", "VOLUME"],
+    properties: dict[str, str | int],
+    user_properties: dict[str, str],
+    create_ancestors: bool,
+    encrypt: dict[str, Any] | None = None,
+) -> None:
+    """
+    Create a ZFS resource (filesystem or volume) and mount it.
+
+    Args:
+        path: The path of the zfs resource to create ('pool/name' form).
+        type_: The type of resource to create.
+        properties: ZFS properties to set at creation time, keyed by
+            native ZFS property name.
+        user_properties: ZFS user properties to set at creation time.
+        create_ancestors: Create any missing ancestor filesystems first
+            (like `zfs create -p`). Ancestors that already exist are
+            left untouched. Ancestors are always created unencrypted /
+            inheriting - `encrypt` applies to `path` only.
+        encrypt: Make `path` a new encryption root. A dict with
+            'keyformat' ('hex' or 'passphrase'), 'key' (the key material),
+            and optionally 'pbkdf2iters'. The key material travels to ZFS
+            through an in-memory key file, never through the property list.
+
+    Raises:
+        ZFSPathAlreadyExistsException: `path` already exists.
+        ZFSPathNotFoundException: the parent of `path` does not exist, or,
+            with `create_ancestors`, the pool itself does not.
+        truenas_pylibzfs.ZFSException: any other libzfs failure.
+    """
+    created_ancestors = []
+    if create_ancestors:
+        for parent in reversed(pathlib.PurePosixPath(path).parents):
+            pp = parent.as_posix()
+            if "/" not in pp:
+                # "." (no parent) or the pool's root filesystem
+                continue
+            try:
+                _create_one(tls, pp, truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM)
+            except ZFSPathAlreadyExistsException:
+                continue
+            created_ancestors.append(pp)
+
+    _create_one(tls, path, ZFS_TYPE_MAP[type_], properties, user_properties, encrypt)
+
+    # `zfs create` mounts what it creates; libzfs itself does not, so
+    # mirror the CLI behavior here.
+    for ancestor in created_ancestors:
+        mount_impl(tls, ancestor, None, False, None, False, False)
+    if type_ == "FILESYSTEM" and _should_mount(properties):
+        mount_impl(tls, path, None, False, None, False, False)

--- a/src/middlewared/middlewared/plugins/zfs/create_rules.py
+++ b/src/middlewared/middlewared/plugins/zfs/create_rules.py
@@ -1,0 +1,531 @@
+"""Validation rules for zfs.resource.create.
+
+Rules are small pure functions with a uniform signature. Each one takes
+the request model and a CreateContext of resolved values and gathered
+facts, raises a single ValidationError on a failed check, and returns
+nothing otherwise. Rules never perform I/O. The service calls them
+explicitly and in order from its create_impl so the control flow reads
+top to bottom in one place. When a rule needs a new fact the service
+gathers it and the context grows a field. The draid and dedup tiering
+functions also take the service since they must inspect the pool
+themselves.
+"""
+
+import dataclasses
+import errno
+import os
+import pathlib
+import typing
+
+import truenas_pylibzfs
+
+from middlewared.service_exception import ValidationError
+from middlewared.utils.crypto import generate_token
+
+from .create_impl import ZFS_TYPE_MAP
+from .utils import has_internal_path
+
+if typing.TYPE_CHECKING:
+    from middlewared.api.current import ZFSResourceCreateArgsData, ZFSResourceCreateProperties
+
+__all__ = (
+    "CreateContext",
+    "ancestor_chain",
+    "apply_draid_recordsize",
+    "apply_draid_volblocksize",
+    "apply_tier_snap",
+    "apply_volume_ssb_pin",
+    "check_acl_combination",
+    "check_dedup_tiering",
+    "check_encryption",
+    "check_name_valid",
+    "check_parent_not_readonly",
+    "check_path_shape",
+    "check_protected_path",
+    "check_tier_managed_ssb",
+    "check_user_property_names",
+    "check_volume_capacity",
+    "check_volume_has_volsize",
+    "resolve_create_request",
+)
+
+SCHEMA = "zfs.resource.create"
+
+_POSIX_OR_OFF_ACLTYPES = frozenset({"posix", "posixacl", "off", "noacl"})
+"""The native acltype values (aliases included) that are not nfsv4."""
+
+
+@dataclasses.dataclass(slots=True, kw_only=True)
+class CreateContext:
+    """Resolved values and gathered facts that the rules read."""
+
+    properties: "ZFSResourceCreateProperties"
+    """Effective zfs properties after creation defaults are applied. A
+    field left as None is not sent to ZFS."""
+    encrypt: dict[str, typing.Any] | None
+    """Resolved encryption config when a new encryption root is requested."""
+    ancestors: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
+    """Existing ancestors of the new resource keyed by name with the
+    properties the active rules read. Populated by the service. A missing
+    ancestor has no entry."""
+    tier_enabled: bool = False
+    """Whether ZFS tiering is enabled on this system."""
+    # TODO uncomment when the truenas.entitlements API is merged
+    # dedup_entitled: bool = False
+    # """Whether this system is licensed to use ZFS deduplication."""
+
+
+def ancestor_chain(path: str) -> list[str]:
+    """Return the ancestors of `path` ordered nearest first."""
+    return [i.as_posix() for i in pathlib.PurePosixPath(path).parents if i.as_posix() != "."]
+
+
+def _secret_value(value: typing.Any) -> str | None:
+    # an unset Secret field holds Secret(None), not None
+    return value.get_secret_value() if value else None
+
+
+def _size_bytes(value: str | int) -> int | None:
+    """Parse a zfs block size value into bytes. Returns None when the
+    value is not understood so the library can judge it instead."""
+    if isinstance(value, int):
+        return value
+    value = value.strip().upper().removesuffix("B")
+    multiplier = 1
+    if value and value[-1] in ("K", "M"):
+        multiplier = 1024 if value[-1] == "K" else 1024 * 1024
+        value = value[:-1]
+    try:
+        return int(value) * multiplier
+    except ValueError:
+        return None
+
+
+def _nearest_ancestor_entry(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> typing.Any | None:
+    """Return the gathered entry of the nearest existing ancestor."""
+    for ancestor in ancestor_chain(data.path):
+        rv = ctx.ancestors.get(ancestor)
+        if rv is not None:
+            return rv
+    return None
+
+
+def _pool_has_special_vdev(service: typing.Any, pool_name: str) -> bool:
+    """Return whether the pool has a SPECIAL allocation class vdev."""
+    if pool := service.middleware.call_sync(
+        "zpool.query_impl", {"pool_names": [pool_name], "properties": ["class_special_size"]}
+    ):
+        size = ((pool[0].get("properties") or {}).get("class_special_size") or {}).get("value")
+        return isinstance(size, int) and size > 0
+    return False
+
+
+def pool_is_draid(service: typing.Any, pool_name: str) -> bool:
+    """Return whether the pool stores data on dRAID vdevs."""
+    if pool := service.middleware.call_sync("zpool.query_impl", {"pool_names": [pool_name], "topology": True}):
+        for group in pool[0]["topology"]["data"] + pool[0]["topology"].get("special", []):
+            if group["vdev_type"].startswith("draid"):
+                return True
+    return False
+
+
+def apply_draid_recordsize(service: typing.Any, data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Default a filesystem on a dRAID pool to a 1M recordsize.
+
+    Small blocks perform poorly on dRAID vdevs. Matches the default
+    pool.dataset applies.
+
+    The service calls this only for filesystems without an explicit
+    recordsize.
+    """
+    if pool_is_draid(service, data.path.split("/")[0]):
+        ctx.properties.recordsize = "1M"
+
+
+def apply_draid_volblocksize(service: typing.Any, data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Apply the dRAID volume block size default and floor.
+
+    Small blocks perform poorly on dRAID vdevs. A volume defaults to a
+    128K volblocksize and an explicitly requested volblocksize must be
+    at least 32K. These match the defaults pool.dataset applies.
+
+    The service calls this only for volumes.
+    """
+    if not pool_is_draid(service, data.path.split("/")[0]):
+        return
+    if ctx.properties.volblocksize is None:
+        ctx.properties.volblocksize = "128K"
+    elif (parsed := _size_bytes(ctx.properties.volblocksize)) is not None and parsed < 32768:
+        raise ValidationError(
+            f"{SCHEMA}.properties",
+            "Volume block size must be greater than or equal to 32K for dRAID pools.",
+            errno.EINVAL,
+        )
+
+
+def resolve_create_request(
+    data: "ZFSResourceCreateArgsData",
+) -> tuple["ZFSResourceCreateProperties", dict[str, typing.Any] | None]:
+    """Apply creation defaults and resolve the requested encryption.
+
+    Returns a copy of the requested properties with the creation
+    defaults applied and the resolved encryption config. The encryption
+    config is None when no encryption root is requested or when the
+    request provides no key material at all. The rules judge the request
+    afterwards so nothing here raises.
+    """
+    properties = data.properties.model_copy()
+    if data.type == "VOLUME":
+        if properties.volsize is not None and properties.refreservation is None:
+            # thick provision unless told otherwise, like `zfs create -V`.
+            # NOTE the CLI sets refreservation=auto (volsize plus metadata
+            # overhead) but libzfs cannot resolve "auto" through our create
+            # path, so reserve the volsize itself
+            properties.refreservation = properties.volsize
+    else:
+        if properties.xattr is None:
+            # its important to set this as "sa" for performance reasons
+            properties.xattr = "sa"
+        acltype = str(properties.acltype or "").lower()
+        if acltype == "nfsv4":
+            # inherited ACL entries must pass through or chmod strips them
+            if properties.aclinherit is None:
+                properties.aclinherit = "passthrough"
+        elif acltype in _POSIX_OR_OFF_ACLTYPES:
+            # a non discard aclmode can prevent the ZFS_ACL_TRIVIAL flag from
+            # being set which results in spurious permission errors
+            if properties.aclmode is None:
+                properties.aclmode = "discard"
+            if properties.aclinherit is None:
+                properties.aclinherit = "discard"
+
+    encrypt = None
+    if data.encryption:
+        passphrase = _secret_value(data.encryption.passphrase)
+        key = _secret_value(data.encryption.key)
+        if passphrase is not None:
+            encrypt = {
+                "keyformat": "passphrase",
+                "key": passphrase,
+                "pbkdf2iters": data.encryption.pbkdf2iters,
+            }
+        elif data.encryption.generate_key:
+            encrypt = {"keyformat": "hex", "key": generate_token(32)}
+        elif key is not None:
+            encrypt = {"keyformat": "hex", "key": key}
+    return properties, encrypt
+
+
+def check_path_shape(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """The path must be a relative pool/resource path and not a snapshot."""
+    if os.path.isabs(data.path):
+        raise ValidationError(
+            SCHEMA,
+            "Absolute path is invalid. Must be in form of <pool>/<resource>.",
+            errno.EINVAL,
+        )
+    elif data.path.endswith("/"):
+        raise ValidationError(SCHEMA, "Path must not end with a forward-slash.", errno.EINVAL)
+    elif "@" in data.path:
+        raise ValidationError(
+            SCHEMA,
+            "Use `zfs.resource.snapshot.create` to create snapshots.",
+        )
+    elif "/" not in data.path:
+        raise ValidationError(
+            SCHEMA,
+            "Creating a root filesystem (zpool) is not allowed.",
+            errno.EINVAL,
+        )
+
+
+def check_protected_path(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Internal paths may only be touched by internal callers."""
+    # NOTE `bypass` is a value only exposed to internal
+    # callers and not to our public API
+    if not data.bypass and has_internal_path(data.path):
+        raise ValidationError(SCHEMA, f"{data.path!r} is a protected path.", errno.EACCES)
+
+
+def check_name_valid(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """The name must be acceptable to ZFS for the requested type and may
+    not end with a space."""
+    if not truenas_pylibzfs.name_is_valid(name=data.path, type=ZFS_TYPE_MAP[data.type]):
+        raise ValidationError(SCHEMA, f"{data.path!r} is not a valid ZFS resource name.", errno.EINVAL)
+    elif data.path.endswith(" "):
+        # ZFS itself accepts a trailing space but it is a classic footgun
+        raise ValidationError(SCHEMA, "Trailing spaces are not permitted in resource names.", errno.EINVAL)
+
+
+def check_user_property_names(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """User property names must contain a colon."""
+    for key in data.user_properties:
+        if ":" not in key:
+            raise ValidationError(
+                f"{SCHEMA}.user_properties",
+                f"{key!r} is not a valid user property name (must contain a colon).",
+                errno.EINVAL,
+            )
+
+
+def check_volume_has_volsize(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """A volume cannot be created without a size.
+
+    The service calls this only for volumes.
+    """
+    if ctx.properties.volsize is None:
+        raise ValidationError(
+            f"{SCHEMA}.properties",
+            "'volsize' is required when creating a VOLUME.",
+            errno.EINVAL,
+        )
+
+
+def check_parent_not_readonly(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """The nearest existing ancestor must not be readonly.
+
+    ZFS allows creating beneath a readonly parent but the new filesystem
+    then fails to mount and a new volume fails on first write. Refuse up
+    front with a clear message instead.
+
+    The service calls this after the ancestor entries have been gathered.
+    """
+    for ancestor in ancestor_chain(data.path):
+        rv = ctx.ancestors.get(ancestor)
+        if rv is None:
+            # a missing ancestor is created (or rejected) later
+            continue
+        if rv["properties"]["readonly"]["raw"] == "on":
+            raise ValidationError(
+                SCHEMA,
+                f"Turn off readonly mode on {ancestor!r} to create {data.path!r}.",
+                errno.EINVAL,
+            )
+        return
+
+
+def check_tier_managed_ssb(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """The tier manager owns special_small_blocks while tiering is enabled.
+
+    The service calls this only when tiering is enabled.
+    """
+    if data.properties.special_small_blocks is not None:
+        raise ValidationError(
+            f"{SCHEMA}.properties",
+            "ZFS tiering is enabled. Use `zfs.tier.dataset_set_tier` to manage 'special_small_blocks'.",
+            errno.EINVAL,
+        )
+
+
+def apply_tier_snap(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Pin a new filesystem to its parent's effective tier.
+
+    That is 16M when the parent places data on the special vdev
+    (PERFORMANCE) and 0 otherwise (REGULAR). This keeps the tier manager
+    the owner of placement instead of floating inheritance.
+
+    The service calls this only for filesystems that do not request
+    special_small_blocks while tiering is enabled and after the ancestor
+    entries have been gathered.
+    """
+    parent = _nearest_ancestor_entry(data, ctx)
+    if parent is None:
+        return
+    parent_ssb = parent["properties"]["special_small_blocks"]["value"] or 0
+    parent_rs = parent["properties"]["recordsize"]["value"] or 0
+    performance = parent_rs > 0 and parent_ssb >= parent_rs
+    ctx.properties.special_small_blocks = 16 * 1024 * 1024 if performance else 0
+
+
+def apply_volume_ssb_pin(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Pin special_small_blocks to 0 for a volume below the threshold.
+
+    A volume whose blocks are smaller than the parent's threshold would
+    land entirely on the special vdev so it is pinned to 0 regardless of
+    tiering.
+
+    The service calls this only for volumes that do not request
+    special_small_blocks and after the ancestor entries have been
+    gathered.
+    """
+    parent = _nearest_ancestor_entry(data, ctx)
+    if parent is None:
+        return
+    parent_ssb = parent["properties"]["special_small_blocks"]["value"] or 0
+    volblocksize = _size_bytes(ctx.properties.volblocksize or 16384) or 16384
+    if parent_ssb and volblocksize < parent_ssb:
+        ctx.properties.special_small_blocks = 0
+
+
+def check_dedup_tiering(service: typing.Any, data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Deduplication may not be enabled on a PERFORMANCE tier filesystem.
+
+    With tiering enabled a filesystem whose effective special_small_blocks
+    is above zero has its data placed on the special vdev and such data
+    may not be deduplicated. The pool topology is only inspected once the
+    cheaper conditions have passed.
+
+    The service calls this only for filesystems that request a dedup
+    value other than off while tiering is enabled and after the tier
+    placement has been applied.
+    """
+    ssb = ctx.properties.special_small_blocks
+    if ssb is None:
+        parent = _nearest_ancestor_entry(data, ctx)
+        ssb = (parent["properties"]["special_small_blocks"]["value"] or 0) if parent else 0
+    else:
+        ssb = _size_bytes(ssb) or 0
+    if not ssb:
+        return
+    if not _pool_has_special_vdev(service, data.path.split("/")[0]):
+        return
+    raise ValidationError(
+        f"{SCHEMA}.properties",
+        "ZFS deduplication is incompatible with tiering and cannot be enabled on a "
+        "dataset assigned to the PERFORMANCE tier (its data is placed on the SPECIAL "
+        "vdev). Switch it to the REGULAR tier first.",
+        errno.EINVAL,
+    )
+
+
+def _effective_value(name: str, data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> str | None:
+    """Return the lowercased effective value of a property. That is the
+    requested value or the value inherited from the nearest existing
+    ancestor."""
+    value = getattr(ctx.properties, name)
+    if value is None:
+        for ancestor in ancestor_chain(data.path):
+            rv = ctx.ancestors.get(ancestor)
+            if rv is not None:
+                value = rv["properties"][name]["raw"]
+                break
+    return str(value).lower() if value is not None else None
+
+
+def check_acl_combination(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """The requested acl properties must form a usable combination.
+
+    The effective acltype and aclmode (the requested value or the value
+    inherited from the nearest existing ancestor) are checked together.
+    A posix or off acltype requires a discard aclmode and a discard
+    aclmode strips nfsv4 acls on chmod.
+
+    The service calls this only for filesystems that request acltype or
+    aclmode and after the ancestor entries have been gathered.
+    """
+    acltype = _effective_value("acltype", data, ctx)
+    aclmode = _effective_value("aclmode", data, ctx)
+    if acltype in _POSIX_OR_OFF_ACLTYPES and aclmode != "discard":
+        raise ValidationError(
+            f"{SCHEMA}.properties",
+            "'aclmode' must be discard when the effective 'acltype' is posix or off.",
+            errno.EINVAL,
+        )
+    elif acltype == "nfsv4" and aclmode == "discard":
+        raise ValidationError(
+            f"{SCHEMA}.properties",
+            "A discard 'aclmode' may not be used with the nfsv4 'acltype'.",
+            errno.EINVAL,
+        )
+
+
+def check_volume_capacity(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """A volume reservation may not consume more than 80% of the available space.
+
+    The effective refreservation (the volsize for a thick volume) is
+    compared against the available space of the nearest existing
+    ancestor. Sparse volumes reserve nothing so they are exempt, which
+    makes oversubscription a deliberate request rather than a force
+    flag. The check is skipped when the reservation is not expressed in
+    bytes since the library validates values itself.
+
+    The service calls this only for volumes and after the ancestor
+    entries have been gathered.
+    """
+    try:
+        reservation = int(ctx.properties.refreservation or 0)
+    except ValueError:
+        # a word value like none means the volume is sparse and reserves nothing
+        return
+
+    for ancestor in ancestor_chain(data.path):
+        rv = ctx.ancestors.get(ancestor)
+        if rv is None:
+            # a missing ancestor is created (or rejected) later
+            continue
+        if reservation > rv["properties"]["available"]["value"] * 0.8:
+            raise ValidationError(
+                f"{SCHEMA}.properties",
+                "The requested refreservation would consume more than 80% of the "
+                f"available space on {ancestor!r}. Reduce volsize or create a sparse "
+                "volume by setting refreservation to none.",
+                errno.EINVAL,
+            )
+        return
+
+
+def check_encryption(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Validate a request to create a new encryption root.
+
+    Exactly one source of key material must be provided. The existing
+    ancestors are then walked nearest first since only the nearest
+    encrypted ancestor (if any) matters. An encryption root may not be
+    created beneath an unencrypted dataset that itself sits inside an
+    encrypted one and a key encrypted root may not be created beneath a
+    passphrase encrypted parent since it could not be unlocked while its
+    parent is locked.
+
+    The service calls this only when `data.encryption` is set and after
+    the ancestor entries have been gathered.
+    """
+    # narrow the optional type for mypy. The service only calls this
+    # when an encryption root is requested
+    assert data.encryption is not None
+
+    provided = [
+        name
+        for name, value in (
+            ("key", _secret_value(data.encryption.key)),
+            ("passphrase", _secret_value(data.encryption.passphrase)),
+        )
+        if value is not None
+    ]
+    if data.encryption.generate_key:
+        provided.append("generate_key")
+    if len(provided) != 1:
+        raise ValidationError(
+            f"{SCHEMA}.encryption",
+            "Exactly one of `key`, `passphrase`, or `generate_key` must be provided.",
+            errno.EINVAL,
+        )
+
+    # the resolved encryption config exists once exactly one source of
+    # key material was provided
+    assert ctx.encrypt is not None
+
+    seen_unencrypted = False
+    for ancestor in ancestor_chain(data.path):
+        rv = ctx.ancestors.get(ancestor)
+        if rv is None:
+            # a missing ancestor is created (or rejected) later
+            continue
+        if rv["properties"]["encryption"]["raw"] == "off":
+            seen_unencrypted = True
+            continue
+        if seen_unencrypted:
+            raise ValidationError(
+                f"{SCHEMA}.encryption",
+                "Creating an encryption root beneath an unencrypted dataset "
+                f"that is itself inside encrypted dataset {ancestor!r} is not "
+                "allowed.",
+                errno.EINVAL,
+            )
+        if ctx.encrypt["keyformat"] == "hex" and rv["properties"]["keyformat"]["raw"] == "passphrase":
+            raise ValidationError(
+                f"{SCHEMA}.encryption.key",
+                f"{ancestor!r} is encrypted with a passphrase; a key-encrypted "
+                "child cannot be created beneath it because it could not be "
+                "unlocked while its parent is locked. Use a passphrase instead.",
+                errno.EINVAL,
+            )
+        break

--- a/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
@@ -4,10 +4,29 @@ from typing import Any
 
 import truenas_pylibzfs
 
+from middlewared.utils.filesystem import attrs as fs_attrs
+
 from .exceptions import ZFSPathHasClonesException, ZFSPathHasHoldsException
 from .utils import open_resource
 
 __all__ = ("destroy_impl",)
+
+
+def _remove_mountpoint_dir(mountpoint: str) -> None:
+    """Remove the destroyed resource's now-unused mountpoint directory.
+
+    The lock flow marks a locked dataset's mountpoint immutable, so clear
+    that first or the rmdir fails and the directory lingers. All failures
+    are silently ignored, which mimics upstream zfs.
+    """
+    try:
+        fs_attrs.set_zfs_file_attributes_dict(mountpoint, {"immutable": False})
+    except Exception:
+        pass
+    try:
+        os.rmdir(mountpoint)
+    except Exception:
+        pass
 
 
 def destroy_nonrecursive_impl(tls: Any, path: str, defer: bool) -> tuple[str | None, int | None]:
@@ -46,12 +65,7 @@ def destroy_nonrecursive_impl(tls: Any, path: str, defer: bool) -> tuple[str | N
         else:
             mntpnt = rsrc.get_properties(properties={truenas_pylibzfs.ZFSProperty.MOUNTPOINT})
             if mntpnt.mountpoint.value != "legacy":
-                try:
-                    os.rmdir(mntpnt.mountpoint.value)
-                except Exception:
-                    # silently ignore rmdir ops
-                    # which mimics upstream zfs
-                    pass
+                _remove_mountpoint_dir(mntpnt.mountpoint.value)
 
     # Both ZFS_TYPE_FILESYSTEM and ZFS_TYPE_VOLUME
     try:
@@ -159,11 +173,6 @@ def destroy_impl(
                 failed += f" ({truenas_pylibzfs.ZFSError(errnum)})"
     else:
         for i in mntpnts:
-            try:
-                os.rmdir(i.mountpoint.value)
-            except Exception:
-                # silently ignore rmdir ops
-                # which mimics upstream zfs
-                pass
+            _remove_mountpoint_dir(i.mountpoint.value)
 
     return failed, errnum

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -3,10 +3,15 @@ import os
 import pathlib
 import typing
 
+import truenas_pylibzfs
+
 from middlewared.api import api_method
 from middlewared.api.current import (
-    ZFSResourceDestroyArgsData,
+    ZFSResourceCreateArgs,
+    ZFSResourceCreateArgsData,
+    ZFSResourceCreateResult,
     ZFSResourceDestroyArgs,
+    ZFSResourceDestroyArgsData,
     ZFSResourceDestroyResult,
     ZFSResourceEntry,
     ZFSResourceQuery,
@@ -16,10 +21,32 @@ from middlewared.api.current import (
 )
 from middlewared.plugins.zfs.snapshot_crud import ZFSResourceSnapshotService
 from middlewared.service import Service, private
-from middlewared.service_exception import ValidationError
 from middlewared.service.decorators import pass_thread_local_storage
+from middlewared.service_exception import CallError, ValidationError
 from middlewared.utils.filter_list import filter_list
 
+from .create_impl import ZFS_INVALID_INPUT_ERRORS, create_impl
+from .create_rules import (
+    CreateContext,
+    ancestor_chain,
+    apply_draid_recordsize,
+    apply_draid_volblocksize,
+    apply_tier_snap,
+    apply_volume_ssb_pin,
+    check_acl_combination,
+    check_dedup_tiering,
+    # check_dedup_entitlement,  TODO uncomment when the truenas.entitlements API is merged
+    check_encryption,
+    check_name_valid,
+    check_parent_not_readonly,
+    check_path_shape,
+    check_protected_path,
+    check_tier_managed_ssb,
+    check_user_property_names,
+    check_volume_capacity,
+    check_volume_has_volsize,
+    resolve_create_request,
+)
 from .destroy_impl import destroy_impl
 from .object_count_impl import estimate_object_count_impl
 from .exceptions import (
@@ -104,9 +131,7 @@ class ZFSResourceService(Service):
         try:
             promote_impl(tls, current_name)
         except ZFSPathInvalidException:
-            raise ValidationError(
-                schema, f"{current_name!r} is ineligible for promotion."
-            )
+            raise ValidationError(schema, f"{current_name!r} is ineligible for promotion.")
         except ZFSPathNotProvidedException:
             raise ValidationError(schema, "'current_name' key is required")
         except ZFSPathNotFoundException as e:
@@ -276,9 +301,7 @@ class ZFSResourceService(Service):
                 "Use `zfs.resource.snapshot.rename` to rename snapshots.",
             )
         try:
-            rename_impl(
-                tls, current_name, new_name, recursive, no_unmount, force_unmount
-            )
+            rename_impl(tls, current_name, new_name, recursive, no_unmount, force_unmount)
         except ZFSPathNotASnapshotException:
             raise ValidationError(schema, "recursive is only valid for snapshots")
         except ZFSPathAlreadyExistsException as e:
@@ -365,6 +388,253 @@ class ZFSResourceService(Service):
 
     @private
     @pass_thread_local_storage
+    def create_impl(self, tls: typing.Any, data: ZFSResourceCreateArgsData) -> dict[str, typing.Any]:
+        """
+        Internal implementation for creating a ZFS resource.
+
+        Validates the path and properties, creates the resource (and any
+        requested ancestors), mounts it, and returns the created resource
+        re-queried from ZFS.
+        """
+        schema = "zfs.resource.create"
+        path = data.path
+        properties, encrypt = resolve_create_request(data)
+        ctx = CreateContext(properties=properties, encrypt=encrypt)
+
+        check_path_shape(data, ctx)
+        check_protected_path(data, ctx)
+        check_name_valid(data, ctx)
+        check_user_property_names(data, ctx)
+
+        ctx.tier_enabled = self.call_sync2(self.s.zfs.tier.config).enabled
+
+        # one query serves the readonly, tier, acl, capacity and encryption
+        # rules. Only the properties the rules below will read are requested.
+        ancestor_props = ["readonly"]
+        if data.type == "VOLUME":
+            ancestor_props.extend(["available", "special_small_blocks"])
+        else:
+            if properties.acltype is not None or properties.aclmode is not None:
+                ancestor_props.extend(["acltype", "aclmode"])
+            if ctx.tier_enabled and data.properties.special_small_blocks is None:
+                ancestor_props.extend(["special_small_blocks", "recordsize"])
+        if data.encryption:
+            ancestor_props.append("encryption")
+        ctx.ancestors = {
+            rv["name"]: rv
+            for rv in self.call_sync2(
+                self.s.zfs.resource.query_impl,
+                ZFSResourceQuery(paths=ancestor_chain(path), properties=ancestor_props),
+            )
+        }
+
+        check_parent_not_readonly(data, ctx)
+        if ctx.tier_enabled:
+            check_tier_managed_ssb(data, ctx)
+
+        if data.type == "VOLUME":
+            check_volume_has_volsize(data, ctx)
+            apply_draid_volblocksize(self, data, ctx)
+            if properties.special_small_blocks is None:
+                apply_volume_ssb_pin(data, ctx)
+            check_volume_capacity(data, ctx)
+        else:
+            if properties.recordsize is None:
+                apply_draid_recordsize(self, data, ctx)
+            if ctx.tier_enabled and properties.special_small_blocks is None:
+                apply_tier_snap(data, ctx)
+            if ctx.tier_enabled and str(properties.dedup or "off").lower() != "off":
+                check_dedup_tiering(self, data, ctx)
+            if properties.acltype is not None or properties.aclmode is not None:
+                check_acl_combination(data, ctx)
+
+        if data.encryption:
+            check_encryption(data, ctx)
+
+        # TODO uncomment when the truenas.entitlements API is merged
+        # from truenas_pylicensed.features import LicenseFeature
+        # if str(properties.dedup or "off").lower() != "off":
+        #     ctx.dedup_entitled = self.call_sync2(self.s.truenas.entitlements.check, LicenseFeature.DEDUP).entitled
+        #     check_dedup_entitlement(data, ctx)
+
+        props = {k: v for k, v in properties.model_dump().items() if v is not None}
+        try:
+            create_impl(tls, path, data.type, props, data.user_properties, data.create_ancestors, encrypt)
+        except truenas_pylibzfs.ZFSException as e:
+            if e.code in ZFS_INVALID_INPUT_ERRORS:
+                raise ValidationError(schema, str(e), errno.EINVAL)
+            elif e.code == truenas_pylibzfs.ZFSError.EZFS_CRYPTOFAILED:
+                raise CallError(
+                    f"Failed to create {path!r}: the parent's encryption key is not "
+                    "loaded. Unlock the parent dataset and try again.",
+                    errno.EACCES,
+                )
+            raise CallError(f"Failed to create {path!r}: {e}")
+
+        if encrypt:
+            # Hex keys are stored by the system (passphrases deliberately are
+            # not) so unlock/export/KMIP flows work; the post_create hook syncs
+            # key material to the standby controller on HA systems. The
+            # storage_encrypteddataset table remains the system of record for
+            # dataset keys.
+            self.middleware.call_sync(
+                "pool.dataset.insert_or_update_encrypted_record",
+                {"name": path, "encryption_key": encrypt["key"], "key_format": encrypt["keyformat"]},
+            )
+            self.middleware.call_hook_sync(
+                "dataset.post_create",
+                {
+                    "encrypted": True,
+                    "name": path,
+                    "encryption_key": encrypt["key"],
+                    "key_format": encrypt["keyformat"],
+                },
+            )
+
+        requested = any(v is not None for v in data.properties.model_dump().values())
+        report_props = list(props) if requested else []
+        if encrypt:
+            report_props.append("encryption")
+        return self.call_sync2(
+            self.s.zfs.resource.query_impl,
+            ZFSResourceQuery(
+                paths=[path],
+                properties=report_props,
+                get_user_properties=bool(data.user_properties),
+            ),
+        )[0]
+
+    @api_method(
+        ZFSResourceCreateArgs,
+        ZFSResourceCreateResult,
+        roles=["ZFS_RESOURCE_WRITE"],
+        check_annotations=True,
+    )
+    def create(self, data: ZFSResourceCreateArgsData) -> ZFSResourceEntry:
+        """
+        Create a ZFS resource (filesystem or volume) and mount it.
+
+        Properties are given by native ZFS property name - exactly the names
+        :method:`zfs.resource.query` returns - and are handed to ZFS as-is. The created
+        resource is re-queried after creation and returned, so the entry reflects the
+        values as canonicalized by ZFS, not the input.
+
+        To create snapshots, use :method:`zfs.resource.snapshot.create` instead.
+
+        Invalid input is returned to the client as a JSON-RPC ``error`` response (code
+        ``-32602``, *Invalid params*); each failing condition appears in the error's
+        ``data.extra`` array with its own ``errno``. A validation error is raised when:
+
+        - a snapshot path (containing ``@``) is supplied
+          (use :method:`zfs.resource.snapshot.create`)
+        - the resource already exists (``EEXIST``)
+        - the pool, or the parent dataset when ``create_ancestors`` is ``false``, does
+          not exist (``ENOENT``)
+        - the target is a pool root filesystem, the path is absolute, ends with ``/``,
+          or is not a valid ZFS name (``EINVAL``)
+        - the path references a protected internal resource (``EACCES``)
+        - a property outside the allowed creation set is supplied, or an allowed
+          property is invalid for the resource type or has an invalid value
+          (``EINVAL``)
+        - an encryption or ZFS native sharing property is supplied through
+          ``properties``, ``volsize`` is missing for a VOLUME, or a user property name
+          lacks a colon (``EINVAL``)
+        - ``encryption`` provides a hex key beneath a passphrase-encrypted parent, or
+          would create an encryption root beneath an unencrypted dataset that itself
+          sits inside an encrypted one (``EINVAL``)
+        - a thick volume's reservation would consume more than 80% of the available
+          space - create a sparse volume (``refreservation`` of ``none``) to
+          deliberately oversubscribe (``EINVAL``)
+        - the effective ``acltype`` and ``aclmode`` combination is unusable - a posix
+          or off acltype requires a discard aclmode and a discard aclmode may not be
+          combined with the nfsv4 acltype (``EINVAL``)
+        - the nearest existing ancestor is readonly - the new filesystem could not be
+          mounted beneath it (``EINVAL``)
+        - ``special_small_blocks`` is supplied while ZFS tiering is enabled - placement
+          is managed with :method:`zfs.tier.dataset_set_tier` (``EINVAL``)
+        - deduplication is requested for a filesystem whose data would be placed on the
+          SPECIAL vdev (the PERFORMANCE tier) while ZFS tiering is enabled (``EINVAL``)
+
+        Examples:
+
+        Create a filesystem:
+
+        .. code:: json
+
+            {"path": "tank/documents"}
+
+        Create a filesystem with properties, creating missing ancestors:
+
+        .. code:: json
+
+            {
+                "path": "tank/a/b/documents",
+                "properties": {"compression": "lz4", "atime": "off"},
+                "create_ancestors": true
+            }
+
+        Create a sparse 10GiB volume:
+
+        .. code:: json
+
+            {
+                "path": "tank/vol1",
+                "type": "VOLUME",
+                "properties": {"volsize": 10737418240, "refreservation": "none"}
+            }
+
+        Create an encryption root with a generated key:
+
+        .. code:: json
+
+            {"path": "tank/secure", "encryption": {"generate_key": true}}
+
+        Create an encryption root protected by a passphrase:
+
+        .. code:: json
+
+            {"path": "tank/private", "encryption": {"passphrase": "correct horse battery staple"}}
+
+        .. note::
+
+            Volumes are thick-provisioned by default (``refreservation`` defaults to
+            the volsize, like ``zfs create -V``); set ``refreservation`` to ``none``
+            for a sparse volume. Filesystems default ``xattr`` to ``sa``.
+
+        .. note::
+
+            A resource created under an encrypted parent inherits that encryption
+            unless ``encryption`` makes it its own encryption root - an unencrypted
+            child cannot be created beneath an encrypted parent. The parent's
+            encryption key must be loaded (unlocked) or the creation fails with a
+            JSON-RPC ``error`` response (code ``-32001``, *Method call error*, errno
+            ``EACCES``).
+
+        .. note::
+
+            Hex keys (provided or generated) are stored by the system and may be
+            retrieved with :method:`pool.dataset.export_key`; passphrases are never
+            stored.
+        """
+        schema = "zfs.resource.create"
+        try:
+            return ZFSResourceEntry(**self.call_sync2(self.s.zfs.resource.create_impl, data))
+        except ZFSPathAlreadyExistsException as e:
+            raise ValidationError(schema, e.message, errno.EEXIST)
+        except ZFSPathNotFoundException as e:
+            missing = e.args[0]
+            if "/" not in missing:
+                msg = f"Pool {missing!r} does not exist."
+            elif data.create_ancestors:
+                msg = f"Parent dataset {missing!r} does not exist."
+            else:
+                msg = f"Parent dataset {missing!r} does not exist. Set create_ancestors to create it."
+            raise ValidationError(schema, msg, errno.ENOENT)
+        except ValueError as e:
+            raise ValidationError(schema, str(e), errno.EINVAL)
+
+    @private
+    @pass_thread_local_storage
     def destroy_impl(
         self,
         tls: typing.Any,
@@ -398,15 +668,11 @@ class ZFSResourceService(Service):
                 errno.EINVAL,
             )
         elif path.endswith("/"):
-            raise ValidationError(
-                schema, "Path must not end with a forward-slash.", errno.EINVAL
-            )
+            raise ValidationError(schema, "Path must not end with a forward-slash.", errno.EINVAL)
         elif not bypass and has_internal_path(path):
             # NOTE: `bypass` is a value only exposed to
             # internal callers and not to our public API.
-            raise ValidationError(
-                schema, f"{path!r} is a protected path.", errno.EACCES
-            )
+            raise ValidationError(schema, f"{path!r} is a protected path.", errno.EACCES)
 
         if "@" in path:
             raise ValidationError(
@@ -416,9 +682,7 @@ class ZFSResourceService(Service):
 
         tmp = path.split("/")
         if len(tmp) == 1 or tmp[-1] == "":
-            raise ValidationError(
-                schema, "Destroying the root filesystem is not allowed.", errno.EINVAL
-            )
+            raise ValidationError(schema, "Destroying the root filesystem is not allowed.", errno.EINVAL)
 
         if not recursive:
             rv = self.call_sync2(
@@ -429,18 +693,15 @@ class ZFSResourceService(Service):
             if not rv:
                 raise ValidationError(schema, f"{path!r} does not exist.", errno.ENOENT)
             elif len(rv) > 1:
-                raise ValidationError(
-                    schema, f"{path!r} has children. {extra}", errno.ENOTEMPTY
-                )
+                raise ValidationError(schema, f"{path!r} has children. {extra}", errno.ENOTEMPTY)
             else:
                 # Check if dataset has snapshots using snapshot.count
                 snap_counts = self.call_sync2(
-                    self.s.zfs.resource.snapshot.count, ZFSResourceSnapshotCountQuery(paths=[path]),
+                    self.s.zfs.resource.snapshot.count,
+                    ZFSResourceSnapshotCountQuery(paths=[path]),
                 )
                 if snap_counts.get(path, 0) > 0:
-                    raise ValidationError(
-                        schema, f"{path!r} has snapshots. {extra}", errno.ENOTEMPTY
-                    )
+                    raise ValidationError(schema, f"{path!r} has snapshots. {extra}", errno.ENOTEMPTY)
 
         return destroy_impl(tls, path, recursive, all_snapshots, bypass, defer)
 
@@ -561,9 +822,6 @@ class ZFSResourceService(Service):
             query({"paths": ["tank"], "nest_results": True, "get_children": True})
         """
         try:
-            return [
-                ZFSResourceEntry(**resource)
-                for resource in self.call_sync2(self.s.zfs.resource.query_impl, data)
-            ]
+            return [ZFSResourceEntry(**resource) for resource in self.call_sync2(self.s.zfs.resource.query_impl, data)]
         except ZFSPathNotFoundException as e:
             raise ValidationError("zfs.resource.query", e.message, errno.ENOENT)

--- a/tests/api2/test_zfs_resource_create.py
+++ b/tests/api2/test_zfs_resource_create.py
@@ -1,0 +1,793 @@
+import os
+
+import pytest
+from auto_config import pool_name
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call, ssh
+
+GiB = 1024**3
+
+
+def destroy(path: str):
+    call("zfs.resource.destroy", {"path": path, "recursive": True})
+
+
+def test_zfs_resource_create_basic_filesystem():
+    """Test basic filesystem creation returns the created entry and mounts it"""
+    path = os.path.join(pool_name, "test_create_fs_basic")
+    try:
+        entry = call("zfs.resource.create", {"path": path})
+        assert entry["name"] == path
+        assert entry["pool"] == pool_name
+        assert entry["type"] == "FILESYSTEM"
+
+        result = call("zfs.resource.query", {"paths": [path], "properties": ["mounted", "xattr"]})
+        assert len(result) == 1
+        assert result[0]["properties"]["mounted"]["raw"] == "yes"
+        # TrueNAS defaults xattr to sa on filesystems
+        assert result[0]["properties"]["xattr"]["raw"] == "sa"
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_with_properties():
+    """Test that native property names are accepted and returned canonicalized"""
+    path = os.path.join(pool_name, "test_create_fs_props")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {
+                "path": path,
+                "properties": {
+                    "compression": "lz4",
+                    "atime": "off",
+                    "recordsize": "1M",
+                },
+            },
+        )
+        props = entry["properties"]
+        assert props["compression"]["raw"] == "lz4"
+        assert props["atime"]["raw"] == "off"
+        # "1M" is canonicalized by ZFS to its byte value
+        assert props["recordsize"]["value"] == 1024**2
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_volume_thick_by_default():
+    """Test volume creation is thick provisioned unless refreservation is given"""
+    path = os.path.join(pool_name, "test_create_zvol_thick")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {"path": path, "type": "VOLUME", "properties": {"volsize": GiB}},
+        )
+        assert entry["type"] == "VOLUME"
+        assert entry["properties"]["volsize"]["value"] == GiB
+        assert entry["properties"]["refreservation"]["value"] == GiB
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_volume_sparse():
+    """Test sparse volume creation via refreservation=none"""
+    path = os.path.join(pool_name, "test_create_zvol_sparse")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {
+                "path": path,
+                "type": "VOLUME",
+                "properties": {"volsize": GiB, "refreservation": "none"},
+            },
+        )
+        assert entry["type"] == "VOLUME"
+        assert entry["properties"]["refreservation"]["value"] in (0, None)
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_volume_capacity_guardrail():
+    """Test that a thick volume reserving over 80% of the available space is
+    rejected while a sparse volume of the same size is allowed"""
+    avail = call("zfs.resource.query", {"paths": [pool_name], "properties": ["available"]})
+    volsize = (int(avail[0]["properties"]["available"]["value"] * 0.9) // 16384) * 16384
+    path = os.path.join(pool_name, "test_create_zvol_capacity")
+    try:
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": path, "type": "VOLUME", "properties": {"volsize": volsize}},
+            )
+        assert "create a sparse volume" in str(exc_info.value)
+
+        entry = call(
+            "zfs.resource.create",
+            {
+                "path": path,
+                "type": "VOLUME",
+                "properties": {"volsize": volsize, "refreservation": "none"},
+            },
+        )
+        assert entry["properties"]["volsize"]["value"] == volsize
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_volume_requires_volsize():
+    """Test that creating a VOLUME without volsize fails"""
+    path = os.path.join(pool_name, "test_create_zvol_novolsize")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "type": "VOLUME"})
+    assert "volsize" in str(exc_info.value)
+
+
+def test_zfs_resource_create_with_user_properties():
+    """Test user properties are set at creation time"""
+    path = os.path.join(pool_name, "test_create_fs_uprops")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {"path": path, "user_properties": {"org.test:canary": "value1"}},
+        )
+        assert entry["user_properties"]["org.test:canary"] == "value1"
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_invalid_user_property_name():
+    """Test that user property names without a colon are rejected"""
+    path = os.path.join(pool_name, "test_create_fs_bad_uprop")
+    with pytest.raises(Exception) as exc_info:
+        call(
+            "zfs.resource.create",
+            {"path": path, "user_properties": {"nocolon": "value"}},
+        )
+    assert "colon" in str(exc_info.value).lower()
+
+
+def test_zfs_resource_create_ancestors():
+    """Test creating missing ancestors like `zfs create -p`"""
+    root = os.path.join(pool_name, "test_create_anc")
+    path = os.path.join(root, "a/b/c")
+    try:
+        entry = call("zfs.resource.create", {"path": path, "create_ancestors": True})
+        assert entry["name"] == path
+
+        result = call(
+            "zfs.resource.query",
+            {"paths": [root], "get_children": True, "properties": ["mounted"]},
+        )
+        assert len(result) == 4
+        assert all(i["properties"]["mounted"]["raw"] == "yes" for i in result)
+    finally:
+        destroy(root)
+
+
+def test_zfs_resource_create_missing_parent_fails():
+    """Test that a missing parent without create_ancestors fails with a helpful message"""
+    parent = os.path.join(pool_name, "test_create_noparent")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": os.path.join(parent, "child")})
+    emsg = str(exc_info.value)
+    assert f"Parent dataset {parent!r} does not exist" in emsg
+    assert "create_ancestors" in emsg
+
+
+@pytest.mark.parametrize(
+    "path,create_ancestors",
+    [
+        pytest.param("nonexistent_pool_xyz123/child", False, id="without create_ancestors"),
+        # a deep path so the failure comes from ancestor creation
+        pytest.param("nonexistent_pool_xyz123/a/b", True, id="with create_ancestors"),
+    ],
+)
+def test_zfs_resource_create_missing_pool_fails(path, create_ancestors):
+    """Test that a nonexistent pool fails with a clear message, with and without create_ancestors"""
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "create_ancestors": create_ancestors})
+    assert "Pool 'nonexistent_pool_xyz123' does not exist" in str(exc_info.value)
+
+
+def test_zfs_resource_create_already_exists():
+    """Test that creating an existing resource fails"""
+    path = os.path.join(pool_name, "test_create_exists")
+    try:
+        call("zfs.resource.create", {"path": path})
+        with pytest.raises(Exception) as exc_info:
+            call("zfs.resource.create", {"path": path})
+        assert "already exists" in str(exc_info.value).lower()
+    finally:
+        destroy(path)
+
+
+@pytest.mark.parametrize(
+    "path,error",
+    [
+        pytest.param("/tank/dataset", "absolute", id="absolute paths not allowed"),
+        pytest.param("tank/dataset/", "forward-slash", id="trailing forward-slash not allowed"),
+        pytest.param(
+            "tank/dataset@snap",
+            "zfs.resource.snapshot.create",
+            id="snapshot paths not allowed",
+        ),
+        pytest.param("tank", "root filesystem", id="creating root filesystem not allowed"),
+        pytest.param("boot-pool/test", "protected", id="protected paths not allowed"),
+        pytest.param(
+            "tank/dataset ",
+            "not a valid ZFS resource name",
+            id="trailing space not allowed",
+        ),
+    ],
+)
+def test_zfs_resource_create_validation_errors(path, error):
+    """Test various path validation errors"""
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path})
+    assert error in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "prop",
+    ["notaprop", "used", "canmount", "mountpoint", "logbias", "primarycache", "sparse"],
+)
+def test_zfs_resource_create_property_outside_allowed_set(prop):
+    """Test that any property outside the allowed creation set is rejected"""
+    path = os.path.join(pool_name, "test_create_fs_badprop")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "properties": {prop: "on"}})
+    assert "Extra inputs are not permitted" in str(exc_info.value)
+
+
+def test_zfs_resource_create_property_invalid_for_type():
+    """Test that volume-only properties are rejected on filesystems"""
+    path = os.path.join(pool_name, "test_create_fs_volprop")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "properties": {"volsize": GiB}})
+    assert "invalid for zfs type" in str(exc_info.value)
+
+
+def test_zfs_resource_create_encryption_property_denied():
+    """Test that encryption properties are rejected by the schema"""
+    path = os.path.join(pool_name, "test_create_fs_crypto")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "properties": {"encryption": "on"}})
+    assert "Extra inputs are not permitted" in str(exc_info.value)
+
+
+@pytest.mark.skip(reason="enable when the truenas.entitlements API is merged and the dedup license check is active")
+def test_zfs_resource_create_dedup_requires_license():
+    """Test that enabling deduplication requires the DEDUP license entitlement"""
+    path = os.path.join(pool_name, "test_create_fs_dedup")
+    if call("truenas.entitlements.check", "DEDUP")["entitled"]:
+        try:
+            entry = call("zfs.resource.create", {"path": path, "properties": {"dedup": "on"}})
+            assert entry["properties"]["dedup"]["raw"] == "on"
+        finally:
+            destroy(path)
+    else:
+        with pytest.raises(Exception) as exc_info:
+            call("zfs.resource.create", {"path": path, "properties": {"dedup": "on"}})
+        assert "not licensed" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("prop", ["sharenfs", "sharesmb"])
+def test_zfs_resource_create_sharing_property_denied(prop):
+    """Test that ZFS native sharing properties are rejected by the schema"""
+    path = os.path.join(pool_name, "test_create_fs_sharing")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "properties": {prop: "on"}})
+    assert "Extra inputs are not permitted" in str(exc_info.value)
+
+
+def test_zfs_resource_create_encryption_root_with_key():
+    """Test creating an encryption root with an explicit hex key; the key is stored by the system"""
+    path = os.path.join(pool_name, "test_create_enc_key")
+    key = "0123456789abcdef" * 4
+    try:
+        entry = call("zfs.resource.create", {"path": path, "encryption": {"key": key}})
+        props = entry["properties"]
+        assert props["encryption"]["raw"] != "off", props
+        assert props["encryptionroot"]["raw"] == path, props
+        assert props["keyformat"]["raw"] == "hex", props
+        assert props["keystatus"]["raw"] == "available", props
+        assert call("pool.dataset.export_key", path, job=True) == key
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_encryption_root_generate_key():
+    """Test creating an encryption root with a generated key retrievable via export_key"""
+    path = os.path.join(pool_name, "test_create_enc_genkey")
+    try:
+        entry = call("zfs.resource.create", {"path": path, "encryption": {"generate_key": True}})
+        assert entry["properties"]["keyformat"]["raw"] == "hex", entry["properties"]
+        key = call("pool.dataset.export_key", path, job=True)
+        assert len(key) == 64
+        int(key, 16)  # valid hex
+    finally:
+        destroy(path)
+
+
+def test_zfs_resource_create_encryption_root_passphrase():
+    """Test creating a passphrase encryption root that the legacy lock flow can lock"""
+    path = os.path.join(pool_name, "test_create_enc_pass")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {"path": path, "encryption": {"passphrase": "passphrase123"}},
+        )
+        props = entry["properties"]
+        assert props["keyformat"]["raw"] == "passphrase", props
+        assert props["encryptionroot"]["raw"] == path, props
+        res = call("zfs.resource.query", {"paths": [path], "properties": ["pbkdf2iters"]})
+        assert res[0]["properties"]["pbkdf2iters"]["value"] == 1300000, res[0]["properties"]
+        assert call("pool.dataset.lock", path, job=True) is True
+    finally:
+        destroy(path)
+
+
+@pytest.mark.parametrize(
+    "encryption",
+    [
+        pytest.param({}, id="nothing provided"),
+        pytest.param({"key": "0" * 64, "passphrase": "passphrase123"}, id="key and passphrase"),
+        pytest.param(
+            {"generate_key": True, "passphrase": "passphrase123"},
+            id="generate_key and passphrase",
+        ),
+        pytest.param({"passphrase": "short"}, id="short passphrase"),
+        pytest.param({"key": "notahexkey"}, id="invalid key"),
+        pytest.param({"key": "0" * 63}, id="wrong key length"),
+        pytest.param(
+            {"passphrase": "passphrase123", "pbkdf2iters": 1000},
+            id="pbkdf2iters too low",
+        ),
+        pytest.param(
+            {"passphrase": "passphrase123", "pbkdf2iters": 100_000_000},
+            id="pbkdf2iters too high",
+        ),
+    ],
+)
+def test_zfs_resource_create_encryption_shape_errors(encryption):
+    """Test invalid encryption option combinations are rejected"""
+    path = os.path.join(pool_name, "test_create_enc_invalid")
+    with pytest.raises(ValidationErrors):
+        call("zfs.resource.create", {"path": path, "encryption": encryption})
+
+
+def test_zfs_resource_create_key_child_under_passphrase_parent():
+    """Test that a key-encrypted root is denied beneath a passphrase parent while a
+    passphrase root is allowed"""
+    parent = os.path.join(pool_name, "test_create_pass_parent")
+    call(
+        "zfs.resource.create",
+        {"path": parent, "encryption": {"passphrase": "passphrase123"}},
+    )
+    try:
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{parent}/keychild", "encryption": {"generate_key": True}},
+            )
+        assert "encrypted with a passphrase" in str(exc_info.value)
+
+        child = f"{parent}/passchild"
+        entry = call(
+            "zfs.resource.create",
+            {"path": child, "encryption": {"passphrase": "passphrase456"}},
+        )
+        assert entry["properties"]["encryptionroot"]["raw"] == child, entry["properties"]
+    finally:
+        destroy(parent)
+
+
+def test_zfs_resource_create_encryption_sandwich_denied():
+    """Test that an encryption root cannot be created beneath an unencrypted dataset
+    that itself sits inside an encrypted one"""
+    root = os.path.join(pool_name, "test_create_sandwich")
+    key_file = "/tmp/test_create_sandwich.key"
+    # enc -> unenc ancestry can only be built outside the API
+    ssh(
+        f"echo -n {'0' * 64} > {key_file} && "
+        f"zfs create -o encryption=on -o keyformat=hex -o keylocation=file://{key_file} {root} && "
+        f"zfs create -o encryption=off {root}/unenc"
+    )
+    try:
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{root}/unenc/child", "encryption": {"generate_key": True}},
+            )
+        assert "beneath an unencrypted dataset" in str(exc_info.value)
+    finally:
+        destroy(root)
+        ssh(f"rm -f {key_file}")
+
+
+def test_zfs_resource_create_under_encrypted_parent():
+    """Test that a child of an encrypted parent inherits the encryption and
+    that an unencrypted child cannot be created beneath it"""
+    parent = os.path.join(pool_name, "test_create_enc_parent")
+    call(
+        "zfs.resource.create",
+        {"path": parent, "encryption": {"passphrase": "passphrase123"}},
+    )
+    try:
+        child = f"{parent}/child"
+        call("zfs.resource.create", {"path": child})
+        props = call("zfs.resource.query", {"paths": [child], "properties": ["encryption"]})[0]["properties"]
+        assert props["encryption"]["raw"] != "off", props
+        assert props["encryptionroot"]["raw"] == parent, props
+        assert props["keystatus"]["raw"] == "available", props
+
+        # the only way ZFS allows an unencrypted child (encryption=off) is denied
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{parent}/child2", "properties": {"encryption": "off"}},
+            )
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+    finally:
+        destroy(parent)
+
+
+def test_zfs_resource_create_under_locked_parent_fails():
+    """Test that creating beneath a locked encrypted parent fails with a clear message"""
+    parent = os.path.join(pool_name, "test_create_locked_parent")
+    call(
+        "zfs.resource.create",
+        {"path": parent, "encryption": {"passphrase": "passphrase123"}},
+    )
+    try:
+        call("pool.dataset.lock", parent, job=True)
+        with pytest.raises(Exception) as exc_info:
+            call("zfs.resource.create", {"path": f"{parent}/child"})
+        emsg = str(exc_info.value)
+        assert "encryption key is not loaded" in emsg
+        assert "Unlock the parent dataset" in emsg
+    finally:
+        destroy(parent)
+
+
+@pytest.fixture(scope="module")
+def draid_pool():
+    unused_disks = call("disk.get_unused")
+    if len(unused_disks) < 2:
+        pytest.skip("Insufficient number of unused disks for a dRAID pool")
+    with another_pool(
+        {
+            "name": "test_zr_draid",
+            "topology": {
+                "data": [
+                    {
+                        "disks": [disk["name"] for disk in unused_disks[:2]],
+                        "type": "DRAID1",
+                        "draid_data_disks": 1,
+                    }
+                ],
+            },
+            "allow_duplicate_serials": True,
+        }
+    ) as pool:
+        yield pool
+
+
+def test_zfs_resource_create_draid_filesystem_recordsize_default(draid_pool):
+    """Test that a filesystem on a dRAID pool defaults to a 1M recordsize"""
+    path = f"{draid_pool['name']}/fs"
+    call("zfs.resource.create", {"path": path})
+    result = call("zfs.resource.query", {"paths": [path], "properties": ["recordsize"]})
+    assert result[0]["properties"]["recordsize"]["value"] == 1024**2, result[0]["properties"]
+
+
+def test_zfs_resource_create_draid_volume_volblocksize_default(draid_pool):
+    """Test that a volume on a dRAID pool defaults to a 128K volblocksize"""
+    path = f"{draid_pool['name']}/vol"
+    call(
+        "zfs.resource.create",
+        {
+            "path": path,
+            "type": "VOLUME",
+            "properties": {"volsize": 128 * 1024**2, "refreservation": "none"},
+        },
+    )
+    result = call("zfs.resource.query", {"paths": [path], "properties": ["volblocksize"]})
+    assert result[0]["properties"]["volblocksize"]["value"] == 128 * 1024, result[0]["properties"]
+
+
+def test_zfs_resource_create_draid_volume_small_volblocksize_rejected(draid_pool):
+    """Test that a volblocksize under 32K is rejected on a dRAID pool"""
+    path = f"{draid_pool['name']}/vol_small"
+    with pytest.raises(Exception) as exc_info:
+        call(
+            "zfs.resource.create",
+            {
+                "path": path,
+                "type": "VOLUME",
+                "properties": {
+                    "volsize": 128 * 1024**2,
+                    "volblocksize": "16K",
+                    "refreservation": "none",
+                },
+            },
+        )
+    assert "32K" in str(exc_info.value)
+
+    entry = call(
+        "zfs.resource.create",
+        {
+            "path": path,
+            "type": "VOLUME",
+            "properties": {
+                "volsize": 128 * 1024**2,
+                "volblocksize": "32K",
+                "refreservation": "none",
+            },
+        },
+    )
+    assert entry["properties"]["volblocksize"]["value"] == 32768, entry["properties"]
+
+
+def test_zfs_resource_create_acl_normalization():
+    """Test that an explicit acltype defaults the coupled acl properties"""
+    path = os.path.join(pool_name, "test_create_fs_acl_posix")
+    try:
+        entry = call("zfs.resource.create", {"path": path, "properties": {"acltype": "posix"}})
+        props = entry["properties"]
+        assert props["acltype"]["raw"] == "posix", props
+        assert props["aclmode"]["raw"] == "discard", props
+        assert props["aclinherit"]["raw"] == "discard", props
+    finally:
+        destroy(path)
+
+    path = os.path.join(pool_name, "test_create_fs_acl_nfsv4")
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {
+                "path": path,
+                "properties": {"acltype": "nfsv4", "aclmode": "passthrough"},
+            },
+        )
+        props = entry["properties"]
+        assert props["acltype"]["raw"] == "nfsv4", props
+        assert props["aclinherit"]["raw"] == "passthrough", props
+    finally:
+        destroy(path)
+
+
+@pytest.mark.parametrize(
+    "properties,error",
+    [
+        pytest.param(
+            {"acltype": "nfsv4", "aclmode": "discard"},
+            "nfsv4",
+            id="nfsv4 with discard aclmode",
+        ),
+        pytest.param(
+            {"acltype": "posix", "aclmode": "passthrough"},
+            "posix or off",
+            id="posix with non discard aclmode",
+        ),
+    ],
+)
+def test_zfs_resource_create_acl_invalid_combinations(properties, error):
+    """Test that unusable acltype and aclmode combinations are rejected"""
+    path = os.path.join(pool_name, "test_create_fs_acl_bad")
+    with pytest.raises(Exception) as exc_info:
+        call("zfs.resource.create", {"path": path, "properties": properties})
+    assert error in str(exc_info.value)
+
+
+def test_zfs_resource_create_acl_effective_from_parent():
+    """Test that a missing acl property resolves from the nearest existing ancestor"""
+    parent = os.path.join(pool_name, "test_create_acl_parent")
+    call("zfs.resource.create", {"path": parent})
+    try:
+        # the parent's effective aclmode is the zfs default of discard
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{parent}/child", "properties": {"acltype": "nfsv4"}},
+            )
+        assert "nfsv4" in str(exc_info.value)
+
+        # the parent's effective acltype is the zfs default of off
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{parent}/child", "properties": {"aclmode": "passthrough"}},
+            )
+        assert "posix or off" in str(exc_info.value)
+    finally:
+        destroy(parent)
+
+    parent = os.path.join(pool_name, "test_create_acl_parent_nfsv4")
+    call(
+        "zfs.resource.create",
+        {"path": parent, "properties": {"acltype": "nfsv4", "aclmode": "passthrough"}},
+    )
+    try:
+        entry = call(
+            "zfs.resource.create",
+            {"path": f"{parent}/child", "properties": {"acltype": "nfsv4"}},
+        )
+        assert entry["properties"]["aclinherit"]["raw"] == "passthrough", entry["properties"]
+    finally:
+        destroy(parent)
+
+
+def test_zfs_resource_create_under_readonly_parent_fails():
+    """Test that creating beneath a readonly parent is refused up front"""
+    parent = os.path.join(pool_name, "test_create_ro_parent")
+    call("zfs.resource.create", {"path": parent, "properties": {"readonly": "on"}})
+    try:
+        with pytest.raises(Exception) as exc_info:
+            call("zfs.resource.create", {"path": f"{parent}/child"})
+        assert f"Turn off readonly mode on {parent!r}" in str(exc_info.value)
+
+        # the nearest existing ancestor is checked when creating ancestors too
+        with pytest.raises(Exception) as exc_info:
+            call(
+                "zfs.resource.create",
+                {"path": f"{parent}/a/b", "create_ancestors": True},
+            )
+        assert "readonly" in str(exc_info.value)
+    finally:
+        destroy(parent)
+
+
+def test_zfs_resource_create_ssb_behavior_without_tiering():
+    """Test special_small_blocks passthrough, volume pinning and filesystem
+    inheritance while tiering is disabled"""
+    if call("zfs.tier.config")["enabled"]:
+        pytest.skip("ZFS tiering is enabled on this system")
+
+    parent = os.path.join(pool_name, "test_create_ssb_parent")
+    # explicit special_small_blocks passes straight through to zfs
+    entry = call(
+        "zfs.resource.create",
+        {"path": parent, "properties": {"special_small_blocks": "128K"}},
+    )
+    assert entry["properties"]["special_small_blocks"]["value"] == 128 * 1024, entry["properties"]
+    try:
+        # a volume with blocks under the parent threshold is pinned to zero
+        vol = f"{parent}/vol"
+        call(
+            "zfs.resource.create",
+            {
+                "path": vol,
+                "type": "VOLUME",
+                "properties": {"volsize": 128 * 1024**2, "refreservation": "none"},
+            },
+        )
+        result = call(
+            "zfs.resource.query",
+            {
+                "paths": [vol],
+                "properties": ["special_small_blocks"],
+                "get_source": True,
+            },
+        )
+        prop = result[0]["properties"]["special_small_blocks"]
+        assert prop["value"] in (0, None), prop
+        assert prop["source"]["type"] == "LOCAL", prop
+
+        # a volume with blocks at the threshold inherits as usual
+        vol2 = f"{parent}/vol2"
+        call(
+            "zfs.resource.create",
+            {
+                "path": vol2,
+                "type": "VOLUME",
+                "properties": {
+                    "volsize": 128 * 1024**2,
+                    "volblocksize": "128K",
+                    "refreservation": "none",
+                },
+            },
+        )
+        result = call(
+            "zfs.resource.query",
+            {
+                "paths": [vol2],
+                "properties": ["special_small_blocks"],
+                "get_source": True,
+            },
+        )
+        prop = result[0]["properties"]["special_small_blocks"]
+        assert prop["value"] == 128 * 1024, prop
+        assert prop["source"]["type"] == "INHERITED", prop
+
+        # a filesystem is not pinned when tiering is disabled
+        fs = f"{parent}/fs"
+        call("zfs.resource.create", {"path": fs})
+        result = call(
+            "zfs.resource.query",
+            {"paths": [fs], "properties": ["special_small_blocks"], "get_source": True},
+        )
+        prop = result[0]["properties"]["special_small_blocks"]
+        assert prop["source"]["type"] == "INHERITED", prop
+    finally:
+        destroy(parent)
+
+
+@pytest.fixture(scope="module")
+def tier_pool():
+    if not call("system.is_enterprise"):
+        pytest.skip("ZFS tiering requires an Enterprise license")
+    unused_disks = call("disk.get_unused")
+    if len(unused_disks) < 6:
+        pytest.skip("Need at least 6 unused disks for a tier pool")
+    with another_pool(
+        {
+            "topology": {
+                "data": [{"type": "RAIDZ1", "disks": [d["name"] for d in unused_disks[:3]]}],
+                "special": [{"type": "RAIDZ1", "disks": [d["name"] for d in unused_disks[3:6]]}],
+            },
+            "allow_duplicate_serials": True,
+        }
+    ) as pool:
+        original = call("zfs.tier.config")
+        call("zfs.tier.update", {"enabled": True})
+        try:
+            yield pool["name"]
+        finally:
+            call("zfs.tier.update", {"enabled": original["enabled"]})
+
+
+def test_zfs_resource_create_tier_managed_ssb_denied(tier_pool):
+    """Test that special_small_blocks is rejected while tiering is enabled"""
+    with pytest.raises(Exception) as exc_info:
+        call(
+            "zfs.resource.create",
+            {"path": f"{tier_pool}/x", "properties": {"special_small_blocks": "64K"}},
+        )
+    assert "zfs.tier.dataset_set_tier" in str(exc_info.value)
+
+
+def test_zfs_resource_create_tier_snaps_filesystem_placement(tier_pool):
+    """Test that a new filesystem is pinned to its parent's effective tier"""
+    # the pool root is REGULAR so the child pins to zero
+    fs = f"{tier_pool}/tier_fs"
+    call("zfs.resource.create", {"path": fs})
+    result = call(
+        "zfs.resource.query",
+        {"paths": [fs], "properties": ["special_small_blocks"], "get_source": True},
+    )
+    prop = result[0]["properties"]["special_small_blocks"]
+    assert prop["value"] in (0, None), prop
+    assert prop["source"]["type"] == "LOCAL", prop
+
+    # a PERFORMANCE parent pins the child to 16M
+    ssh(f"zfs set special_small_blocks=16M {fs}")
+    child = f"{fs}/child"
+    call("zfs.resource.create", {"path": child})
+    result = call(
+        "zfs.resource.query",
+        {"paths": [child], "properties": ["special_small_blocks"], "get_source": True},
+    )
+    prop = result[0]["properties"]["special_small_blocks"]
+    assert prop["value"] == 16 * 1024**2, prop
+    assert prop["source"]["type"] == "LOCAL", prop
+
+
+def test_zfs_resource_create_tier_dedup_denied_on_performance(tier_pool):
+    """Test that dedup is rejected beneath a PERFORMANCE parent but allowed on REGULAR"""
+    parent = f"{tier_pool}/dedup_parent"
+    call("zfs.resource.create", {"path": parent})
+    ssh(f"zfs set special_small_blocks=16M {parent}")
+    with pytest.raises(Exception) as exc_info:
+        call(
+            "zfs.resource.create",
+            {"path": f"{parent}/child", "properties": {"dedup": "on"}},
+        )
+    assert "PERFORMANCE tier" in str(exc_info.value)
+
+    entry = call(
+        "zfs.resource.create",
+        {"path": f"{tier_pool}/dedup_ok", "properties": {"dedup": "on"}},
+    )
+    assert entry["properties"]["dedup"]["raw"] == "on", entry["properties"]

--- a/tests/api2/test_zfs_resource_destroy.py
+++ b/tests/api2/test_zfs_resource_destroy.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, ssh
 
 from auto_config import pool_name
 
@@ -45,8 +45,13 @@ def test_zfs_resource_destroy_recursive_filesystem():
     """Test recursive deletion of filesystem hierarchy"""
     root_name = "test_fs_recursive"
     root = create_resource(root_name)
-    create_resource(os.path.join(root_name, "lvl0/lvl1/lvl2/lvl3"), {"create_ancestors": True})
-    result = call("zfs.resource.query", {"paths": [root], "get_children": True, "properties": None})
+    create_resource(
+        os.path.join(root_name, "lvl0/lvl1/lvl2/lvl3"), {"create_ancestors": True}
+    )
+    result = call(
+        "zfs.resource.query",
+        {"paths": [root], "get_children": True, "properties": None},
+    )
     assert len(result) == 5
     call("zfs.resource.destroy", {"path": root, "recursive": True})
     result = call("zfs.resource.query", {"paths": [root]})
@@ -56,7 +61,7 @@ def test_zfs_resource_destroy_recursive_filesystem():
 def test_zfs_resource_destroy_volume():
     """Test deletion of zvols"""
     vol = "test_zvol"
-    args = {"type": "VOLUME", "sparse": True, "volsize": 1024 ** 3}
+    args = {"type": "VOLUME", "sparse": True, "volsize": 1024**3}
     zvol = create_resource(vol, args)
     result = call("zfs.resource.query", {"paths": [zvol]})
     assert len(result) == 1
@@ -88,7 +93,10 @@ def test_zfs_resource_destroy_with_clone():
     snap = "snap"
     call("zfs.resource.snapshot.create", {"dataset": source, "name": snap})
     clone_name = os.path.join(source.split("/")[0], "test_fs_clone")
-    call("zfs.resource.snapshot.clone", {"snapshot": f"{source}@{snap}", "dataset": clone_name})
+    call(
+        "zfs.resource.snapshot.clone",
+        {"snapshot": f"{source}@{snap}", "dataset": clone_name},
+    )
     # Try to destroy source dataset without removing clone (should fail)
     with pytest.raises(Exception) as exc_info:
         call("zfs.resource.destroy", {"path": source})
@@ -143,11 +151,15 @@ def test_zfs_resource_destroy_non_recursive_with_snapshots_fails():
 @pytest.mark.parametrize(
     "path,error",
     [
-        pytest.param("tank", "root filesystem", id="delete root filesystem not allowed"),
+        pytest.param(
+            "tank", "root filesystem", id="delete root filesystem not allowed"
+        ),
         pytest.param("/tank/dataset", "absolute", id="absolute paths not allowed"),
         pytest.param("tank/dataset/", "slash", id="trailing forward-slash not allowed"),
-        pytest.param("tank/nonexistent_dataset_xyz123", "not exist", id="dataset doesnt exist")
-    ]
+        pytest.param(
+            "tank/nonexistent_dataset_xyz123", "not exist", id="dataset doesnt exist"
+        ),
+    ],
 )
 def test_zfs_resource_destroy_validation_errors(path, error):
     """Test various validation errors"""
@@ -155,6 +167,19 @@ def test_zfs_resource_destroy_validation_errors(path, error):
     with pytest.raises(Exception) as exc_info:
         call("zfs.resource.destroy", {"path": path})
     assert error in str(exc_info.value).lower()
+
+
+def test_zfs_resource_destroy_locked_dataset_removes_mountpoint():
+    """Test that destroying a locked dataset removes its mountpoint directory,
+    which the lock flow marked immutable"""
+    path = os.path.join(pool_name, "test_destroy_locked")
+    call(
+        "zfs.resource.create",
+        {"path": path, "encryption": {"passphrase": "passphrase123"}},
+    )
+    assert call("pool.dataset.lock", path, job=True) is True
+    call("zfs.resource.destroy", {"path": path})
+    assert ssh(f"test -d /mnt/{path} && echo exists || echo gone").strip() == "gone"
 
 
 def test_zfs_resource_destroy_complex_hierarchy():
@@ -165,14 +190,17 @@ def test_zfs_resource_destroy_complex_hierarchy():
     branch1 = "/".join([f"branch1_{i}" for i in range(1, 4)])
     branch2 = "/".join([f"branch2_{i}" for i in range(1, 4)])
     br1 = create_resource(os.path.join(lvl0, branch1), {"create_ancestors": True})
-    br1 = br1.removeprefix(f'{pool_name}/')
-    args = {"type": "VOLUME", "sparse": True, "volsize": 1024 ** 3}
+    br1 = br1.removeprefix(f"{pool_name}/")
+    args = {"type": "VOLUME", "sparse": True, "volsize": 1024**3}
     create_resource(f"{br1}/zv1", args)
     br2 = create_resource(os.path.join(lvl0, branch2), {"create_ancestors": True})
-    br2 = br2.removeprefix(f'{pool_name}/')
+    br2 = br2.removeprefix(f"{pool_name}/")
     zv2 = create_resource(f"{br2}/zv2", args)
     snap1 = "snap1"
-    call("zfs.resource.snapshot.create", {"dataset": root, "name": snap1, "recursive": True})
+    call(
+        "zfs.resource.snapshot.create",
+        {"dataset": root, "name": snap1, "recursive": True},
+    )
     snap2 = "snap2"
     call("zfs.resource.snapshot.create", {"dataset": zv2, "name": snap2})
 
@@ -183,6 +211,6 @@ def test_zfs_resource_destroy_complex_hierarchy():
             "paths": [root],
             "properties": None,
             "get_children": True,
-        }
+        },
     )
     assert len(result) == 0


### PR DESCRIPTION
This adds zfs.resource.create, a from scratch replacement for pool.dataset.create built on the three layer design already used by destroy and query. The biggest simplification is in what we accept from the API consumer. Instead of uppercase enum fields, INHERIT sentinel strings, a sparse flag, and a translation table mapping api names to real names, the consumer now sends native ZFS property names with verbatim CLI values and we hand them straight to libzfs, so an omitted property simply inherits and the returned entry shows what ZFS actually canonicalized. The allowed property set from pool.dataset is carried over as a single frozenset, and everything outside it, including the encryption and sharing families, is denied with a message pointing at the right API. Encryption roots are created through a typed sub model that takes exactly one of a hex key, a passphrase, or generate_key, derives keyformat itself, persists hex keys for the unlock and KMIP flows, and never lets key material travel through generic properties. All of the old product guardrails were carried over as small explicit rule functions in create_rules.py, covering the thick volume 80 percent capacity check where sparse is the deliberate escape hatch instead of a force_size flag, dRAID recordsize and volblocksize defaults, acl combination validation with coupled aclinherit defaults, a readonly parent pre flight, and the tiering placement plus dedup rules. Validation is fail fast with a single query gathering only the ancestor properties the active rules will read. Everything is covered by API tests in tests/api2/test_zfs_resource_create.py and was verified live against a running system throughout.

Original PR: https://github.com/truenas/middleware/pull/19580
