### PR TITLE
NAS-143371 / 27.0.0-BETA.1 / Return snapshot user properties from pool.snapshot.query

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot.py
@@ -102,7 +102,7 @@ class PoolSnapshotService(CRUDService):
         ))
 
     def _transform_snapshot_entry(self, snap, *, include_holds=True, include_user_properties=False,
-                                  requested_props=None):
+                                  requested_props=None, requested_user_props=None):
         """Transform zfs.resource.snapshot.query result to PoolSnapshotEntry format.
 
         Args:
@@ -127,6 +127,18 @@ class PoolSnapshotService(CRUDService):
                     'rawvalue': prop_data.get('raw', ''),
                     'source': source,
                     'parsed': prop_data.get('value'),
+                }
+
+        # ZFS reports no source for a user property, so it is called LOCAL here.
+        # `pool.dataset.query` makes the same compromise in normalize_user_properties().
+        for prop_name in requested_user_props or ():
+            value = snap.get('user_properties', {}).get(prop_name)
+            if value is not None:
+                old_props[prop_name] = {
+                    'value': value,
+                    'rawvalue': value,
+                    'source': 'LOCAL',
+                    'parsed': value,
                 }
 
         # Add fast-path properties to properties dict if they were explicitly requested
@@ -232,7 +244,12 @@ class PoolSnapshotService(CRUDService):
         # Determine which properties were requested and filter out fast-path ones
         # Fast-path properties (name, createtxg) don't need ZFS property lookup
         requested_props = set(extra.get('properties', []))
-        non_fast_path_props = requested_props - frozenset({'name', 'createtxg'})
+
+        # A ZFS user property is exactly a name containing a colon. Those are read
+        # with `get_user_properties`; naming one alongside the native properties
+        # gets it dropped by the property builder without a word.
+        requested_user_props = {i for i in requested_props if ':' in i}
+        non_fast_path_props = requested_props - requested_user_props - frozenset({'name', 'createtxg'})
 
         # Only pass non-fast-path properties to the backend
         if non_fast_path_props:
@@ -252,6 +269,9 @@ class PoolSnapshotService(CRUDService):
             # are no paths that were requested, then set recursive
             # to be true.
             query_args['recursive'] = True
+
+        if requested_user_props:
+            query_args["get_user_properties"] = True
 
         if extra.get("holds", False):
             query_args["get_holds"] = True
@@ -280,6 +300,7 @@ class PoolSnapshotService(CRUDService):
                     i,
                     include_user_properties=include_user_properties,
                     requested_props=requested_props if requested_props else None,
+                    requested_user_props=requested_user_props or None,
                 ))
         except ZFSPathNotFoundException:
             # Path not found - return empty results (legacy behavior)

--- a/tests/api2/test_snapshot_query.py
+++ b/tests/api2/test_snapshot_query.py
@@ -58,3 +58,47 @@ def test_query_names_by_pool_or_dataset(fixture1, filters, names):
         snapshot["name"]
         for snapshot in call("pool.snapshot.query", filters, {"select": ["name"]})
     } == names
+
+
+def test_extra_properties_returns_user_properties():
+    """A name containing a colon is a user property and is read as one."""
+    with dataset("test_snap_query_user_props") as ds:
+        call("pool.snapshot.create", {
+            "dataset": ds, "name": "snap",
+            "properties": {"com.example:one": "1", "com.example:two": "2"},
+        })
+
+        snap = call("pool.snapshot.query", [["dataset", "=", ds]], {
+            "extra": {"properties": ["creation", "com.example:one", "com.example:two"]},
+        })[0]
+
+        assert snap["properties"]["com.example:one"]["value"] == "1"
+        assert snap["properties"]["com.example:one"]["source"] == "LOCAL"
+        assert snap["properties"]["com.example:two"]["value"] == "2"
+        assert snap["properties"]["creation"]["source"] == "NONE"
+
+
+def test_extra_properties_omits_user_properties_that_are_not_set():
+    with dataset("test_snap_query_unset_user_prop") as ds:
+        call("pool.snapshot.create", {"dataset": ds, "name": "snap"})
+
+        snap = call("pool.snapshot.query", [["dataset", "=", ds]], {
+            "extra": {"properties": ["com.example:nope"]},
+        })[0]
+
+        assert snap["properties"] == {}
+
+
+def test_extra_properties_user_properties_alongside_retention_and_holds():
+    with dataset("test_snap_query_user_props_extra") as ds:
+        call("pool.snapshot.create", {
+            "dataset": ds, "name": "snap", "properties": {"com.example:one": "1"},
+        })
+
+        snap = call("pool.snapshot.query", [["dataset", "=", ds]], {
+            "extra": {"retention": True, "holds": True, "properties": ["com.example:one"]},
+        })[0]
+
+        assert snap["properties"]["com.example:one"]["value"] == "1"
+        assert "holds" in snap
+        assert "retention" in snap


### PR DESCRIPTION
[NAS-143371](https://ixsystems.atlassian.net/browse/NAS-143371)

`pool.snapshot.query` cannot return a snapshot's user properties. Naming one in `extra.properties` returns nothing and reports no error, so a caller cannot tell "that property is not set" from "this endpoint will never give it to you".

`pool.dataset.query` returns dataset user properties. `pool.snapshot.create` accepts them by name. The query side of the snapshot API was the gap.

### Cause

`query()` puts everything from `extra.properties` into `query_args['properties']`. That reaches `__build_snapshot_cache`, which resolves each name with `ZFSProperty[i.upper()]` inside a `try` whose `except KeyError` is `continue`. A user property name is not an enum member, so it is dropped there, silently.

`extra.retention` is not a way round it — it sets `get_user_properties` internally, but `zettarepl.annotate_snapshots` pops the whole dict and keeps one removal-date key.

### Fix

A ZFS user property is exactly a name containing a colon, the same rule `check_user_property_names` uses in `plugins/zfs/create_rules.py`. `query()` splits those out, asks for them with `get_user_properties`, and `_transform_snapshot_entry` merges the ones the caller named into the `properties` map the entry already carries. No API model change — `PoolSnapshotEntry.properties` is `dict[str, PoolSnapshotEntryPropertyFields]`, so the keys are open.

ZFS reports no source for a user property, so the merged entry says `LOCAL`. That is the same compromise `normalize_user_properties()` already makes for `pool.dataset.query`, and its docstring says so. Anything else would make the two endpoints disagree.

### Verified on 26.0.0-BETA.2

* a user property on its own comes back with `source LOCAL` and the right value
* mixed with `creation`, both come back; `creation` still `source NONE`
* a user property that is not set is simply absent, not an error
* a native-only request is byte for byte what it was
* `extra.retention` and `extra.holds` in the same call still work

Three tests added to `tests/api2/test_snapshot_query.py`.

### One thing deliberately not patched

The same silent drop also swallows real ZFS properties that are not valid on a snapshot — `__build_snapshot_cache` resolves the name then applies `if prop in valid_props` with no `else`. So `extra.properties: ["mountpoint", "quota", "creation"]` returns only `creation`, and about fifty names behave that way.

I left it alone: it is a separate decision, and unlike the user-property case there is no correct value to return, so the answer is either an error or nothing. The same `except KeyError: continue` shape is also in `pool.dataset.query`'s `extra.properties` and `extra.snapshots_properties`, so whatever is decided should probably cover all of them. Happy to open a second ticket.

### Note on shape

I first wrote this as a validation error rejecting any name that is not a ZFS property. Review talked me out of it. Rejecting would be a breaking change to a method with no internal callers, so the whole cost lands on external clients, with no API version to pin against because `extra` is untyped; it would also take down the response entirely for a caller who asked for `holds` and `retention` in the same call and previously got both.

Applies to `stable/26` unchanged. `stable/goldeye` has a different query implementation and would need its own patch.
