### PR TITLE
NAS-143330 / 27.0.0-BETA.1 / Split CSR profiles by certificate role

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v26_0_0/crypto_cert_profiles.py
@@ -11,15 +11,11 @@ __all__ = (
 )
 
 
-# Defines the default lifetime of a certificate
-# (https://support.apple.com/en-us/HT211025)
-DEFAULT_LIFETIME_DAYS = 397
 RSA = "RSA"
 EC = "EC"
 EC_CURVE = "SECP384R1"
 SHA256 = "SHA256"
 KEY_LENGTH = 2048
-EX_KEY_USAGE = ["SERVER_AUTH", "CLIENT_AUTH"]
 
 
 @final
@@ -30,109 +26,202 @@ class BasicConstraintsModel(BaseModel):
 
 
 @final
-class ExtendedKeyUsageModel(BaseModel):
-    # These days, most TLS certs want "ClientAuth".
-    # LetsEncrypt appears to want this extension to issue.
-    # https://community.letsencrypt.org/t/extendedkeyusage-tls-client-
-    # authentication-in-tls-server-certificates/59140/7
+class ServerAuthExtendedKeyUsageModel(BaseModel):
+    # clientAuth is deliberately absent: Google Trust Services answers badCSR to any request asserting it,
+    # and the Chrome root programme requires server certificates issued from March 2027 to assert serverAuth
+    # alone. Naming serverAuth rather than staying silent matters for a private CA that copies extensions
+    # from the request, since relying parties such as Apple require this purpose to be present on a TLS
+    # server certificate. A public CA sets the purpose from its own profile regardless.
     enabled: bool = Field(default=True, description="Whether the extended key usage extension is enabled.")
-    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
+    extension_critical: bool = Field(default=False, description="Whether this extension is marked as critical.")
     usages: list[str] = Field(
-        default=EX_KEY_USAGE,
+        default_factory=lambda: ["SERVER_AUTH"],
         description="Array of extended key usage purposes for the certificate.",
     )
 
 
 @final
-class RSAKeyUsageModel(BaseModel):
-    # RSA certs need "digitalSignature" for DHE,
-    # and "keyEncipherment" for nonDHE
-    # Include "keyAgreement" for compatibility (DH_DSS / DH_RSA)
-    # See rfc5246
+class ClientAuthExtendedKeyUsageModel(BaseModel):
+    # A certificate carrying an extended key usage is only usable for the purposes it names, so a client
+    # certificate has to say so or the peer rejects it. Requesting clientAuth means no public CA will issue
+    # this, since the baseline requirements make serverAuth mandatory; these profiles target a private CA.
+    enabled: bool = Field(default=True, description="Whether the extended key usage extension is enabled.")
+    extension_critical: bool = Field(default=False, description="Whether this extension is marked as critical.")
+    usages: list[str] = Field(
+        default_factory=lambda: ["CLIENT_AUTH"],
+        description="Array of extended key usage purposes for the certificate.",
+    )
+
+
+@final
+class SigningKeyUsageModel(BaseModel):
+    enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
+    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
+    digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
+
+
+@final
+class ServerRSAKeyUsageModel(BaseModel):
+    # keyEncipherment is only exercised by the RSA key transport cipher suites, which TLS 1.3 dropped and the
+    # nginx template no longer offers. It stays for FTPS and app workloads, which can still negotiate them over
+    # TLS 1.2. CA/Browser Forum TLS Baseline Requirements v2.2.9 section 7.1.2.7.11 calls asserting it alongside
+    # digitalSignature NOT RECOMMENDED, which is accepted here; the same section marks keyAgreement
+    # "Permitted: N" for RSA subscriber certificates, so that one is left off.
     enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
     extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
     digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
     key_encipherment: bool = Field(default=True, description="Whether the key can be used for key encipherment.")
-    key_agreement: bool = Field(default=True, description="Whether the key can be used for key agreement.")
 
 
 @final
-class ECCKeyUsageModel(BaseModel):
-    # keyAgreement is not generally required for EC certs.
-    # See Google, cloudflare certs
-    enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
-    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
-    digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
-
-
-@final
-class RSACSRExtensionsModel(BaseModel):
+class ServerRSACSRExtensionsModel(BaseModel):
     BasicConstraints: BasicConstraintsModel = Field(
         default=BasicConstraintsModel(),
         description="Basic constraints extension configuration.",
     )
-    ExtendedKeyUsage: ExtendedKeyUsageModel = Field(
-        default=ExtendedKeyUsageModel(),
+    ExtendedKeyUsage: ServerAuthExtendedKeyUsageModel = Field(
+        default=ServerAuthExtendedKeyUsageModel(),
         description="Extended key usage extension configuration.",
     )
-    KeyUsage: RSAKeyUsageModel = Field(
-        default=RSAKeyUsageModel(),
+    KeyUsage: ServerRSAKeyUsageModel = Field(
+        default=ServerRSAKeyUsageModel(),
         description="Key usage extension configuration for RSA certificates.",
     )
 
 
 @final
-class ECCCSRExtensionsModel(BaseModel):
+class ServerECCSRExtensionsModel(BaseModel):
     BasicConstraints: BasicConstraintsModel = Field(
         default=BasicConstraintsModel(),
         description="Basic constraints extension configuration.",
     )
-    ExtendedKeyUsage: ExtendedKeyUsageModel = Field(
-        default=ExtendedKeyUsageModel(),
+    ExtendedKeyUsage: ServerAuthExtendedKeyUsageModel = Field(
+        default=ServerAuthExtendedKeyUsageModel(),
         description="Extended key usage extension configuration.",
     )
-    KeyUsage: ECCKeyUsageModel = Field(
-        default=ECCKeyUsageModel(),
-        description="Key usage extension configuration for ECC certificates.",
+    KeyUsage: SigningKeyUsageModel = Field(
+        default=SigningKeyUsageModel(),
+        description="Key usage extension configuration for EC certificates.",
     )
 
 
 @final
-class RSACSRExtensions(BaseModel):
-    cert_extensions: RSACSRExtensionsModel = Field(
-        default=RSACSRExtensionsModel(),
+class ClientCSRExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = Field(
+        default=BasicConstraintsModel(),
+        description="Basic constraints extension configuration.",
+    )
+    ExtendedKeyUsage: ClientAuthExtendedKeyUsageModel = Field(
+        default=ClientAuthExtendedKeyUsageModel(),
+        description="Extended key usage extension configuration.",
+    )
+    KeyUsage: SigningKeyUsageModel = Field(
+        default=SigningKeyUsageModel(),
+        description="Key usage extension configuration for client certificates.",
+    )
+
+
+@final
+class TLSServerRSAProfile(BaseModel):
+    cert_extensions: ServerRSACSRExtensionsModel = Field(
+        default=ServerRSACSRExtensionsModel(),
         description="Certificate extensions configuration for RSA certificates.",
     )
     key_length: int = Field(default=KEY_LENGTH, description="RSA key length in bits.")
     key_type: str = Field(default=RSA, description="Type of cryptographic key (RSA).")
-    lifetime: int = Field(default=DEFAULT_LIFETIME_DAYS, description="Certificate validity period in days.")
     digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
 
 
 @final
-class ECCCSRExtensions(BaseModel):
-    cert_extensions: ECCCSRExtensionsModel = Field(
-        default=ECCCSRExtensionsModel(),
-        description="Certificate extensions configuration for ECC certificates.",
+class TLSServerECProfile(BaseModel):
+    cert_extensions: ServerECCSRExtensionsModel = Field(
+        default=ServerECCSRExtensionsModel(),
+        description="Certificate extensions configuration for EC certificates.",
     )
     ec_curve: str = Field(default=EC_CURVE, description="Elliptic curve to use for key generation.")
-    key_type: str = Field(default=EC, description="Type of cryptographic key (ECC).")
-    lifetime: int = Field(default=DEFAULT_LIFETIME_DAYS, description="Certificate validity period in days.")
+    key_type: str = Field(default=EC, description="Type of cryptographic key (EC).")
+    digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
+
+
+@final
+class TLSClientRSAProfile(BaseModel):
+    cert_extensions: ClientCSRExtensionsModel = Field(
+        default=ClientCSRExtensionsModel(),
+        description="Certificate extensions configuration for RSA certificates.",
+    )
+    key_length: int = Field(default=KEY_LENGTH, description="RSA key length in bits.")
+    key_type: str = Field(default=RSA, description="Type of cryptographic key (RSA).")
+    digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
+
+
+@final
+class TLSClientECProfile(BaseModel):
+    cert_extensions: ClientCSRExtensionsModel = Field(
+        default=ClientCSRExtensionsModel(),
+        description="Certificate extensions configuration for EC certificates.",
+    )
+    ec_curve: str = Field(default=EC_CURVE, description="Elliptic curve to use for key generation.")
+    key_type: str = Field(default=EC, description="Type of cryptographic key (EC).")
     digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
 
 
 @final
 class CSRProfilesModel(BaseModel):
-    https_rsa_certificate: RSACSRExtensions = Field(
-        default_factory=RSACSRExtensions,
-        alias="HTTPS RSA Certificate",
-        description="Certificate profile configuration for HTTPS RSA certificates.",
+    # This catalogue is declared identically in v26_0_0 and v27_0_0, because v26_0_0 is the current version
+    # on the stable branch and carries the to_previous conversion for earlier clients. Editing one copy alone
+    # is caught by tests/api2/test_legacy_api.py::test_misc_methods rather than by anything at import time.
+    tls_server_rsa: TLSServerRSAProfile = Field(
+        default_factory=TLSServerRSAProfile,
+        alias="TLS Server (e.g. Web UI, FTPS, Apps) - RSA",
+        description=(
+            "RSA certificate for services where TrueNAS accepts incoming TLS connections, such as the web UI, "
+            "FTPS, and apps. Requests TLS Web Server Authentication only, which every public and ACME CA "
+            "accepts."
+        ),
     )
-    https_ecc_certificate: ECCCSRExtensions = Field(
-        default_factory=ECCCSRExtensions,
-        alias="HTTPS ECC Certificate",
-        description="Certificate profile configuration for HTTPS ECC certificates.",
+    tls_server_ec: TLSServerECProfile = Field(
+        default_factory=TLSServerECProfile,
+        alias="TLS Server (e.g. Web UI, FTPS, Apps) - EC",
+        description=(
+            "Elliptic curve certificate for services where TrueNAS accepts incoming TLS connections, such as the "
+            "web UI, FTPS, and apps. Requests TLS Web Server Authentication only, which every public and ACME CA "
+            "accepts."
+        ),
     )
+    tls_client_rsa: TLSClientRSAProfile = Field(
+        default_factory=TLSClientRSAProfile,
+        alias="TLS Client (e.g. Syslog, LDAP, KMIP) - RSA",
+        description=(
+            "RSA certificate for services where TrueNAS connects out and must authenticate itself, such as remote "
+            "syslog over TLS, LDAP mutual TLS, and KMIP. Requests TLS Web Client Authentication and is intended "
+            "for a private CA."
+        ),
+    )
+    tls_client_ec: TLSClientECProfile = Field(
+        default_factory=TLSClientECProfile,
+        alias="TLS Client (e.g. Syslog, LDAP, KMIP) - EC",
+        description=(
+            "Elliptic curve certificate for services where TrueNAS connects out and must authenticate itself, such "
+            "as remote syslog over TLS, LDAP mutual TLS, and KMIP. Requests TLS Web Client Authentication and is "
+            "intended for a private CA."
+        ),
+    )
+
+    @classmethod
+    def to_previous(cls, value):
+        # Older API versions declare a different set of profiles, which the adapter has already back-filled
+        # from their own defaults. Our keys are aliases, so the adapter's field-name based cleanup will not
+        # remove them; drop them here so the caller only sees the profiles its version knows about.
+        for name, field in cls.model_fields.items():
+            value.pop(field.alias or name, None)
+
+        # Back-filled defaults arrive as model instances, and the adapter only descends into dicts and lists.
+        # Left as instances they reach the next version down unconverted and fail validation against its own
+        # equally named classes, so flatten them here.
+        return {
+            key: profile.model_dump() if isinstance(profile, BaseModel) else profile
+            for key, profile in value.items()
+        }
 
 
 class WebUICryptoCsrProfilesArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v26_0_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v26_0_0/crypto_cert_profiles.py
@@ -167,9 +167,6 @@ class TLSClientECProfile(BaseModel):
 
 @final
 class CSRProfilesModel(BaseModel):
-    # This catalogue is declared identically in v26_0_0 and v27_0_0, because v26_0_0 is the current version
-    # on the stable branch and carries the to_previous conversion for earlier clients. Editing one copy alone
-    # is caught by tests/api2/test_legacy_api.py::test_misc_methods rather than by anything at import time.
     tls_server_rsa: TLSServerRSAProfile = Field(
         default_factory=TLSServerRSAProfile,
         alias="TLS Server (e.g. Web UI, FTPS, Apps) - RSA",

--- a/src/middlewared/middlewared/api/v27_0_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v27_0_0/crypto_cert_profiles.py
@@ -11,15 +11,11 @@ __all__ = (
 )
 
 
-# Defines the default lifetime of a certificate
-# (https://support.apple.com/en-us/HT211025)
-DEFAULT_LIFETIME_DAYS = 397
 RSA = "RSA"
 EC = "EC"
 EC_CURVE = "SECP384R1"
 SHA256 = "SHA256"
 KEY_LENGTH = 2048
-EX_KEY_USAGE = ["SERVER_AUTH", "CLIENT_AUTH"]
 
 
 @final
@@ -30,108 +26,185 @@ class BasicConstraintsModel(BaseModel):
 
 
 @final
-class ExtendedKeyUsageModel(BaseModel):
-    # These days, most TLS certs want "ClientAuth".
-    # LetsEncrypt appears to want this extension to issue.
-    # https://community.letsencrypt.org/t/extendedkeyusage-tls-client-
-    # authentication-in-tls-server-certificates/59140/7
+class ServerAuthExtendedKeyUsageModel(BaseModel):
+    # clientAuth is deliberately absent: Google Trust Services answers badCSR to any request asserting it,
+    # and the Chrome root programme requires server certificates issued from March 2027 to assert serverAuth
+    # alone. Naming serverAuth rather than staying silent matters for a private CA that copies extensions
+    # from the request, since relying parties such as Apple require this purpose to be present on a TLS
+    # server certificate. A public CA sets the purpose from its own profile regardless.
     enabled: bool = Field(default=True, description="Whether the extended key usage extension is enabled.")
-    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
+    extension_critical: bool = Field(default=False, description="Whether this extension is marked as critical.")
     usages: list[str] = Field(
-        default=EX_KEY_USAGE,
+        default_factory=lambda: ["SERVER_AUTH"],
         description="Array of extended key usage purposes for the certificate.",
     )
 
 
 @final
-class RSAKeyUsageModel(BaseModel):
-    # RSA certs need "digitalSignature" for DHE,
-    # and "keyEncipherment" for nonDHE
-    # Include "keyAgreement" for compatibility (DH_DSS / DH_RSA)
-    # See rfc5246
+class ClientAuthExtendedKeyUsageModel(BaseModel):
+    # A certificate carrying an extended key usage is only usable for the purposes it names, so a client
+    # certificate has to say so or the peer rejects it. Requesting clientAuth means no public CA will issue
+    # this, since the baseline requirements make serverAuth mandatory; these profiles target a private CA.
+    enabled: bool = Field(default=True, description="Whether the extended key usage extension is enabled.")
+    extension_critical: bool = Field(default=False, description="Whether this extension is marked as critical.")
+    usages: list[str] = Field(
+        default_factory=lambda: ["CLIENT_AUTH"],
+        description="Array of extended key usage purposes for the certificate.",
+    )
+
+
+@final
+class SigningKeyUsageModel(BaseModel):
+    enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
+    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
+    digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
+
+
+@final
+class ServerRSAKeyUsageModel(BaseModel):
+    # keyEncipherment is only exercised by the RSA key transport cipher suites, which TLS 1.3 dropped and the
+    # nginx template no longer offers. It stays for FTPS and app workloads, which can still negotiate them over
+    # TLS 1.2. CA/Browser Forum TLS Baseline Requirements v2.2.9 section 7.1.2.7.11 calls asserting it alongside
+    # digitalSignature NOT RECOMMENDED, which is accepted here; the same section marks keyAgreement
+    # "Permitted: N" for RSA subscriber certificates, so that one is left off.
     enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
     extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
     digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
     key_encipherment: bool = Field(default=True, description="Whether the key can be used for key encipherment.")
-    key_agreement: bool = Field(default=True, description="Whether the key can be used for key agreement.")
 
 
 @final
-class ECCKeyUsageModel(BaseModel):
-    # keyAgreement is not generally required for EC certs.
-    # See Google, cloudflare certs
-    enabled: bool = Field(default=True, description="Whether the key usage extension is enabled.")
-    extension_critical: bool = Field(default=True, description="Whether this extension is marked as critical.")
-    digital_signature: bool = Field(default=True, description="Whether the key can be used for digital signatures.")
-
-
-@final
-class RSACSRExtensionsModel(BaseModel):
+class ServerRSACSRExtensionsModel(BaseModel):
     BasicConstraints: BasicConstraintsModel = Field(
         default=BasicConstraintsModel(),
         description="Basic constraints extension configuration.",
     )
-    ExtendedKeyUsage: ExtendedKeyUsageModel = Field(
-        default=ExtendedKeyUsageModel(),
+    ExtendedKeyUsage: ServerAuthExtendedKeyUsageModel = Field(
+        default=ServerAuthExtendedKeyUsageModel(),
         description="Extended key usage extension configuration.",
     )
-    KeyUsage: RSAKeyUsageModel = Field(
-        default=RSAKeyUsageModel(),
+    KeyUsage: ServerRSAKeyUsageModel = Field(
+        default=ServerRSAKeyUsageModel(),
         description="Key usage extension configuration for RSA certificates.",
     )
 
 
 @final
-class ECCCSRExtensionsModel(BaseModel):
+class ServerECCSRExtensionsModel(BaseModel):
     BasicConstraints: BasicConstraintsModel = Field(
         default=BasicConstraintsModel(),
         description="Basic constraints extension configuration.",
     )
-    ExtendedKeyUsage: ExtendedKeyUsageModel = Field(
-        default=ExtendedKeyUsageModel(),
+    ExtendedKeyUsage: ServerAuthExtendedKeyUsageModel = Field(
+        default=ServerAuthExtendedKeyUsageModel(),
         description="Extended key usage extension configuration.",
     )
-    KeyUsage: ECCKeyUsageModel = Field(
-        default=ECCKeyUsageModel(),
-        description="Key usage extension configuration for ECC certificates.",
+    KeyUsage: SigningKeyUsageModel = Field(
+        default=SigningKeyUsageModel(),
+        description="Key usage extension configuration for EC certificates.",
     )
 
 
 @final
-class RSACSRExtensions(BaseModel):
-    cert_extensions: RSACSRExtensionsModel = Field(
-        default=RSACSRExtensionsModel(),
+class ClientCSRExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = Field(
+        default=BasicConstraintsModel(),
+        description="Basic constraints extension configuration.",
+    )
+    ExtendedKeyUsage: ClientAuthExtendedKeyUsageModel = Field(
+        default=ClientAuthExtendedKeyUsageModel(),
+        description="Extended key usage extension configuration.",
+    )
+    KeyUsage: SigningKeyUsageModel = Field(
+        default=SigningKeyUsageModel(),
+        description="Key usage extension configuration for client certificates.",
+    )
+
+
+@final
+class TLSServerRSAProfile(BaseModel):
+    cert_extensions: ServerRSACSRExtensionsModel = Field(
+        default=ServerRSACSRExtensionsModel(),
         description="Certificate extensions configuration for RSA certificates.",
     )
     key_length: int = Field(default=KEY_LENGTH, description="RSA key length in bits.")
     key_type: str = Field(default=RSA, description="Type of cryptographic key (RSA).")
-    lifetime: int = Field(default=DEFAULT_LIFETIME_DAYS, description="Certificate validity period in days.")
     digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
 
 
 @final
-class ECCCSRExtensions(BaseModel):
-    cert_extensions: ECCCSRExtensionsModel = Field(
-        default=ECCCSRExtensionsModel(),
-        description="Certificate extensions configuration for ECC certificates.",
+class TLSServerECProfile(BaseModel):
+    cert_extensions: ServerECCSRExtensionsModel = Field(
+        default=ServerECCSRExtensionsModel(),
+        description="Certificate extensions configuration for EC certificates.",
     )
     ec_curve: str = Field(default=EC_CURVE, description="Elliptic curve to use for key generation.")
-    key_type: str = Field(default=EC, description="Type of cryptographic key (ECC).")
-    lifetime: int = Field(default=DEFAULT_LIFETIME_DAYS, description="Certificate validity period in days.")
+    key_type: str = Field(default=EC, description="Type of cryptographic key (EC).")
+    digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
+
+
+@final
+class TLSClientRSAProfile(BaseModel):
+    cert_extensions: ClientCSRExtensionsModel = Field(
+        default=ClientCSRExtensionsModel(),
+        description="Certificate extensions configuration for RSA certificates.",
+    )
+    key_length: int = Field(default=KEY_LENGTH, description="RSA key length in bits.")
+    key_type: str = Field(default=RSA, description="Type of cryptographic key (RSA).")
+    digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
+
+
+@final
+class TLSClientECProfile(BaseModel):
+    cert_extensions: ClientCSRExtensionsModel = Field(
+        default=ClientCSRExtensionsModel(),
+        description="Certificate extensions configuration for EC certificates.",
+    )
+    ec_curve: str = Field(default=EC_CURVE, description="Elliptic curve to use for key generation.")
+    key_type: str = Field(default=EC, description="Type of cryptographic key (EC).")
     digest_algorithm: str = Field(default=SHA256, description="Hash algorithm for certificate signing.")
 
 
 @final
 class CSRProfilesModel(BaseModel):
-    https_rsa_certificate: RSACSRExtensions = Field(
-        default_factory=RSACSRExtensions,
-        alias="HTTPS RSA Certificate",
-        description="Certificate profile configuration for HTTPS RSA certificates.",
+    # This catalogue is declared identically in v26_0_0 and v27_0_0, because v26_0_0 is the current version
+    # on the stable branch and carries the to_previous conversion for earlier clients. Editing one copy alone
+    # is caught by tests/api2/test_legacy_api.py::test_misc_methods rather than by anything at import time.
+    tls_server_rsa: TLSServerRSAProfile = Field(
+        default_factory=TLSServerRSAProfile,
+        alias="TLS Server (e.g. Web UI, FTPS, Apps) - RSA",
+        description=(
+            "RSA certificate for services where TrueNAS accepts incoming TLS connections, such as the web UI, "
+            "FTPS, and apps. Requests TLS Web Server Authentication only, which every public and ACME CA "
+            "accepts."
+        ),
     )
-    https_ecc_certificate: ECCCSRExtensions = Field(
-        default_factory=ECCCSRExtensions,
-        alias="HTTPS ECC Certificate",
-        description="Certificate profile configuration for HTTPS ECC certificates.",
+    tls_server_ec: TLSServerECProfile = Field(
+        default_factory=TLSServerECProfile,
+        alias="TLS Server (e.g. Web UI, FTPS, Apps) - EC",
+        description=(
+            "Elliptic curve certificate for services where TrueNAS accepts incoming TLS connections, such as the "
+            "web UI, FTPS, and apps. Requests TLS Web Server Authentication only, which every public and ACME CA "
+            "accepts."
+        ),
+    )
+    tls_client_rsa: TLSClientRSAProfile = Field(
+        default_factory=TLSClientRSAProfile,
+        alias="TLS Client (e.g. Syslog, LDAP, KMIP) - RSA",
+        description=(
+            "RSA certificate for services where TrueNAS connects out and must authenticate itself, such as remote "
+            "syslog over TLS, LDAP mutual TLS, and KMIP. Requests TLS Web Client Authentication and is intended "
+            "for a private CA."
+        ),
+    )
+    tls_client_ec: TLSClientECProfile = Field(
+        default_factory=TLSClientECProfile,
+        alias="TLS Client (e.g. Syslog, LDAP, KMIP) - EC",
+        description=(
+            "Elliptic curve certificate for services where TrueNAS connects out and must authenticate itself, such "
+            "as remote syslog over TLS, LDAP mutual TLS, and KMIP. Requests TLS Web Client Authentication and is "
+            "intended for a private CA."
+        ),
     )
 
 

--- a/src/middlewared/middlewared/api/v27_0_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v27_0_0/crypto_cert_profiles.py
@@ -167,9 +167,6 @@ class TLSClientECProfile(BaseModel):
 
 @final
 class CSRProfilesModel(BaseModel):
-    # This catalogue is declared identically in v26_0_0 and v27_0_0, because v26_0_0 is the current version
-    # on the stable branch and carries the to_previous conversion for earlier clients. Editing one copy alone
-    # is caught by tests/api2/test_legacy_api.py::test_misc_methods rather than by anything at import time.
     tls_server_rsa: TLSServerRSAProfile = Field(
         default_factory=TLSServerRSAProfile,
         alias="TLS Server (e.g. Web UI, FTPS, Apps) - RSA",

--- a/src/middlewared/middlewared/plugins/webui/crypto.py
+++ b/src/middlewared/middlewared/plugins/webui/crypto.py
@@ -36,10 +36,15 @@ class WebUICryptoService(Service):
         roles=['CERTIFICATE_READ']
     )
     async def csr_profiles(self):
-        """Return predefined CSR profiles for common certificate types.
+        """Return predefined CSR profiles for common certificate roles.
 
-        Each profile provides recommended defaults for key type, key length or
-        curve, lifetime, digest algorithm, and X.509 extensions (basic constraints,
-        key usage, extended key usage).
+        There is a profile for each combination of role (a TLS server certificate, or a TLS
+        client certificate used when TrueNAS authenticates itself to a remote service) and key
+        type (RSA or EC). Each one provides recommended defaults for the key parameters, the
+        digest algorithm, and the X.509 extensions (basic constraints, key usage, extended key
+        usage).
+
+        The profiles are advisory: they are intended to prefill the CSR form and are not applied
+        by :method:`certificate.create`, which must be passed these values explicitly.
         """
         return CSRProfilesModel().model_dump()

--- a/tests/api2/test_certificate_create_types.py
+++ b/tests/api2/test_certificate_create_types.py
@@ -63,6 +63,60 @@ def test_create_csr_ec(ec_curve):
         call("certificate.delete", csr["id"], job=True)
 
 
+CSR_PROFILE_NAMES = {
+    "server_rsa": "TLS Server (e.g. Web UI, FTPS, Apps) - RSA",
+    "server_ec": "TLS Server (e.g. Web UI, FTPS, Apps) - EC",
+    "client_rsa": "TLS Client (e.g. Syslog, LDAP, KMIP) - RSA",
+    "client_ec": "TLS Client (e.g. Syslog, LDAP, KMIP) - EC",
+}
+
+
+@pytest.mark.parametrize("profile_key", list(CSR_PROFILE_NAMES))
+def test_create_csr_from_profile(profile_key):
+    # The profiles only prefill the CSR form in the UI, so nothing server side validates them.
+    # Every one of them still has to be something certificate.create accepts, otherwise the UI
+    # hands the user a form that cannot be submitted. The names are spelled out here rather than
+    # taken from the response so that a profile going missing fails instead of silently shrinking
+    # the parameter set.
+    profile_name = CSR_PROFILE_NAMES[profile_key]
+    profiles = call("webui.crypto.csr_profiles")
+    assert set(profiles) == set(CSR_PROFILE_NAMES.values()), list(profiles)
+
+    profile = profiles[profile_name]
+    params = {**get_cert_params(), **profile}
+    if "key_length" not in profile:
+        params.pop("key_length", None)
+
+    csr = call(
+        "certificate.create",
+        {
+            "name": f"csr_profile_{profile_key}",
+            "create_type": "CERTIFICATE_CREATE_CSR",
+            **params,
+        },
+        job=True,
+    )
+    try:
+        assert csr["cert_type_CSR"] is True, csr
+        assert csr["parsed"] is True, csr
+
+        extensions = csr["extensions"]
+        if profile_key.startswith("client"):
+            assert extensions["ExtendedKeyUsage"] == "TLS Web Client Authentication", csr
+        else:
+            # Asking for exactly one purpose is what keeps the request acceptable to every public CA.
+            assert extensions["ExtendedKeyUsage"] == "TLS Web Server Authentication", csr
+
+        # Spelled out in full rather than checking that keyAgreement is absent, so that the assertion
+        # still means something if the extension itself stops being emitted.
+        if profile_key == "server_rsa":
+            assert extensions["KeyUsage"] == "Digital Signature, Key Encipherment", csr
+        else:
+            assert extensions["KeyUsage"] == "Digital Signature", csr
+    finally:
+        call("certificate.delete", csr["id"], job=True)
+
+
 def test_create_csr_validation_empty_san():
     params = {**get_cert_params(), "san": []}
     with pytest.raises(ValidationErrors):

--- a/tests/api2/test_legacy_api.py
+++ b/tests/api2/test_legacy_api.py
@@ -54,6 +54,7 @@ def misc_methods() -> list[tuple[tuple, str]]:
     return [
         (("fcport.status",), APIVersions.FT.value[0]),
         (("audit.query", {"query-options": {"count": True}}), APIVersions.GE.value[0]),
+        (("webui.crypto.csr_profiles",), APIVersions.FT.value[0]),
     ]
 
 


### PR DESCRIPTION
This commit adds changes to replace the two HTTPS CSR profiles with four role specific ones covering TLS server and TLS client use, in both RSA and EC. Both old profiles asked for SERVER_AUTH and CLIENT_AUTH together, which Google Trust Services now rejects outright with badCSR. Once you can no longer name both purposes in one request, a single shape stops serving both roles, since a certificate is only usable for the purposes its extended key usage names.

The server profiles now request SERVER_AUTH alone, which is what Google and the Chrome root programme want by 2027 and what relying parties like Apple expect to find on a TLS server certificate, and the client profiles request CLIENT_AUTH so mutual TLS against syslog, LDAP and KMIP has something usable. This also drops the RSA keyAgreement bit the baseline requirements forbid, makes the EKU non critical, and removes the dead lifetime key that certificate.create would have rejected. The catalogue is declared in v26 and v27 both, since v26 is the current version on the stable branch, so backporting means keeping the v26 hunk and omitting the v27 one; to_previous on v26 is what keeps older API clients on the profiles they already know.