### PR TITLE
NAS-143127 / 27.0.0-BETA.1 / Remove custom user properties from `PoolDatasetEntry` documentation

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_dataset.py
@@ -70,6 +70,25 @@ class PoolDatasetEntryProperty(BaseModel, metaclass=ForUpdateMetaclass):
     )
 
 
+class PoolDatasetEntryUserProperties(BaseModel, metaclass=ForUpdateMetaclass):
+    model_config = ConfigDict(extra="allow")
+
+    comments: PoolDatasetEntryProperty = Field(
+        description="ZFS comments property for storing descriptive text about the dataset.",
+    )
+    quota_warning: PoolDatasetEntryProperty = Field(description="ZFS quota warning threshold property as a percentage.")
+    quota_critical: PoolDatasetEntryProperty = Field(
+        description="ZFS quota critical threshold property as a percentage.",
+    )
+    refquota_warning: PoolDatasetEntryProperty = Field(
+        description="ZFS reference quota warning threshold property as a percentage.",
+    )
+    refquota_critical: PoolDatasetEntryProperty = Field(
+        description="ZFS reference quota critical threshold property as a percentage.",
+    )
+    managedby: PoolDatasetEntryProperty = Field(description="Identifies which service or system manages this dataset.")
+
+
 class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     model_config = ConfigDict(extra="allow", strict=False)
     id: str = Field(examples=['tank/dataset/child'], description="The full dataset path including pool name.")
@@ -86,7 +105,7 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
         ),
     )
     children: list = Field(description="Array of child dataset objects nested under this dataset.")
-    user_properties: dict = Field(
+    user_properties: PoolDatasetEntryUserProperties = Field(
         description="Custom user-defined ZFS properties set on this dataset as key-value pairs.",
     )
     locked: bool = Field(description="Whether an encrypted dataset is currently locked (key not loaded).")
@@ -96,20 +115,6 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
             "deduplication is enabled on the dataset."
         ),
     )
-    comments: PoolDatasetEntryProperty = Field(
-        description="ZFS comments property for storing descriptive text about the dataset.",
-    )
-    quota_warning: PoolDatasetEntryProperty = Field(description="ZFS quota warning threshold property as a percentage.")
-    quota_critical: PoolDatasetEntryProperty = Field(
-        description="ZFS quota critical threshold property as a percentage.",
-    )
-    refquota_warning: PoolDatasetEntryProperty = Field(
-        description="ZFS reference quota warning threshold property as a percentage.",
-    )
-    refquota_critical: PoolDatasetEntryProperty = Field(
-        description="ZFS reference quota critical threshold property as a percentage.",
-    )
-    managedby: PoolDatasetEntryProperty = Field(description="Identifies which service or system manages this dataset.")
     deduplication: PoolDatasetEntryProperty = Field(
         description="ZFS deduplication setting - whether identical data blocks are stored only once.",
     )

--- a/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
@@ -69,6 +69,25 @@ class PoolDatasetEntryProperty(BaseModel, metaclass=ForUpdateMetaclass):
     )
 
 
+class PoolDatasetEntryUserProperties(BaseModel, metaclass=ForUpdateMetaclass):
+    model_config = ConfigDict(extra="allow")
+
+    comments: PoolDatasetEntryProperty = Field(
+        description="ZFS comments property for storing descriptive text about the dataset.",
+    )
+    quota_warning: PoolDatasetEntryProperty = Field(description="ZFS quota warning threshold property as a percentage.")
+    quota_critical: PoolDatasetEntryProperty = Field(
+        description="ZFS quota critical threshold property as a percentage.",
+    )
+    refquota_warning: PoolDatasetEntryProperty = Field(
+        description="ZFS reference quota warning threshold property as a percentage.",
+    )
+    refquota_critical: PoolDatasetEntryProperty = Field(
+        description="ZFS reference quota critical threshold property as a percentage.",
+    )
+    managedby: PoolDatasetEntryProperty = Field(description="Identifies which service or system manages this dataset.")
+
+
 class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
     model_config = ConfigDict(extra="allow", strict=False)
     id: str = Field(examples=['tank/dataset/child'], description="The full dataset path including pool name.")
@@ -85,24 +104,10 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
         ),
     )
     children: list = Field(description="Array of child dataset objects nested under this dataset.")
-    user_properties: dict = Field(
+    user_properties: PoolDatasetEntryUserProperties = Field(
         description="Custom user-defined ZFS properties set on this dataset as key-value pairs.",
     )
     locked: bool = Field(description="Whether an encrypted dataset is currently locked (key not loaded).")
-    comments: PoolDatasetEntryProperty = Field(
-        description="ZFS comments property for storing descriptive text about the dataset.",
-    )
-    quota_warning: PoolDatasetEntryProperty = Field(description="ZFS quota warning threshold property as a percentage.")
-    quota_critical: PoolDatasetEntryProperty = Field(
-        description="ZFS quota critical threshold property as a percentage.",
-    )
-    refquota_warning: PoolDatasetEntryProperty = Field(
-        description="ZFS reference quota warning threshold property as a percentage.",
-    )
-    refquota_critical: PoolDatasetEntryProperty = Field(
-        description="ZFS reference quota critical threshold property as a percentage.",
-    )
-    managedby: PoolDatasetEntryProperty = Field(description="Identifies which service or system manages this dataset.")
     deduplication: PoolDatasetEntryProperty = Field(
         description="ZFS deduplication setting - whether identical data blocks are stored only once.",
     )


### PR DESCRIPTION
They belong to `user_properties` since 25.10.0.