### PR TITLE
NAS-143324 / 27.0.0-BETA.1 / Skip IPA DNS registration when DNS updates are disabled

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -105,8 +105,9 @@ class IPAJoinMixin:
         job.set_progress(description='Deleting NFS and SMB service principals.')
         self._ipa_del_spn()
 
-        job.set_progress(description='Removing DNS entries.')
-        self.unregister_dns(ds_config_to_fqdn(ds_config), False)
+        if ds_config['enable_dns_updates']:
+            job.set_progress(description='Removing DNS entries.')
+            self.unregister_dns(ds_config_to_fqdn(ds_config), False)
 
         # now leave IPA
         job.set_progress(description='Leaving IPA domain.')
@@ -661,7 +662,8 @@ class IPAJoinMixin:
         elif not cred['name'].startswith('host/'):
             raise CallError(f'{cred}: not host principal.')
 
-        self.register_dns(ds_config_to_fqdn(ds_config))
+        if ds_config['enable_dns_updates']:
+            self.register_dns(ds_config_to_fqdn(ds_config))
         self._ipa_setup_services(job)
         job.set_progress(description='Activating IPA service.')
         self._ipa_activate()


### PR DESCRIPTION
Jira: https://ixsystems.atlassian.net/browse/NAS-143324

### Problem

`_ipa_join()` and `_ipa_leave()` call `register_dns()` / `unregister_dns()` unconditionally, but `register_dns()` raises when the directory service has `enable_dns_updates` set to false:

```python
# plugins/directoryservices_/connection.py:343
if not ds_config['enable_dns_updates']:
    raise CallError('DNS updates are disabled for the directory service')
```

In `_ipa_join()` that call sits immediately before `_ipa_setup_services()`. So on a FreeIPA domain whose DNS is not served by IPA — zones maintained in a separate BIND instance, GSS-TSIG unavailable — the join aborts with

```
CallError: DNS updates are disabled for the directory service
```

before any NFS/SMB service principal is created, before the keytabs are inserted, and before the `IPA_SMB_KEYTAB` `kerberos.keytab` row is written. Since `smb.generate_smb_configuration()` gates `smb_domain` on the presence of that row, SMB is left entirely unconfigured — and `join_domain(force=True)` and leave-then-rejoin fail identically, so there is no supported path to repair it.

`_ipa_leave()` has the same defect: the unguarded `unregister_dns()` aborts the leave before local configuration is cleaned up.

### Fix

Guard both call sites on `enable_dns_updates`, which is what the Active Directory path in the same directory already does:

- `activedirectory_join_mixin.py:274` — guards `unregister_dns()`
- `activedirectory_join_mixin.py:387` — guards `register_dns()`

The IPA path guarded neither. This change brings it in line; no other behaviour is altered.

### Testing

`ruff check src/middlewared` passes.

`tests/directory_services/test_ipa_join.py` needs a live FreeIPA fixture, which I have no way to run here. The change is guard-only and mirrors the AD path exactly, so I have not added a test — glad to add one if you would like this covered.

### How it was found

Two TrueNAS SCALE 25.10.6 arrays joined to a FreeIPA realm whose DNS zones are hand-maintained in BIND. Both had to have their SMB service principals and keytabs configured by hand, outside middleware, because every supported join path aborts on this line — and any upgrade or re-join returns them to a broken state.
