### PR TITLE
NAS-143325 / 25.10.8 / Release a login whose connection closed while it ran

### DIFF
--- a/src/middlewared/middlewared/api/base/server/app.py
+++ b/src/middlewared/middlewared/api/base/server/app.py
@@ -19,3 +19,6 @@ class App:
         self.py_exceptions = False
         self.websocket = False
         self.rest = False
+        # Set when the connection is torn down, before its CLOSE callbacks
+        # run, so that work still in flight can tell it has gone away.
+        self.closed = False

--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -131,6 +131,13 @@ class RpcWebSocketApp(App):
         self.callbacks[event.value].append(callback)
 
     async def run_callback(self, event, *args, **kwargs):
+        if event is RpcWebSocketAppEvent.CLOSE:
+            # CLOSE is dispatched once, when the connection is torn down.
+            # Record it before running the callbacks, so that work still in
+            # flight can tell the connection has gone away and does not rely
+            # on a callback it registers too late to be run.
+            self.closed = True
+
         for callback in self.callbacks[event.value]:
             try:
                 if asyncio.iscoroutinefunction(callback):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -121,9 +121,44 @@ class SessionManager:
         self.sessions = {}
         self.middleware = None
 
+    async def __aborted_because_closed(self, app, credentials, resp) -> bool:
+        """ Undo a login whose connection went away while it was running.
+
+        Method calls are dispatched with ensure_future, so the read loop
+        reaches its CLOSE callbacks as soon as the socket closes, which can be
+        before this login has registered one. Such a close is delivered to
+        nobody: the session would stay in self.sessions, which holds the
+        credentials, so neither logout() nor __del__ would return the utmp
+        session id to the pool, and the id scavenger only reclaims ids that
+        have no utmp entry. Release the credentials here instead, before there
+        is a session to leak.
+        """
+        if not app.closed:
+            return False
+
+        if resp.code == pam.PAM_SUCCESS:
+            if not is_internal_login(app, credentials):
+                # credentials.login() has already written the utmp and wtmp
+                # login records, so record the attempt rather than leaving
+                # those with no matching audit entry. The caller never reaches
+                # the point where a successful authentication is logged.
+                await self.middleware.log_audit_message(app, "AUTHENTICATION", {
+                    "credentials": dump_credentials(credentials),
+                    "error": "Connection was closed while logging in.",
+                }, False)
+
+            # Only a login that reached PAM_SUCCESS holds a utmp entry and a
+            # session id to give back. logout() on an authenticator at any
+            # other stage raises instead.
+            await self.middleware.run_in_thread(credentials.logout)
+
+        return True
+
     async def login(self, app, credentials):
         if app.authenticated:
-            await self.middleware.run_in_thread(credentials.login, app.session_id)
+            resp = await self.middleware.run_in_thread(credentials.login, app.session_id)
+            if await self.__aborted_because_closed(app, credentials, resp):
+                return
             # If previous credential had associated utmp entry then it will be automatically
             # cleared when old credentials object is garbage collected
             self.sessions[app.session_id].credentials = credentials
@@ -144,6 +179,9 @@ class SessionManager:
 
         if resp.code != pam.PAM_SUCCESS:
             raise CallError(f'Login with credentials failed: {resp.reason}')
+
+        if await self.__aborted_because_closed(app, credentials, resp):
+            return
 
         session = Session(self, credentials, app)
         self.sessions[app.session_id] = session
@@ -213,19 +251,22 @@ class Session:
         }
 
 
-def is_internal_session(session) -> bool:
+def is_internal_login(app, credentials) -> bool:
+    """ Whether a login is internal, for a caller that has no Session yet
+    and so has not set app.authenticated_credentials. """
     try:
-        is_root_sock = session.app.origin.is_unix_family and session.app.origin.uid == 0
+        is_root_sock = app.origin.is_unix_family and app.origin.uid == 0
         if is_root_sock:
             return True
     except AttributeError:
-        # session.app.origin can be NoneType
+        # app.origin can be NoneType
         pass
 
-    if isinstance(session.app.authenticated_credentials, TruenasNodeSessionManagerCredentials):
-        return True
+    return isinstance(credentials, TruenasNodeSessionManagerCredentials)
 
-    return False
+
+def is_internal_session(session) -> bool:
+    return is_internal_login(session.app, session.app.authenticated_credentials)
 
 
 class UserWebUIAttributeModel(sa.Model):
@@ -1107,7 +1148,10 @@ class AuthService(Service):
         match resp['pam_response']['code']:
             case pam.PAM_SUCCESS:
                 response['response_type'] = AuthResp.SUCCESS
-                if data['login_options']['user_info']:
+                if data['login_options']['user_info'] and app.authenticated_credentials is not None:
+                    # The credentials are unset when the connection closed
+                    # while the login was running, in which case there is no
+                    # session to describe and nobody left to describe it to.
                     response['user_info'] = await self.me(app)
                 else:
                     response['user_info'] = None


### PR DESCRIPTION
Ticket: https://ixsystems.atlassian.net/browse/NAS-143325

Against `stable/goldeye`. 26.0 reworked the authenticator and does not have this bug, so there is no master equivalent.

## Problem

`process_message` dispatches method calls with `asyncio.ensure_future` (`rpc.py:330`), so the read loop does not wait for them. When the socket closes, the loop's `finally` runs `run_callback(CLOSE)` (`rpc.py:266`) — dispatched exactly once.

That can land while `SessionManager.login` is suspended at `await run_in_thread(credentials.login, ...)` (`auth.py:138`), which has already popped an id from `AVAILABLE_SESSION_IDS` and written the utmp entry, and **before** login registers its CLOSE callback (`auth.py:155`).

The close reaches nobody. The login then installs the session, and:

- the `Session` sits in `self.sessions` holding a strong reference to the credentials, so `__del__` never runs;
- `logout()` is never called, so the utmp entry is never cleared and the id never returned;
- the scavenger `__recover_ids` only reclaims ids with no `USER_PROCESS` `ws/N` entry, and these all have one.

The pool is 10000. A client whose logins time out and retries burns one per attempt; once drained every login fails with *Available utmp session ids exhausted*. We saw roughly 288 of those an hour across our fleet before shipping a client-side backoff, which hides it rather than fixing it.

## Reproduced

25.10.7, 30 concurrent `auth.login_ex` with each socket closed right after the request was written and never read: `auth.sessions` 8 → 28, utmp `ws/N` 7 → 27, unchanged after 10 minutes with one live socket on the box, and the stale utmp entries survive a middlewared restart. Successful logins and bad-password logins leak nothing. 26.0.0-BETA.3 leaks nothing.

## Change

- `app.py` — `App.closed`, default False.
- `rpc.py` — `run_callback` sets it when dispatching CLOSE, before running the callbacks. `WebSocketApplication` subclasses `RpcWebSocketApp`, so the legacy path is covered by the same line.
- `auth.py` — check it as soon as `credentials.login()` returns, in both the fresh-login and re-login branches. If the connection is gone, release the credentials (clearing the utmp entry and returning the id) and return without creating a session.

Nothing yields between that check and `register_callback(CLOSE, ...)`, so a login that passes the check cannot miss the close.

The release runs only for `PAM_SUCCESS`, since `logout()` on an authenticator at any earlier stage raises in `truenas_check_stage`. An aborted login is audited, gated on `is_internal_login()` so internal and HA-node logins stay out of the audit trail as they do today — otherwise `credentials.login()` leaves a utmp/wtmp login record with no matching audit entry. `is_internal_session()` is split so the same test can run before a `Session` exists; it is otherwise unchanged. `login_ex` builds `user_info` only when credentials are set, since an aborted login has none.

## Not addressed

Both pre-existing, both on lines this patch touches, so listed rather than silently left:

- The re-login branch ignores `credentials.login()`'s return code. A `PAM_ABORT` from id exhaustion on a live connection is still installed as the session credential and audited as a success, leaving a session with no utmp record. The fresh-login branch retries `PAM_ABORT` once and raises on anything else; this one does neither.
- In the same branch `self.sessions[app.session_id]` can `KeyError` if `_app_on_message` logs out an expired session concurrently with an in-flight re-login. `app.closed` is false in that race, so this does not cover it.