### PR TITLE
NAS-143382 / 26.0.0 / Fix rsync extra arguments quoting

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -17,7 +17,7 @@ from middlewared.api.current import (
     RsyncTaskRunArgs, RsyncTaskRunResult,
 )
 from middlewared.common.attachment import LockableFSAttachmentDelegate
-from middlewared.plugins.rsync_.utils import get_host_key_file_contents_from_ssh_credentials
+from middlewared.plugins.rsync_.utils import get_host_key_file_contents_from_ssh_credentials, quote_extra_args
 from middlewared.service import (
     CallError, ValidationErrors, job, private, TaskPathService,
 )
@@ -508,7 +508,7 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
                 if rsync[name]:
                     line.append(flag)
             if rsync['extra']:
-                line.extend(shlex.quote(arg) for arg in rsync['extra'])
+                line.extend(quote_extra_args(rsync['extra']))
 
             if not rsync['ssh_credentials']:
                 # Do not use username if one is specified in host field

--- a/src/middlewared/middlewared/plugins/rsync_/utils.py
+++ b/src/middlewared/middlewared/plugins/rsync_/utils.py
@@ -1,3 +1,6 @@
+import shlex
+
+
 def get_host_key_file_contents_from_ssh_credentials(credentials: dict) -> str:
     return '\n'.join([
         (
@@ -7,3 +10,12 @@ def get_host_key_file_contents_from_ssh_credentials(credentials: dict) -> str:
         for host_key in credentials['remote_host_key'].split('\n')
         if host_key.strip() and not host_key.strip().startswith('#')
     ])
+
+
+def quote_extra_args(extra: list[str]) -> list[str]:
+    try:
+        args = shlex.split(' '.join(extra))
+    except ValueError:
+        args = extra
+
+    return [shlex.quote(arg) for arg in args]

--- a/src/middlewared/middlewared/plugins/rsync_/utils.py
+++ b/src/middlewared/middlewared/plugins/rsync_/utils.py
@@ -13,9 +13,11 @@ def get_host_key_file_contents_from_ssh_credentials(credentials: dict) -> str:
 
 
 def quote_extra_args(extra: list[str]) -> list[str]:
-    try:
-        args = shlex.split(' '.join(extra))
-    except ValueError:
-        args = extra
+    args = []
+    for arg in extra:
+        try:
+            args.extend(shlex.split(arg))
+        except ValueError:
+            args.append(arg)
 
     return [shlex.quote(arg) for arg in args]

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
@@ -49,6 +49,10 @@ def test_glob_is_quoted_against_the_local_shell():
     [
         (['"'], ["'\"'"]),
         (["--exclude", '"unclosed'], ["--exclude", "'\"unclosed'"]),
+        (
+            ['--rsync-path="sudo rsync"', "--exclude=foo\\"],
+            ["'--rsync-path=sudo rsync'", "'--exclude=foo\\'"],
+        ),
     ],
 )
 def test_unbalanced_quotes_are_passed_through(extra, expected):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
@@ -1,0 +1,56 @@
+import pytest
+
+from middlewared.plugins.rsync_.utils import quote_extra_args
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (['--rsync-path="sudo rsync"'], ["'--rsync-path=sudo rsync'"]),
+        (["--rsync-path='sudo rsync'"], ["'--rsync-path=sudo rsync'"]),
+        (['--rsync-path="/usr/bin/env rsync"'], ["'--rsync-path=/usr/bin/env rsync'"]),
+        (['--exclude="my file"'], ["'--exclude=my file'"]),
+        (
+            ['--rsync-path="sudo rsync"', '--exclude="my file"'],
+            ["'--rsync-path=sudo rsync'", "'--exclude=my file'"],
+        ),
+    ],
+)
+def test_quoted_value_is_regrouped(extra, expected):
+    """The user's quotes group the value; they must not survive into the argument itself."""
+    assert quote_extra_args(extra) == expected
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (["-avz"], ["-avz"]),
+        (["--rsync-path=/usr/bin/rsync"], ["--rsync-path=/usr/bin/rsync"]),
+        (['--rsync-path="/usr/bin/rsync"'], ["--rsync-path=/usr/bin/rsync"]),
+        (["--exclude", "excluded_file"], ["--exclude", "excluded_file"]),
+        ([], []),
+    ],
+)
+def test_options_needing_no_grouping(extra, expected):
+    assert quote_extra_args(extra) == expected
+
+
+def test_glob_is_quoted_against_the_local_shell():
+    """The command line is run through a shell, so patterns rsync expands itself must stay unexpanded."""
+    assert quote_extra_args(["--bwlimit=1000", "--exclude", "*.tmp"]) == [
+        "--bwlimit=1000",
+        "--exclude",
+        "'*.tmp'",
+    ]
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (['"'], ["'\"'"]),
+        (["--exclude", '"unclosed'], ["--exclude", "'\"unclosed'"]),
+    ],
+)
+def test_unbalanced_quotes_are_passed_through(extra, expected):
+    """A misconfigured value stored by an older version has no grouping to resolve, so it is left alone."""
+    assert quote_extra_args(extra) == expected

--- a/tests/api2/test_rsync_ssh_authentication.py
+++ b/tests/api2/test_rsync_ssh_authentication.py
@@ -367,3 +367,24 @@ def test_keyscan(cleanup, localuser, remoteuser, src, dst, ssh_credentials):
         "validate_rpath": False,
     }):
         pass
+
+
+def test_run_with_quoted_multiword_rsync_path(cleanup, localuser, remoteuser, src, dst, ssh_credentials):
+    """A quoted multi-word ``--rsync-path`` (e.g. ``"sudo rsync"``) must reach rsync without its quotes.
+
+    Quoting the value verbatim makes rsync ask the remote shell for a single word named
+    ``/usr/bin/env rsync``, which fails with ``command not found``.
+    """
+    with task({
+        "path": f"{src}/",
+        "user": "localuser",
+        "ssh_credentials": ssh_credentials["credentials"]["id"],
+        "mode": "SSH",
+        "remotepath": dst,
+        "extra": ['--rsync-path="/usr/bin/env rsync"'],
+    }) as t:
+        assert t["extra"] == ['--rsync-path="/usr/bin/env rsync"']
+
+        run_task(t)
+
+    assert ssh(f"ls -1 {dst}") == "test\n"


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/19496 introduced a regression: the user had `--rsync-path="sudo rsync"` in their `extra` args, and the argument value was used literally, causing `bash: line 1: sudo rsync: command not found` error (it tried to launch `sudo rsync` binary which didn't exist).

This is a 25.10.7 bug that didn't exist in 25.10.6, so, if we're ever publishing 25.10.8, it should be backported there.