### PR TITLE
NAS-142768 / 26.0.0-RC.1 / Check API key user roles through privilege API (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/api_key.py
+++ b/src/middlewared/middlewared/api/v26_0_0/api_key.py
@@ -37,7 +37,9 @@ class ApiKeyEntry(BaseModel):
         default=None,
         description="Expiration timestamp for the API key or `null` for no expiration.",
     )
-    local: bool = Field(description="Whether this API key is for local system use only.")
+    local: bool = Field(
+        description="Whether the API key belongs to a local user account rather than a directory services one.",
+    )
     revoked: bool = Field(description="Whether the API key has been revoked and is no longer valid.")
     revoked_reason: str | None = Field(description="Reason for API key revocation or `null` if not revoked.")
 

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -408,6 +408,37 @@ class PrivilegeService(CRUDService):
         return compose
 
     @private
+    async def roles_for_user(self, username):
+        """
+        Return the roles currently granted to `username` by evaluating its
+        group membership as reported by NSS.
+
+        Directory services cache entries are not authoritative for privilege
+        determination. They carry no group membership, because populating it
+        while enumerating the domain would require a group lookup per account
+        and overload the domain controller, and so `user.query` reports an
+        empty `roles` list for every directory services account. Anything that
+        determines privilege must go directly through NSS the way that
+        authentication does.
+        """
+        try:
+            user_obj = await self.middleware.call('user.get_user_obj', {
+                'username': username, 'get_groups': True
+            })
+        except KeyError:
+            return []
+
+        privileges = await self.privileges_for_groups(
+            'local_groups' if user_obj['local'] else 'ds_groups',
+            # synthetic accounts (container root) have no group list
+            user_obj['grouplist'] or []
+        )
+        if not privileges:
+            return []
+
+        return sorted((await self.compose_privilege(privileges))['roles'])
+
+    @private
     async def full_privilege(self):
         return {
             'roles': {'FULL_ADMIN'},

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -12,6 +12,7 @@ from middlewared.api.current import (
     ApiKeyConvertRawKeyArgs, ApiKeyConvertRawKeyResult,
 )
 from middlewared.plugins.auth_.login_ex_impl import login_ex_api_key_plain
+from middlewared.plugins.idmap_.idmap_constants import BASE_SYNTHETIC_DATASTORE_ID
 from middlewared.service import CRUDService, pass_app, private, ValidationErrors
 from middlewared.service_exception import CallError
 import middlewared.sqlalchemy as sa
@@ -65,6 +66,27 @@ class ApiKeyService(CRUDService):
 
         by_id = {x['id']: x['username'] for x in users}
 
+        # Keys for directory services accounts that have no SID (plain LDAP)
+        # are stored by the `user.query` id synthesized from the account's UID,
+        # which the local user table cannot resolve. Look each distinct one up
+        # through NSS once per query.
+        for row in rows:
+            if not row['user_identifier'].isdigit():
+                continue
+
+            synthetic_id = int(row['user_identifier'])
+            if synthetic_id < BASE_SYNTHETIC_DATASTORE_ID or synthetic_id in by_id:
+                continue
+
+            try:
+                pwdobj = await self.middleware.call(
+                    'user.get_user_obj', {'uid': synthetic_id - BASE_SYNTHETIC_DATASTORE_ID}
+                )
+            except KeyError:
+                by_id[synthetic_id] = None
+            else:
+                by_id[synthetic_id] = pwdobj['pw_name']
+
         # We want to convert legacy keys into the appropriate local
         # administrator account
         if (admin_user := filter_list(users, [['uid', '=', 950]])):
@@ -102,11 +124,14 @@ class ApiKeyService(CRUDService):
             # If we can't resolve the ID then the account was probably deleted
             # and we didn't quite get to clean up yet.
             item['user_identifier'] = int(user_identifier)
+            # Ids at or above the synthetic base belong to directory services accounts.
+            item['local'] = item['user_identifier'] < BASE_SYNTHETIC_DATASTORE_ID
             item['username'] = ctx['by_id'].get(item['user_identifier'])
         elif user_identifier == LEGACY_API_KEY_USERNAME:
             # This may be magic string designating a migrated API key
             item['username'] = ctx['root_name']
         elif sid_is_valid(user_identifier):
+            item['local'] = False
             if (username := ctx['by_sid'].get(user_identifier)) is None:
                 resp = await self.middleware.call('idmap.convert_sids', [user_identifier])
                 if entry := resp['mapped'].get(user_identifier):
@@ -193,7 +218,9 @@ class ApiKeyService(CRUDService):
         if not user:
             verrors.add('api_key_create', 'User does not exist.')
 
-        if user and not user[0]['roles']:
+        if user and not self.middleware.call_sync('privilege.roles_for_user', data['username']):
+            # We cannot use user[0]['roles'] as a fast check because it is not populated
+            # for directory services users via cache.
             verrors.add('api_key_create', 'User lacks privilege role membership.')
 
         verrors.check()

--- a/tests/directory_services/test_directory_services_basic.py
+++ b/tests/directory_services/test_directory_services_basic.py
@@ -1,7 +1,9 @@
 import pytest
 from functions import SSH_TEST
 
+from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.assets.directory_service import directoryservice
+from middlewared.test.integration.assets.privilege import privilege
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.utils.audit import expect_audit_method_calls
 from middlewared.service_exception import ValidationErrors
@@ -69,3 +71,33 @@ def test_directory_services_network_domain(service_type):
     # Final test: restore default (if necessary)
     if service_type == 'LDAP':
         call('network.configuration.update', {'domain': DEFAULT_NETWORK_DOMAIN})
+
+
+@pytest.mark.parametrize('service_type', ['ACTIVEDIRECTORY', 'IPA', 'LDAP'])
+def test_directory_services_api_key(service_type):
+    """
+    API keys may only be created for accounts that have roles granted to them by
+    a privilege. Directory services cache entries carry no group membership and
+    so `user.query` reports no roles for them, which means the check has to
+    evaluate the group membership of the account through NSS.
+    """
+    with directoryservice(service_type) as ds:
+        username = ds['account'].user_obj['pw_name']
+
+        with pytest.raises(Exception, match='User lacks privilege role membership'):
+            with api_key(username):
+                pass
+
+        with privilege({
+            'name': f'DS API key privilege ({service_type})',
+            'local_groups': [],
+            'ds_groups': [ds['account'].user_obj['pw_gid']],
+            'roles': ['READONLY_ADMIN'],
+            'web_shell': False,
+        }):
+            assert 'READONLY_ADMIN' in call('privilege.roles_for_user', username)
+
+            with api_key(username):
+                key_info = call('api_key.query', [['username', '=', username]], {'get': True})
+                assert key_info['local'] is False
+                assert key_info['revoked'] is False, key_info['revoked_reason']


### PR DESCRIPTION
Directory services cache entries are not authoritative for privilege determination. They carry no group membership, because populating it while enumerating the domain would require a group lookup per account and overload the domain controller, so user.query reports an empty roles list for every directory services account. api_key.create read that list and rejected every directory services user.

Add privilege.roles_for_user(), which goes directly through NSS and evaluates the account's group membership the same way authentication does, and use it in do_create().

That makes two gaps in extend() reachable. A directory services account with no SID (plain LDAP) is stored by its synthesized user.query id, which never matched the local-only by_id map, so the key read back as revoked with "User does not exist" and was dropped from the PAM configuration. Resolve those ids through user.get_user_obj() instead, memoizing the lookup the way the SID branch already does.

`local` was initialized True and never cleared, so keys owned by directory services accounts claimed to be local and defeated the filter in user.user_extend_context(). Set it on both directory services paths and correct the field description.

Original PR: https://github.com/truenas/middleware/pull/19556
