### PR TITLE
NAS-143111 / 26.0.0-RC.1 / Write a hardware entitlement record on unlicensed iX appliances (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/bin/truenas-hw-license.py
+++ b/src/freenas/usr/local/bin/truenas-hw-license.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Write a bare hardware entitlement record on an iX appliance that holds no license.
+
+Runs chrooted inside the new boot environment partway through an upgrade, before
+middleware has ever started there. An appliance that shipped from iX carrying no
+license blob reads as wholly unlicensed once the per-feature entitlement gates
+apply, which withdraws capabilities the chassis was sold with. A minimal legacy
+record restores them.
+
+The record is stamped with a marker in its customer_key so the legacy parser can
+tell it apart from a license an issuer actually signed, and bound it to the bare
+hardware entitlement set instead of everything a legacy license implies. Nothing
+is written if any license record already exists.
+"""
+
+import os
+import sys
+from datetime import date
+
+from ixhardware import TRUENAS_UNKNOWN, get_chassis_hardware, parse_dmi
+from licenselib.license import ContractHardware, ContractSoftware, ContractType, License
+
+# Duplicated from middlewared/utils/license/constants.py and legacy.py rather than
+# imported: middlewared.utils.license executes its package __init__, which pulls in
+# truenas_pylicensed, the license daemon client and truenas_api_client -- far more
+# than can be depended on inside a half-populated chroot midway through an upgrade.
+LEGACY_LICENSE_FILE = "/data/license"
+LICENSE_FILE = "/data/subsystems/truenas_license/license"
+LICENSE_BACKUP = "/data/subsystems/truenas_license/license.bak"
+HW_ONLY_MARKER = "TRUENAS-HW-ONLY-V1"
+
+# An allowlist rather than a denylist, so a platform family added to ixhardware
+# upstream is excluded here until someone decides it ships with this entitlement.
+MINTABLE_PREFIXES = ("TRUENAS-R",)
+
+
+def log(message):
+    print(message, file=sys.stderr)
+
+
+def main():
+    for path in (LEGACY_LICENSE_FILE, LICENSE_FILE, LICENSE_BACKUP):
+        if os.path.exists(path):
+            log(f"{path} exists, leaving the license on this system alone")
+            return
+
+    dmi = parse_dmi()
+    chassis = get_chassis_hardware(dmi)
+    if chassis == TRUENAS_UNKNOWN:
+        log("Chassis does not identify itself as iX hardware")
+        return
+
+    if "MINI" in chassis:
+        log(f"{chassis} is a Mini")
+        return
+
+    if not chassis.startswith(MINTABLE_PREFIXES):
+        log(f"{chassis} is not an eligible platform")
+        return
+
+    serial = dmi.system_serial_number.strip()
+    if not serial:
+        log("Chassis reports no system serial number")
+        return
+
+    if len(serial.encode()) > 16:
+        log(f"System serial number does not fit the license field: {serial!r}")
+        return
+
+    model = chassis.removeprefix("TRUENAS-").split("-")[0]
+    if len(model.encode()) > 16:
+        log(f"Model does not fit the license field: {model!r}")
+        return
+
+    lic = License(
+        1,
+        # Derived exactly the way the license-status alert derives the running system's
+        # model, so that alert cannot report a mismatch against the record written here.
+        model,
+        serial,
+        # An empty HA serial holds the parsed type at ENTERPRISE_SINGLE, keeping
+        # failover.licensed false; a populated one would advertise a single head as a pair.
+        "",
+        ContractType.legacy,
+        ContractHardware.parts,
+        ContractSoftware.none,
+        date.today(),
+        36500,
+        "",
+        HW_ONLY_MARKER,
+        [],
+        [],
+    )
+
+    fd = os.open(LEGACY_LICENSE_FILE, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        # The installer's pass over /data has already applied its modes by this point, so
+        # nothing comes along afterwards to correct a file created here.
+        os.fchmod(fd, 0o600)
+        os.fchown(fd, 0, 0)
+        os.write(fd, lic.dump() + b"\n")
+    finally:
+        os.close(fd)
+
+    log(f"Wrote a hardware entitlement record for {chassis} ({serial})")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        log(f"Failed to write a hardware entitlement record: {e!r}")
+
+    # An upgrade must not fail over entitlement bookkeeping.
+    sys.exit(0)

--- a/src/freenas/usr/local/bin/truenas-hw-license.py
+++ b/src/freenas/usr/local/bin/truenas-hw-license.py
@@ -14,49 +14,32 @@ hardware entitlement set instead of everything a legacy license implies. Nothing
 is written if any license record already exists.
 """
 
-import json
 import os
 import sys
-from datetime import date, datetime, timezone
+from datetime import date
 
-from ixhardware import TRUENAS_UNKNOWN, get_chassis_hardware, parse_dmi
+from ixhardware import get_chassis_hardware, parse_dmi
 from licenselib.license import ContractHardware, ContractSoftware, ContractType, License
 from truenas_os_pyutils.io import atomic_write
 
-# Duplicated from middlewared/utils/license/constants.py and legacy.py rather than
-# imported: middlewared.utils.license executes its package __init__, which pulls in
-# truenas_pylicensed, the license daemon client and truenas_api_client -- far more
-# than can be depended on inside a half-populated chroot midway through an upgrade.
+
 LEGACY_LICENSE_FILE = "/data/license"
 LICENSE_FILE = "/data/subsystems/truenas_license/license"
 LICENSE_BACKUP = "/data/subsystems/truenas_license/license.bak"
-HW_LICENSE_RESULT_FILE = "/data/truenas-hw-license.json"
+HW_LICENSE_ERROR_FILE = "/data/truenas-hw-license.err"
 HW_ONLY_MARKER = "TRUENAS-HW-ONLY-V1"
 
 # An allowlist rather than a denylist, so a platform family added to ixhardware
 # upstream is excluded here until someone decides it ships with this entitlement.
+# Anything that reads as unknown or as a Mini fails it too.
 MINTABLE_PREFIXES = ("TRUENAS-R",)
 
 
-def record_outcome(outcome, chassis=None, serial=None, model=None, error=None):
-    """Leave a record middleware relays into middlewared.log and deletes on first boot.
-
-    Every outcome is recorded, not just failures: a chassis reading as unknown is
-    indistinguishable here from dmidecode having failed,
-    so which outcomes deserve attention is middleware's call, not ours.
-    """
+def record_error(message):
+    """Leave a message middleware logs and deletes on first boot."""
     try:
-        record = {
-            "version": 1,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "outcome": outcome,
-            "chassis": chassis,
-            "serial": serial,
-            "model": model,
-            "error": None if error is None else str(error)[:512],
-        }
-        with atomic_write(HW_LICENSE_RESULT_FILE, "w", perms=0o600) as f:
-            f.write(json.dumps(record) + "\n")
+        with atomic_write(HW_LICENSE_ERROR_FILE, "w", perms=0o600) as f:
+            f.write(message + "\n")
     except Exception:
         pass
 
@@ -64,46 +47,25 @@ def record_outcome(outcome, chassis=None, serial=None, model=None, error=None):
 def main():
     for path in (LEGACY_LICENSE_FILE, LICENSE_FILE, LICENSE_BACKUP):
         if os.path.exists(path):
-            record_outcome("license_present")
             return
 
     dmi = parse_dmi()
     chassis = get_chassis_hardware(dmi)
-    if chassis == TRUENAS_UNKNOWN:
-        record_outcome("chassis_unknown")
-        return
-
-    if "MINI" in chassis:
-        record_outcome("mini", chassis=chassis)
-        return
-
     if not chassis.startswith(MINTABLE_PREFIXES):
-        record_outcome("ineligible_platform", chassis=chassis)
         return
 
     serial = dmi.system_serial_number.strip()
     if not serial:
-        record_outcome("serial", chassis=chassis, error="Chassis reports no system serial number")
+        record_error(f"{chassis}: chassis reports no system serial number")
         return
 
     if len(serial.encode()) > 16:
-        record_outcome(
-            "serial",
-            chassis=chassis,
-            serial=serial,
-            error=f"System serial number does not fit the license field: {serial!r}",
-        )
+        record_error(f"{chassis}: system serial number does not fit the license field: {serial!r}")
         return
 
     model = chassis.removeprefix("TRUENAS-").split("-")[0]
     if len(model.encode()) > 16:
-        record_outcome(
-            "model",
-            chassis=chassis,
-            serial=serial,
-            model=model,
-            error=f"Model does not fit the license field: {model!r}",
-        )
+        record_error(f"{chassis}: model does not fit the license field: {model!r}")
         return
 
     lic = License(
@@ -130,17 +92,14 @@ def main():
         with atomic_write(LEGACY_LICENSE_FILE, "wb", perms=0o600, noclobber=True) as f:
             f.write(lic.dump() + b"\n")
     except Exception as e:
-        record_outcome("write", chassis=chassis, serial=serial, model=model, error=repr(e))
-        return
-
-    record_outcome("written", chassis=chassis, serial=serial, model=model)
+        record_error(f"{chassis}: failed to write {LEGACY_LICENSE_FILE} for serial {serial!r}: {e!r}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        record_outcome("unexpected", error=repr(e))
+        record_error(f"unexpected failure: {e!r}")
 
     # An upgrade must not fail over entitlement bookkeeping.
     sys.exit(0)

--- a/src/freenas/usr/local/bin/truenas-hw-license.py
+++ b/src/freenas/usr/local/bin/truenas-hw-license.py
@@ -14,12 +14,14 @@ hardware entitlement set instead of everything a legacy license implies. Nothing
 is written if any license record already exists.
 """
 
+import json
 import os
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 
 from ixhardware import TRUENAS_UNKNOWN, get_chassis_hardware, parse_dmi
 from licenselib.license import ContractHardware, ContractSoftware, ContractType, License
+from truenas_os_pyutils.io import atomic_write
 
 # Duplicated from middlewared/utils/license/constants.py and legacy.py rather than
 # imported: middlewared.utils.license executes its package __init__, which pulls in
@@ -28,6 +30,7 @@ from licenselib.license import ContractHardware, ContractSoftware, ContractType,
 LEGACY_LICENSE_FILE = "/data/license"
 LICENSE_FILE = "/data/subsystems/truenas_license/license"
 LICENSE_BACKUP = "/data/subsystems/truenas_license/license.bak"
+HW_LICENSE_RESULT_FILE = "/data/truenas-hw-license.json"
 HW_ONLY_MARKER = "TRUENAS-HW-ONLY-V1"
 
 # An allowlist rather than a denylist, so a platform family added to ixhardware
@@ -35,42 +38,72 @@ HW_ONLY_MARKER = "TRUENAS-HW-ONLY-V1"
 MINTABLE_PREFIXES = ("TRUENAS-R",)
 
 
-def log(message):
-    print(message, file=sys.stderr)
+def record_outcome(outcome, chassis=None, serial=None, model=None, error=None):
+    """Leave a record middleware relays into middlewared.log and deletes on first boot.
+
+    Every outcome is recorded, not just failures: a chassis reading as unknown is
+    indistinguishable here from dmidecode having failed,
+    so which outcomes deserve attention is middleware's call, not ours.
+    """
+    try:
+        record = {
+            "version": 1,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "outcome": outcome,
+            "chassis": chassis,
+            "serial": serial,
+            "model": model,
+            "error": None if error is None else str(error)[:512],
+        }
+        with atomic_write(HW_LICENSE_RESULT_FILE, "w", perms=0o600) as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception:
+        pass
 
 
 def main():
     for path in (LEGACY_LICENSE_FILE, LICENSE_FILE, LICENSE_BACKUP):
         if os.path.exists(path):
-            log(f"{path} exists, leaving the license on this system alone")
+            record_outcome("license_present")
             return
 
     dmi = parse_dmi()
     chassis = get_chassis_hardware(dmi)
     if chassis == TRUENAS_UNKNOWN:
-        log("Chassis does not identify itself as iX hardware")
+        record_outcome("chassis_unknown")
         return
 
     if "MINI" in chassis:
-        log(f"{chassis} is a Mini")
+        record_outcome("mini", chassis=chassis)
         return
 
     if not chassis.startswith(MINTABLE_PREFIXES):
-        log(f"{chassis} is not an eligible platform")
+        record_outcome("ineligible_platform", chassis=chassis)
         return
 
     serial = dmi.system_serial_number.strip()
     if not serial:
-        log("Chassis reports no system serial number")
+        record_outcome("serial", chassis=chassis, error="Chassis reports no system serial number")
         return
 
     if len(serial.encode()) > 16:
-        log(f"System serial number does not fit the license field: {serial!r}")
+        record_outcome(
+            "serial",
+            chassis=chassis,
+            serial=serial,
+            error=f"System serial number does not fit the license field: {serial!r}",
+        )
         return
 
     model = chassis.removeprefix("TRUENAS-").split("-")[0]
     if len(model.encode()) > 16:
-        log(f"Model does not fit the license field: {model!r}")
+        record_outcome(
+            "model",
+            chassis=chassis,
+            serial=serial,
+            model=model,
+            error=f"Model does not fit the license field: {model!r}",
+        )
         return
 
     lic = License(
@@ -93,24 +126,21 @@ def main():
         [],
     )
 
-    fd = os.open(LEGACY_LICENSE_FILE, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        # The installer's pass over /data has already applied its modes by this point, so
-        # nothing comes along afterwards to correct a file created here.
-        os.fchmod(fd, 0o600)
-        os.fchown(fd, 0, 0)
-        os.write(fd, lic.dump() + b"\n")
-    finally:
-        os.close(fd)
+        with atomic_write(LEGACY_LICENSE_FILE, "wb", perms=0o600, noclobber=True) as f:
+            f.write(lic.dump() + b"\n")
+    except Exception as e:
+        record_outcome("write", chassis=chassis, serial=serial, model=model, error=repr(e))
+        return
 
-    log(f"Wrote a hardware entitlement record for {chassis} ({serial})")
+    record_outcome("written", chassis=chassis, serial=serial, model=model)
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        log(f"Failed to write a hardware entitlement record: {e!r}")
+        record_outcome("unexpected", error=repr(e))
 
     # An upgrade must not fail over entitlement bookkeeping.
     sys.exit(0)

--- a/src/freenas/usr/local/bin/truenas-hw-license.py
+++ b/src/freenas/usr/local/bin/truenas-hw-license.py
@@ -3,9 +3,10 @@
 
 Runs chrooted inside the new boot environment partway through an upgrade, before
 middleware has ever started there. An appliance that shipped from iX carrying no
-license blob reads as wholly unlicensed once the per-feature entitlement gates
-apply, which withdraws capabilities the chassis was sold with. A minimal legacy
-record restores them.
+license blob resolves entitlements on the unlicensed column, which leaves nowhere
+to gate a feature that every appliance of this class is meant to have. Writing a
+minimal legacy record moves it onto the licensed column, where such a feature can
+be granted without also granting it to commodity hardware.
 
 The record is stamped with a marker in its customer_key so the legacy parser can
 tell it apart from a license an issuer actually signed, and bound it to the bare

--- a/src/middlewared/middlewared/alert/applicability/vocabulary.py
+++ b/src/middlewared/middlewared/alert/applicability/vocabulary.py
@@ -57,8 +57,9 @@ def NOT_APPLIANCE_HARDWARE(facts: EntitlementFacts) -> bool:
 
 def ANY_LICENSE(facts: EntitlementFacts) -> bool:
     """Machines carrying a license of any type, on any hardware. For declarations whose subject is
-    the license itself. This is not "is this an enterprise system": a licensed Mini satisfies it and
-    an unlicensed appliance does not."""
+    the license itself. This is not "is this an enterprise system": a licensed Mini satisfies it, and
+    an appliance satisfies it only once it holds a record -- including one the system generated for
+    itself."""
     return facts.license is not None
 
 

--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -12,6 +12,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.alert.applicability import EXPECTED_TO_BE_LICENSED
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
+from middlewared.utils.license import LicenseOrigin
 
 
 class LicenseAlertClass(AlertClass):
@@ -47,7 +48,9 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         alerts = []
 
         local_license = self.call_sync2(self.s.truenas.license.info_private)
-        if local_license is None:
+        # A system-generated record licenses no shelves, so the shelf check below would fire on it
+        # permanently.
+        if local_license is None or local_license.origin is LicenseOrigin.SYSTEM_GENERATED:
             if not self.middleware.call_sync('system.is_ha_capable'):
                 return []
 

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -23,6 +23,7 @@ from middlewared.service import CallError, ConfigService, job, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils import sw_version
 from middlewared.utils.entitlements import DerivedEntitlement
+from middlewared.utils.license import LicenseOrigin
 from middlewared.utils.network import INTERNET_TIMEOUT
 
 ADDRESS = 'support-proxy.truenas.com'
@@ -175,7 +176,7 @@ class SupportService(ConfigService):
             required_attrs = ('category', 'phone', 'name', 'email', 'criticality', 'environment')
             data['serial'] = (await self.middleware.call('system.dmidecode_info'))['system-serial-number']
             license_ = (await self.call2(self.s.truenas.license.info_private))
-            if license_:
+            if license_ and license_.origin is LicenseOrigin.ISSUED:
                 data['license_id'] = license_.id
 
         for i in required_attrs:

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -22,6 +22,7 @@ from middlewared.plugins.truenas.tn import EULA_PENDING_PATH
 from middlewared.utils.license import (
     LEGACY_LICENSE_FILE,
     LicenseInfo,
+    LicenseOrigin,
     get_fingerprint_b64,
     get_legacy_license_info,
     get_license,
@@ -75,7 +76,8 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
     )
     def upload(self, license_: Secret[LongNonEmptyString], options: TrueNASLicenseUploadOptions) -> None:
         """Upload a PEM-wrapped license file."""
-        had_license = self.info_private() is not None
+        current = self.info_private()
+        had_license = current is not None and current.origin is LicenseOrigin.ISSUED
 
         # `check_annotations` hands the method the undumped model value, so the PEM has to be
         # unwrapped twice: out of the Secret that keeps it off the audit trail, then out of the

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -1,5 +1,7 @@
 import contextlib
+import json
 import os
+from typing import Any, TYPE_CHECKING
 
 from pydantic import Secret
 
@@ -20,6 +22,7 @@ from middlewared.service import Service, ValidationError, private
 from middlewared.plugins.truenas.license_reconcile import TrueNASLicenseReconcileService
 from middlewared.plugins.truenas.tn import EULA_PENDING_PATH
 from middlewared.utils.license import (
+    HW_LICENSE_RESULT_FILE,
     LEGACY_LICENSE_FILE,
     LicenseInfo,
     LicenseOrigin,
@@ -29,6 +32,9 @@ from middlewared.utils.license import (
     upload_license,
 )
 from truenas_pylicensed import LicenseType
+
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
 
 def _license_entry(info: LicenseInfo) -> LicenseInfoEntry:
@@ -164,3 +170,32 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
     @private
     def info_private(self) -> LicenseInfo | None:
         return get_license()
+
+    @private
+    def process_hw_license_result(self) -> None:
+        if os.path.exists(HW_LICENSE_RESULT_FILE):
+            try:
+                with open(HW_LICENSE_RESULT_FILE) as f:
+                    data = json.load(f)
+
+                # The record is written for every outcome, most of which are the script
+                # correctly declining to act. An error is what makes one worth surfacing.
+                if data.get("error"):
+                    self.logger.error(
+                        "truenas-hw-license.py did not write a record during upgrade: "
+                        "outcome %r, chassis %r, serial %r: %s",
+                        data.get("outcome"), data.get("chassis"), data.get("serial"), data.get("error"),
+                    )
+            finally:
+                os.unlink(HW_LICENSE_RESULT_FILE)
+
+
+async def on_system_ready(middleware: "Middleware", event_type: str, args: Any) -> None:
+    try:
+        await middleware.call("truenas.license.process_hw_license_result")
+    except Exception:
+        middleware.logger.error("Error processing hardware entitlement result file", exc_info=True)
+
+
+async def setup(middleware: "Middleware") -> None:
+    middleware.event_subscribe("system.ready", on_system_ready)

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 import os
 from typing import Any, TYPE_CHECKING
 
@@ -22,7 +21,7 @@ from middlewared.service import Service, ValidationError, private
 from middlewared.plugins.truenas.license_reconcile import TrueNASLicenseReconcileService
 from middlewared.plugins.truenas.tn import EULA_PENDING_PATH
 from middlewared.utils.license import (
-    HW_LICENSE_RESULT_FILE,
+    HW_LICENSE_ERROR_FILE,
     LEGACY_LICENSE_FILE,
     LicenseInfo,
     LicenseOrigin,
@@ -172,29 +171,20 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
         return get_license()
 
     @private
-    def process_hw_license_result(self) -> None:
-        if os.path.exists(HW_LICENSE_RESULT_FILE):
+    def process_hw_license_error(self) -> None:
+        if os.path.exists(HW_LICENSE_ERROR_FILE):
             try:
-                with open(HW_LICENSE_RESULT_FILE) as f:
-                    data = json.load(f)
-
-                # The record is written for every outcome, most of which are the script
-                # correctly declining to act. An error is what makes one worth surfacing.
-                if data.get("error"):
-                    self.logger.error(
-                        "truenas-hw-license.py did not write a record during upgrade: "
-                        "outcome %r, chassis %r, serial %r: %s",
-                        data.get("outcome"), data.get("chassis"), data.get("serial"), data.get("error"),
-                    )
+                with open(HW_LICENSE_ERROR_FILE) as f:
+                    self.logger.error("truenas-hw-license.py: %s", f.read().strip())
             finally:
-                os.unlink(HW_LICENSE_RESULT_FILE)
+                os.unlink(HW_LICENSE_ERROR_FILE)
 
 
 async def on_system_ready(middleware: "Middleware", event_type: str, args: Any) -> None:
     try:
-        await middleware.call("truenas.license.process_hw_license_result")
+        await middleware.call("truenas.license.process_hw_license_error")
     except Exception:
-        middleware.logger.error("Error processing hardware entitlement result file", exc_info=True)
+        middleware.logger.error("Error processing hardware entitlement error file", exc_info=True)
 
 
 async def setup(middleware: "Middleware") -> None:

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -7,6 +7,7 @@ from truenas_connect_utils.urls import get_heartbeat_url
 
 from middlewared.service import CallError, Service
 from middlewared.utils.disks_.disk_class import iterate_disks
+from middlewared.utils.license import LicenseOrigin
 from middlewared.utils.version import parse_version_string
 
 from .mixin import TNCAPIMixin
@@ -188,10 +189,11 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
         # license_id is the delivery acknowledgement: once we report the id of an installed license,
         # TNC marks it accepted and stops resending the PEM. Null when we hold no valid license.
         license_info = await self.call2(self.s.truenas.license.info_private)
+        issued = license_info is not None and license_info.origin is LicenseOrigin.ISSUED
 
         return {
             'alerts': await self.middleware.call('alert.list'),
             'stats': stats,
             'fingerprint': fingerprint,
-            'license_id': license_info.id if license_info else None,
+            'license_id': license_info.id if issued else None,
         }

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -12,6 +12,7 @@ from middlewared.api.current import (
     TrueNASConnectGenerateClaimTokenArgs, TrueNASConnectGenerateClaimTokenResult,
 )
 from middlewared.utils.crypto import ssl_uuid4
+from middlewared.utils.license import LicenseOrigin
 from middlewared.service import CallError, Service
 
 from .utils import CLAIM_TOKEN_CACHE_KEY
@@ -96,8 +97,10 @@ class TrueNASConnectService(Service):
             'port': (await self.middleware.call('system.general.config'))['ui_httpsport']
         }
 
-        license_info = await self.middleware.call('system.license', True)
-        if license_info is not None and license_info['raw_license'] is not None:
-            query_params['license'] = license_info['raw_license']
+        info = await self.middleware.call('truenas.license.info_private')
+        if info is not None and info.origin is LicenseOrigin.ISSUED:
+            license_info = await self.middleware.call('system.license', True)
+            if license_info is not None and license_info['raw_license'] is not None:
+                query_params['license'] = license_info['raw_license']
 
         return f'{get_registration_uri(config)}?{urlencode(query_params)}'

--- a/src/middlewared/middlewared/pytest/unit/entitlements.py
+++ b/src/middlewared/middlewared/pytest/unit/entitlements.py
@@ -11,7 +11,7 @@ from truenas_pylicensed import LicenseType
 
 from middlewared.api.current import EntitlementEntry
 from middlewared.utils.entitlements import EntitlementFacts, HardwareClass, Reason, check_entitlement
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 
 def make_license(
@@ -21,6 +21,7 @@ def make_license(
     model: str | None = "H10",
     expires_at: date | None = None,
     support_type: str | None = None,
+    origin: LicenseOrigin = LicenseOrigin.ISSUED,
 ) -> LicenseInfo:
     features = {
         name: FeatureInfo(
@@ -41,6 +42,7 @@ def make_license(
         serials=("TEST-000001",),
         enclosures={},
         contract_type=support_type,
+        origin=origin,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
@@ -6,7 +6,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.plugins.failover import mismatch_nics
 from middlewared.plugins.failover_.ha_hardware import is_licensed_for_ha
 from middlewared.utils.hardware import HardwareClass
-from middlewared.utils.license import LicenseInfo
+from middlewared.utils.license import LicenseInfo, LicenseOrigin
 
 
 @pytest.mark.parametrize(
@@ -45,6 +45,7 @@ def _license(type_):
         serials=("TEST-000001",),
         enclosures={},
         contract_type=None,
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_system_product.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_system_product.py
@@ -5,7 +5,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.plugins.system.product import SystemService
 from middlewared.pytest.unit.helpers import create_service
 from middlewared.pytest.unit.middleware import Middleware
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 START = date(2026, 4, 8)
 END = date(2026, 4, 30)
@@ -30,6 +30,7 @@ def _info(**overrides) -> LicenseInfo:
         "serials": ("TEST-000001", "TEST-000002"),
         "enclosures": {"E24": 3},
         "contract_type": "GOLD",
+        "origin": LicenseOrigin.ISSUED,
     }
     fields.update(overrides)
     return LicenseInfo(**fields)

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -8,7 +8,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.pytest.unit.helpers import create_service
 from middlewared.pytest.unit.middleware import Middleware
 from middlewared.service import CallError, ValidationErrors
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 from middlewared.plugins.truenas_connect.acme import TNCACMEService
 from middlewared.plugins.truenas_connect.heartbeat import TNCHeartbeatService
 from middlewared.plugins.truenas_connect.register import TrueNASConnectService as TNCRegistrationService
@@ -819,7 +819,7 @@ async def test_handle_response_202_pending_without_pem_is_quiet():
     warn.assert_not_called()
 
 
-# --- Registration URI: the license PEM is attached unconditionally ---------------------------------
+# --- Registration URI: the license PEM is attached when an issuer signed it ------------------------
 
 def _registration_service(license_info):
     service = TNCRegistrationService(MagicMock())
@@ -839,13 +839,15 @@ def _registration_service(license_info):
             return {'ui_httpsport': 443}
         if method == 'system.license':
             return license_info
+        if method == 'truenas.license.info_private':
+            return None if license_info is None else MagicMock(origin=LicenseOrigin.ISSUED)
         raise ValueError(f'Unexpected: {method}')
 
     service.middleware.call = AsyncMock(side_effect=mock_call)
     return service
 
 
-# The PEM's presence is the only thing that decides this.
+# These all hold an issued license, so the PEM's presence is what decides them.
 @pytest.mark.asyncio
 @pytest.mark.parametrize('license_info, expected', [
     ({'raw_license': 'THE-PEM'}, 'license=THE-PEM'),

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -611,6 +611,7 @@ def _license_info(id_='LIC-1'):
         serials=('TEST-000001',),
         enclosures={'E24': 3},
         contract_type='GOLD',
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_entitlements_api.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_entitlements_api.py
@@ -20,7 +20,7 @@ from middlewared.utils.entitlements import (
     LicenseFeature,
     Reason,
 )
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 
 def test_check_returns_the_endpoint_model_not_the_engine_dataclass(monkeypatch):
@@ -112,6 +112,7 @@ def make_license(feature_names, license_type, support_type):
         serials=("TEST-000001",),
         enclosures={},
         contract_type=support_type,
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_get_license.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_get_license.py
@@ -4,7 +4,7 @@ import pytest
 from truenas_pylicensed import LicenseError, LicenseStatus, LicenseType
 
 import middlewared.utils.license as license_utils
-from middlewared.utils.license import LicenseInfo, get_license
+from middlewared.utils.license import LicenseInfo, LicenseOrigin, get_license
 
 # The daemon is certain there is no v2 license, which is the only condition under
 # which the legacy blob underneath is consulted.
@@ -37,6 +37,7 @@ LEGACY = LicenseInfo(
     serials=("TEST-000001",),
     enclosures={},
     contract_type="GOLD",
+    origin=LicenseOrigin.ISSUED,
 )
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_license_legacy_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_license_legacy_utils.py
@@ -19,6 +19,7 @@ from middlewared.utils.entitlements import (
 from middlewared.utils.license import (
     FeatureInfo,
     LicenseInfo,
+    LicenseOrigin,
     get_legacy_license_info,
     parse_legacy_license,
 )
@@ -101,6 +102,7 @@ FREENAS_MINI_BLOB = (
                 serials=("TEST-000001", "TEST-000002"),
                 enclosures={"E24": 3, "E16": 2},
                 contract_type="GOLD",
+                origin=LicenseOrigin.ISSUED,
             ),
         ),
         # Enterprise single license (X10, STANDARD contract): the jails->APPS bit is
@@ -117,6 +119,7 @@ FREENAS_MINI_BLOB = (
                 serials=("TEST-000001",),
                 enclosures={},
                 contract_type="STANDARD",
+                origin=LicenseOrigin.ISSUED,
             ),
         ),
     ],

--- a/src/middlewared/middlewared/pytest/unit/utils/test_license_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_license_utils.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 from truenas_pylicensed import FeatureEntry, LicenseError, LicenseStatus, LicenseType
 
-from middlewared.utils.license import FeatureInfo, LicenseInfo, from_license_status
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin, from_license_status
 
 
 def _make_status(features: dict[str, FeatureEntry]) -> LicenseStatus:
@@ -30,6 +30,7 @@ def _license(**overrides) -> LicenseInfo:
         "serials": (),
         "enclosures": {},
         "contract_type": None,
+        "origin": LicenseOrigin.ISSUED,
     }
     fields.update(overrides)
     return LicenseInfo(**fields)
@@ -74,6 +75,7 @@ def test__from_license_status__renames_vm_to_vms():
         serials=("TEST-000001", "TEST-000002"),
         enclosures={"E24": 3},
         contract_type="GOLD",
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/utils/license/__init__.py
+++ b/src/middlewared/middlewared/utils/license/__init__.py
@@ -21,7 +21,7 @@ from .constants import (
 )
 from .daemon import from_license_status, get_fingerprint_b64, upload_license
 from .legacy import describe_legacy_license, get_legacy_license_info, parse_legacy_license
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 __all__ = [
     "LEGACY_LICENSE_FILE",
@@ -31,6 +31,7 @@ __all__ = [
     "LICENSE_FILE",
     "FeatureInfo",
     "LicenseInfo",
+    "LicenseOrigin",
     "describe_legacy_license",
     "from_license_status",
     "get_fingerprint_b64",

--- a/src/middlewared/middlewared/utils/license/__init__.py
+++ b/src/middlewared/middlewared/utils/license/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from truenas_pylicensed import LicenseError, LicenseStatus, verify
 
 from .constants import (
+    HW_LICENSE_RESULT_FILE,
     LEGACY_LICENSE_FILE,
     LICENSE_ADDHW_MAPPING,
     LICENSE_BACKUP,
@@ -24,6 +25,7 @@ from .legacy import describe_legacy_license, get_legacy_license_info, parse_lega
 from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 __all__ = [
+    "HW_LICENSE_RESULT_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",

--- a/src/middlewared/middlewared/utils/license/__init__.py
+++ b/src/middlewared/middlewared/utils/license/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from truenas_pylicensed import LicenseError, LicenseStatus, verify
 
 from .constants import (
-    HW_LICENSE_RESULT_FILE,
+    HW_LICENSE_ERROR_FILE,
     LEGACY_LICENSE_FILE,
     LICENSE_ADDHW_MAPPING,
     LICENSE_BACKUP,
@@ -25,7 +25,7 @@ from .legacy import describe_legacy_license, get_legacy_license_info, parse_lega
 from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 __all__ = [
-    "HW_LICENSE_RESULT_FILE",
+    "HW_LICENSE_ERROR_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",

--- a/src/middlewared/middlewared/utils/license/constants.py
+++ b/src/middlewared/middlewared/utils/license/constants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import MappingProxyType
 
 __all__ = (
+    "HW_LICENSE_RESULT_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",
@@ -17,6 +18,8 @@ LICENSE_FILE = f"{LICENSE_DIR}/license"
 LICENSE_BACKUP = f"{LICENSE_DIR}/license.bak"
 
 LEGACY_LICENSE_FILE = "/data/license"
+
+HW_LICENSE_RESULT_FILE = "/data/truenas-hw-license.json"
 
 LICENSE_ADDHW_MAPPING = MappingProxyType(
     {

--- a/src/middlewared/middlewared/utils/license/constants.py
+++ b/src/middlewared/middlewared/utils/license/constants.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import MappingProxyType
 
 __all__ = (
-    "HW_LICENSE_RESULT_FILE",
+    "HW_LICENSE_ERROR_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",
@@ -19,7 +19,7 @@ LICENSE_BACKUP = f"{LICENSE_DIR}/license.bak"
 
 LEGACY_LICENSE_FILE = "/data/license"
 
-HW_LICENSE_RESULT_FILE = "/data/truenas-hw-license.json"
+HW_LICENSE_ERROR_FILE = "/data/truenas-hw-license.err"
 
 LICENSE_ADDHW_MAPPING = MappingProxyType(
     {

--- a/src/middlewared/middlewared/utils/license/daemon.py
+++ b/src/middlewared/middlewared/utils/license/daemon.py
@@ -19,7 +19,7 @@ from truenas_pylicensed import FEATURE_NAME_MAP, LicenseStatus, get_fingerprint,
 from middlewared.service_exception import CallError
 
 from .constants import LICENSE_BACKUP, LICENSE_DIR, LICENSE_FILE
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 logger = logging.getLogger(__name__)
 
@@ -181,4 +181,5 @@ def from_license_status(status: LicenseStatus | None = None) -> LicenseInfo | No
             {model: entry["count"] for model, entry in (status.enclosures or {}).items()}
         ),
         contract_type=contract_type,
+        origin=LicenseOrigin.ISSUED,
     )

--- a/src/middlewared/middlewared/utils/license/legacy.py
+++ b/src/middlewared/middlewared/utils/license/legacy.py
@@ -17,7 +17,7 @@ import errno
 from functools import lru_cache
 import logging
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Final
 
 from licenselib.license import Features, License
 from licenselib.utils import proactive_support_allowed
@@ -30,6 +30,7 @@ from .types import FeatureInfo, LicenseInfo
 logger = logging.getLogger(__name__)
 
 __all__ = (
+    "HW_ONLY_MARKER",
     "LegacyStatus",
     "describe_legacy_license",
     "get_legacy_license_info",
@@ -66,6 +67,21 @@ _LEGACY_INJECT: frozenset[LicenseFeature] = frozenset(
         LicenseFeature.TRUESEARCH,
         LicenseFeature.VMS,
         LicenseFeature.WEBSHARE,
+    }
+)
+
+HW_ONLY_MARKER: Final[str] = "TRUENAS-HW-ONLY-V1"
+
+# Reproduces the bare TRUENAS_HW entitlement column: what an iX chassis carries on the
+# strength of the hardware alone, with no support contract behind it. Deliberately not a
+# subset of _LEGACY_INJECT -- SED is a bitmask feature a real blob could carry, so it was
+# never among the names injected into one.
+_HW_ONLY_INJECT: frozenset[LicenseFeature] = frozenset(
+    {
+        LicenseFeature.APPS,
+        LicenseFeature.CONTAINERS,
+        LicenseFeature.SED,
+        LicenseFeature.VMS,
     }
 )
 
@@ -130,6 +146,7 @@ def legacy_license_fields(lic: Any) -> dict[str, Any]:
         "contract_end": lic.contract_end.isoformat(),
         "features": [feature.name for feature in lic.features],
         "addhw": [list(entry) for entry in lic.addhw],
+        "hw_only": lic.customer_key == HW_ONLY_MARKER,
     }
 
 
@@ -186,16 +203,23 @@ def parse_legacy_license(text: str) -> LicenseInfo:
     enclosures = {
         LICENSE_ADDHW_MAPPING[code]: quantity for quantity, code in lic.addhw if code in LICENSE_ADDHW_MAPPING
     }
-    # Iterate the enum rather than the frozenset so injected names land in declaration order.
-    for feat in LicenseFeature:
-        if feat in _LEGACY_INJECT and feat not in feature_names:
-            feature_names.append(feat.value)
+    if lic.customer_key == HW_ONLY_MARKER:
+        # Replaces the list rather than extending it: the bitmask-derived names and the
+        # conditional SUPPORT append both already happened above, and replacing is what
+        # holds a marked record to the bare hardware set.
+        feature_names = [f.value for f in LicenseFeature if f in _HW_ONLY_INJECT]
+    else:
+        # Iterate the enum rather than the frozenset so injected names land in declaration order.
+        for feat in LicenseFeature:
+            if feat in _LEGACY_INJECT and feat not in feature_names:
+                feature_names.append(feat.value)
 
     return LicenseInfo(
         id=f"legacy_{lic.system_serial}",
         type=LicenseType.ENTERPRISE_HA if lic.system_serial_ha else LicenseType.ENTERPRISE_SINGLE,
         model=model,
-        support_expires_at=lic.contract_end,
+        # A marked record has no support contract behind it, so it carries no expiry to act on.
+        support_expires_at=None if lic.customer_key == HW_ONLY_MARKER else lic.contract_end,
         # A legacy blob carries only the support contract's dates, not per-feature ones.
         features=MappingProxyType(
             {

--- a/src/middlewared/middlewared/utils/license/legacy.py
+++ b/src/middlewared/middlewared/utils/license/legacy.py
@@ -2,7 +2,8 @@
 
 Legacy licenses predate the per-feature key vocabulary, so a modern gate reading
 one would see almost no keys and revoke functionality the holder already has.
-Every surviving legacy blob therefore gets _LEGACY_INJECT granted outright.
+Every surviving legacy blob therefore gets _LEGACY_INJECT granted outright, except a
+system-generated record, which gets _HW_ONLY_INJECT.
 
 A blob whose model starts with "freenas" bought none of that functionality, so it
 is rejected entirely and the system reads as unlicensed. The rejection is silent:
@@ -25,7 +26,7 @@ from truenas_pylicensed import FEATURE_NAME_MAP, LicenseType
 from truenas_pylicensed.features import LicenseFeature, SupportTier
 
 from .constants import LEGACY_LICENSE_FILE, LICENSE_ADDHW_MAPPING
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +73,10 @@ _LEGACY_INJECT: frozenset[LicenseFeature] = frozenset(
 
 HW_ONLY_MARKER: Final[str] = "TRUENAS-HW-ONLY-V1"
 
-# Reproduces the bare TRUENAS_HW entitlement column: what an iX chassis carries on the
-# strength of the hardware alone, with no support contract behind it. Deliberately not a
-# subset of _LEGACY_INJECT -- SED is a bitmask feature a real blob could carry, so it was
-# never among the names injected into one.
+# The keys a system-generated record carries. Writing the record moves the appliance off the
+# unlicensed column, so this list is what holds it to the answers the bare chassis already gave --
+# but only for features the matrix gates on a key. One gated on holding a license at all is
+# granted by the record's existence, whatever this list says.
 _HW_ONLY_INJECT: frozenset[LicenseFeature] = frozenset(
     {
         LicenseFeature.APPS,
@@ -203,10 +204,8 @@ def parse_legacy_license(text: str) -> LicenseInfo:
     enclosures = {
         LICENSE_ADDHW_MAPPING[code]: quantity for quantity, code in lic.addhw if code in LICENSE_ADDHW_MAPPING
     }
-    if lic.customer_key == HW_ONLY_MARKER:
-        # Replaces the list rather than extending it: the bitmask-derived names and the
-        # conditional SUPPORT append both already happened above, and replacing is what
-        # holds a marked record to the bare hardware set.
+    hw_only = lic.customer_key == HW_ONLY_MARKER
+    if hw_only:
         feature_names = [f.value for f in LicenseFeature if f in _HW_ONLY_INJECT]
     else:
         # Iterate the enum rather than the frozenset so injected names land in declaration order.
@@ -219,7 +218,7 @@ def parse_legacy_license(text: str) -> LicenseInfo:
         type=LicenseType.ENTERPRISE_HA if lic.system_serial_ha else LicenseType.ENTERPRISE_SINGLE,
         model=model,
         # A marked record has no support contract behind it, so it carries no expiry to act on.
-        support_expires_at=None if lic.customer_key == HW_ONLY_MARKER else lic.contract_end,
+        support_expires_at=None if hw_only else lic.contract_end,
         # A legacy blob carries only the support contract's dates, not per-feature ones.
         features=MappingProxyType(
             {
@@ -236,4 +235,5 @@ def parse_legacy_license(text: str) -> LicenseInfo:
         serials=tuple(serials),
         enclosures=MappingProxyType(enclosures),
         contract_type=lic.contract_type.name.upper(),
+        origin=LicenseOrigin.SYSTEM_GENERATED if hw_only else LicenseOrigin.ISSUED,
     )

--- a/src/middlewared/middlewared/utils/license/types.py
+++ b/src/middlewared/middlewared/utils/license/types.py
@@ -74,7 +74,7 @@ class LicenseInfo:
     """Licensed enclosure models mapped to count."""
     contract_type: str | None
     """Support contract type."""
-    origin: LicenseOrigin = LicenseOrigin.ISSUED
+    origin: LicenseOrigin
     """Whether an issuer signed this record or the system wrote it for itself."""
 
     def has_feature(self, name: str) -> bool:

--- a/src/middlewared/middlewared/utils/license/types.py
+++ b/src/middlewared/middlewared/utils/license/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 import typing
 from dataclasses import dataclass
 from datetime import date
@@ -11,7 +12,21 @@ if typing.TYPE_CHECKING:
 
     from truenas_pylicensed import LicenseType
 
-__all__ = ("FeatureInfo", "LicenseInfo")
+__all__ = ("FeatureInfo", "LicenseInfo", "LicenseOrigin")
+
+
+class LicenseOrigin(enum.Enum):
+    """Who produced a license record.
+
+    Entitlement resolution deliberately does not read this: a system-generated record is meant
+    to resolve exactly as an issued one does. It exists for consumers that mean "iX issued
+    this" -- what to report outward, and which lifecycle transitions to fire.
+
+    TODO: Remove once legacy licenses are removed.
+    """
+
+    ISSUED = "ISSUED"
+    SYSTEM_GENERATED = "SYSTEM_GENERATED"
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -59,6 +74,8 @@ class LicenseInfo:
     """Licensed enclosure models mapped to count."""
     contract_type: str | None
     """Support contract type."""
+    origin: LicenseOrigin = LicenseOrigin.ISSUED
+    """Whether an issuer signed this record or the system wrote it for itself."""
 
     def has_feature(self, name: str) -> bool:
         return name in self.features  # membership only; the feature's own expiry is not consulted


### PR DESCRIPTION
This PR adds changes to give an iX appliance that shipped without a license a minimal legacy license record during upgrade, written by a new script that runs chrooted in the new boot environment. The record is stamped with a marker in customer_key, and parse_legacy_license grants it exactly what bare appliance hardware already gives rather than everything a legacy license implies. SED is the motivating case, since its vector moves to hardware plus key later and these machines would otherwise lose it.

LicenseInfo grows an origin field so we can tell a record we wrote from one an issuer signed. Entitlements never read it, since a system generated record has to resolve exactly as an issued one does; it is there for the alert source, the unlicensed to licensed hook, TNC, and support tickets, which all mean "iX issued this". 


Original PR: https://github.com/truenas/middleware/pull/19643
