### PR TITLE
NAS-142893 / 27.0.0-BETA.1 / Make `filesystem.file_tail_follow` tail the file on repeated connect

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v26_0_0/filesystem.py
@@ -469,7 +469,12 @@ class FilesystemPutResult(BaseModel):
 
 class FileFollowTailEventSourceArgs(BaseModel):
     path: str = Field(description="Path to the file to follow/tail.")
-    tail_lines: int = Field(default=3, description="Number of log lines to tail from the end of the log.")
+    tail_lines: int = Field(
+        default=3,
+        ge=1,
+        le=1000,
+        description="Number of log lines to tail from the end of the log.",
+    )
 
 
 @single_argument_result

--- a/src/middlewared/middlewared/api/v27_0_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v27_0_0/filesystem.py
@@ -500,7 +500,12 @@ class FilesystemPutResult(BaseModel):
 
 class FileFollowTailEventSourceArgs(BaseModel):
     path: str = Field(description="Path to the file to follow/tail.")
-    tail_lines: int = Field(default=3, description="Number of log lines to tail from the end of the log.")
+    tail_lines: int = Field(
+        default=3,
+        ge=1,
+        le=1000,
+        description="Number of log lines to tail from the end of the log.",
+    )
 
 
 @single_argument_result

--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -152,8 +152,7 @@ class EventSourceManager:
         try:
             await instance.send_initial_state(subscriber)
         except Exception:
-            self.middleware.logger.error("EventSource %r:%r send_initial_state() failed", name, arg,
-                                         exc_info=True)
+            self.middleware.logger.exception("EventSource %r:%r send_initial_state() failed", name, arg)
 
     async def unsubscribe(self, ident: str, error: Exception | None = None) -> None:
         ident_data = self.idents.pop(ident, None)

--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -131,9 +131,9 @@ class EventSourceManager:
         self.idents[ident] = IdentData(subscriber, name, arg)
         self.subscriptions[name][arg].add(ident)
 
-        if arg not in self.instances[name]:
+        if (instance := self.instances[name].get(arg)) is None:
             self.middleware.logger.trace("Creating new instance of event source %r:%r", name, arg)
-            self.instances[name][arg] = self.event_sources[name](
+            instance = self.instances[name][arg] = self.event_sources[name](
                 self.middleware, name, arg,
                 functools.partial(self._send_event, name, arg),
                 functools.partial(self._unsubscribe_all, name, arg),
@@ -143,10 +143,17 @@ class EventSourceManager:
                 await self.instances[name][arg].validate_arg()
             except ValidationErrors as e:
                 await self.unsubscribe(ident, e)
+                return
             else:
                 self.middleware.create_task(self.instances[name][arg].process())
         else:
             self.middleware.logger.trace("Re-using existing instance of event source %r:%r", name, arg)
+
+        try:
+            await instance.send_initial_state(subscriber)
+        except Exception:
+            self.middleware.logger.error("EventSource %r:%r send_initial_state() failed", name, arg,
+                                         exc_info=True)
 
     async def unsubscribe(self, ident: str, error: Exception | None = None) -> None:
         ident_data = self.idents.pop(ident, None)

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -9,6 +9,7 @@ from middlewared.service import ValidationErrors
 
 if typing.TYPE_CHECKING:
     from middlewared.api.base import BaseModel
+    from middlewared.common.event_source.manager import Subscriber
     from middlewared.main import Middleware
     from middlewared.utils.types import EventType
 
@@ -132,6 +133,9 @@ class EventSource:
 
     def run_sync(self) -> None:
         raise NotImplementedError('run_sync() method not implemented')
+
+    async def send_initial_state(self, subscriber: 'Subscriber') -> None:
+        pass
 
     async def cancel(self) -> None:
         self._canceled = True

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -53,6 +53,7 @@ from middlewared.api.current import (
     QueryOptions,
     ZFSFileAttrsData,
 )
+from middlewared.common.event_source.manager import Subscriber
 from middlewared.event import TypedEventSource
 from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
@@ -97,6 +98,19 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
     args = FileFollowTailEventSourceArgs
     event = FileFollowTailEventSourceEvent
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._buffer: list[str] = []
+
+    async def send_initial_state(self, subscriber: Subscriber) -> None:
+        if buffer := self._buffer:
+            subscriber.send_event('ADDED', fields={'data': ''.join(buffer)})
+
+    def send_lines(self, lines: list[str]) -> None:
+        buffer = self._buffer + lines
+        self._buffer = buffer[max(len(buffer) - self.typed_arg.tail_lines, 0):]
+        self.send_event('ADDED', fields={'data': ''.join(lines)})
+
     def run_sync(self) -> None:
         path, lines = self.typed_arg.path, self.typed_arg.tail_lines
 
@@ -120,13 +134,13 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
                 if len(data) >= lines or f.tell() == 0:
                     break
 
-            self.send_event('ADDED', fields={'data': ''.join(data[-lines:])})
+            self.send_lines(data[-lines:])
             f.seek(fsize)
 
             for chunk in self._follow_path(path, f):
-                self.send_event('ADDED', fields={'data': chunk})
+                self.send_lines(chunk)
 
-    def _follow_path(self, path: str, f: IO[str]) -> Generator[str, None, None]:
+    def _follow_path(self, path: str, f: IO[str]) -> Generator[list[str], None, None]:
         queue: list[str] = []
         watch_manager = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(watch_manager)
@@ -134,7 +148,7 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
 
         data = f.read()
         if data:
-            yield data
+            yield data.splitlines(keepends=True)
 
         last_sent_at = time.monotonic()
         interval = 0.5  # For performance reasons do not send websocket events more than twice a second
@@ -142,9 +156,8 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
             notifier.process_events()
 
             if time.monotonic() - last_sent_at >= interval:
-                data = "".join(queue)
-                if data:
-                    yield data
+                if queue:
+                    yield queue[:]
                 queue[:] = []
                 last_sent_at = time.monotonic()
 
@@ -156,7 +169,7 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
     def _follow_callback(self, queue: list[str], f: IO[str], event: Any) -> None:
         data = f.read()
         if data:
-            queue.append(data)
+            queue.extend(data.splitlines(keepends=True))
 
 
 class FilesystemService(Service):

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -90,6 +90,18 @@ class FilesystemReceiveFileResult(BaseModel):
     result: Literal[True]
 
 
+MAX_LINE_LENGTH = 1024
+
+
+def splitlines_maxlen(data: str, maxlen: int) -> list[str]:
+    """Split `data` into lines, also splitting lines longer than `maxlen` characters."""
+    return [
+        line[i:i + maxlen]
+        for line in data.splitlines(keepends=True)
+        for i in range(0, len(line), maxlen)
+    ]
+
+
 class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs]):
     """
     Retrieve last ``tail_lines`` lines specified as an integer argument for a specified ``path`` and then
@@ -118,21 +130,17 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
             # FIXME: Error?
             return
 
-        bufsize = 8192
         fsize = os.stat(path).st_size
-        if fsize < bufsize:
-            bufsize = fsize
-        i = 0
         with safe_open(path, encoding='utf-8', errors='ignore') as f:
-            data = []
+            read_back = lines * 100  # average log file line length
             while True:
-                i += 1
-                if bufsize * i > fsize:
+                offset = max(fsize - read_back, 0)
+                f.seek(offset)
+                data = splitlines_maxlen(f.read(), MAX_LINE_LENGTH)
+                # The first line read is incomplete unless we are at the very beginning of the file
+                if len(data) > lines or offset == 0:
                     break
-                f.seek(fsize - bufsize * i)
-                data.extend(f.readlines())
-                if len(data) >= lines or f.tell() == 0:
-                    break
+                read_back *= 2
 
             self.send_lines(data[-lines:])
             f.seek(fsize)
@@ -148,7 +156,7 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
 
         data = f.read()
         if data:
-            yield data.splitlines(keepends=True)
+            yield splitlines_maxlen(data, MAX_LINE_LENGTH)
 
         last_sent_at = time.monotonic()
         interval = 0.5  # For performance reasons do not send websocket events more than twice a second
@@ -169,7 +177,7 @@ class FileFollowTailEventSource(TypedEventSource[FileFollowTailEventSourceArgs])
     def _follow_callback(self, queue: list[str], f: IO[str], event: Any) -> None:
         data = f.read()
         if data:
-            queue.extend(data.splitlines(keepends=True))
+            queue.extend(splitlines_maxlen(data, MAX_LINE_LENGTH))
 
 
 class FilesystemService(Service):

--- a/tests/api2/test_filesystem__file_tail_follow.py
+++ b/tests/api2/test_filesystem__file_tail_follow.py
@@ -1,14 +1,8 @@
-import os
-import sys
 import time
 
 import pytest
 
 from middlewared.test.integration.utils import client, ssh
-
-
-apifolder = os.getcwd()
-sys.path.append(apifolder)
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=5)
@@ -33,7 +27,7 @@ def test_filesystem__file_tail_follow__grouping():
         assert 4 <= len(received) <= 6, str(received)
         # All blocks should have been received uniformly in time
         assert all(0.4 <= b2[0] - b1[0] <= 1.0 for b1, b2 in zip(received[:-1], received[1:])), str(received)
-        # All blocks should contain more or less same amount of data
+        # All blocks should contain more or less same amount of data: (0.5s grouping / 0.01s interval) <= 60
         assert all(len(block[1].split("\n")) <= 60 for block in received[:-1]), str(received)
 
         # One single send
@@ -44,3 +38,42 @@ def test_filesystem__file_tail_follow__grouping():
 
         # Make sure we can cleanly end the subscription
         c.unsubscribe(sub_id)
+
+
+def test_filesystem__file_tail_follow__shared_instance_initial_tail():
+    ssh("seq 1 10 > /tmp/file_tail_follow2.txt")
+
+    name = 'filesystem.file_tail_follow:{"path": "/tmp/file_tail_follow2.txt", "tail_lines": 5}'
+    with client() as c1, client() as c2:
+        received1 = []
+        received2 = []
+
+        c1.subscribe(name, lambda type, **kwargs: received1.append(kwargs["fields"]["data"]))
+        time.sleep(2)
+        assert received1 and received1[0] == "6\n7\n8\n9\n10\n", str(received1)
+
+        # An identical subscription re-uses the already running event source instance but must still
+        # receive the initial tail
+        sub_id2 = c2.subscribe(name, lambda type, **kwargs: received2.append(kwargs["fields"]["data"]))
+        time.sleep(2)
+        assert received2 and received2[0] == "6\n7\n8\n9\n10\n", str(received2)
+
+        # Both subscribers receive newly appended data
+        ssh("echo 11 >> /tmp/file_tail_follow2.txt")
+        time.sleep(2)
+        assert received1[-1] == "11\n", str(received1)
+        assert received2[-1] == "11\n", str(received2)
+
+        # Removing one subscriber must not affect the other one
+        c2.unsubscribe(sub_id2)
+        ssh("echo 12 >> /tmp/file_tail_follow2.txt")
+        time.sleep(2)
+        assert received1[-1] == "12\n", str(received1)
+        assert received2[-1] == "11\n", str(received2)
+
+        # A client that connects later receives the tail with the lines appended in the meantime
+        with client() as c3:
+            received3 = []
+            c3.subscribe(name, lambda type, **kwargs: received3.append(kwargs["fields"]["data"]))
+            time.sleep(2)
+            assert received3 and received3[0] == "8\n9\n10\n11\n12\n", str(received3)


### PR DESCRIPTION
Previously, if one browser tab is already connected to this event source and a second tab is opened, the second tab does not receive anything from `filesystem.file_tail_follow` source (it is re-used).

Now, the last N read lines are buffered in RAM, so newly connected tab will also receive last N files.

The buffer is capped: it is not possible to request more than 1000 lines (currently, UI requests 500), and each line is no longer than 1024 characters (otherwise, it is counted as `len(line) // 1024` lines).