### PR TITLE
NAS-143389 / 27.0.0-BETA.1 / Log when two disks collapse onto one storage_disk row

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -189,6 +189,14 @@ class DiskService(Service, ServiceChangeMixin):
             if disk := [i for i in qs if i['disk_identifier'] == disk_identifier]:
                 new = False
                 disk = disk[0]
+                if (other := disk['disk_name']) != name and other in sys_disks:
+                    # Two present block devices produced the same identifier, so they
+                    # share this row and only one of them is reachable through
+                    # disk.query. USB enclosures that report a canned serial do this.
+                    self.logger.warning(
+                        'Disks %r and %r share identifier %r; only one of them will be '
+                        'visible in disk.query', other, name, disk_identifier,
+                    )
                 job.set_progress(progress_percent, f'Updating disk {name!r}')
             else:
                 new = True


### PR DESCRIPTION
[NAS-143389](https://ixsystems.atlassian.net/browse/NAS-143389)

Two block devices reporting the same serial *and* lunid collapse onto one `storage_disk` row, so one of them disappears from `disk.query` with no error, no alert, and nothing in the response to indicate a disk is missing.

Observed on 26.0.0-BETA.3 with two ASM236X USB-NVMe enclosures: 18 attached disks, 17 rows, `sdo` absent — and no duplicate serial visible in the output, because the losing device has no row at all.

### Mechanism

`dev_to_ident()` (`utils/disks.py:42`) derives identity from `serial_lunid`, and both enclosures report `0000000000CA` / `5000000000000001`, so both produce `{serial_lunid}0000000000CA_5000000000000001`. The `{devicename}` fallback only applies when a disk has *no* serial, so a duplicate serial never reaches it.

`disk.sync_all` then merges rather than adding a row: the first device is resolved by `ident_to_dev` into `seen_disks`, the second falls into the second loop, matches the existing row by identifier, takes the `new = False` branch and overwrites `disk_name` on it.

### What this PR does

Only makes the merge visible in the log:

```
Disks 'sdo' and 'sdp' share identifier '{serial_lunid}0000000000CA_5000000000000001';
only one of them will be visible in disk.query
```

Verified on the box above. Today the condition is not diagnosable from a debug at all.

**This is not the fix**, and I would rather you pick that one:

1. Raise an alert when `disk.sync_all` merges two present devices — `availability.py` already computes the `duplicate_serial` relationship, so the data exists.
2. Or surface the collision in `disk.query`, so a caller can see a row stands for more than one device.

I deliberately did not touch `dev_to_ident`. Disambiguating the identifier is the obvious third option, but identifiers are persisted in `storage_disk` and referenced for pool membership, so that has migration consequences I can't judge from outside.

### Note on prior art

NAS-141295 ("Not all dirves are reported in GUI") is the same symptom, closed *Not Applicable* as unsupported hardware — the reporter had no diagnosis. This is a middleware identity collision rather than a hardware limitation, and the codebase already treats duplicate-serial USB disks as a real case: `availability.py:112` adds `duplicate_serial` specifically so the WebUI can warn ("I'm looking at you USB 'disks'"), and `pool.create` / `pool.attach_disk` both take `allow_duplicate_serials`.

Same code path on `stable/goldeye` and `stable/26`; I only have the hardware on the 26.0 box.
