### PR TITLE
NAS-143318 / 27.0.0-BETA.1 / Report a failed job on /_download instead of an empty 200

### DIFF
--- a/src/middlewared/middlewared/apps/file_app.py
+++ b/src/middlewared/middlewared/apps/file_app.py
@@ -15,6 +15,7 @@ from middlewared.auth import (
     LoginPasswordSessionManagerCredentials,
     TokenSessionManagerCredentials,
 )
+from middlewared.job import State as JobState
 from middlewared.pipe import InputPipes, Pipes
 from middlewared.plugins.auth_.login_ex_impl import login_ex_password_plain
 from middlewared.service_exception import CallError
@@ -312,6 +313,19 @@ class FileApplication:
             resp = web.Response()
             resp.set_status(410)
             return resp
+
+        if job.state in (JobState.FAILED, JobState.ABORTED):
+            # The response below is prepared with a 200 before anything is read
+            # from the pipe, so a job that failed before writing would be served
+            # as a successful, empty download. Report the failure instead, and
+            # release the pipe and its cleanup timer the way the copy below
+            # does on its way out.
+            await self._cleanup_cancel(job_id)
+            await job.pipes.close()
+            return web.Response(
+                status=500,
+                body=job.error or f"Job {job_id} {job.state.name.lower()}",
+            )
 
         resp = web.StreamResponse(
             status=200,


### PR DESCRIPTION
Ticket: https://ixsystems.atlassian.net/browse/NAS-143318

## Problem

`FileApplication.download` builds a `StreamResponse(status=200)` and calls `resp.prepare(request)` (`file_app.py:316,325`) before reading anything from the job pipe. A job that failed before its first write leaves the write end closed, so `do_copy` reads `b""` immediately and the client gets a clean, complete, empty **200**. The failure appears only in `core.get_jobs`, so any client trusting the HTTP status saves an empty file and reports success.

Reproduced on 26.0.0-BETA.3:

```
midclt call core.download filesystem.get '["/sys/class/net/lo/mtu"]' mtu.txt
curl -o /tmp/mtu.txt -w '%{http_code} %{size_download}\n' "http://127.0.0.1<url>"
# 200 0   — job FAILED with [Errno 40] Symlink detected in path
```

Any `filesystem.get` that raises before its first write behaves the same; a nonexistent path is the simplest case.

## Change

Check the job state before preparing the response. If it is already `FAILED` or `ABORTED`, return 500 with the job error, releasing the pipe and its cleanup timer the way the normal path does on its way out (otherwise a buffered download's temp file stays open for the full cleanup timer, and the stale timer later indexes a job that may have been evicted).

## What this does not cover

The check is a snapshot taken before `prepare()`, so it catches a job that had already failed when the client connected. That is the common case, since `core.download` returns the URL as soon as the job is queued. Two cases remain:

- the client connects while the job is still `WAITING`/`RUNNING` and the job then fails without writing;
- the job fails mid-stream, so the client stores a truncated file as a successful download.

Both could be closed with a `job.state` recheck after `do_copy` — EOF on the pipe means the job is terminal by then — but the response then has to be aborted rather than drained, and terminating the chunked stream abnormally is not something I wanted to write untested against the aiohttp version you ship. Happy to add it here if you would like it in the same change.

## Knock-on for the one in-tree consumer

`plugins/system/debug.py:123` fetches the standby node's debug through this endpoint with `requests.get(url, stream=True)` and no `raise_for_status()`, writing whatever comes back into the archive. Today a failed standby `filesystem.get` contributes a 0-byte member; with this change it would contribute the error text. Neither is a usable archive and the error text is at least self-describing, but that consumer probably wants a `raise_for_status()`. Not touched here, since failing the debug job outright is a behaviour change on an HA path.

## Related read-side findings (no code here)

Both produce the same empty-but-successful download from a job that did **not** fail. Both look deliberate, so they are written up in the ticket rather than patched:

1. `filesystem.get` cannot read anything under `/sys/class` since `ca6f6d07a0` (NAS-140151) moved it to `safe_open()` / `RESOLVE_NO_SYMLINKS`. Not a revert request — the question is whether a read-only FULL_ADMIN caller should have a supported way to read pseudo-filesystem paths.
2. `filesystem.py:583` skips the copy when `st_size == 0`, so procfs files with real contents return an empty successful download. Arrived with `4fc5405484` (NAS-141825); BETA.3 still used `copyfileobj` and read them correctly. The obvious `copyfileobj` fallback was tried and discarded: `/proc/kmsg` has `st_size` 0 and never reaches EOF, so it would block an io thread forever.

## Branches

`file_app.py` is identical on `stable/26` and materially the same on `stable/goldeye`, where the empty-200 behaviour is the same.