### PR TITLE
NAS-143329 / 27.0.0-BETA.1 / Make pool.snapshot.update actually update the snapshot

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot.py
@@ -1,6 +1,8 @@
 import errno
 from typing import Any
 
+from truenas_pylibzfs import ZFSException
+
 from middlewared.api import api_method
 from middlewared.api.current import (
     PoolSnapshotCloneArgs,
@@ -381,10 +383,28 @@ class PoolSnapshotService(CRUDService):
 
     @api_method(PoolSnapshotUpdateArgs, PoolSnapshotUpdateResult)
     def do_update(self, snap_id, data):
-        """Update the user properties of the snapshot identified by ``snap_id``."""
-        # TODO: add zfs.resource.snapshot.update (what is this even used for???)
-        data['user_properties_update'].extend({'key': k, 'remove': True} for k in data.pop('user_properties_remove'))
-        # return self.middleware.call_sync('zfs.snapshot.update', snap_id, data)
+        """Update the user properties of the snapshot identified by ``id``.
+
+        A property named in both ``user_properties_update`` and ``user_properties_remove``
+        ends up removed.
+        """
+        try:
+            snap = self.call_sync2(
+                self.s.zfs.resource.snapshot.update_impl,
+                snap_id,
+                {i['key']: i['value'] for i in data['user_properties_update']},
+                data['user_properties_remove'],
+            )
+        except ZFSPathNotFoundException as e:
+            raise InstanceNotFound(e.message)
+        except ZFSException as e:
+            raise ValidationError('pool.snapshot.update', f'Failed to update properties: {e}')
+
+        entry = self._transform_snapshot_entry(snap, include_holds=False)
+        self.middleware.send_event(
+            f'{self._config.namespace}.query', 'CHANGED', id=entry['id'], fields=entry
+        )
+        return entry
 
     @api_method(PoolSnapshotDeleteArgs, PoolSnapshotDeleteResult)
     def do_delete(self, id_, options):

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -581,6 +581,45 @@ class ZFSResourceSnapshotService(Service):
 
     @private
     @pass_thread_local_storage
+    def update_impl(
+        self, tls: Any, path: str, user_properties: dict[str, str], remove: list[str]
+    ) -> dict[str, Any]:
+        """Set and/or clear user properties on a single snapshot.
+
+        Args:
+            tls: Thread local storage containing lzh (libzfs handle)
+            path: Snapshot path (e.g. 'pool/dataset@snapshot').
+            user_properties: Property names mapped to their new values.
+            remove: Property names to clear. Applied after `user_properties`,
+                so a name given in both ends up removed.
+
+        Returns:
+            dict: The snapshot as it stands after the change.
+        """
+        schema = "zfs.resource.snapshot.update"
+
+        # open_resource() opens any resource type, so without this a dataset
+        # path would write the properties to the dataset itself.
+        if "@" not in path:
+            raise ValidationError(
+                schema, f"{path!r} must be a snapshot path (containing '@').", errno.EINVAL
+            )
+        if has_internal_path(path.split("@")[0]):
+            raise ValidationError(schema, f"{path!r} is a protected path.", errno.EACCES)
+
+        snap = open_resource(tls, path)
+        if user_properties:
+            snap.set_user_properties(user_properties=user_properties)
+        for key in remove:
+            snap.inherit_property(property=key)
+
+        # The requested properties are the ones the create path returns.
+        return query_snapshots_impl(
+            tls.lzh, {"paths": [path], "properties": ["creation", "createtxg"]}
+        )[0]
+
+    @private
+    @pass_thread_local_storage
     def hold_impl(self, tls: Any, data: ZFSResourceSnapshotHoldQuery) -> None:
         schema = "zfs.resource.snapshot.hold"
 

--- a/tests/api2/test_pool_snapshot_update.py
+++ b/tests/api2/test_pool_snapshot_update.py
@@ -1,0 +1,81 @@
+import pytest
+
+from middlewared.test.integration.assets.pool import dataset, snapshot
+from middlewared.test.integration.utils import call
+
+
+def user_properties(snap):
+    return call(
+        "zfs.resource.snapshot.query",
+        {"paths": [snap], "get_user_properties": True},
+    )[0]["user_properties"]
+
+
+def test_pool_snapshot_update_sets_user_properties():
+    with dataset("test_snap_update_set") as ds:
+        with snapshot(ds, "snap") as snap:
+            entry = call("pool.snapshot.update", snap, {
+                "user_properties_update": [
+                    {"key": "com.example:one", "value": "1"},
+                    {"key": "com.example:two", "value": "2"},
+                ],
+            })
+
+            assert entry["id"] == snap
+            assert entry["properties"]["createtxg"]["value"]
+            assert user_properties(snap) == {
+                "com.example:one": "1",
+                "com.example:two": "2",
+            }
+
+
+def test_pool_snapshot_update_removes_user_properties():
+    with dataset("test_snap_update_remove") as ds:
+        with snapshot(ds, "snap") as snap:
+            call("pool.snapshot.update", snap, {
+                "user_properties_update": [
+                    {"key": "com.example:keep", "value": "yes"},
+                    {"key": "com.example:drop", "value": "no"},
+                ],
+            })
+
+            call("pool.snapshot.update", snap, {
+                "user_properties_remove": ["com.example:drop"],
+            })
+
+            assert user_properties(snap) == {"com.example:keep": "yes"}
+
+
+def test_pool_snapshot_update_remove_wins_over_update():
+    with dataset("test_snap_update_conflict") as ds:
+        with snapshot(ds, "snap") as snap:
+            call("pool.snapshot.update", snap, {
+                "user_properties_update": [{"key": "com.example:x", "value": "v"}],
+                "user_properties_remove": ["com.example:x"],
+            })
+
+            assert user_properties(snap) == {}
+
+
+def test_pool_snapshot_update_rejects_dataset_path():
+    """A path without '@' must not fall through and update the dataset itself."""
+    with dataset("test_snap_update_dataset_path") as ds:
+        with pytest.raises(Exception) as exc_info:
+            call("pool.snapshot.update", ds, {
+                "user_properties_update": [{"key": "com.example:x", "value": "v"}],
+            })
+        assert "must be a snapshot path" in str(exc_info.value).lower()
+
+        assert call(
+            "zfs.resource.query",
+            {"paths": [ds], "get_user_properties": True},
+        )[0]["user_properties"] == {}
+
+
+def test_pool_snapshot_update_nonexistent_snapshot():
+    with dataset("test_snap_update_missing") as ds:
+        with pytest.raises(Exception) as exc_info:
+            call("pool.snapshot.update", f"{ds}@nope", {
+                "user_properties_update": [{"key": "com.example:x", "value": "v"}],
+            })
+        assert "not found" in str(exc_info.value).lower()


### PR DESCRIPTION
[NAS-143329](https://ixsystems.atlassian.net/browse/NAS-143329)

`pool.snapshot.update` does nothing. Its body is commented out under a TODO, so it writes no properties and returns `None` against a schema that declares `PoolSnapshotCreateUpdateEntry`. The call reports success, and the contract violation only shows up as a `serialize_result` warning in `middlewared.log` because `dump_result_allow_fallback` defaults to `True`.

The method works on 25.10. It regressed in 26.0 with 586b22053c (NAS-138870), which removed `zfs.snapshot.update` and commented out the call rather than porting it.

### What this does

* Adds `zfs.resource.snapshot.update_impl`: set the given user properties, `inherit_property` the ones to remove, return the refreshed entry from the same libzfs handle. It requests `creation` and `createtxg`, the same properties `create_snapshots_impl` requests, so update and create return the same shape.
* `pool.snapshot.do_update` calls it, maps the exceptions, sends a `CHANGED` event and returns the entry.
* Adds `tests/api2/test_pool_snapshot_update.py`.

Two guards in `update_impl` are worth calling out. `open_resource()` opens any resource type, so a path with no `@` would write the properties to the **dataset** — `pool.snapshot.update` resolves to `SNAPSHOT_WRITE` while `pool.dataset.update` gates the same write behind `DATASET_WRITE`. It also applies the `has_internal_path()` check every other write in that service has. Both are covered by the tests.

The surviving line in the old body built `{'key': k, 'remove': True}`, a shape `PoolSnapshotUserPropertyUpdate` can no longer express, and nothing read the mutated dict afterwards.

### Verified on 26.0.0-BETA.2

* setting two properties returns an entry carrying `creation` and `createtxg`, and both land on disk
* removing one leaves the other with source `local`
* a name in both lists ends up removed, matching what the commented-out code did (removes were appended after updates)
* a dataset path is refused with `[EINVAL] ... must be a snapshot path (containing '@')`, dataset properties untouched
* a missing snapshot gives `[ENOENT] ... not found`
* `boot-pool/ROOT/26.0.0-BETA.2@x` is refused with `[EACCES] ... is a protected path`
* an empty id is refused with EINVAL rather than reaching libzfs
* a `pool.snapshot.query` subscriber receives `CHANGED`
* no serialization warning is logged

### Notes

No public `zfs.resource.snapshot.update` method or `ZFSResourceSnapshotUpdateQuery` model. Every other operation in that service has both, and a model would also give this one a `bypass` field. Nothing needs it today, so this keeps the private impl only — say the word and I will add both.

`do_update` now sends a `CHANGED` event, which the old code did not. `do_create` and `do_delete` send their own (the service sets `event_send = False`) and `pool.dataset.do_update` sends `CHANGED`, so this brings it in line. Easy to drop if you would rather keep the change minimal.

Applies to `stable/26` at the same two functions; the only difference there is that `do_update` has no docstring. `stable/goldeye` is not affected.
