### PR TITLE
NAS-143111 / 27.0.0-BETA.1 / Write a hardware entitlement record on unlicensed iX appliances (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/bin/truenas-hw-license.py
+++ b/src/freenas/usr/local/bin/truenas-hw-license.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Write a bare hardware entitlement record on an iX appliance that holds no license.
+
+Runs chrooted inside the new boot environment partway through an upgrade, before
+middleware has ever started there. An appliance that shipped from iX carrying no
+license blob resolves entitlements on the unlicensed column, which leaves nowhere
+to gate a feature that every appliance of this class is meant to have. Writing a
+minimal legacy record moves it onto the licensed column, where such a feature can
+be granted without also granting it to commodity hardware.
+
+The record is stamped with a marker in its customer_key so the legacy parser can
+tell it apart from a license an issuer actually signed, and bound it to the bare
+hardware entitlement set instead of everything a legacy license implies. Nothing
+is written if any license record already exists.
+"""
+
+import os
+import sys
+from datetime import date
+
+from licenselib.license import ContractHardware, ContractSoftware, ContractType, License
+from truenas_os_pyutils.io import atomic_write
+from truenas_pydmi.reader import read_dmi
+
+
+LEGACY_LICENSE_FILE = "/data/license"
+LICENSE_FILE = "/data/subsystems/truenas_license/license"
+LICENSE_BACKUP = "/data/subsystems/truenas_license/license.bak"
+HW_LICENSE_ERROR_FILE = "/data/truenas-hw-license.err"
+HW_ONLY_MARKER = "TRUENAS-HW-ONLY-V1"
+
+# An allowlist rather than a denylist, so a platform family added to truenas_pydmi
+# upstream is excluded here until someone decides it ships with this entitlement.
+# Anything that reads as unknown or as a Mini fails it too.
+MINTABLE_PREFIXES = ("TRUENAS-R",)
+
+
+def record_error(message):
+    """Leave a message middleware logs and deletes on first boot."""
+    try:
+        with atomic_write(HW_LICENSE_ERROR_FILE, "w", perms=0o600) as f:
+            f.write(message + "\n")
+    except Exception:
+        pass
+
+
+def main():
+    for path in (LEGACY_LICENSE_FILE, LICENSE_FILE, LICENSE_BACKUP):
+        if os.path.exists(path):
+            return
+
+    dmi = read_dmi()
+    chassis = dmi.tn_model
+    if not chassis.startswith(MINTABLE_PREFIXES):
+        return
+
+    serial = (dmi.system.serial_number if dmi.system else "").strip()
+    if not serial:
+        record_error(f"{chassis}: chassis reports no system serial number")
+        return
+
+    if len(serial.encode()) > 16:
+        record_error(f"{chassis}: system serial number does not fit the license field: {serial!r}")
+        return
+
+    model = chassis.removeprefix("TRUENAS-").split("-")[0]
+    if len(model.encode()) > 16:
+        record_error(f"{chassis}: model does not fit the license field: {model!r}")
+        return
+
+    lic = License(
+        1,
+        # Derived exactly the way the license-status alert derives the running system's
+        # model, so that alert cannot report a mismatch against the record written here.
+        model,
+        serial,
+        # An empty HA serial holds the parsed type at ENTERPRISE_SINGLE, keeping
+        # failover.licensed false; a populated one would advertise a single head as a pair.
+        "",
+        ContractType.legacy,
+        ContractHardware.parts,
+        ContractSoftware.none,
+        date.today(),
+        36500,
+        "",
+        HW_ONLY_MARKER,
+        [],
+        [],
+    )
+
+    try:
+        with atomic_write(LEGACY_LICENSE_FILE, "wb", perms=0o600, noclobber=True) as f:
+            f.write(lic.dump() + b"\n")
+    except Exception as e:
+        record_error(f"{chassis}: failed to write {LEGACY_LICENSE_FILE} for serial {serial!r}: {e!r}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        record_error(f"unexpected failure: {e!r}")
+
+    # An upgrade must not fail over entitlement bookkeeping.
+    sys.exit(0)

--- a/src/middlewared/middlewared/alert/applicability/vocabulary.py
+++ b/src/middlewared/middlewared/alert/applicability/vocabulary.py
@@ -57,8 +57,9 @@ def NOT_APPLIANCE_HARDWARE(facts: EntitlementFacts) -> bool:
 
 def ANY_LICENSE(facts: EntitlementFacts) -> bool:
     """Machines carrying a license of any type, on any hardware. For declarations whose subject is
-    the license itself. This is not "is this an enterprise system": a licensed Mini satisfies it and
-    an unlicensed appliance does not."""
+    the license itself. This is not "is this an enterprise system": a licensed Mini satisfies it, and
+    an appliance satisfies it only once it holds a record -- including one the system generated for
+    itself."""
     return facts.license is not None
 
 

--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -22,6 +22,7 @@ from middlewared.alert.base import (
 )
 from middlewared.alert.schedule import IntervalSchedule
 from middlewared.api.current import MailSendMessage
+from middlewared.utils.license import LicenseOrigin
 
 
 class LicenseAlert(NonDataclassAlertClass[str], AlertClass):
@@ -63,7 +64,9 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         alerts: list[Alert[Any]] = []
 
         local_license = self.call_sync2(self.s.truenas.license.info_private)
-        if local_license is None:
+        # A system-generated record licenses no shelves, so the shelf check below would fire on it
+        # permanently.
+        if local_license is None or local_license.origin is LicenseOrigin.SYSTEM_GENERATED:
             if not self.middleware.call_sync('system.is_ha_capable'):
                 return []
 

--- a/src/middlewared/middlewared/plugins/support/execute.py
+++ b/src/middlewared/middlewared/plugins/support/execute.py
@@ -23,6 +23,7 @@ from middlewared.pipe import InputPipes, Pipes
 from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
 from middlewared.service import CallError
 from middlewared.utils import sw_version
+from middlewared.utils.license import LicenseOrigin
 from middlewared.utils.network import INTERNET_TIMEOUT
 
 if TYPE_CHECKING:
@@ -90,7 +91,7 @@ async def new_ticket(
         required_attrs = ("category", "phone", "name", "email", "criticality", "environment")
         payload["serial"] = (await context.middleware.call("system.dmidecode_info"))["system-serial-number"]
         license_ = await context.call2(context.s.truenas.license.info_private)
-        if license_:
+        if license_ and license_.origin is LicenseOrigin.ISSUED:
             payload["license_id"] = license_.id
 
     for attr in required_attrs:

--- a/src/middlewared/middlewared/plugins/truenas/license.py
+++ b/src/middlewared/middlewared/plugins/truenas/license.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+from typing import TYPE_CHECKING, Any
 
 from truenas_pylicensed import LicenseType
 
@@ -19,13 +20,18 @@ from middlewared.plugins.truenas.license_reconcile import TrueNASLicenseReconcil
 from middlewared.plugins.truenas.tn import EULA_PENDING_PATH
 from middlewared.service import Service, ValidationError, private
 from middlewared.utils.license import (
+    HW_LICENSE_ERROR_FILE,
     LEGACY_LICENSE_FILE,
     LicenseInfo,
+    LicenseOrigin,
     get_fingerprint_b64,
     get_legacy_license_info,
     get_license,
     upload_license,
 )
+
+if TYPE_CHECKING:
+    from middlewared.main import Middleware
 
 
 def _license_entry(info: LicenseInfo) -> LicenseInfoEntry:
@@ -73,7 +79,8 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
     )
     def upload(self, license_: str, options: TrueNASLicenseUploadOptions) -> None:
         """Upload a PEM-wrapped license file."""
-        had_license = self.info_private() is not None
+        current = self.info_private()
+        had_license = current is not None and current.origin is LicenseOrigin.ISSUED
 
         with upload_license(str(license_)) as lic:
             if not lic.valid:
@@ -157,3 +164,23 @@ class TrueNASLicenseService(TrueNASLicenseReconcileService, Service):
     @private
     def info_private(self) -> LicenseInfo | None:
         return get_license()
+
+    @private
+    def process_hw_license_error(self) -> None:
+        if os.path.exists(HW_LICENSE_ERROR_FILE):
+            try:
+                with open(HW_LICENSE_ERROR_FILE) as f:
+                    self.logger.error("truenas-hw-license.py: %s", f.read().strip())
+            finally:
+                os.unlink(HW_LICENSE_ERROR_FILE)
+
+
+async def on_system_ready(middleware: "Middleware", event_type: str, args: Any) -> None:
+    try:
+        await middleware.call("truenas.license.process_hw_license_error")
+    except Exception:
+        middleware.logger.error("Error processing hardware entitlement error file", exc_info=True)
+
+
+async def setup(middleware: "Middleware") -> None:
+    middleware.event_subscribe("system.ready", on_system_ready)

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -11,6 +11,7 @@ from truenas_connect_utils.urls import get_heartbeat_url
 from middlewared.alert.source.truenas_connect import TNCHeartbeatConnectionFailureAlert
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.disks_.disk_class import iterate_disks
+from middlewared.utils.license import LicenseOrigin
 from middlewared.utils.version import parse_version_string
 
 from .internal import config_internal, handle_tnc_deregistration
@@ -67,12 +68,13 @@ async def _build_payload(
     # license_id is the delivery acknowledgement: once we report the id of an installed license,
     # TNC marks it accepted and stops resending the PEM. Null when we hold no valid license.
     license_info = await context.call2(context.s.truenas.license.info_private)
+    license_id = license_info.id if license_info is not None and license_info.origin is LicenseOrigin.ISSUED else None
 
     return {
         'alerts': [alert.model_dump() for alert in await context.call2(context.s.alert.list)],
         'stats': stats,
         'fingerprint': fingerprint,
-        'license_id': license_info.id if license_info else None,
+        'license_id': license_id,
     }
 
 

--- a/src/middlewared/middlewared/plugins/truenas_connect/register.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/register.py
@@ -11,6 +11,7 @@ from truenas_connect_utils.urls import get_registration_uri
 
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.crypto import ssl_uuid4
+from middlewared.utils.license import LicenseOrigin
 
 from .internal import config_internal, set_status
 from .utils import CLAIM_TOKEN_CACHE_KEY
@@ -80,9 +81,11 @@ async def get_registration_uri_impl(context: ServiceContext) -> str:
         'port': (await context.middleware.call('system.general.config'))['ui_httpsport']
     }
 
-    license_info = await context.middleware.call('system.license', True)
-    if license_info is not None and license_info['raw_license'] is not None:
-        query_params['license'] = license_info['raw_license']
+    info = await context.call2(context.s.truenas.license.info_private)
+    if info is not None and info.origin is LicenseOrigin.ISSUED:
+        license_info = await context.middleware.call('system.license', True)
+        if license_info is not None and license_info['raw_license'] is not None:
+            query_params['license'] = license_info['raw_license']
 
     # get_registration_uri composes from raw config dict — pass config_internal()'s dict shape.
     raw_config = await config_internal(context)

--- a/src/middlewared/middlewared/pytest/unit/entitlements.py
+++ b/src/middlewared/middlewared/pytest/unit/entitlements.py
@@ -11,7 +11,7 @@ from truenas_pylicensed import LicenseType
 
 from middlewared.api.current import EntitlementEntry
 from middlewared.utils.entitlements import EntitlementFacts, HardwareClass, Reason, check_entitlement
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 
 def make_license(
@@ -21,6 +21,7 @@ def make_license(
     model: str | None = "H10",
     expires_at: date | None = None,
     support_type: str | None = None,
+    origin: LicenseOrigin = LicenseOrigin.ISSUED,
 ) -> LicenseInfo:
     features = {
         name: FeatureInfo(
@@ -41,6 +42,7 @@ def make_license(
         serials=("TEST-000001",),
         enclosures={},
         contract_type=support_type,
+        origin=origin,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
@@ -6,7 +6,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.plugins.failover import mismatch_nics
 from middlewared.plugins.failover_.ha_hardware import is_licensed_for_ha
 from middlewared.utils.hardware import HardwareClass
-from middlewared.utils.license import LicenseInfo
+from middlewared.utils.license import LicenseInfo, LicenseOrigin
 
 
 @pytest.mark.parametrize(
@@ -45,6 +45,7 @@ def _license(type_):
         serials=("TEST-000001",),
         enclosures={},
         contract_type=None,
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_system_product.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_system_product.py
@@ -5,7 +5,7 @@ from truenas_pylicensed import LicenseType
 from middlewared.plugins.system.product import SystemService
 from middlewared.pytest.unit.helpers import create_service
 from middlewared.pytest.unit.middleware import Middleware
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 START = date(2026, 4, 8)
 END = date(2026, 4, 30)
@@ -30,6 +30,7 @@ def _info(**overrides) -> LicenseInfo:
         "serials": ("TEST-000001", "TEST-000002"),
         "enclosures": {"E24": 3},
         "contract_type": "GOLD",
+        "origin": LicenseOrigin.ISSUED,
     }
     fields.update(overrides)
     return LicenseInfo(**fields)

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_truenas_connect.py
@@ -11,7 +11,7 @@ from middlewared.plugins.truenas_connect.config import TrueNASConnectConfigServi
 from middlewared.plugins.truenas_connect.hostname import TNCHostnameService
 from middlewared.plugins.truenas_connect.utils import CONFIGURED_TNC_STATES, TNC_IPS_CACHE_KEY
 from middlewared.service import CallError, ValidationErrors
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 
 def make_tnc_entry(**overrides: Any) -> TrueNASConnectEntry:
@@ -702,6 +702,7 @@ def _license_info(id_='LIC-1'):
         serials=('TEST-000001',),
         enclosures={'E24': 3},
         contract_type='GOLD',
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_entitlements_api.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/truenas/test_entitlements_api.py
@@ -20,7 +20,7 @@ from middlewared.utils.entitlements import (
     LicenseFeature,
     Reason,
 )
-from middlewared.utils.license import FeatureInfo, LicenseInfo
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin
 
 
 def test_check_returns_the_endpoint_model_not_the_engine_dataclass(monkeypatch):
@@ -112,6 +112,7 @@ def make_license(feature_names, license_type, support_type):
         serials=("TEST-000001",),
         enclosures={},
         contract_type=support_type,
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_get_license.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_get_license.py
@@ -4,7 +4,7 @@ import pytest
 from truenas_pylicensed import LicenseError, LicenseStatus, LicenseType
 
 import middlewared.utils.license as license_utils
-from middlewared.utils.license import LicenseInfo, get_license
+from middlewared.utils.license import LicenseInfo, LicenseOrigin, get_license
 
 # The daemon is certain there is no v2 license, which is the only condition under
 # which the legacy blob underneath is consulted.
@@ -37,6 +37,7 @@ LEGACY = LicenseInfo(
     serials=("TEST-000001",),
     enclosures={},
     contract_type="GOLD",
+    origin=LicenseOrigin.ISSUED,
 )
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_license_legacy_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_license_legacy_utils.py
@@ -18,6 +18,7 @@ from middlewared.utils.entitlements import (
 from middlewared.utils.license import (
     FeatureInfo,
     LicenseInfo,
+    LicenseOrigin,
     get_legacy_license_info,
     parse_legacy_license,
 )
@@ -100,6 +101,7 @@ FREENAS_MINI_BLOB = (
                 serials=("TEST-000001", "TEST-000002"),
                 enclosures={"E24": 3, "E16": 2},
                 contract_type="GOLD",
+                origin=LicenseOrigin.ISSUED,
             ),
         ),
         # Enterprise single license (X10, STANDARD contract): the jails->APPS bit is
@@ -116,6 +118,7 @@ FREENAS_MINI_BLOB = (
                 serials=("TEST-000001",),
                 enclosures={},
                 contract_type="STANDARD",
+                origin=LicenseOrigin.ISSUED,
             ),
         ),
     ],

--- a/src/middlewared/middlewared/pytest/unit/utils/test_license_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_license_utils.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 from truenas_pylicensed import FeatureEntry, LicenseError, LicenseStatus, LicenseType
 
-from middlewared.utils.license import FeatureInfo, LicenseInfo, from_license_status
+from middlewared.utils.license import FeatureInfo, LicenseInfo, LicenseOrigin, from_license_status
 
 
 def _make_status(features: dict[str, FeatureEntry]) -> LicenseStatus:
@@ -30,6 +30,7 @@ def _license(**overrides) -> LicenseInfo:
         "serials": (),
         "enclosures": {},
         "contract_type": None,
+        "origin": LicenseOrigin.ISSUED,
     }
     fields.update(overrides)
     return LicenseInfo(**fields)
@@ -74,6 +75,7 @@ def test__from_license_status__renames_vm_to_vms():
         serials=("TEST-000001", "TEST-000002"),
         enclosures={"E24": 3},
         contract_type="GOLD",
+        origin=LicenseOrigin.ISSUED,
     )
 
 

--- a/src/middlewared/middlewared/utils/license/__init__.py
+++ b/src/middlewared/middlewared/utils/license/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from truenas_pylicensed import LicenseError, LicenseStatus, verify
 
 from .constants import (
+    HW_LICENSE_ERROR_FILE,
     LEGACY_LICENSE_FILE,
     LICENSE_ADDHW_MAPPING,
     LICENSE_BACKUP,
@@ -21,9 +22,10 @@ from .constants import (
 )
 from .daemon import from_license_status, get_fingerprint_b64, upload_license
 from .legacy import describe_legacy_license, get_legacy_license_info, parse_legacy_license
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 __all__ = [
+    "HW_LICENSE_ERROR_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",
@@ -31,6 +33,7 @@ __all__ = [
     "LICENSE_FILE",
     "FeatureInfo",
     "LicenseInfo",
+    "LicenseOrigin",
     "describe_legacy_license",
     "from_license_status",
     "get_fingerprint_b64",

--- a/src/middlewared/middlewared/utils/license/constants.py
+++ b/src/middlewared/middlewared/utils/license/constants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import MappingProxyType
 
 __all__ = (
+    "HW_LICENSE_ERROR_FILE",
     "LEGACY_LICENSE_FILE",
     "LICENSE_ADDHW_MAPPING",
     "LICENSE_BACKUP",
@@ -17,6 +18,8 @@ LICENSE_FILE = f"{LICENSE_DIR}/license"
 LICENSE_BACKUP = f"{LICENSE_DIR}/license.bak"
 
 LEGACY_LICENSE_FILE = "/data/license"
+
+HW_LICENSE_ERROR_FILE = "/data/truenas-hw-license.err"
 
 LICENSE_ADDHW_MAPPING = MappingProxyType(
     {

--- a/src/middlewared/middlewared/utils/license/daemon.py
+++ b/src/middlewared/middlewared/utils/license/daemon.py
@@ -19,7 +19,7 @@ from truenas_pylicensed import FEATURE_NAME_MAP, LicenseStatus, get_fingerprint,
 from middlewared.service_exception import CallError
 
 from .constants import LICENSE_BACKUP, LICENSE_DIR, LICENSE_FILE
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 logger = logging.getLogger(__name__)
 
@@ -179,4 +179,5 @@ def from_license_status(status: LicenseStatus | None = None) -> LicenseInfo | No
         serials=tuple(status.system_id["serials"]) if status.system_id else (),
         enclosures=MappingProxyType({model: entry["count"] for model, entry in (status.enclosures or {}).items()}),
         contract_type=contract_type,
+        origin=LicenseOrigin.ISSUED,
     )

--- a/src/middlewared/middlewared/utils/license/legacy.py
+++ b/src/middlewared/middlewared/utils/license/legacy.py
@@ -2,7 +2,8 @@
 
 Legacy licenses predate the per-feature key vocabulary, so a modern gate reading
 one would see almost no keys and revoke functionality the holder already has.
-Every surviving legacy blob therefore gets _LEGACY_INJECT granted outright.
+Every surviving legacy blob therefore gets _LEGACY_INJECT granted outright, except a
+system-generated record, which gets _HW_ONLY_INJECT.
 
 A blob whose model starts with "freenas" bought none of that functionality, so it
 is rejected entirely and the system reads as unlicensed. The rejection is silent:
@@ -17,7 +18,7 @@ import errno
 from functools import lru_cache
 import logging
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Final
 
 from licenselib.license import Features, License
 from licenselib.utils import proactive_support_allowed
@@ -25,11 +26,12 @@ from truenas_pylicensed import FEATURE_NAME_MAP, LicenseType
 from truenas_pylicensed.features import LicenseFeature, SupportTier
 
 from .constants import LEGACY_LICENSE_FILE, LICENSE_ADDHW_MAPPING
-from .types import FeatureInfo, LicenseInfo
+from .types import FeatureInfo, LicenseInfo, LicenseOrigin
 
 logger = logging.getLogger(__name__)
 
 __all__ = (
+    "HW_ONLY_MARKER",
     "LegacyStatus",
     "describe_legacy_license",
     "get_legacy_license_info",
@@ -66,6 +68,21 @@ _LEGACY_INJECT: frozenset[LicenseFeature] = frozenset(
         LicenseFeature.TRUESEARCH,
         LicenseFeature.VMS,
         LicenseFeature.WEBSHARE,
+    }
+)
+
+HW_ONLY_MARKER: Final[str] = "TRUENAS-HW-ONLY-V1"
+
+# The keys a system-generated record carries. Writing the record moves the appliance off the
+# unlicensed column, so this list is what holds it to the answers the bare chassis already gave --
+# but only for features the matrix gates on a key. One gated on holding a license at all is
+# granted by the record's existence, whatever this list says.
+_HW_ONLY_INJECT: frozenset[LicenseFeature] = frozenset(
+    {
+        LicenseFeature.APPS,
+        LicenseFeature.CONTAINERS,
+        LicenseFeature.SED,
+        LicenseFeature.VMS,
     }
 )
 
@@ -130,6 +147,7 @@ def legacy_license_fields(lic: Any) -> dict[str, Any]:
         "contract_end": lic.contract_end.isoformat(),
         "features": [feature.name for feature in lic.features],
         "addhw": [list(entry) for entry in lic.addhw],
+        "hw_only": lic.customer_key == HW_ONLY_MARKER,
     }
 
 
@@ -186,16 +204,21 @@ def parse_legacy_license(text: str) -> LicenseInfo:
     enclosures = {
         LICENSE_ADDHW_MAPPING[code]: quantity for quantity, code in lic.addhw if code in LICENSE_ADDHW_MAPPING
     }
-    # Iterate the enum rather than the frozenset so injected names land in declaration order.
-    for feat in LicenseFeature:
-        if feat in _LEGACY_INJECT and feat not in feature_names:
-            feature_names.append(feat.value)
+    hw_only = lic.customer_key == HW_ONLY_MARKER
+    if hw_only:
+        feature_names = [f.value for f in LicenseFeature if f in _HW_ONLY_INJECT]
+    else:
+        # Iterate the enum rather than the frozenset so injected names land in declaration order.
+        for feat in LicenseFeature:
+            if feat in _LEGACY_INJECT and feat not in feature_names:
+                feature_names.append(feat.value)
 
     return LicenseInfo(
         id=f"legacy_{lic.system_serial}",
         type=LicenseType.ENTERPRISE_HA if lic.system_serial_ha else LicenseType.ENTERPRISE_SINGLE,
         model=model,
-        support_expires_at=lic.contract_end,
+        # A marked record has no support contract behind it, so it carries no expiry to act on.
+        support_expires_at=None if hw_only else lic.contract_end,
         # A legacy blob carries only the support contract's dates, not per-feature ones.
         features=MappingProxyType(
             {
@@ -212,4 +235,5 @@ def parse_legacy_license(text: str) -> LicenseInfo:
         serials=tuple(serials),
         enclosures=MappingProxyType(enclosures),
         contract_type=lic.contract_type.name.upper(),
+        origin=LicenseOrigin.SYSTEM_GENERATED if hw_only else LicenseOrigin.ISSUED,
     )

--- a/src/middlewared/middlewared/utils/license/types.py
+++ b/src/middlewared/middlewared/utils/license/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+import enum
 import typing
 
 if typing.TYPE_CHECKING:
@@ -11,7 +12,21 @@ if typing.TYPE_CHECKING:
 
     from truenas_pylicensed import LicenseType
 
-__all__ = ("FeatureInfo", "LicenseInfo")
+__all__ = ("FeatureInfo", "LicenseInfo", "LicenseOrigin")
+
+
+class LicenseOrigin(enum.Enum):
+    """Who produced a license record.
+
+    Entitlement resolution deliberately does not read this: a system-generated record is meant
+    to resolve exactly as an issued one does. It exists for consumers that mean "iX issued
+    this" -- what to report outward, and which lifecycle transitions to fire.
+
+    TODO: Remove once legacy licenses are removed.
+    """
+
+    ISSUED = "ISSUED"
+    SYSTEM_GENERATED = "SYSTEM_GENERATED"
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -59,6 +74,8 @@ class LicenseInfo:
     """Licensed enclosure models mapped to count."""
     contract_type: str | None
     """Support contract type."""
+    origin: LicenseOrigin
+    """Whether an issuer signed this record or the system wrote it for itself."""
 
     def has_feature(self, name: str) -> bool:
         return name in self.features  # membership only; the feature's own expiry is not consulted


### PR DESCRIPTION
This PR adds changes to give an iX appliance that shipped without a license a minimal legacy license record during upgrade, written by a new script that runs chrooted in the new boot environment. The record is stamped with a marker in customer_key, and parse_legacy_license grants it exactly what bare appliance hardware already gives rather than everything a legacy license implies. SED is the motivating case, since its vector moves to hardware plus key later and these machines would otherwise lose it.

LicenseInfo grows an origin field so we can tell a record we wrote from one an issuer signed. Entitlements never read it, since a system generated record has to resolve exactly as an issued one does; it is there for the alert source, the unlicensed to licensed hook, TNC, and support tickets, which all mean "iX issued this". 


Original PR: https://github.com/truenas/middleware/pull/19643
