### PR TITLE
NAS-143004 / 27.0.0-BETA.1 / Add private entitlements debug endpoint for debug bundles (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas/entitlements.py
+++ b/src/middlewared/middlewared/plugins/truenas/entitlements.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from truenas_pylicensed import verify
+
 from middlewared.api import api_method
 from middlewared.api.current import (
     EntitlementEntry,
@@ -7,7 +11,7 @@ from middlewared.api.current import (
     TrueNASEntitlementsInfoArgs,
     TrueNASEntitlementsInfoResult,
 )
-from middlewared.service import CallError, Service
+from middlewared.service import CallError, Service, private
 from middlewared.utils.entitlements import (
     POLICY,
     Entitlement,
@@ -16,6 +20,8 @@ from middlewared.utils.entitlements import (
     get_entitlement,
     get_facts,
 )
+from middlewared.utils.hardware import get_hardware_info
+from middlewared.utils.license import describe_legacy_license
 
 
 def _entry(entitlement: Entitlement) -> EntitlementEntry:
@@ -85,3 +91,61 @@ class TrueNASEntitlementsService(Service):
             features[str(key)] = _entry(check_entitlement(key, facts))
 
         return EntitlementsInfo(features=features)
+
+    @private
+    def debug_info(self) -> dict[str, Any]:
+        """Each section degrades to an error rather than raising: the systems this is collected
+        from are the ones whose licensing is already misbehaving."""
+        info: dict[str, Any] = {}
+
+        try:
+            hw = get_hardware_info()
+            info["hardware"] = {
+                "error": None,
+                "platform": hw.platform.value,
+                "hardware_class": hw.hardware_class.value,
+                "chassis": hw.chassis,
+                "ha_platform": hw.ha_platform,
+                "is_ha_capable": hw.is_ha_capable,
+            }
+        except Exception as e:
+            info["hardware"] = {"error": f"{type(e).__name__}: {e}"}
+
+        try:
+            status = verify()
+            info["daemon"] = {
+                "error": None,
+                "valid": status.valid,
+                "code": status.code.name,
+                "message": status.error,
+                "test": status.test,
+                "reload_seq": status.reload_seq,
+                "version": status.version,
+                "issued_at": status.issued_at,
+            }
+        except Exception as e:
+            info["daemon"] = {"error": f"{type(e).__name__}: {e}"}
+
+        try:
+            facts = get_facts()
+            decisions: dict[str, Any] = {"error": None}
+            for key in POLICY:
+                entitlement = check_entitlement(key, facts)
+                decisions[str(key)] = {
+                    "entitled": entitlement.entitled,
+                    "reason": str(entitlement.reason),
+                    # `_entry` withholds this from the public API.
+                    "column": entitlement.column,
+                    "message": entitlement.message,
+                }
+
+            info["decisions"] = decisions
+        except Exception as e:
+            info["decisions"] = {"error": f"{type(e).__name__}: {e}"}
+
+        try:
+            info["legacy"] = describe_legacy_license()
+        except Exception as e:
+            info["legacy"] = {"error": f"{type(e).__name__}: {e}"}
+
+        return info

--- a/src/middlewared/middlewared/utils/license/__init__.py
+++ b/src/middlewared/middlewared/utils/license/__init__.py
@@ -20,7 +20,7 @@ from .constants import (
     LICENSE_FILE,
 )
 from .daemon import from_license_status, get_fingerprint_b64, upload_license
-from .legacy import get_legacy_license_info, parse_legacy_license
+from .legacy import describe_legacy_license, get_legacy_license_info, parse_legacy_license
 from .types import FeatureInfo, LicenseInfo
 
 __all__ = [
@@ -31,6 +31,7 @@ __all__ = [
     "LICENSE_FILE",
     "FeatureInfo",
     "LicenseInfo",
+    "describe_legacy_license",
     "from_license_status",
     "get_fingerprint_b64",
     "get_legacy_license_info",

--- a/src/middlewared/middlewared/utils/license/legacy.py
+++ b/src/middlewared/middlewared/utils/license/legacy.py
@@ -12,9 +12,12 @@ a caller cannot distinguish a rejected blob from a missing one.
 from __future__ import annotations
 
 from datetime import date
+from enum import StrEnum
+import errno
 from functools import lru_cache
 import logging
 from types import MappingProxyType
+from typing import Any
 
 from licenselib.license import Features, License
 from licenselib.utils import proactive_support_allowed
@@ -27,9 +30,20 @@ from .types import FeatureInfo, LicenseInfo
 logger = logging.getLogger(__name__)
 
 __all__ = (
+    "LegacyStatus",
+    "describe_legacy_license",
     "get_legacy_license_info",
+    "legacy_license_fields",
     "parse_legacy_license",
 )
+
+
+class LegacyStatus(StrEnum):
+    NOT_PRESENT = "NOT_PRESENT"
+    READ_ERROR = "READ_ERROR"
+    MALFORMED = "MALFORMED"
+    REJECTED_FREENAS_MODEL = "REJECTED_FREENAS_MODEL"
+    DECODED = "DECODED"
 
 
 _LEGACY_INJECT: frozenset[LicenseFeature] = frozenset(
@@ -74,6 +88,10 @@ def _support_tier(contract_type_name: str) -> str:
         return SupportTier.BRONZE.value
 
 
+def _is_freenas_model(model: str | None) -> bool:
+    return model is not None and model.lower().startswith("freenas")
+
+
 @lru_cache()
 def get_legacy_license_info() -> LicenseInfo | None:
     try:
@@ -85,10 +103,65 @@ def get_legacy_license_info() -> LicenseInfo | None:
         logger.warning("Error loading legacy license: %r", e)
         return None
 
-    if info.model is not None and info.model.lower().startswith("freenas"):
+    if _is_freenas_model(info.model):
         return None
 
     return info
+
+
+def legacy_license_fields(lic: Any) -> dict[str, Any]:
+    """Project a decoded license onto the fields a debug bundle may carry.
+
+    An allowlist so that a field added to ``License`` upstream cannot arrive here by default:
+    it carries ``customer_name`` and ``customer_key``. ``licenselib`` is untyped, hence ``Any``.
+    """
+    contract_type = lic.contract_type
+    return {
+        "version": lic.version,
+        "model": lic.model or None,
+        "system_serial": lic.system_serial or None,
+        "system_serial_ha": lic.system_serial_ha or None,
+        # ``License.load`` leaves the raw byte in place when it matches no ContractType member.
+        "contract_type": {
+            "value": getattr(contract_type, "value", contract_type),
+            "name": getattr(contract_type, "name", None),
+        },
+        "contract_start": lic.contract_start.isoformat(),
+        "contract_end": lic.contract_end.isoformat(),
+        "features": [feature.name for feature in lic.features],
+        "addhw": [list(entry) for entry in lic.addhw],
+    }
+
+
+def describe_legacy_license(path: str = LEGACY_LICENSE_FILE) -> dict[str, Any]:
+    """Report the on-disk legacy license as it actually is.
+
+    Uncached, and separate from ``get_legacy_license_info``, which answers ``None`` for an
+    absent, an unreadable, a malformed and a rejected blob alike. A rejected blob is reported
+    with its fields: that is the case where a system lost functionality it used to have.
+    """
+    try:
+        with open(path) as f:
+            text = f.read().strip("\n")
+    except FileNotFoundError:
+        return {"status": LegacyStatus.NOT_PRESENT.value, "error": None, "fields": None}
+    except OSError as e:
+        code = e.errno
+        return {
+            "status": LegacyStatus.READ_ERROR.value,
+            "error": errno.errorcode.get(code, str(code)) if code is not None else None,
+            "fields": None,
+        }
+
+    try:
+        lic = License.load(text)
+        fields = legacy_license_fields(lic)
+    except Exception as e:
+        # Neither the blob nor `lic` may reach this string: a License repr carries customer_key.
+        return {"status": LegacyStatus.MALFORMED.value, "error": f"{type(e).__name__}: {e}", "fields": None}
+
+    status = LegacyStatus.REJECTED_FREENAS_MODEL if _is_freenas_model(fields["model"]) else LegacyStatus.DECODED
+    return {"status": status.value, "error": None, "fields": fields}
 
 
 def parse_legacy_license(text: str) -> LicenseInfo:


### PR DESCRIPTION
This commit adds changes to expose truenas.entitlements.debug_info, a private method a debug bundle can call to see what an entitlement decision was made from: the hardware facts, the raw license daemon verdict that get_license() otherwise discards, the on-disk legacy license as it actually is (a rejected or malformed blob currently reads the same as no license at all) and every decision with the matrix column it resolved to. Each section degrades to an error field rather than raising, since the systems this is collected from are the ones whose licensing is already misbehaving, and the legacy projection is an allowlist so customer name and key never reach a bundle.

Original PR: https://github.com/truenas/middleware/pull/19598
