### PR TITLE
NAS-143053 / 26.0.0 / Make VM and container UUID immutable after creation (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/container.py
+++ b/src/middlewared/middlewared/api/v26_0_0/container.py
@@ -149,6 +149,7 @@ class ContainerCreateResult(BaseModel):
 
 
 class ContainerUpdate(ContainerCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     pool: Excluded = excluded_field()
     image: Excluded = excluded_field()
     idmap: Excluded = excluded_field()

--- a/src/middlewared/middlewared/api/v26_0_0/vm.py
+++ b/src/middlewared/middlewared/api/v26_0_0/vm.py
@@ -178,6 +178,7 @@ class VMCreateResult(BaseModel):
 
 
 class VMUpdate(VMCreate, metaclass=ForUpdateMetaclass):
+    uuid: Excluded = excluded_field()
     bootloader_ovmf: Excluded = excluded_field()
     enable_secure_boot: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/plugins/container/container.py
+++ b/src/middlewared/middlewared/plugins/container/container.py
@@ -173,6 +173,13 @@ class ContainerService(CRUDService):
         if data['uuid'] is None:
             data['uuid'] = str(uuid.uuid4())
 
+        if not old or data['uuid'] != old['uuid']:
+            uuid_filters = [('uuid', '=', data['uuid'])]
+            if old:
+                uuid_filters.append(('id', '!=', old['id']))
+            if await self.middleware.call('datastore.query', 'container.container', uuid_filters):
+                verrors.add(f'{schema_name}.uuid', 'A container with this UUID already exists.', errno.EEXIST)
+
         if data['idmap'] is not None:
             if data['idmap']['type'] == 'ISOLATED':
                 if data['idmap']['slice'] is None:

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -217,6 +217,13 @@ class VMService(CRUDService):
         if not data.get('uuid'):
             data['uuid'] = str(uuid.uuid4())
 
+        if not old or data['uuid'] != old['uuid']:
+            uuid_filters = [('uuid', '=', data['uuid'])]
+            if old:
+                uuid_filters.append(('id', '!=', old['id']))
+            if await self.middleware.call('datastore.query', 'vm.vm', uuid_filters):
+                verrors.add(f'{schema_name}.uuid', 'A VM with this UUID already exists.', errno.EEXIST)
+
         if not await self.middleware.call('vm.license_active'):
             verrors.add(
                 f'{schema_name}.name',

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_vm.py
@@ -47,6 +47,7 @@ async def test_vm_creation_for_licensed_and_unlicensed_systems(license_active):
     m['vm.bootloader_ovmf_choices'] = lambda *args: {'OVMF_CODE.fd': 'OVMF_CODE.fd'}
     m['vm.license_active'] = lambda *args: license_active
     m['vm.query'] = lambda *args: []
+    m['datastore.query'] = lambda *args, **kwargs: []
     m['vm.flags'] = lambda *args: {'intel_vmx': True, 'unrestricted_guest': True, 'amd_rvi': False, 'amd_asids': False}
     m['vm.maximum_supported_vcpus'] = lambda *args: 255
     m['vm.supports_virtualization'] = lambda *args: True
@@ -127,6 +128,7 @@ async def test_vm_secure_boot_ovmf_validation(enable_secure_boot, bootloader_ovm
     }
     m['vm.license_active'] = lambda *args: True
     m['vm.query'] = mock_vm_query
+    m['datastore.query'] = lambda *args, **kwargs: []
     m['vm.flags'] = lambda *args: {'intel_vmx': True, 'unrestricted_guest': True, 'amd_rvi': False, 'amd_asids': False}
     m['vm.maximum_supported_vcpus'] = lambda *args: 255
     m['vm.supports_virtualization'] = lambda *args: True


### PR DESCRIPTION
## Problem
`vm.update` and `container.update` accepted `uuid` and persisted it, purely because the update models inherit the field from their create models and never excluded it. In this system the UUID is not metadata, it is the identity of the libvirt object: the domain XML writes it to both `<name>` and `<uuid>` (the friendly name only lands in `<title>`), and every lookup goes through `lookupByName(uuid)`. Neither `do_update` touches libvirt, so changing the UUID rewrites one DB column and re-points middleware at a domain that no longer exists — a running instance reports STOPPED, which defeats the active-state guard in `do_delete`, stop/suspend/reset raise `DomainDoesNotExistError`, a later start defines a second domain over the same zvol or rootfs, and container runtime mounts under the old UUID are orphaned. Worse, an explicit `uuid: null` was not "leave it alone": it reached the auto-generate branch in `validate()` and silently re-randomised a live instance's identity.

Separately, UUID uniqueness was enforced nowhere — no validation and no DB constraint. Because the libvirt domain name is the UUID, creating a second instance with an existing UUID and starting it redefines the first instance's domain.

## Solution
- **Exclude `uuid` from `VMUpdate` and `ContainerUpdate`**, in both the v26 and v27 API versions, using the same `excluded_field()` idiom these classes already use for `pool`, `image`, `idmap`, `bootloader_ovmf` and `enable_secure_boot`. The field disappears from the update schema and any attempt to set it — including `null` — is rejected. No service-layer guard is needed: with the field excluded the merged value always equals the stored one, so a comparison in `validate()` would be dead code.
- **Reject duplicate UUIDs at create time** in both `validate()` methods, mirroring the adjacent name-uniqueness checks (same filter shape, `EEXIST`). It goes through `datastore.query` rather than `self.query` so the check does not depend on libvirt being reachable, and it lives in `validate()` so it also covers `container.create_with_dataset`, which the legacy incus migration uses.

Setting the UUID at creation is untouched, which is where the real use cases live — importing an existing guest, restoring from a backup, or pinning a UUID so guest licensing survives a rebuild. That matches how libvirt, Proxmox and Veeam handle it: the UUID is chosen before first boot, never re-keyed on a live object.


Original PR: https://github.com/truenas/middleware/pull/19600
