### PR TITLE
NAS-143123 / 27.0.0-BETA.1 / `auth` tests

### DIFF
--- a/tests/api2/test_auth_authenticate.py
+++ b/tests/api2/test_auth_authenticate.py
@@ -1,0 +1,86 @@
+import pytest
+
+from middlewared.test.integration.assets.account import user as create_user
+from middlewared.test.integration.utils import call
+
+
+def test_authenticate_root():
+    """auth.authenticate_root always returns the full-privilege root credential."""
+    cred = call("auth.authenticate_root")
+    assert cred["username"] == "root"
+    assert "LOCAL" in cred["account_attributes"]
+    assert "SYS_ADMIN" in cred["account_attributes"]
+    assert cred["privilege"]["webui_access"]
+
+
+def test_authenticate_user_unknown_username():
+    """A username with no matching account row is denied (MatchNotFound branch)."""
+    result = call(
+        "auth.authenticate_user",
+        {
+            "pw_name": "this_user_does_not_exist_zzz",
+            "pw_uid": 999999,
+            "local": True,
+            "grouplist": [],
+            "account_attributes": [],
+            "source": "LOCAL",
+        },
+    )
+    assert result is None
+
+
+def test_authenticate_user_uid_mismatch():
+    """A uid that disagrees with the configuration row is denied."""
+    result = call(
+        "auth.authenticate_user",
+        {
+            "pw_name": "root",
+            "pw_uid": 999999,  # real root is uid 0
+            "local": True,
+            "grouplist": [0],
+            "account_attributes": [],
+            "source": "LOCAL",
+        },
+    )
+    assert result is None
+
+
+def test_authenticate_user_local_mismatch():
+    """A source disagreement (local vs directory) for a matching uid is denied."""
+    result = call(
+        "auth.authenticate_user",
+        {
+            "pw_name": "root",
+            "pw_uid": 0,
+            "local": False,  # root is a local account
+            "grouplist": [0],
+            "account_attributes": [],
+            "source": "ACTIVEDIRECTORY",
+        },
+    )
+    assert result is None
+
+
+def test_authenticate_user_no_privileges():
+    """A valid local user whose groups grant no privilege gets no middleware credential."""
+    with create_user(
+        {
+            "username": "noprivuser",
+            "full_name": "noprivuser",
+            "group_create": True,
+            "password": "test1234",
+        }
+    ):
+        user_obj = call("user.get_user_obj", {"username": "noprivuser", "get_groups": True})
+        result = call(
+            "auth.authenticate_user",
+            {
+                "pw_name": user_obj["pw_name"],
+                "pw_uid": user_obj["pw_uid"],
+                "local": True,
+                "grouplist": list(user_obj["grouplist"]),
+                "account_attributes": ["LOCAL"],
+                "source": "LOCAL",
+            },
+        )
+        assert result is None

--- a/tests/api2/test_auth_login_ex.py
+++ b/tests/api2/test_auth_login_ex.py
@@ -1,0 +1,160 @@
+import errno
+
+import pytest
+
+from middlewared.service_exception import CallError
+from middlewared.test.integration.assets.account import user as create_user
+from middlewared.test.integration.assets.two_factor_auth import (
+    enabled_twofactor_auth,
+    get_user_secret,
+    get_2fa_totp_token,
+)
+from middlewared.test.integration.utils import call, client, password
+
+
+LEGACY_VERSION = "v26.0.0"
+
+
+@pytest.fixture(scope="function")
+def clear_ratelimit():
+    call("rate.limit.cache_clear")
+
+
+def test_otp_token_without_login_in_progress():
+    """Submitting an OTP token with no authentication in progress is rejected with EINVAL."""
+    with client(auth=None) as c:
+        with pytest.raises(CallError) as ce:
+            c.call(
+                "auth.login_ex",
+                {
+                    "mechanism": "OTP_TOKEN",
+                    "otp_token": "123456",
+                },
+            )
+        assert ce.value.errno == errno.EINVAL
+
+
+def test_login_ex_continue_without_login_in_progress():
+    """auth.login_ex_continue funnels into login_ex; with no progress it also errors EINVAL."""
+    with client(auth=None) as c:
+        with pytest.raises(CallError) as ce:
+            c.call(
+                "auth.login_ex_continue",
+                {
+                    "mechanism": "OTP_TOKEN",
+                    "otp_token": "123456",
+                },
+            )
+        assert ce.value.errno == errno.EINVAL
+
+
+def test_scram_final_without_first_message():
+    """A SCRAM CLIENT_FINAL_MESSAGE with no preceding CLIENT_FIRST_MESSAGE has no PAM handle."""
+    with client(auth=None) as c:
+        with pytest.raises(RuntimeError, match="pam handle was not initialized"):
+            c.call(
+                "auth.login_ex",
+                {
+                    "mechanism": "SCRAM",
+                    "scram_type": "CLIENT_FINAL_MESSAGE",
+                    "rfc_str": "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=",
+                },
+            )
+
+
+def test_password_plain_no_api_access_denied():
+    """A valid local user with no privilege is refused with response_type DENIED."""
+    with create_user(
+        {
+            "username": "noapiuser",
+            "full_name": "noapiuser",
+            "group_create": True,
+            "password": "test1234",
+        }
+    ):
+        with client(auth=None) as c:
+            resp = c.call(
+                "auth.login_ex",
+                {
+                    "mechanism": "PASSWORD_PLAIN",
+                    "username": "noapiuser",
+                    "password": "test1234",
+                },
+            )
+            assert resp["response_type"] == "DENIED"
+
+
+def test_twofactor_login_no_api_access_denied(clear_ratelimit):
+    """A 2FA user with no API privilege is refused with DENIED after a valid OTP token."""
+    with create_user(
+        {
+            "username": "twofa_noapi",
+            "full_name": "twofa_noapi",
+            "group_create": True,
+            "password": "test1234",
+        }
+    ) as user_obj:
+        with enabled_twofactor_auth():
+            call("user.renew_2fa_secret", user_obj["username"], {"interval": 60})
+            secret = get_user_secret(user_obj["id"])
+            with client(auth=None) as c:
+                resp = c.call(
+                    "auth.login_ex",
+                    {
+                        "mechanism": "PASSWORD_PLAIN",
+                        "username": "twofa_noapi",
+                        "password": "test1234",
+                    },
+                )
+                assert resp["response_type"] == "OTP_REQUIRED"
+
+                resp = c.call(
+                    "auth.login_ex_continue",
+                    {
+                        "mechanism": "OTP_TOKEN",
+                        "otp_token": get_2fa_totp_token(secret),
+                    },
+                )
+                assert resp["response_type"] == "DENIED"
+
+
+def test_legacy_login_success():
+    """The removed-in-v27 auth.login still authenticates root over an older API version."""
+    with client(auth=None, version=LEGACY_VERSION) as c:
+        assert c.call("auth.login", "root", password()) is True
+
+
+def test_legacy_login_bad_password():
+    """auth.login returns False for an incorrect password."""
+    with client(auth=None, version=LEGACY_VERSION) as c:
+        assert c.call("auth.login", "root", "wrong-password") is False
+
+
+def test_legacy_login_with_twofactor(clear_ratelimit):
+    """auth.login honors the OTP second factor: no token fails, the right token succeeds."""
+    with create_user(
+        {
+            "username": "legacy2fa",
+            "full_name": "legacy2fa",
+            "group_create": True,
+            "groups": [call("group.query", [["group", "=", "builtin_administrators"]], {"get": True})["id"]],
+            "password": "test1234",
+        }
+    ) as user_obj:
+        with enabled_twofactor_auth():
+            call("user.renew_2fa_secret", user_obj["username"], {"interval": 60})
+            secret = get_user_secret(user_obj["id"])
+
+            # Password alone returns OTP_REQUIRED, which legacy login maps to False
+            # when no otp_token was supplied.
+            with client(auth=None, version=LEGACY_VERSION) as c:
+                assert c.call("auth.login", "legacy2fa", "test1234") is False
+
+            with client(auth=None, version=LEGACY_VERSION) as c:
+                assert c.call("auth.login", "legacy2fa", "test1234", get_2fa_totp_token(secret)) is True
+
+
+def test_legacy_login_with_api_key_invalid():
+    """The removed-in-v27 auth.login_with_api_key returns False for a malformed key."""
+    with client(auth=None, version=LEGACY_VERSION) as c:
+        assert c.call("auth.login_with_api_key", "not-a-valid-key") is False

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -29,19 +29,32 @@ def test_works_for_token():
         assert 'LOCAL' in user['account_attributes']
 
 
+def _clear_root_webui_attribute(key):
+    rows = call("datastore.query", "account.bsdusers_webui_attribute", [["uid", "=", 0]])
+    if rows and key in rows[0]["attributes"]:
+        remaining = {k: v for k, v in rows[0]["attributes"].items() if k != key}
+        call("datastore.update", "account.bsdusers_webui_attribute", rows[0]["id"], {"attributes": remaining})
+
+
 def test_attributes():
-    user = call("auth.me")
-    assert "test" not in user["attributes"]
+    # Keep this idempotent: auth.set_attribute persists in the datastore, so remove any
+    # leftover value from a previous run before asserting and clean up afterwards.
+    _clear_root_webui_attribute("test")
+    try:
+        user = call("auth.me")
+        assert "test" not in user["attributes"]
 
-    call("auth.set_attribute", "test", "value")
+        call("auth.set_attribute", "test", "value")
 
-    user = call("auth.me")
-    assert user["attributes"]["test"] == "value"
+        user = call("auth.me")
+        assert user["attributes"]["test"] == "value"
 
-    call("auth.set_attribute", "test", "new_value")
+        call("auth.set_attribute", "test", "new_value")
 
-    user = call("auth.me")
-    assert user["attributes"]["test"] == "new_value"
+        user = call("auth.me")
+        assert user["attributes"]["test"] == "new_value"
+    finally:
+        _clear_root_webui_attribute("test")
 
 
 def test_distinguishes_attributes():

--- a/tests/api2/test_auth_onetime.py
+++ b/tests/api2/test_auth_onetime.py
@@ -1,7 +1,7 @@
 import errno
 import pytest
 
-from middlewared.service_exception import CallError, ValidationErrors
+from middlewared.service_exception import CallError, ValidationError, ValidationErrors
 from middlewared.test.integration.utils import client, call
 
 
@@ -78,6 +78,12 @@ def test_onetime_password_generate_token_fail(onetime_password):
             c.call('auth.generate_token')
 
         assert ce.value.errno == errno.EOPNOTSUPP
+
+
+def test_onetime_password_nonexistent_user():
+    """Generating a one-time password for an unknown username is a validation error."""
+    with pytest.raises(ValidationError, match='user does not exist'):
+        call('auth.generate_onetime_password', {'username': 'this_user_does_not_exist_zzz'})
 
 
 @pytest.mark.parametrize('data,revert,errmsg', (

--- a/tests/api2/test_auth_sessions.py
+++ b/tests/api2/test_auth_sessions.py
@@ -1,0 +1,26 @@
+from middlewared.test.integration.utils import call, client, password
+
+
+def test_terminate_nonexistent_session_returns_false():
+    """Terminating a session id that does not exist returns False rather than erroring."""
+    assert call("auth.terminate_session", "not-a-real-session-id") is False
+
+
+def test_logout_authenticated_session():
+    """auth.logout tears down an authenticated session."""
+    with client(auth=None) as c:
+        resp = c.call(
+            "auth.login_ex",
+            {
+                "mechanism": "PASSWORD_PLAIN",
+                "username": "root",
+                "password": password(),
+            },
+        )
+        assert resp["response_type"] == "SUCCESS"
+        session_id = c.call("auth.sessions", [["current", "=", True]], {"get": True})["id"]
+
+        assert c.call("auth.logout") is True
+
+        # The session is gone from the manager's point of view.
+        assert call("auth.sessions", [["id", "=", session_id]]) == []

--- a/tests/api2/test_auth_token.py
+++ b/tests/api2/test_auth_token.py
@@ -1,5 +1,6 @@
 import io
 import json
+import time
 
 import pytest
 import requests
@@ -131,6 +132,99 @@ def test_token_job_validation(job_with_pipe):
     with unprivileged_user_client(roles=['READONLY_ADMIN']) as c:
         with pytest.raises(CallError, match='Job is not owned by current session'):
             c.call("auth.generate_token", 300, {'job': job_with_pipe})
+
+
+def test_token_action_upload():
+    """A plain (attribute-less) token authorizes a file upload via auth.get_token_for_action."""
+    token = call('auth.generate_token', 300, {}, True, True)  # no attrs, match origin, single-use
+    r = requests.post(
+        f'http://{truenas_server.ip}/_upload',
+        headers={'Authorization': f'Token {token}'},
+        files={
+            'data': (None, io.StringIO(json.dumps({
+                'method': 'filesystem.put',
+                'params': ['/tmp/token_action_upload'],
+            }))),
+            'file': (None, io.StringIO('token-action-payload')),
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    job_id = r.json()['job_id']
+    assert call('core.job_wait', job_id, job=True) is True
+
+
+def test_get_token_via_download():
+    """A single-use download token is validated (and consumed) by auth.get_token via the download endpoint."""
+    job_id, download_url = call('core.download', 'config.save', [], 'freenas.db')
+
+    # First GET succeeds: auth.get_token validates the token and returns its attributes.
+    r = requests.get(f'http://{truenas_server.ip}{download_url}', timeout=30)
+    assert r.status_code == 200
+    assert len(r.content) > 0
+
+    # The token was single-use, so a second attempt is rejected.
+    r = requests.get(f'http://{truenas_server.ip}{download_url}', timeout=30)
+    assert r.status_code == 401
+
+
+def test_generate_token_null_ttl():
+    """Passing ttl=None falls back to the default token lifetime and still authenticates."""
+    token = call('auth.generate_token', None)
+    with client(auth=None) as c:
+        assert c.call('auth.login_with_token', token)
+
+
+def test_expired_token_is_rejected():
+    """A token whose ttl has elapsed is purged on lookup and can no longer authenticate."""
+    token = call('auth.generate_token', 1)
+    time.sleep(3)
+    with client(auth=None) as c:
+        assert not c.call('auth.login_with_token', token)
+
+
+@pytest.fixture(scope="module")
+def reconnect_pref_user():
+    # A dedicated user so the reconnect-token lifetime preference can be set without
+    # touching root's (real) UI preferences; the user's attributes are removed on teardown.
+    with unprivileged_user_template(
+        username="reconpref",
+        group_name="reconpref_grp",
+        privilege_name="reconpref_priv",
+        roles=["READONLY_ADMIN"],
+        web_shell=False,
+    ) as u:
+        yield u
+
+
+def _login_ex_with_reconnect(user):
+    with client(auth=None) as c:
+        return c.call('auth.login_ex', {
+            'mechanism': 'PASSWORD_PLAIN',
+            'username': user.username,
+            'password': user.password,
+            'login_options': {'reconnect_token': True},
+        })
+
+
+def test_reconnect_token_uses_ui_lifetime_preference(reconnect_pref_user):
+    """The reconnect token ttl is derived from the UI 'preferences.lifetime' attribute."""
+    with client(auth=(reconnect_pref_user.username, reconnect_pref_user.password)) as ac:
+        ac.call('auth.set_attribute', 'preferences', {'lifetime': 120})
+
+    resp = _login_ex_with_reconnect(reconnect_pref_user)
+    assert resp['response_type'] == 'SUCCESS'
+    assert isinstance(resp['reconnect_token'], str)
+
+
+def test_reconnect_token_ignores_too_small_lifetime_preference(reconnect_pref_user):
+    """A 'preferences.lifetime' below the minimum is ignored in favor of the default ttl."""
+    with client(auth=(reconnect_pref_user.username, reconnect_pref_user.password)) as ac:
+        ac.call('auth.set_attribute', 'preferences', {'lifetime': 5})
+
+    resp = _login_ex_with_reconnect(reconnect_pref_user)
+    assert resp['response_type'] == 'SUCCESS'
+    assert isinstance(resp['reconnect_token'], str)
 
 
 def test_reconnect_token_not_requested():

--- a/tests/api2/test_auth_twofactor_internal.py
+++ b/tests/api2/test_auth_twofactor_internal.py
@@ -1,0 +1,45 @@
+import base64
+
+from middlewared.test.integration.assets.account import user as create_user
+from middlewared.test.integration.utils import call
+
+
+def test_generate_base32_secret():
+    """auth.twofactor.generate_base32_secret returns a decodable base32 secret."""
+    secret = call("auth.twofactor.generate_base32_secret")
+    assert isinstance(secret, str)
+    # A valid base32 secret decodes without error.
+    assert base64.b32decode(secret)
+
+
+def test_get_user_config_defaults_for_unconfigured_user():
+    """get_user_config returns the default template when a user has no 2FA row."""
+    config = call("auth.twofactor.get_user_config", 999999, True)
+    assert config["exists"] is False
+    assert config["secret"] is None
+    assert config["otp_digits"] == 6
+    assert config["interval"] == 30
+
+
+def test_get_user_config_and_users_config_for_local_user():
+    """A local user with a renewed secret appears in both the per-user and aggregate configs."""
+    with create_user(
+        {
+            "username": "tfa_internal_user",
+            "full_name": "tfa_internal_user",
+            "group_create": True,
+            "password": "test1234",
+        }
+    ) as user_obj:
+        call("user.renew_2fa_secret", user_obj["username"], {"interval": 30, "otp_digits": 6})
+
+        user_config = call("auth.twofactor.get_user_config", user_obj["id"], True)
+        assert user_config["exists"] is True
+        assert user_config["secret"] is not None
+
+        users = call("auth.twofactor.get_users_config")
+        entry = next((u for u in users if u["username"] == "tfa_internal_user"), None)
+        assert entry is not None
+        assert entry["ad_user"] is False
+        assert entry["otp_digits"] == 6
+        assert entry["interval"] == 30

--- a/tests/api2/test_authenticator_assurance_level.py
+++ b/tests/api2/test_authenticator_assurance_level.py
@@ -40,6 +40,24 @@ def test_mechanism_choices(level, expected):
         assert call('auth.mechanism_choices') == expected
 
 
+def test_get_and_set_assurance_level_3():
+    """LEVEL_3 round-trips through set/get before being restored to LEVEL_1."""
+    with client() as c:
+        try:
+            c.call('auth.set_authenticator_assurance_level', 'LEVEL_3')
+            assert c.call('auth.get_authenticator_assurance_level') == 'LEVEL_3'
+        finally:
+            c.call('auth.set_authenticator_assurance_level', 'LEVEL_1')
+        assert c.call('auth.get_authenticator_assurance_level') == 'LEVEL_1'
+
+
+def test_set_unknown_assurance_level():
+    """An unrecognized assurance level is rejected."""
+    with client() as c:
+        with pytest.raises(CallError, match='unknown authenticator assurance level'):
+            c.call('auth.set_authenticator_assurance_level', 'LEVEL_BOGUS')
+
+
 def test_level2_api_key_plain():
     """ API_KEY_PLAIN lacks replay resistance
     and so authentication attempts must fail with AUTH_ERR


### PR DESCRIPTION
File | Before | After
-- | -- | --
plugins/auth.py | 42% | 82%
plugins/auth_/2fa.py | 44% | 81%
plugins/auth_/authenticate.py | 57% | 95%
plugins/auth_/login_ex_impl.py | 29% | 75%
