### PR TITLE
NAS-143328 / 27.0.0-BETA.1 / Make pool.scrub a job the caller can follow

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool_operations.py
@@ -96,7 +96,7 @@ class PoolService(Service):
             f.write(str(priority.scrub_max_active))
 
     @api_method(PoolScrubArgs, PoolScrubResult, roles=['POOL_WRITE'])
-    @job(transient=True)
+    @job()
     async def scrub(self, job, oid, action):
         """
         Performs a scrub action to pool of ``id``.


### PR DESCRIPTION
Ticket: https://ixsystems.atlassian.net/browse/NAS-143328

## Problem

`pool.scrub` (`pool_/pool_operations.py:99`) is `@job(transient=True)`. It answers with a job id and `core.get_methods` reports it as `job: true`, but transient means, per the decorator's own docs, that no `core.get_jobs` ADDED/CHANGED event is sent and the job is removed from the queue when it finishes:

- `job.py` `send_job_event()` returns early when `options['transient']` is set;
- the run `finally` calls `queue.remove(self.id)` for a transient job.

So the id handed to the caller names something no job-aware client can follow — `midclt call -j`, the UI job tracker, `truenas_api_client`.

The two decorators also contradict each other. `job.wrap()` is there to proxy the inner `pool.scrub.scrub` job's progress and result onto this job; transient makes that job unobservable.

Measured on 26.0.0-BETA.3 with `core.get_jobs` subscribed: `pool.scrub [id, "START"]` returned `75230`, no event ever named 75230, `core.get_jobs [["id","=",75230]]` returned nothing, the work ran as 75231 `pool.scrub.scrub` with `message_ids: []`, and `midclt call -j` hung until its 120 s timeout while the scrub finished in about a second. For contrast `zpool.scrub.run` returned 75233 and emitted `added` with `message_ids: [11]`. On 25.10.7 `pool.scrub` returns a normal, listable job.

## Change

Drop `transient=True`, so the job handed to the caller is one the caller can follow.

## Related, not changed here

`ipmi.sel.elist` is also a public API method declared `@job(..., transient=True)`, so it has the same combination. Left alone since it returns quickly and nobody has reported it, but it would behave the same for a client that waits on it.

There is a second, independent half in `truenas_api_client`: with new-style jobs the server does not answer a job method with its id, the id arrives via a `core.get_jobs` event that `_process_message` substitutes into `call.result`. With no event, the call returns the method's own result and `wait()` builds a `Job` around it, waiting forever on an id the server never issued — which is why this surfaces as a hang rather than an error, and why it also affects `job=True` on any non-job method. Fixed separately in truenas/api_client.

## Branches

Applies to `stable/26` at line 94 of the same file. `stable/goldeye` does not need it.