### PR TITLE
NAS-143033 / 26.0.0-RC.1 / add private internal zfs props to zfs.resource.create (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_crud.py
@@ -412,6 +412,7 @@ class ZFSResourceCreateProperties(BaseModel):
 
     Each field is the native ZFS property name and values are handed to ZFS verbatim.
     A field left as null is simply not sent to ZFS so the property inherits from the parent as usual.
+    Fields marked `Private` are settable by internal callers only.
     """
 
     aclinherit: str | None = Field(
@@ -463,6 +464,60 @@ class ZFSResourceCreateProperties(BaseModel):
     xattr: str | None = Field(
         default=None,
         description="Extended attribute storage mode. Defaults to 'sa' for performance.",
+    )
+    # Internal-only properties. Hidden from the published schema and rejected for
+    # API callers exactly like an unknown property (see `Private`). Internal callers
+    # construct this model directly. Each is a foot-gun for API users but a
+    # requirement for system-managed datasets (.system, ix-apps, containers).
+    canmount: Private[str | None] = Field(
+        default=None,
+        description=(
+            "Whether the filesystem is mounted after creation (on, off, or noauto). Anything but on leaves the "
+            "new filesystem unmounted for the caller to mount itself."
+        ),
+    )
+    encryption: Private[Literal["off"] | None] = Field(
+        default=None,
+        description=(
+            "Set to off to create an unencrypted resource beneath an encrypted parent so system datasets stay "
+            "usable while a passphrase-encrypted pool is locked. Enabling encryption goes through the "
+            "`encryption` argument, never through this property."
+        ),
+    )
+    mountpoint: Private[str | None] = Field(
+        default=None,
+        description=(
+            "Mount point of the filesystem, or legacy / none. API callers always get the TrueNAS default "
+            "beneath /mnt/<pool>; system datasets need legacy or a fixed location."
+        ),
+    )
+    normalization: Private[str | None] = Field(
+        default=None,
+        description="Unicode normalization applied to filenames. Settable at creation time only.",
+    )
+    overlay: Private[str | None] = Field(
+        default=None,
+        description="Whether the filesystem may be mounted over a non-empty directory.",
+    )
+    prefetch: Private[str | None] = Field(
+        default=None,
+        description="Prefetch behavior for the resource (all, metadata, or none).",
+    )
+    primarycache: Private[str | None] = Field(
+        default=None,
+        description="What the ARC caches for this resource (all, metadata, or none).",
+    )
+    secondarycache: Private[str | None] = Field(
+        default=None,
+        description="What the L2ARC caches for this resource (all, metadata, or none).",
+    )
+    setuid: Private[str | None] = Field(
+        default=None,
+        description="Whether the setuid and setgid bits are honored on the filesystem.",
+    )
+    utf8only: Private[str | None] = Field(
+        default=None,
+        description="Whether only UTF-8 filenames are allowed. Settable at creation time only.",
     )
 
 

--- a/src/middlewared/middlewared/plugins/zfs/create_rules.py
+++ b/src/middlewared/middlewared/plugins/zfs/create_rules.py
@@ -482,6 +482,15 @@ def check_encryption(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> N
     # when an encryption root is requested
     assert data.encryption is not None
 
+    if ctx.properties.encryption is not None:
+        # the internal-only property opts out of the parent's encryption. It
+        # cannot be combined with a request for a new encryption root
+        raise ValidationError(
+            f"{SCHEMA}.encryption",
+            "An encryption root cannot be requested together with the 'encryption' property.",
+            errno.EINVAL,
+        )
+
     provided = [
         name
         for name, value in (

--- a/tests/api2/test_zfs_resource_create.py
+++ b/tests/api2/test_zfs_resource_create.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from auto_config import pool_name
-from middlewared.service_exception import ValidationErrors
+from middlewared.service_exception import ValidationError, ValidationErrors
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, ssh
 
@@ -205,7 +205,7 @@ def test_zfs_resource_create_already_exists():
 @pytest.mark.parametrize(
     "path,error",
     [
-        pytest.param("/tank/dataset", "absolute", id="absolute paths not allowed"),
+        pytest.param("/tank/dataset", "Absolute path", id="absolute paths not allowed"),
         pytest.param("tank/dataset/", "forward-slash", id="trailing forward-slash not allowed"),
         pytest.param(
             "tank/dataset@snap",
@@ -230,7 +230,23 @@ def test_zfs_resource_create_validation_errors(path, error):
 
 @pytest.mark.parametrize(
     "prop",
-    ["notaprop", "used", "canmount", "mountpoint", "logbias", "primarycache", "sparse"],
+    [
+        "notaprop",
+        "used",
+        "logbias",
+        "sparse",
+        # internal-only (Private) properties must be indistinguishable from unknown ones
+        "canmount",
+        "encryption",
+        "mountpoint",
+        "normalization",
+        "overlay",
+        "prefetch",
+        "primarycache",
+        "secondarycache",
+        "setuid",
+        "utf8only",
+    ],
 )
 def test_zfs_resource_create_property_outside_allowed_set(prop):
     """Test that any property outside the allowed creation set is rejected"""
@@ -329,31 +345,40 @@ def test_zfs_resource_create_encryption_root_passphrase():
 
 
 @pytest.mark.parametrize(
-    "encryption",
+    "encryption,exc",
     [
-        pytest.param({}, id="nothing provided"),
-        pytest.param({"key": "0" * 64, "passphrase": "passphrase123"}, id="key and passphrase"),
+        # the exactly-one-of rule lives in the plugin and raises a single ValidationError
+        pytest.param({}, ValidationError, id="nothing provided"),
+        pytest.param(
+            {"key": "0" * 64, "passphrase": "passphrase123"},
+            ValidationError,
+            id="key and passphrase",
+        ),
         pytest.param(
             {"generate_key": True, "passphrase": "passphrase123"},
+            ValidationError,
             id="generate_key and passphrase",
         ),
-        pytest.param({"passphrase": "short"}, id="short passphrase"),
-        pytest.param({"key": "notahexkey"}, id="invalid key"),
-        pytest.param({"key": "0" * 63}, id="wrong key length"),
+        # per-field shape constraints live on the model and are rejected by the schema
+        pytest.param({"passphrase": "short"}, ValidationErrors, id="short passphrase"),
+        pytest.param({"key": "notahexkey"}, ValidationErrors, id="invalid key"),
+        pytest.param({"key": "0" * 63}, ValidationErrors, id="wrong key length"),
         pytest.param(
             {"passphrase": "passphrase123", "pbkdf2iters": 1000},
+            ValidationErrors,
             id="pbkdf2iters too low",
         ),
         pytest.param(
             {"passphrase": "passphrase123", "pbkdf2iters": 100_000_000},
+            ValidationErrors,
             id="pbkdf2iters too high",
         ),
     ],
 )
-def test_zfs_resource_create_encryption_shape_errors(encryption):
+def test_zfs_resource_create_encryption_shape_errors(encryption, exc):
     """Test invalid encryption option combinations are rejected"""
     path = os.path.join(pool_name, "test_create_enc_invalid")
-    with pytest.raises(ValidationErrors):
+    with pytest.raises(exc):
         call("zfs.resource.create", {"path": path, "encryption": encryption})
 
 


### PR DESCRIPTION
Adds the ability to toggle some zfs properties internally without exposing them to the public API. This will be useful when internal callers migrate to calling the internal `create_impl` method in future PRs.

Also fixes test failures.

Original PR: https://github.com/truenas/middleware/pull/19590
