### PR TITLE
NAS-143293 / 26.0.0 / Fail interface.commit when a bridge member cannot be added, and reject members that host a VM or container NIC in MACVLAN mode

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import socket
 
+from truenas_pynetif.address.get_links import get_link
 from truenas_pynetif.configure import (
     BridgeConfig,
     configure_bridge as pynetif_configure_bridge,
 )
-from truenas_pynetif.netlink import LinkInfo
+from truenas_pynetif.netlink import DeviceNotFound, LinkInfo
 from middlewared.service import ServiceContext
 
 from .sync_data import SyncData
@@ -19,7 +20,7 @@ def configure_bridges_impl(
     sock: socket.socket,
     links: dict[str, LinkInfo],
     sync_data: SyncData,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Configure all bridge interfaces from database.
 
     Args:
@@ -29,20 +30,53 @@ def configure_bridges_impl(
         sync_data: Combined database data
 
     Returns:
-        List of configured bridge interface names
+        Tuple of (configured bridge interface names, descriptions of bridges that failed)
     """
     configured = []
+    failures = []
     for bridge in sync_data.bridges:
+        name = bridge["interface"]["int_interface"]
         try:
             configure_bridge_impl(ctx, sock, links, bridge)
-            configured.append(bridge["interface"]["int_interface"])
-        except Exception:
-            ctx.logger.error(
-                "Error configuring bridge %s",
-                bridge["interface"]["int_interface"],
-                exc_info=True,
-            )
-    return configured
+            configured.append(name)
+        except Exception as e:
+            ctx.logger.error("Error configuring bridge %s", name, exc_info=True)
+            failures.append(describe_bridge_failure(sock, name, bridge["members"], e))
+    return configured, failures
+
+
+def describe_bridge_failure(sock: socket.socket, name: str, members: list[str], error: Exception) -> str:
+    """Describe a failed bridge configuration, naming the members that were not enslaved.
+
+    The netlink error alone does not say which member was refused, and the
+    kernel gives no reason beyond an errno (EBUSY, for one, means the member
+    already hosts macvlan/macvtap ports).
+
+    Args:
+        sock: Netlink socket from netlink_route()
+        name: Bridge interface name
+        members: Members the bridge should have
+        error: Exception raised while configuring the bridge
+
+    Returns:
+        One-line description suitable for an error message
+    """
+    try:
+        bridge_index = get_link(sock, name).index
+    except DeviceNotFound:
+        return f"{name}: failed to create bridge ({error})"
+
+    missing = []
+    for member in members:
+        try:
+            if get_link(sock, member).master != bridge_index:
+                missing.append(member)
+        except DeviceNotFound:
+            missing.append(member)
+
+    if missing:
+        return f"{name}: failed to add member(s) {', '.join(missing)} ({error})"
+    return f"{name}: {error}"
 
 
 def configure_bridge_impl(

--- a/src/middlewared/middlewared/plugins/interface/sync.py
+++ b/src/middlewared/middlewared/plugins/interface/sync.py
@@ -22,7 +22,7 @@ def sync_impl(
     ctx: ServiceContext,
     sync_data: SyncData,
     internal_interfaces: tuple[str, ...],
-) -> tuple[list[str], list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str], list[str]]:
     """Configure all interfaces from database to OS, unconfigure those not in database.
 
     Args:
@@ -31,7 +31,7 @@ def sync_impl(
         internal_interfaces: Interface name prefixes to skip (internal/system interfaces)
 
     Returns:
-        Tuple of (configured_interfaces, interfaces_needing_dhcp, interfaces_to_autoconfigure)
+        Tuple of (configured_interfaces, interfaces_needing_dhcp, interfaces_to_autoconfigure, failures)
     """
     configured = []
     run_dhcp = []  # interfaces configured in database with int_dhcp=True
@@ -83,7 +83,7 @@ def sync_impl(
                     )
 
         # 4. Configure bridges
-        bridge_names = configure_bridges_impl(ctx, sock, links, sync_data)
+        bridge_names, failures = configure_bridges_impl(ctx, sock, links, sync_data)
         for name in bridge_names:
             configured.append(name)
             if name in sync_data.interfaces:
@@ -116,7 +116,7 @@ def sync_impl(
                 # Interface is not in database, so unconfigure it
                 unconfigure_impl(ctx, sock, links, name, configured, sync_data)
 
-    return configured, run_dhcp, autoconfigure
+    return configured, run_dhcp, autoconfigure, failures
 
 
 def sync_interface_impl(

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -674,6 +674,8 @@ class InterfaceService(CRUDService):
     async def commit(self, options):
         """
         Commit/apply pending interfaces changes.
+
+        Fails if any interface could not be configured, rolling the changes back first when ``rollback`` is set.
         """
         verrors = ValidationErrors()
         schema = 'interface.commit'
@@ -682,7 +684,8 @@ class InterfaceService(CRUDService):
         verrors.check()
 
         try:
-            await self.sync()
+            if failures := await self.sync():
+                raise CallError(f'Failed to apply interface changes: {"; ".join(failures)}')
         except Exception:
             if options['rollback']:
                 await self.rollback()
@@ -873,6 +876,7 @@ class InterfaceService(CRUDService):
                     await self.middleware.call('interface.validate_name', InterfaceType.BRIDGE, data['name'])
                 except ValueError as e:
                     verrors.add(f'{schema_name}.name', str(e))
+            nic_attach_used = await self.nic_attach_users() if data.get('bridge_members') else {}
             for i, member in enumerate(data.get('bridge_members') or []):
                 if member not in ifaces:
                     verrors.add(f'{schema_name}.bridge_members.{i}', 'Not a valid interface.')
@@ -886,6 +890,12 @@ class InterfaceService(CRUDService):
                     verrors.add(
                         f'{schema_name}.bridge_members.{i}',
                         f'Interface {member} is currently in use by {lag_used[member]}.',
+                    )
+                elif member in nic_attach_used:
+                    verrors.add(
+                        f'{schema_name}.bridge_members.{i}',
+                        f'Interface {member} is currently in use by {", ".join(nic_attach_used[member])} '
+                        '(NIC device attached directly to it). Attach the device to the bridge instead.',
                     )
         elif itype == 'LINK_AGGREGATION':
             if 'name' in data:
@@ -1566,7 +1576,25 @@ class InterfaceService(CRUDService):
             # if it was also added to the exclusion list
             include.update({interface['id']: interface['id']})
 
+        exclude.update({i: i for i in await self.nic_attach_users()})
+
         return {k: v for k, v in include.items() if k not in exclude}
+
+    @private
+    async def nic_attach_users(self):
+        """
+        Map each interface hosting a VM or container NIC device attached directly to it (MACVLAN mode) to the
+        names of those VMs and containers. Such an interface cannot also be a bridge member: the kernel lets a
+        NIC carry either macvlan/macvtap ports or a bridge port, not both.
+        """
+        users = {}
+        for kind, method in (('VM', 'vm.query'), ('container', 'container.query')):
+            for instance in await self.middleware.call(method):
+                for device in instance['devices']:
+                    nic = device['attributes'].get('nic_attach')
+                    if device['attributes']['dtype'] == 'NIC' and nic and not nic.startswith('br'):
+                        users.setdefault(nic, []).append(f'{kind} {instance["name"]!r}')
+        return users
 
     @api_method(InterfaceLagPortsChoicesArgs, InterfaceLagPortsChoicesResult, roles=['NETWORK_INTERFACE_READ'])
     async def lag_ports_choices(self, id_):
@@ -1630,6 +1658,9 @@ class InterfaceService(CRUDService):
     async def sync(self, wait_dhcp: int | None = None):
         """
         Sync interfaces configured in database to the OS.
+
+        Returns a description of each interface that could not be configured. The sync carries on past those so
+        that boot and rollback still bring up everything else; `interface.commit` turns them into an error.
         """
         await self.middleware.call_hook('interface.pre_sync')
         # The VRRP event thread just reads directly from the database
@@ -1668,7 +1699,7 @@ class InterfaceService(CRUDService):
         internal_interfaces = tuple(await self.middleware.call('interface.internal_interfaces'))
 
         # Configure all interfaces and unconfigure those not in database
-        cloned_interfaces, run_dhcp, autoconfigure = await self.middleware.run_in_thread(
+        cloned_interfaces, run_dhcp, autoconfigure, failures = await self.middleware.run_in_thread(
             sync_impl,
             self.context,
             sync_data,
@@ -1742,6 +1773,8 @@ class InterfaceService(CRUDService):
             self.logger.info('Failed to sync routes', exc_info=True)
 
         await self.middleware.call_hook('interface.post_sync')
+
+        return failures
 
     @private
     async def run_dhcp(self, name, wait_dhcp: int | None = None):

--- a/tests/api2/test_interface_bridge_member_busy.py
+++ b/tests/api2/test_interface_bridge_member_busy.py
@@ -1,0 +1,51 @@
+import pytest
+
+from auto_config import ha, interface
+from middlewared.service_exception import CallError
+from middlewared.test.integration.utils import call, ssh
+
+MACVTAP = "mvtest0"
+
+pytestmark = pytest.mark.skipif(ha, reason="Bridging the primary interface is not attempted on HA")
+
+
+@pytest.fixture(scope="module")
+def primary_interface():
+    # The commit below must fail *while this connection stays up*. Without a database row the sync
+    # flushes the NIC's address, and with DHCP it restarts dhcpcd, so either way the address flaps and
+    # the CallError never reaches the client. test_005 normally leaves the NIC static.
+    if not call("datastore.query", "network.interfaces", [["int_interface", "=", interface]]):
+        pytest.skip(f"{interface} has no persisted network configuration")
+    iface = call("interface.query", [["name", "=", interface]], {"get": True})
+    if iface["ipv4_dhcp"] or not iface["aliases"]:
+        pytest.skip(f"{interface} is not configured with a static address")
+    return iface
+
+
+@pytest.fixture
+def macvtap_on_primary_interface():
+    # A macvtap takes the NIC's rx_handler just as a VM NIC attached in MACVLAN mode does, so the
+    # kernel refuses to enslave the NIC to a bridge (EBUSY).
+    ssh(f"ip link add link {interface} name {MACVTAP} type macvtap")
+    try:
+        yield
+    finally:
+        ssh(f"ip link del {MACVTAP}", check=False)
+
+
+def test_bridge_member_hosting_macvtap_fails_commit_and_rolls_back(primary_interface, macvtap_on_primary_interface):
+    # No address on the bridge, so the NIC keeps its own and this connection survives the attempt.
+    bridge = call("interface.create", {"type": "BRIDGE", "bridge_members": [interface]})
+    try:
+        with pytest.raises(CallError) as e:
+            call("interface.commit", {"rollback": True, "checkin_timeout": 10})
+        assert f"{bridge['name']}: failed to add member(s) {interface}" in str(e.value)
+
+        assert call("interface.checkin_waiting") is None
+        assert not call("interface.has_pending_changes")
+        assert not call("interface.query", [["name", "=", bridge["name"]]])
+        after = call("interface.query", [["name", "=", interface]], {"get": True})
+        assert after["aliases"] == primary_interface["aliases"]
+    finally:
+        if call("interface.has_pending_changes"):
+            call("interface.rollback")


### PR DESCRIPTION
A NIC that hosts macvtap or macvlan ports, which is what a VM or container NIC device attached to it directly (MACVLAN mode) creates, cannot also be a bridge port: `br_add_if()` fails at `netdev_rx_handler_register()` with EBUSY because the macvlan port already owns the device's rx_handler. `configure_bridges_impl` caught that, logged it and carried on, so `interface.sync()` reported success. The user then either lost the network until the checkin timer rolled the change back, because the address had already moved off the NIC, or, if the NIC kept its address, ended up with a bridge persisted in the database that the kernel has no member for. No error was shown either way.

`configure_bridges_impl` now returns the failures, naming the members that did not end up enslaved since the netlink error alone does not say which, `interface.sync()` returns them, and `interface.commit` raises a `CallError` and rolls back, so the user gets an immediate error instead of a silent blackout. The boot, HA and rollback callers of `interface.sync()` ignore its return value, so nothing changes for them.

BRIDGE validation also rejects a member that any VM or container NIC device is attached to directly, and `bridge_members_choices` stops offering such NICs. This mirrors the existing check in the other direction, where `nic_attach_choices` already excludes bridge members. The check is against the database rather than the live macvtap because the configuration is unrealizable either way: with the VM stopped the bridge would come up and the VM would then fail to start with the mirror-image EBUSY from `macvlan_port_create()`.

Bonds, VLANs and addresses swallow failures the same way in `sync_impl`. They are left alone here on purpose, since surfacing those on this branch would turn currently silent partial failures on existing systems into rollbacks of unrelated edits.
