### PR TITLE
NAS-143041 / 27.0.0-BETA.1 / Remove dead `force_remove_ix_volumes` app delete option

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/app.py
+++ b/src/middlewared/middlewared/api/v26_0_0/app.py
@@ -199,10 +199,6 @@ class AppDelete(BaseModel):
         description="Whether to remove Docker images associated with the application.",
     )
     remove_ix_volumes: bool = Field(default=False, description="Whether to remove TrueNAS-managed storage volumes.")
-    force_remove_ix_volumes: bool = Field(
-        default=False,
-        description="Force removal of TrueNAS-managed volumes even if they contain data.",
-    )
     force_remove_custom_app: bool = Field(
         default=False,
         description="Force removal of custom applications that might have important data or configurations.",

--- a/src/middlewared/middlewared/api/v27_0_0/app.py
+++ b/src/middlewared/middlewared/api/v27_0_0/app.py
@@ -245,10 +245,6 @@ class AppDelete(BaseModel):
         description="Whether to remove Docker images associated with the application.",
     )
     remove_ix_volumes: bool = Field(default=False, description="Whether to remove TrueNAS-managed storage volumes.")
-    force_remove_ix_volumes: bool = Field(
-        default=False,
-        description="Force removal of TrueNAS-managed volumes even if they contain data.",
-    )
     force_remove_custom_app: bool = Field(
         default=False,
         description="Force removal of custom applications that might have important data or configurations.",

--- a/src/middlewared/middlewared/plugins/apps/__init__.py
+++ b/src/middlewared/middlewared/plugins/apps/__init__.py
@@ -229,12 +229,6 @@ class AppService(GenericCRUDService[AppEntry, str]):
         """
         Delete ``app_name`` app.
 
-        ``force_remove_ix_volumes`` should be set when the ix-volumes were created by the system for apps which were
-        migrated from k8s to docker and the user wants to remove them. This is to prevent accidental deletion of the
-        original ix-volumes which were created in dragonfish and before for kubernetes based apps. When this is set,
-        it will result in the deletion of ix-volumes from both docker based apps and k8s based apps and should be
-        carefully set.
-
         ``force_remove_custom_app`` should be set when the app being deleted is a custom app and the user wants to
         forcefully remove the app. A use-case for this attribute is that the user had an invalid yaml in their custom
         app and there are no actual docker resources (network/containers/volumes) in place for the custom app, then


### PR DESCRIPTION
## Problem
`app.delete` accepts `options.force_remove_ix_volumes`, validates it as a bool and documents it in the method docstring, but nothing reads it. It was live when introduced in 0c4381a2b4, where it picked which kwarg to hand to `zfs.dataset.delete` — `recursively_remove_dependents` when set, `recursive` otherwise. 9712dc3084 ("remove zfs.dataset.delete (replace w/ zfs.resource.destroy)") swapped that call for an unconditional `recursive=True, bypass=True` destroy and dropped the conditional along with it, leaving the flag accepted but inert. The capability it selected is gone too: `zfs.resource.destroy_impl` has no dependents-removal parameter, so there is nothing left to wire it back up to.

## Solution
Dropped the field from `AppDelete` in both v26_0_0 and v27_0_0 and removed the docstring paragraph describing it. `remove_ix_volumes` is unaffected — it is still the live gate on ix-volume deletion.

No version adapter is needed or possible here. `AppDelete` only ever appears nested in `AppDeleteArgs`, so the downgrade direction never sees it, and the older version dirs still declare the field, which is what lets the version adapter pop it for clients on v25.10.5 and below. 