### PR TITLE
NAS-143146 / 26.0.0 / Include webshare shares in usage reporting (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -351,7 +351,7 @@ class UsageService(Service):
 
     async def gather_sharing(self, context):
         sharing_list = []
-        for service in {'iscsi', 'nfs', 'smb'}:
+        for service in {'iscsi', 'nfs', 'smb', 'webshare'}:
             service_upper = service.upper()
             namespace = f'sharing.{service}' if service != 'iscsi' else 'iscsi.targetextent'
             for s in await self.middleware.call(f'{namespace}.query'):
@@ -359,6 +359,10 @@ class UsageService(Service):
                     sharing_list.append({'type': service_upper, 'purpose': s['purpose']})
                 elif service == 'nfs':
                     sharing_list.append({'type': service_upper, 'readonly': s['ro']})
+                elif service == 'webshare':
+                    sharing_list.append({
+                        'type': service_upper, 'enabled': s['enabled'], 'is_home_base': s['is_home_base'],
+                    })
                 elif service == 'iscsi':
                     tar = await self.middleware.call('iscsi.target.query', [('id', '=', s['target'])], {'get': True})
                     ext = await self.middleware.call(


### PR DESCRIPTION
## Summary
- Add `webshare` to the share types collected by `gather_sharing` in `plugins/usage/gather.py`
- Each webshare is reported as `{"type": "WEBSHARE", "enabled": ..., "is_home_base": ...}`; name, path and dataset are omitted to keep the report anonymous, matching how SMB only reports `purpose` and NFS only `ro`

## Test plan
- `python3 -m py_compile` on the changed file
- `tests/api2/test_usage_reporting.py` (only asserts the `shares` key exists, so no update needed)

Original PR: https://github.com/truenas/middleware/pull/19622
