### PR TITLE
NAS-143121 / 26.0.0-RC.1 / fix TODO in zfs.resource.create

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs/create_rules.py
+++ b/src/middlewared/middlewared/plugins/zfs/create_rules.py
@@ -26,7 +26,7 @@ from .create_impl import ZFS_TYPE_MAP
 from .utils import has_internal_path
 
 if typing.TYPE_CHECKING:
-    from middlewared.api.current import ZFSResourceCreateArgsData, ZFSResourceCreateProperties
+    from middlewared.api.current import EntitlementEntry, ZFSResourceCreateArgsData, ZFSResourceCreateProperties
 
 __all__ = (
     "CreateContext",
@@ -36,6 +36,7 @@ __all__ = (
     "apply_tier_snap",
     "apply_volume_ssb_pin",
     "check_acl_combination",
+    "check_dedup_entitlement",
     "check_dedup_tiering",
     "check_encryption",
     "check_name_valid",
@@ -70,9 +71,9 @@ class CreateContext:
     ancestor has no entry."""
     tier_enabled: bool = False
     """Whether ZFS tiering is enabled on this system."""
-    # TODO uncomment when the truenas.entitlements API is merged
-    # dedup_entitled: bool = False
-    # """Whether this system is licensed to use ZFS deduplication."""
+    dedup_entitlement: "EntitlementEntry | None" = None
+    """The DEDUP entitlement decision for this system. Populated by the
+    service only when the request enables deduplication."""
 
 
 def ancestor_chain(path: str) -> list[str]:
@@ -355,6 +356,25 @@ def apply_volume_ssb_pin(data: "ZFSResourceCreateArgsData", ctx: CreateContext) 
     volblocksize = _size_bytes(ctx.properties.volblocksize or 16384) or 16384
     if parent_ssb and volblocksize < parent_ssb:
         ctx.properties.special_small_blocks = 0
+
+
+def check_dedup_entitlement(data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:
+    """Deduplication may only be enabled on a system entitled to it.
+
+    Licensed systems must carry the DEDUP feature; unlicensed iX hardware
+    is blocked; Community Edition may use it freely. The entitlement
+    engine decides and supplies the message. Matches the gate
+    pool.dataset applies.
+
+    The service calls this only for requests with a dedup value other
+    than off and after the entitlement has been gathered.
+    """
+    # narrow the optional type for mypy. The service only calls this
+    # after gathering the entitlement
+    assert ctx.dedup_entitlement is not None
+
+    if not ctx.dedup_entitlement.entitled:
+        raise ValidationError(f"{SCHEMA}.properties", ctx.dedup_entitlement.message, errno.EINVAL)
 
 
 def check_dedup_tiering(service: typing.Any, data: "ZFSResourceCreateArgsData", ctx: CreateContext) -> None:

--- a/src/middlewared/middlewared/plugins/zfs/resource_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/resource_crud.py
@@ -4,6 +4,7 @@ import pathlib
 import typing
 
 import truenas_pylibzfs
+from truenas_pylicensed.features import LicenseFeature
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -34,8 +35,8 @@ from .create_rules import (
     apply_tier_snap,
     apply_volume_ssb_pin,
     check_acl_combination,
+    check_dedup_entitlement,
     check_dedup_tiering,
-    # check_dedup_entitlement,  TODO uncomment when the truenas.entitlements API is merged
     check_encryption,
     check_name_valid,
     check_parent_not_readonly,
@@ -408,6 +409,14 @@ class ZFSResourceService(Service):
 
         ctx.tier_enabled = self.call_sync2(self.s.zfs.tier.config).enabled
 
+        # any value other than off (on, verify, a checksum) enables dedup.
+        # The entitlement is settled before anything is gathered from the
+        # pool so an unlicensed request fails without further work.
+        dedup_requested = str(properties.dedup or "off").lower() != "off"
+        if dedup_requested:
+            ctx.dedup_entitlement = self.call_sync2(self.s.truenas.entitlements.check, LicenseFeature.DEDUP)
+            check_dedup_entitlement(data, ctx)
+
         # one query serves the readonly, tier, acl, capacity and encryption
         # rules. Only the properties the rules below will read are requested.
         ancestor_props = ["readonly"]
@@ -443,19 +452,13 @@ class ZFSResourceService(Service):
                 apply_draid_recordsize(self, data, ctx)
             if ctx.tier_enabled and properties.special_small_blocks is None:
                 apply_tier_snap(data, ctx)
-            if ctx.tier_enabled and str(properties.dedup or "off").lower() != "off":
+            if ctx.tier_enabled and dedup_requested:
                 check_dedup_tiering(self, data, ctx)
             if properties.acltype is not None or properties.aclmode is not None:
                 check_acl_combination(data, ctx)
 
         if data.encryption:
             check_encryption(data, ctx)
-
-        # TODO uncomment when the truenas.entitlements API is merged
-        # from truenas_pylicensed.features import LicenseFeature
-        # if str(properties.dedup or "off").lower() != "off":
-        #     ctx.dedup_entitled = self.call_sync2(self.s.truenas.entitlements.check, LicenseFeature.DEDUP).entitled
-        #     check_dedup_entitlement(data, ctx)
 
         props = {k: v for k, v in properties.model_dump().items() if v is not None}
         try:
@@ -550,6 +553,8 @@ class ZFSResourceService(Service):
           combined with the nfsv4 acltype (``EINVAL``)
         - the nearest existing ancestor is readonly - the new filesystem could not be
           mounted beneath it (``EINVAL``)
+        - deduplication is requested on a system that is not entitled to it - licensed
+          systems must carry the DEDUP feature (``EINVAL``)
         - ``special_small_blocks`` is supplied while ZFS tiering is enabled - placement
           is managed with :method:`zfs.tier.dataset_set_tier` (``EINVAL``)
         - deduplication is requested for a filesystem whose data would be placed on the

--- a/tests/api2/test_zfs_resource_create.py
+++ b/tests/api2/test_zfs_resource_create.py
@@ -272,7 +272,6 @@ def test_zfs_resource_create_encryption_property_denied():
     assert "Extra inputs are not permitted" in str(exc_info.value)
 
 
-@pytest.mark.skip(reason="enable when the truenas.entitlements API is merged and the dedup license check is active")
 def test_zfs_resource_create_dedup_requires_license():
     """Test that enabling deduplication requires the DEDUP license entitlement"""
     path = os.path.join(pool_name, "test_create_fs_dedup")
@@ -285,7 +284,7 @@ def test_zfs_resource_create_dedup_requires_license():
     else:
         with pytest.raises(Exception) as exc_info:
             call("zfs.resource.create", {"path": path, "properties": {"dedup": "on"}})
-        assert "not licensed" in str(exc_info.value)
+        assert "ZFS deduplication" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("prop", ["sharenfs", "sharesmb"])


### PR DESCRIPTION
This module was merged while new licensing was still being written. A TODO was added but this fixes it since we've merged in the relevant changes.