### PR TITLE
NAS-143161 / 26.0.0-RC.1 / Run the S3 service suites unconditionally

### DIFF
--- a/tests/api2/test_s3_bucket.py
+++ b/tests/api2/test_s3_bucket.py
@@ -1,5 +1,3 @@
-# TODO: re-enable once the truenas_s3 daemon is added to the TrueNAS image.
-# Every test here starts the service and talks to the daemon.
 """S3 buckets: a dataset this plugin creates and registers with the S3
 service, with its access grants embedded. Registering, dropping,
 enabling or disabling a bucket restarts the service; its owner, grants
@@ -17,12 +15,6 @@ from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.pool import dataset, pool
 from middlewared.test.integration.utils import call, ssh
-
-# TRUENAS_S3_DAEMON=1 runs them on a box that has the daemon installed by hand.
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TRUENAS_S3_DAEMON"),
-    reason="the truenas_s3 daemon is not in the TrueNAS image yet",
-)
 
 SERVICE = "truenas_s3"
 BUCKETS_CONF = "/etc/truenas_s3/buckets.conf"

--- a/tests/api2/test_s3_config.py
+++ b/tests/api2/test_s3_config.py
@@ -1,5 +1,3 @@
-# TODO: re-enable once the truenas_s3 daemon is added to the TrueNAS image.
-# Every test here starts the service and talks to the daemon.
 """The S3 service's global configuration, the files it renders and the
 verb each change costs. The daemon answers a reload request with whether
 it took the files or wants a restart, and middleware acts on that, so
@@ -7,19 +5,12 @@ the tests watch the service's pid: a reload keeps it, a restart replaces
 it."""
 
 import contextlib
-import os
 from configparser import RawConfigParser
 
 import pytest
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.utils import call, ssh
-
-# TRUENAS_S3_DAEMON=1 runs them on a box that has the daemon installed by hand.
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TRUENAS_S3_DAEMON"),
-    reason="the truenas_s3 daemon is not in the TrueNAS image yet",
-)
 
 SERVICE = "truenas_s3"
 BUCKETS_CONF = "/etc/truenas_s3/buckets.conf"


### PR DESCRIPTION
The daemon is in the TrueNAS image now, so the two suites that start it no longer wait for TRUENAS_S3_DAEMON to say a box has one. The access key suite never needed it.