### PR TITLE
NAS-143053 / 27.0.0-BETA.1 / Make VM and container UUID immutable after creation

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -154,6 +154,7 @@ class ContainerCreateResult(BaseModel):
 
 
 class ContainerUpdate(ContainerCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     pool: Excluded = excluded_field()
     image: Excluded = excluded_field()
     idmap: Excluded = excluded_field()

--- a/src/middlewared/middlewared/api/v26_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm.py
@@ -183,6 +183,7 @@ class VMCreateResult(BaseModel):
 
 
 class VMUpdate(VMCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     bootloader_ovmf: Excluded = excluded_field()
     enable_secure_boot: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/api/v27_0_0/container.py
+++ b/src/middlewared/middlewared/api/v27_0_0/container.py
@@ -60,7 +60,11 @@ class ContainerStatus(BaseModel):
 
 class ContainerEntry(BaseModel):
     id: int = Field(description="Container ID.")
-    uuid: UUIDv4String = Field(description="Container UUID (for libvirt).")
+    uuid: UUIDv4String = Field(
+        description=(
+            "Container UUID (for libvirt). Assigned when the container is created and cannot be changed afterwards."
+        ),
+    )
     name: NonEmptyString = Field(description="Container name.")
     description: str = Field(default="", description="Container description.")
     devices: list[ContainerDeviceEntry] = Field(default=[], description="Container's devices.")
@@ -127,7 +131,9 @@ class ContainerCreate(ContainerEntry):
     default_network: Excluded = excluded_field()
     uuid: UUIDv4String | None = Field(
         default=None,
-        description="Container UUID (for libvirt). Auto-generated if not provided.",
+        description=(
+            "Container UUID (for libvirt). Auto-generated if not provided. It cannot be changed after creation."
+        ),
     )
     pool: str | None = Field(
         default=None,
@@ -152,6 +158,7 @@ class ContainerCreateResult(BaseModel):
 
 
 class ContainerUpdate(ContainerCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     pool: Excluded = excluded_field()
     image: Excluded = excluded_field()
     idmap: Excluded = excluded_field()

--- a/src/middlewared/middlewared/api/v27_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v27_0_0/vm.py
@@ -170,7 +170,9 @@ class VMEntry(BaseModel):
         default=None,
         description="Virtual machine type/chipset. `null` to use hypervisor default.",
     )
-    uuid: UUIDv4String = Field(description="Unique UUID for the VM.")
+    uuid: UUIDv4String = Field(
+        description="Unique UUID for the VM. Assigned when the VM is created and cannot be changed afterwards.",
+    )
     devices: list[VMDeviceEntry] = Field(description="Array of virtual devices attached to this VM.")
     display_available: bool = Field(description="Whether at least one display device is available for this VM.")
     id: int = Field(description="Unique identifier for the virtual machine.")
@@ -186,7 +188,10 @@ class VMCreate(VMEntry):
     id: Excluded = excluded_field()
     display_available: Excluded = excluded_field()
     devices: Excluded = excluded_field()
-    uuid: UUIDv4String | None = Field(default=None, description="Unique UUID for the VM. `null` to auto-generate.")
+    uuid: UUIDv4String | None = Field(
+        default=None,
+        description="Unique UUID for the VM. `null` to auto-generate. It cannot be changed after creation.",
+    )
     bootloader_ovmf: str | None = Field(
         default=None,
         examples=['OVMF_CODE.fd', 'OVMF_CODE.secboot.fd'],
@@ -203,6 +208,7 @@ class VMCreateResult(BaseModel):
 
 
 class VMUpdate(VMCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     bootloader_ovmf: Excluded = excluded_field()
     enable_secure_boot: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/plugins/container/crud.py
+++ b/src/middlewared/middlewared/plugins/container/crud.py
@@ -365,6 +365,13 @@ class ContainerServicePart(CRUDServicePart[ContainerEntry]):
         if data.uuid is None:
             data = data.model_copy(update={'uuid': str(uuid.uuid4())})
 
+        if not old or data.uuid != old.uuid:
+            uuid_filters: list[tuple[str, str, Any]] = [('uuid', '=', data.uuid)]
+            if old:
+                uuid_filters.append(('id', '!=', old.id))
+            if await self.middleware.call('datastore.query', 'container.container', uuid_filters):
+                verrors.add(f'{schema_name}.uuid', 'A container with this UUID already exists.', errno.EEXIST)
+
         if data.idmap is not None:
             if data.idmap.type == 'ISOLATED':
                 if data.idmap.slice is None:

--- a/src/middlewared/middlewared/plugins/vm/crud.py
+++ b/src/middlewared/middlewared/plugins/vm/crud.py
@@ -327,6 +327,13 @@ class VMServicePart(CRUDServicePart[VMEntry]):
         if data.uuid is None:
             data = data.model_copy(update={'uuid': str(uuid.uuid4())})
 
+        if not old or data.uuid != old.uuid:
+            uuid_filters: list[tuple[str, str, Any]] = [('uuid', '=', data.uuid)]
+            if old:
+                uuid_filters.append(('id', '!=', old.id))
+            if await self.middleware.call('datastore.query', 'vm.vm', uuid_filters):
+                verrors.add(f'{schema_name}.uuid', 'A VM with this UUID already exists.', errno.EEXIST)
+
         if not await license_active(self):
             verrors.add(f'{schema_name}.name', 'System is not licensed to use VMs')
 


### PR DESCRIPTION
## Problem
`vm.update` and `container.update` accepted `uuid` and persisted it, purely because the update models inherit the field from their create models and never excluded it. In this system the UUID is not metadata, it is the identity of the libvirt object: the domain XML writes it to both `<name>` and `<uuid>` (the friendly name only lands in `<title>`), and every lookup goes through `lookupByName(uuid)`. Neither `do_update` touches libvirt, so changing the UUID rewrites one DB column and re-points middleware at a domain that no longer exists — a running instance reports STOPPED, which defeats the active-state guard in `do_delete`, stop/suspend/reset raise `DomainDoesNotExistError`, a later start defines a second domain over the same zvol or rootfs, and container runtime mounts under the old UUID are orphaned. Worse, an explicit `uuid: null` was not "leave it alone": it reached the auto-generate branch in `validate()` and silently re-randomised a live instance's identity.

Separately, UUID uniqueness was enforced nowhere — no validation and no DB constraint. Because the libvirt domain name is the UUID, creating a second instance with an existing UUID and starting it redefines the first instance's domain.

## Solution
- **Exclude `uuid` from `VMUpdate` and `ContainerUpdate`**, in both the v26 and v27 API versions, using the same `excluded_field()` idiom these classes already use for `pool`, `image`, `idmap`, `bootloader_ovmf` and `enable_secure_boot`. The field disappears from the update schema and any attempt to set it — including `null` — is rejected. No service-layer guard is needed: with the field excluded the merged value always equals the stored one, so a comparison in `validate()` would be dead code.
- **Reject duplicate UUIDs at create time** in both `validate()` methods, mirroring the adjacent name-uniqueness checks (same filter shape, `EEXIST`). It goes through `datastore.query` rather than `self.query` so the check does not depend on libvirt being reachable, and it lives in `validate()` so it also covers `container.create_with_dataset`, which the legacy incus migration uses.

Setting the UUID at creation is untouched, which is where the real use cases live — importing an existing guest, restoring from a backup, or pinning a UUID so guest licensing survives a rebuild. That matches how libvirt, Proxmox and Veeam handle it: the UUID is chosen before first boot, never re-keyed on a live object.
