### PR TITLE
NAS-142731 / 26.0.0 / Fix bond transmit hash policy never reaching the kernel (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/bond.py
+++ b/src/middlewared/middlewared/plugins/interface/bond.py
@@ -10,6 +10,7 @@ from truenas_pynetif.address.bond import BondXmitHashPolicy, BondLacpRate
 from truenas_pynetif.netlink import LinkInfo
 from middlewared.service import ServiceContext
 
+from .lag_options import LacpduRateChoices, XmitHashChoices
 from .sync_data import SyncData
 
 __all__ = ("configure_bonds_impl",)
@@ -82,12 +83,18 @@ def configure_bond_impl(
     # Map xmit_hash_policy to enum
     xmit_hash_policy = None
     if lxhp := bond.get("lagg_xmit_hash_policy"):
-        xmit_hash_policy = getattr(BondXmitHashPolicy, lxhp.upper(), None)
+        try:
+            xmit_hash_policy = BondXmitHashPolicy[XmitHashChoices(lxhp.upper()).name]
+        except (KeyError, ValueError):
+            ctx.logger.error("%s: unsupported xmit_hash_policy %r", name, lxhp)
 
     # Map lacpdu_rate to enum
     lacpdu_rate = None
     if llr := bond.get("lagg_lacpdu_rate"):
-        lacpdu_rate = getattr(BondLacpRate, llr.upper(), None)
+        try:
+            lacpdu_rate = BondLacpRate[LacpduRateChoices(llr.upper()).name]
+        except (KeyError, ValueError):
+            ctx.logger.error("%s: unsupported lacpdu_rate %r", name, llr)
 
     # Get primary interface for FAILOVER mode
     primary = member_names[0] if mode == "FAILOVER" and member_names else None


### PR DESCRIPTION
## Problem
The stored hash policy string was translated into the `truenas_pynetif` enum by member-name lookup. The stored values are `layer2`, `layer2+3` and `layer3+4`, while the enum members are `LAYER2`, `LAYER23` and `LAYER34` — `+` cannot appear in a Python identifier, so two of the three resolved to `None`, and `getattr`'s default swallowed the miss with no log or exception. The netlink attribute was then never packed and the kernel silently kept its default `layer2`, so outbound traffic could not spread across bond members. Every LACP/LOADBALANCE bond defaults to `layer2+3`, so this was not limited to people who picked a policy explicitly. `lacpdu_rate` goes through the identical construct and only works because `SLOW` and `FAST` happen to be valid identifiers.

## Solution
Map the choice enums to library members explicitly, behind two helpers that take the stored string and return an enum or `None`. Dict literals rather than a name lookup, so a rename on the library side becomes a static attribute error at import time instead of another silent `None`.

Original PR: https://github.com/truenas/middleware/pull/19586
