### PR TITLE
NAS-143057 / 27.0.0-BETA.1 / Redact uploaded license from the audit trail (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/truenas.py
+++ b/src/middlewared/middlewared/api/v26_0_0/truenas.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, LongNonEmptyString, LongString, NonEmptyString
 
@@ -103,7 +103,7 @@ class TrueNASLicenseUploadOptions(BaseModel):
 
 
 class TrueNASLicenseUploadArgs(BaseModel):
-    license: LongNonEmptyString = Field(description="PEM-wrapped license to apply to the system.")
+    license: Secret[LongNonEmptyString] = Field(description="PEM-wrapped license to apply to the system.")
     options: TrueNASLicenseUploadOptions = Field(default=TrueNASLicenseUploadOptions(), description="Options.")
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/truenas.py
+++ b/src/middlewared/middlewared/api/v27_0_0/truenas.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, LongNonEmptyString, LongString, NonEmptyString
 
@@ -103,7 +103,7 @@ class TrueNASLicenseUploadOptions(BaseModel):
 
 
 class TrueNASLicenseUploadArgs(BaseModel):
-    license: LongNonEmptyString = Field(description="PEM-wrapped license to apply to the system.")
+    license: Secret[LongNonEmptyString] = Field(description="PEM-wrapped license to apply to the system.")
     options: TrueNASLicenseUploadOptions = Field(default=TrueNASLicenseUploadOptions(), description="Options.")
 
 

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -2,9 +2,8 @@ import contextlib
 import os
 from typing import TYPE_CHECKING, Any
 
-from truenas_pylicensed import LicenseType
-
 from pydantic import Secret
+from truenas_pylicensed import LicenseType
 
 from middlewared.api import api_method
 from middlewared.api.base import LongNonEmptyString
@@ -85,10 +84,9 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
         current = self.info_private()
         had_license = current is not None and current.origin is LicenseOrigin.ISSUED
 
-        # `check_annotations` hands the method the undumped model value, so the PEM has to be
-        # unwrapped twice: out of the Secret that keeps it off the audit trail, then out of the
-        # LongStringWrapper that carries strings over the default length limit.
-        with upload_license(license_.get_secret_value().value) as lic:
+        # `check_annotations` hands the method the undumped model value, so the PEM arrives still
+        # boxed in the Secret that keeps it off the audit trail.
+        with upload_license(license_.get_secret_value()) as lic:
             if not lic.valid:
                 raise ValidationError("license", f"Invalid license: {lic.error}")
 

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 from truenas_pylicensed import LicenseType
 
+from pydantic import Secret
+
 from middlewared.api import api_method
+from middlewared.api.base import LongNonEmptyString
 from middlewared.api.current import (
     LicenseFeatureEntry,
     LicenseInfoEntry,
@@ -77,12 +80,15 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
         roles=["FULL_ADMIN"],
         check_annotations=True,
     )
-    def upload(self, license_: str, options: TrueNASLicenseUploadOptions) -> None:
+    def upload(self, license_: Secret[LongNonEmptyString], options: TrueNASLicenseUploadOptions) -> None:
         """Upload a PEM-wrapped license file."""
         current = self.info_private()
         had_license = current is not None and current.origin is LicenseOrigin.ISSUED
 
-        with upload_license(str(license_)) as lic:
+        # `check_annotations` hands the method the undumped model value, so the PEM has to be
+        # unwrapped twice: out of the Secret that keeps it off the audit trail, then out of the
+        # LongStringWrapper that carries strings over the default length limit.
+        with upload_license(license_.get_secret_value().value) as lic:
             if not lic.valid:
                 raise ValidationError("license", f"Invalid license: {lic.error}")
 

--- a/tests/api2/test_audit_license.py
+++ b/tests/api2/test_audit_license.py
@@ -1,0 +1,33 @@
+import pytest
+
+from middlewared.test.integration.utils import call
+
+LICENSE_UPLOAD_METHOD = "truenas.license.upload"
+
+
+def test_uploaded_license_is_redacted_in_the_audit_log():
+    """
+    Whatever installed the license on this system -- CI, TrueNAS Connect or an operator -- went
+    through the audited API, so the entry it left behind must carry the redaction placeholder
+    instead of the license.
+    """
+    entries = call(
+        "audit.query",
+        {
+            "query-filters": [["event_data.method", "=", LICENSE_UPLOAD_METHOD]],
+            "query-options": {"limit": 1000},
+        },
+    )
+    if not entries:
+        pytest.skip(f"nothing has called {LICENSE_UPLOAD_METHOD} on this system")
+
+    for entry in entries:
+        params = entry["event_data"]["params"]
+        if not params:
+            continue
+
+        # Asserting the shape of the placeholder rather than its exact text keeps this independent
+        # of how long it is, and holds for a legacy base64 blob as much as for a v2 PEM: any
+        # license that reached the audit log unredacted carries something other than an asterisk.
+        recorded = str(params[0])
+        assert set(recorded) == {"*"}, params


### PR DESCRIPTION
This commit fixes an issue where `truenas.license.upload` recorded its license argument verbatim in the audit trail, because the field was never declared `Secret[...]`. Uploading needs FULL_ADMIN but audit records come back with SYSTEM_AUDIT_READ, so a read-only admin could pull out the blob a full admin installed, and the same record went to remote syslog and into debug bundles.

Marking the field `Secret[LongNonEmptyString]` means `check_annotations` stops accepting the old `license_: str` signature, and the `str(license_)` that went with it turned out to be wrong already: it stringified the `LongStringWrapper` and wrote `LongStringWrapper(<pem>)` into the license file. The daemon's PEM scan skips the leading garbage so nothing ever failed, but the on-disk copy never matched what was uploaded, which defeats the TNC heartbeat's raw_license comparison and makes every HA send_license add another wrapper layer. Unwrapping both boxes writes the PEM back byte for byte.

Original PR: https://github.com/truenas/middleware/pull/19603
