### PR TITLE
NAS-143129 / 27.0.0-BETA.1 / Document `tier` field in 27 API

### DIFF
--- a/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
+++ b/src/middlewared/middlewared/api/v27_0_0/pool_dataset.py
@@ -16,6 +16,7 @@ from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 
 from .common import QueryFilters, QueryOptions
 from .pool import PoolAttachment, PoolCreateEncryptionOptions, PoolProcess
+from .zfs_tier import TierInfo
 
 __all__ = [
     "PoolDatasetEntry", "PoolDatasetAttachmentsArgs", "PoolDatasetAttachmentsResult", "PoolDatasetCreateArgs",
@@ -108,6 +109,12 @@ class PoolDatasetEntry(BaseModel, metaclass=ForUpdateMetaclass):
         description="Custom user-defined ZFS properties set on this dataset as key-value pairs.",
     )
     locked: bool = Field(description="Whether an encrypted dataset is currently locked (key not loaded).")
+    tier: TierInfo | None = Field(
+        description=(
+            "Performance tier. `null` if tiering disabled, if underlying pool does not support tiering, or if "
+            "deduplication is enabled on the dataset."
+        ),
+    )
     deduplication: PoolDatasetEntryProperty = Field(
         description="ZFS deduplication setting - whether identical data blocks are stored only once.",
     )


### PR DESCRIPTION
It was added to the 26 file, but not to 27. `model_config = ConfigDict(extra="allow")` made it work, but the field is missing from the documentation.