### PR TITLE
NAS-143369 / 27.0.0-BETA.1 / Stop nginx closing idle VM SPICE console channels

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -281,6 +281,13 @@ ${spaces}gzip off;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
+            # Every SPICE channel gets its own websocket, and the server only
+            # pings the inputs and cursor channels every 300s, so the 60s
+            # default closes them on a console nobody is touching. The display
+            # channel keeps painting, which leaves a console that looks alive
+            # but ignores the keyboard and mouse.
+            proxy_read_timeout 3600;
+            proxy_send_timeout 3600;
         }
 % endfor
         location /progress {


### PR DESCRIPTION
[NAS-143369](https://ixsystems.atlassian.net/browse/NAS-143369)

A VM SPICE console that nobody touches for a minute stops responding to the keyboard and mouse. The picture keeps updating, so the console looks alive.

The VM display proxy is the last websocket location in `nginx.conf.mako` still on nginx's 60s `proxy_read_timeout` default. [NAS-140066](https://github.com/truenas/middleware/pull/18412) (5a9a2a522a) fixed exactly this for `/api` and `/websocket`, and its description notes `/websocket/shell` already had its own — the VM display proxy was not in that audit.

### Why it presents as "input is dead" rather than "console disconnected"

A SPICE session opens one websocket per channel (`spice-html5` builds each channel as its own `SpiceConn`, and every `SpiceConn` constructor runs `new WebSocket(o.uri, 'binary')`), so a stock display device produces four: main, display, inputs, cursor. The server pings main and display about every 15s but inputs and cursor only every 300s — five times nginx's default — so those two are closed on any console the user is not actively driving. The display channel survives and keeps repainting. `spice_auto.html` has no reconnect path for a closed channel, so it stays that way until the page is reloaded.

### Measured

TrueNAS 25.10.5, Windows 7 guest, console opened in Chrome with the `WebSocket` constructor wrapped to record open/close/message times per socket, guest left untouched.

Through nginx:

| channel | last server message | outcome |
|---|---|---|
| main | 91.1s (16 messages) | open |
| display | 91.6s (10 messages) | open |
| inputs | 1.2s (4 messages) | **closed at 61.24s, code 1006** |
| cursor | 1.3s (4 messages) | **closed at 61.41s, code 1006** |

Same console straight to websockify on 5915, bypassing nginx: all four still open at 95s. Left running there, inputs and cursor received their next server message at **301.3s** and **301.4s** — that 300s ping is what sizes the fix.

A bare websocket to the same location with no SPICE traffic is closed after exactly 60.0s having read 0 bytes; the same bare websocket direct to 5915 is still open at 150s.

### On the value

I first wrote this as `7d` to match `/websocket/shell` and then measured the ping interval, which showed there is no case for it. A shell has no application keepalive, which is what justifies 7d there; SPICE has one. 3600 covers the measured 300s worst case twelve times over, keeps this file to one value for the websocket locations NAS-140066 already decided, and still eventually reclaims a connection whose peer has vanished.

### Notes

* NAS-140066 does not appear to have been backported to `stable/goldeye` — on 25.10.5 the generated config has `proxy_read_timeout` only under `/websocket/shell` and `/_download`, so `/api` and `/websocket` are on the default there too. Separate call about a stable train; not touched here.
* `websockify --heartbeat 30` would fix this a layer lower and would also survive a middlebox with its own idle cap. It is reachable on 25.10 (`plugins/vm/devices/display.py post_start_vm` builds the argv) but not on 26 or master, where the spawn moved into `truenas_pylibvirt`. The nginx change covers all three trains from this repo. Happy to do the heartbeat instead, or as well.

The same two lines apply to `stable/26` and `stable/goldeye` at the same block.
