### PR TITLE
NAS-143378 / 27.0.0-BETA.1 / Answer a DDP ping on the legacy websocket endpoint

### DIFF
--- a/src/middlewared/middlewared/apps/websocket_app.py
+++ b/src/middlewared/middlewared/apps/websocket_app.py
@@ -337,6 +337,14 @@ class WebSocketApplication(RpcWebSocketApp):
                     self.middleware.create_task(
                         self.call_method(message, serviceobj, methodobj)
                     )
+        elif message["msg"] == "ping":
+            # DDP heartbeat. Without this a client that keeps the connection warm
+            # the way the protocol describes gets no answer and concludes the peer
+            # is gone, even though the socket is fine.
+            pong = {"msg": "pong"}
+            if "id" in message:
+                pong["id"] = message["id"]
+            self._send(pong)
         elif message["msg"] == "sub":
             if not self.middleware.can_subscribe(
                 self, message["name"].split(":", 1)[0]


### PR DESCRIPTION
[NAS-143378](https://ixsystems.atlassian.net/browse/NAS-143378)

The legacy websocket endpoint ignores a DDP `ping`. A client that keeps the connection warm the way the protocol describes gets no answer at all, so it concludes the peer is gone and tears down a socket that is perfectly healthy.

Low priority, and nothing of mine is blocked on it. Worth the four lines because the current behaviour is a silent drop rather than an error.

### Cause

`WebSocketApplication.on_message` dispatches `connect`, `method`, `sub` and `unsub`, with no `ping` branch and no trailing `else`, so a ping falls off the end of the chain. The route is live — `main.py` registers `GET /websocket` — and the same five branches are present unchanged on `stable/26` and `stable/goldeye`.

### Measured on 25.10.5

```
connect -> {"msg": "connected", "session": "3b2d6e5e-..."}
{'msg': 'ping'}              -> NO REPLY (WebSocketTimeoutException)
{'msg': 'ping', 'id': 'p1'}  -> NO REPLY (WebSocketTimeoutException)
core.ping method             -> {"id": "1", "msg": "result", "result": "pong"}
```

That last line is the point: after both ignored pings the same socket answers a `core.ping` RPC call normally. The connection is fine, the message is simply dropped — so a client cannot tell "this server does not implement DDP ping" from "this server is dead", which is exactly the distinction a heartbeat exists to make.

### With the patch, same box

* `{"msg": "ping"}` returns `{"msg": "pong"}`
* `{"msg": "ping", "id": "p1"}` returns `{"msg": "pong", "id": "p1"}`, echoing the id
* an ordinary `method` call on the same socket still works
* a ping before the handshake still returns `{"msg": "failed", "version": "1"}`, since the branch sits after the handshake gate

Nothing changes for a client that never sends a ping.

### Notes

An inbound `pong` is still ignored — harmless, since the server never sends a ping and so will never receive one; a no-op branch for it seemed like noise. Applies unchanged to `stable/26` and `stable/goldeye`.

If the legacy protocol is considered frozen and you would rather not touch it, that is a reasonable answer and I have no objection to this being closed. It is worth knowing about either way, because the failure is silent.
