### PR TITLE
NAS-143377 / 25.10.6 / Move both nvram and TPM state when a VM is renamed

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import errno
 import functools
 import os
@@ -20,7 +21,10 @@ from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.service import CallError, CRUDService, item_method, job, private, ValidationErrors
 from middlewared.plugins.vm.numeric_set import parse_numeric_set
 
-from .utils import ACTIVE_STATES, get_default_status, get_vm_nvram_file_name, SYSTEM_NVRAM_FOLDER_PATH
+from .utils import (
+    ACTIVE_STATES, get_default_status, get_vm_nvram_file_name, get_vm_tpm_state_dir_name,
+    SYSTEM_NVRAM_FOLDER_PATH, SYSTEM_TPM_FOLDER_PATH,
+)
 from .vm_supervisor import VMSupervisorMixin
 
 
@@ -356,26 +360,40 @@ class VMService(CRUDService, VMSupervisorMixin):
         vm_data = await self.get_instance(id_)
         if new['name'] != old['name']:
             await self.middleware.run_in_thread(self._rename_domain, old, vm_data)
-            try:
-                new_path = os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(new))
-                await self.middleware.run_in_thread(
-                    os.rename, os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(old)), new_path
-                )
-            except FileNotFoundError:
-                if old['bootloader'] == new['bootloader'] == 'UEFI':
-                    # So we only want to raise an error if bootloader is UEFI because for BIOS
-                    # nvram file will not exist and it is fine. If bootloader is changed from
-                    # BIOS to UEFI, even then we will not have it and it is fine so we don't want
-                    # to raise an error in that case.
-                    raise CallError(
-                        f'VM name has been updated but nvram file for {old["name"]} does not exist '
-                        f'which can result in {new["name"]} VM not booting properly.'
-                    )
+            await self.middleware.run_in_thread(self._rename_vm_state, old, new)
 
         if old['shutdown_timeout'] != new['shutdown_timeout']:
             await self.middleware.call('etc.generate', 'libvirt_guests')
 
         return await self.get_instance(id_)
+
+    def _rename_vm_state(self, old, new):
+        """Move the on-disk state that libvirt and swtpm address by VM name.
+
+        Both the nvram file and the TPM state directory are named
+        `{id}_{name}`, and `_rename_domain` above has already re-defined the
+        domain against the new names, so they have to follow.
+
+        A VM that has never been started has neither: libvirt creates the nvram
+        file and swtpm the TPM directory on first boot, so a missing source is
+        not an error. It is still worth a line in the log, because a UEFI VM
+        that *has* booted and lost its nvram will quietly come up with a fresh
+        one and no enrolled Secure Boot keys.
+        """
+        renamed = set()
+        for folder, get_name in (
+            (SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name),
+            (SYSTEM_TPM_FOLDER_PATH, get_vm_tpm_state_dir_name),
+        ):
+            with contextlib.suppress(FileNotFoundError):
+                os.rename(os.path.join(folder, get_name(old)), os.path.join(folder, get_name(new)))
+                renamed.add(folder)
+
+        if old['bootloader'] == 'UEFI' and SYSTEM_NVRAM_FOLDER_PATH not in renamed:
+            self.logger.warning(
+                'Renamed VM %r to %r with no nvram file to move; libvirt will create one on next boot.',
+                old['name'], new['name'],
+            )
 
     @api_method(VMDeleteArgs, VMDeleteResult)
     async def do_delete(self, id_, data):


### PR DESCRIPTION
[NAS-143377](https://ixsystems.atlassian.net/browse/NAS-143377) — against `stable/goldeye`.

Renaming a VM on 25.10 does two wrong things:

1. A UEFI VM that has never been started reports an error for a rename that succeeded.
2. A VM with a TPM silently loses its TPM state — the rename moves the nvram file but not the TPM state directory, and the re-defined domain points swtpm at a directory that does not exist.

Both are already fixed on 26.0 and master by [NAS-140717](https://github.com/truenas/middleware/pull/18764) (`8945d05571`, "Move VM NVRAM and TPM atomically with VM rename"). This backports that decision.

### The error on a rename that worked

`do_update` raises whenever the nvram file is missing and the bootloader is UEFI on both sides. A UEFI VM that has never booted has no nvram file — libvirt creates it from the `<nvram template=...>` attribute at first start — so "never booted" and "nvram was lost" are indistinguishable and the code treats both as the second, *after* `datastore.update` has committed. On 25.10.5:

```
[EFAULT] VM name has been updated but nvram file for probe does not exist which can
result in probe_renamed VM not booting properly.
```

…while `vm.query` returns `probe_renamed`.

### The TPM state left behind

`get_vm_tpm_state_dir_name` builds `{id}_{name}_tpm_state` exactly the way the nvram file is built, and has one consumer — the swtpm backend in `supervisor/domain_xml.py`. Nothing renames it. Measured on 25.10.5 with a TPM VM booted once, then stopped and renamed:

```
### before rename, XML tpm path:
<source type='dir' path='/var/db/system/vm/tpm/61_probe_tpm_state'/>
### rename returned success
### after rename, XML tpm path:
<source type='dir' path='/var/db/system/vm/tpm/61_probe_renamed_tpm_state'/>
### on disk:
/var/db/system/vm/tpm/61_probe_tpm_state
```

swtpm initialises blank state on the next boot. For a Windows guest the TPM looks factory reset: BitLocker asks for the recovery key and anything sealed to the TPM is gone.

### Fix

A `_rename_vm_state` helper that moves both artefacts and logs when there was no nvram to move. Missing sources are skipped rather than raised — NAS-140717's wording: *"Missing sources are silently skipped, a VM that has never booted has no on-disk state and libvirt/swtpm will initialise both on first start."* The warning is kept because 26.0 keeps one too.

### Verified on 25.10.5

* a never-booted UEFI VM renames with no error, new name returned
* `middlewared.log` gets `Renamed VM 'f7a' to 'f7a_renamed' with no nvram file to move; libvirt will create one on next boot.`
* a `UEFI_CSM` VM renames with no warning — it legitimately has no nvram
* a booted UEFI + TPM VM renames and **both** move: `63_f7b_VARS.fd` → `63_f7b_renamed_VARS.fd`, `63_f7b_tpm_state` → `63_f7b_renamed_tpm_state`
* the re-defined domain XML then addresses both new paths

### Found while testing, not patched

`vm.delete` does not remove the TPM state directory either — `undefine_domain` passes `VIR_DOMAIN_UNDEFINE_NVRAM` so libvirt reaps the nvram file, but `VIR_DOMAIN_UNDEFINE_TPM` is never passed and nothing unlinks the directory. Not theoretical: the 25.10.5 box I tested on carries three orphans from VMs that no longer exist (`7_`, `8_`, `9_Windows_11_Pro_tpm_state`; ids 7/8/9 are not in `vm.query`). NAS-140717 fixed this in the same commit with `delete_vm_state()` — happy to fold it in.

### Scope

Keeps 25.10's plain `os.rename`; `truenas_os`/`renameat2`/`openat2` do not exist on this branch, so `AT_RENAME_NOREPLACE` and `RESOLVE_NO_SYMLINKS` can't come across. Stale-destination reach is low — `vm_vm` uses `sqlite_autoincrement`, so ids are not reused.

Two further things NAS-140717 changed that this does not: it moved the filesystem work ahead of `datastore.update` with rollback, and added unit tests for the helper. The ordering is the deeper fix and anything other than `FileNotFoundError` still surfaces after the commit here — I kept this to the two user-visible failures rather than restructuring `do_update` on a stable branch, but say the word.
