### PR TITLE
NAS-143316 / 27.0.0-BETA.1 / Report a failed dataset destroy instead of returning true

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -986,9 +986,15 @@ class PoolDatasetService(CRUDService):
             )
 
         async with self.s.truesearch.remove_mountpoint(mountpoint):
-            await self.call2(
+            # destroy_impl reports a failed destroy by return value, not by
+            # raising, so it has to be checked or a failure is reported to the
+            # caller as a successful delete.
+            failed, errnum = await self.call2(
                 self.s.zfs.resource.destroy_impl, id_, recursive=options['recursive']
             )
+
+        if failed:
+            raise CallError(failed, errnum or errno.EFAULT)
 
         return True
 

--- a/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/destroy_impl.py
@@ -67,7 +67,14 @@ def destroy_nonrecursive_impl(tls: Any, path: str, defer: bool) -> tuple[str | N
             if mntpnt.mountpoint.value != "legacy":
                 _remove_mountpoint_dir(mntpnt.mountpoint.value)
 
-    # Both ZFS_TYPE_FILESYSTEM and ZFS_TYPE_VOLUME
+    # Both ZFS_TYPE_FILESYSTEM and ZFS_TYPE_VOLUME.
+    #
+    # Discard any unmount failure recorded above first. The destroy is
+    # attempted either way, and the return value describes the destroy, so a
+    # failed unmount followed by a successful destroy has to report success.
+    # Otherwise callers that check this tuple report a delete that did happen
+    # as a failure.
+    failed, errnum = None, None
     try:
         tls.lzh.destroy_resource(name=path)
     except truenas_pylibzfs.ZFSException as e:


### PR DESCRIPTION
Ticket: https://ixsystems.atlassian.net/browse/NAS-143316

## Problem

`zfs.resource.destroy_impl` reports a failed destroy by return value, `(failed, errnum)`, not by raising. Only clones, holds and path-not-found leave by exception, so those already fail loudly; everything else is silent.

`pool.dataset.delete` discarded that tuple and unconditionally returned `True` (`pool_/dataset.py:988-993`). A destroy that failed, for example EBUSY because the mountpoint was pinned from outside middleware, was reported to the caller as a successful delete while the dataset was still there. Seen in the field on 26.0.0-BETA.2: an app uninstall got `true` back and the dataset remained.

This is a regression against 25.10, where `do_delete` returned the result of `zfs.dataset.delete`, which raised.

Every other caller of `destroy_impl` checks the tuple. `zfs.resource.destroy` (`zfs/resource_crud.py:758`) raises `ValidationError`, and `sysdataset` does the same and documents why: *"with hard return-value checking, since destroy_impl reports logical failures via tuple return rather than raising"*. Only `pool.dataset.delete` was missed.

## Change

**`pool_/dataset.py`** — read the tuple, raise `CallError(failed, errnum)`. `CallError` rather than `ValidationError` because the input was valid and the operation failed, because it matches the sibling *filesystem has children* error a few lines above, and because it is what callers saw on 25.10. The raise sits after the `truesearch.remove_mountpoint` block so that context manager still completes exactly as it does today.

**`zfs/destroy_impl.py`** — clear `failed`/`errnum` before attempting `destroy_resource()` in `destroy_nonrecursive_impl`.

The second hunk is required for the first to be correct. An `unmount()` failure there sets `failed` and then falls through to the destroy attempt without clearing it, so a successful destroy after a failed unmount still returns an error string. Checking that tuple without this would raise for a delete that did happen. Nothing notices today because the only other caller of that path, `zfs.resource.destroy`, has the same latent problem.

Nothing else is affected by it: the snapshot branch returns before that point, and the zvol path reaches it with both values already `None`.

## Adjacent gaps, noticed and deliberately left alone

- `errnum` is a POSIX errno on the channel-program path but a `truenas_pylibzfs.ZFSError` code on the non-recursive path, so the same busy dataset surfaces a different `errno` depending on `recursive`. `zfs.resource.destroy` already inherits this; mapping the two is a wider change.
- When the destroy fails after a failed unmount, only the destroy message is surfaced. Pre-existing: that branch already overwrote the unmount message.
- `_remove_mountpoint_dir()` runs only in the `else` of the unmount `try`, so the unmount-failed/destroy-succeeded path leaves the mountpoint directory behind. Pre-existing and unchanged here, but worth a look, since re-creating the dataset then mounts over a non-empty path.
- `do_delete` removes SMB shares and iSCSI extents via the attachment delegates *before* the destroy. With this change the operator now gets an error for a delete that already removed those, with no rollback. Better than a silent `true`, but the share removal probably wants to be conditional on the destroy succeeding.

## Branches

Applies to `stable/26` at `pool_/dataset.py:969` and `zfs/destroy_impl.py:72`.

Does not apply to `stable/goldeye`: 25.10 calls `zfs.dataset.delete`, which raises, and does not have this bug.