### PR TITLE
NAS-143315 / 27.0.0-BETA.1 / Serialize libzfs pool discovery scans

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
@@ -1,11 +1,22 @@
 import errno
 import functools
+from threading import Lock
 
 import libzfs
 
 from middlewared.service import CallError, Service
 
 from .pool_utils import SEARCH_PATHS, find_vdev
+
+
+# Pool discovery (`zfs.find_import`) reads the label of every candidate block
+# device and then re-opens it O_EXCL to verify it is not in use. Two discovery
+# scans running at the same time make each other's exclusive opens fail with
+# EBUSY, and a device that cannot be opened is dropped from the result instead
+# of being retried, so a scan that loses the race reports an exported pool with
+# missing members (its disks then look unused) or omits the pool entirely.
+# Serialize discovery so that every caller sees a complete view.
+POOL_DISCOVERY_LOCK = Lock()
 
 
 class ZFSPoolService(Service):
@@ -118,7 +129,7 @@ class ZFSPoolService(Service):
 
     def find_import(self):
         sp = self.get_search_paths()
-        with libzfs.ZFS() as zfs:
+        with POOL_DISCOVERY_LOCK, libzfs.ZFS() as zfs:
             return [i.asdict() for i in zfs.find_import(search_paths=sp)]
 
     def import_pool(
@@ -138,10 +149,11 @@ class ZFSPoolService(Service):
             found = None
             sp = self.get_search_paths()
             try:
-                for pool in zfs.find_import(cachefile=cachefile, search_paths=sp):
-                    if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
-                        found = pool
-                        break
+                with POOL_DISCOVERY_LOCK:
+                    for pool in zfs.find_import(cachefile=cachefile, search_paths=sp):
+                        if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
+                            found = pool
+                            break
             except libzfs.ZFSInvalidCachefileException:
                 raise CallError('Invalid or missing cachefile', errno.ENOENT)
             except libzfs.ZFSException as e:


### PR DESCRIPTION
Ticket: https://ixsystems.atlassian.net/browse/NAS-143315

## Problem

`zfs.find_import` reads the label of every candidate block device, then re-opens each one `O_RDONLY | O_EXCL` to verify it (`zutil_import.c` 1540-1541). A device whose exclusive open fails is dropped from the result rather than retried, because py-libzfs calls `zpool_search_import` with `can_be_active` unset. The per-pool `ZFS_IOC_POOL_TRYIMPORT` that follows takes the same devices exclusively in the kernel (`vdev_bdev_mode()` always adds `BLK_OPEN_EXCL`).

Two scans in the same process therefore knock devices out of each other's results, in both directions, with no retry on either side.

Nothing serializes them. `disk.details` (`disk_/availability.py:48`), `pool.import_find` (`pool_/import_pool.py:119`, a `@job()` with no job lock) and `pool.reimport` (`:260`) all reach `zfs.pool.find_import`, and `pool.import_pool` runs the same scan internally. `@job(lock='import_pool')` serializes imports against each other but not against the other three.

The visible result is that `disk.details` moves an exported pool's members to the unused list with `exported_zpool` null, so `disk.get_unused` offers them for a new pool and `replace_disk.py:50` stops refusing them. `pool.import_find` filters `status == 'UNAVAIL'`, so the pool can also vanish from the import list for one call. The Disks and Import Pool pages issue this pair of calls in normal use.

## Change

A module level lock around the `zfs.find_import()` scan in `find_import()` and around the scan `import_pool()` uses to locate its pool. Concurrent callers wait rather than receiving a partial view.

## Scope, so these do not read as oversights

- The lock covers discovery only, not the `zfs.import_pool()` call after it. An import also holds member devices exclusively, so a scan overlapping an in-flight import can still see a partial view. Holding the lock across the import would block `disk.details` for the whole import and mount phase, which seemed the worse trade. Happy to extend it if you would rather.
- No acquire timeout. Every path that takes this lock then runs the same full device scan, so a device stuck in uninterruptible I/O hangs those callers with or without it. The lock adds queueing, not new hang exposure.
- `pool.import_on_boot_impl` imports through a `zpool import` subprocess, which runs its own label scan in another process. An in-process lock cannot cover that.

## Branches

Applies unchanged to `stable/26` (`find_import` at line 117).

Not correct for `stable/goldeye` as written: `zfs.pool` sets `process_pool = True` there, so these methods run in one of several worker processes and a `threading.Lock` would only serialize within a single worker. That train would need cross-process serialization if you want the fix on 25.10.