### PR TITLE
NAS-143453 / 27.0.0-BETA.1 / Give S3 object ownership its own key (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-09-03_15-00_truenas_s3_service.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-09-03_15-00_truenas_s3_service.py
@@ -44,6 +44,7 @@ def upgrade():
     sa.Column('owner_uid', sa.Integer(), nullable=False),
     sa.Column('grants', sa.TEXT(), nullable=False, server_default='[]'),
     sa.Column('permissions_model', sa.String(length=32), nullable=False, server_default='S3'),
+    sa.Column('object_ownership', sa.String(length=32), nullable=False, server_default='BUCKET_OWNER_ENFORCED'),
     sa.Column('versioning', sa.String(length=16), nullable=False, server_default='OFF'),
     sa.Column('snapshot_versions', sa.TEXT(), nullable=False, server_default='[]'),
     sa.Column('snapshot_versions_max', sa.Integer(), nullable=False, server_default='64'),

--- a/src/middlewared/middlewared/api/v26_0_0/s3.py
+++ b/src/middlewared/middlewared/api/v26_0_0/s3.py
@@ -28,6 +28,8 @@ __all__ = [
     "S3AuditMask",
     "S3Listener",
     "S3PrincipalType",
+    "S3PermissionsModel",
+    "S3ObjectOwnership",
     "S3Grant",
     "S3GrantEntry",
     "S3Entry",
@@ -73,6 +75,18 @@ S3AuditMask = list[S3AuditAction] | Literal["ALL"]
 S3AuditOverflow = Literal["DROP", "BACKPRESSURE"]
 S3Access = Literal["READONLY", "WRITEONLY", "READWRITE", "DENY"]
 S3PrincipalType = Literal["USER", "GROUP", "EVERYONE"]
+
+# `S3_BUCKET_OWNER_ENFORCED` is accepted and stored as `S3` beside an
+# `object_ownership` of `BUCKET_OWNER_ENFORCED`, undocumented on purpose:
+# it carries the last API consumer over and goes when that consumer does,
+# with `SharingS3Service.normalize_ownership`'s handling of it.
+S3PermissionsModel = Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"]
+"""How the S3 service treats the filesystem permissions on a bucket's
+tree."""
+
+S3ObjectOwnership = Literal["BUCKET_OWNER_ENFORCED", "BUCKET_OWNER_PREFERRED", "OBJECT_WRITER"]
+"""S3 Object Ownership: the bucket-level setting that controls ownership
+of objects uploaded to a bucket and disables or enables ACLs."""
 
 S3AccessKeyId = Annotated[str, Field(pattern=r"^[A-Z0-9]{16,128}$")]
 """An S3 access key id. Uppercase alphanumerics only, so it is safe inside
@@ -306,16 +320,17 @@ class SharingS3Entry(BaseModel):
         description=(
             "The ZFS dataset the bucket is. Created by `sharing.s3.create` and owned by it. Objects live in the "
             "`s3data` directory under its mount point, which the S3 service creates on its next start, owned by "
-            "`owner`. Under the `S3` and `MULTIPROTOCOL` permissions models every object is written under the "
-            "account that put it, so a grantee other than the owner can write only where that directory's "
-            "permissions allow; set an ACL on it as for any share, or choose `S3_BUCKET_OWNER_ENFORCED`."
+            "`owner`. Under the `MULTIPROTOCOL` permissions model the filesystem permissions on that tree "
+            "govern S3 callers too, so a grantee other than the owner reaches only what they allow; set an ACL "
+            "on the directory as for any share. Under `S3` they are ignored and the grants decide instead."
         ),
     )
     enabled: bool = Field(default=True, description="Whether the bucket is served. Toggling restarts the S3 service.")
     owner: NonEmptyString = Field(
         description=(
             "Account that owns the bucket and bypasses its grants, owns the `s3data` directory when the S3 "
-            "service creates it, and owns every object under the `S3_BUCKET_OWNER_ENFORCED` permissions model. "
+            "service creates it, and owns every object written under the `BUCKET_OWNER_ENFORCED` object "
+            "ownership setting. "
             "Given by name, held by uid: the name is resolved when set and again whenever the "
             "bucket is read, so a renamed account reads as its new name, a reused name never inherits the bucket, "
             "and an account that no longer exists reads as its uid. Changing the owner later moves the grants, not "
@@ -324,16 +339,36 @@ class SharingS3Entry(BaseModel):
     )
     owner_uid: int = Field(description="The uid that owns the bucket.")
     grants: list[S3GrantEntry] = Field(default=[], description="Who may access the bucket and how, beyond its owner.")
-    permissions_model: Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"] = Field(
+    permissions_model: S3PermissionsModel = Field(
         default="S3",
         description=(
-            "Whose account the S3 service touches the dataset under. `S3` when only the S3 service writes it: "
-            "the grants alone decide a read, and every object is written under the account that put it. "
-            "`MULTIPROTOCOL` when other protocols share the tree: a read is also subject to the file permissions "
-            "those protocols set. `S3_BUCKET_OWNER_ENFORCED` when only the S3 service writes it and every object "
-            "is to be `owner`'s: every read and write runs as the owner, so the grants are the whole of the "
-            "bucket's access control and a grantee needs no permissions on the `s3data` directory. A request is "
-            "still authorized and audited as the account that made it."
+            "How the S3 service treats the filesystem permissions on the bucket's tree. `S3` when the S3 "
+            "service is the only door: those permissions are ignored in their entirety, and access is decided "
+            "by the bucket's grants and, where `object_ownership` supports them, its S3 ACLs. `MULTIPROTOCOL` "
+            "when SMB or NFS share the tree: the filesystem ACL is enforced as well as the grants, so an ACL "
+            "set on the tree governs S3 callers too and narrowing it takes effect for them immediately. S3 ACLs "
+            "are not supported on such a bucket at all, whatever `object_ownership` says, since no stored S3 "
+            "record may decide what a write from another protocol could contradict. Which account an S3 "
+            "operation runs as is `object_ownership`'s answer, not this one's."
+        ),
+    )
+    object_ownership: S3ObjectOwnership = Field(
+        default="BUCKET_OWNER_ENFORCED",
+        description=(
+            "S3 Object Ownership, the bucket-level setting that controls ownership of objects uploaded to the "
+            "bucket and disables or enables ACLs, and what `GetBucketOwnershipControls` reports. "
+            "`BUCKET_OWNER_ENFORCED` (the default): ACLs are disabled, and the bucket owner automatically owns "
+            "and has full control over every object in the bucket. ACLs no longer affect permissions to data in "
+            "the bucket, and the bucket uses its grants to define access control. Requests to set or update "
+            "ACLs fail with `AccessControlListNotSupported`; requests to read ACLs are supported. Only uploads "
+            "with bucket owner full control ACLs, or uploads that do not specify an ACL, are accepted. "
+            "`BUCKET_OWNER_PREFERRED`: the bucket owner owns and has full control over new objects that other "
+            "accounts write to the bucket with the `bucket-owner-full-control` canned ACL. Objects uploaded "
+            "with other ACLs are owned by the writing account. ACLs can be updated and can grant permissions. "
+            "`OBJECT_WRITER`: the account that uploads an object owns the object, has full control over it, and "
+            "can grant other users access to it through ACLs. "
+            "A `MULTIPROTOCOL` bucket is always `OBJECT_WRITER` whatever is given here, and its ACLs stay "
+            "disabled: the other protocols' users own the filesystem permissions on the tree."
         ),
     )
     versioning: Literal["OFF", "ENABLED", "SUSPENDED"] = Field(default="OFF", description="Bucket versioning state.")

--- a/src/middlewared/middlewared/api/v27_0_0/s3.py
+++ b/src/middlewared/middlewared/api/v27_0_0/s3.py
@@ -28,6 +28,8 @@ __all__ = [
     "S3AuditMask",
     "S3Listener",
     "S3PrincipalType",
+    "S3PermissionsModel",
+    "S3ObjectOwnership",
     "S3Grant",
     "S3GrantEntry",
     "S3Entry",
@@ -73,6 +75,18 @@ S3AuditMask = list[S3AuditAction] | Literal["ALL"]
 S3AuditOverflow = Literal["DROP", "BACKPRESSURE"]
 S3Access = Literal["READONLY", "WRITEONLY", "READWRITE", "DENY"]
 S3PrincipalType = Literal["USER", "GROUP", "EVERYONE"]
+
+# `S3_BUCKET_OWNER_ENFORCED` is accepted and stored as `S3` beside an
+# `object_ownership` of `BUCKET_OWNER_ENFORCED`, undocumented on purpose:
+# it carries the last API consumer over and goes when that consumer does,
+# with `SharingS3Service.normalize_ownership`'s handling of it.
+S3PermissionsModel = Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"]
+"""How the S3 service treats the filesystem permissions on a bucket's
+tree."""
+
+S3ObjectOwnership = Literal["BUCKET_OWNER_ENFORCED", "BUCKET_OWNER_PREFERRED", "OBJECT_WRITER"]
+"""S3 Object Ownership: the bucket-level setting that controls ownership
+of objects uploaded to a bucket and disables or enables ACLs."""
 
 S3AccessKeyId = Annotated[str, Field(pattern=r"^[A-Z0-9]{16,128}$")]
 """An S3 access key id. Uppercase alphanumerics only, so it is safe inside
@@ -306,16 +320,17 @@ class SharingS3Entry(BaseModel):
         description=(
             "The ZFS dataset the bucket is. Created by `sharing.s3.create` and owned by it. Objects live in the "
             "`s3data` directory under its mount point, which the S3 service creates on its next start, owned by "
-            "`owner`. Under the `S3` and `MULTIPROTOCOL` permissions models every object is written under the "
-            "account that put it, so a grantee other than the owner can write only where that directory's "
-            "permissions allow; set an ACL on it as for any share, or choose `S3_BUCKET_OWNER_ENFORCED`."
+            "`owner`. Under the `MULTIPROTOCOL` permissions model the filesystem permissions on that tree "
+            "govern S3 callers too, so a grantee other than the owner reaches only what they allow; set an ACL "
+            "on the directory as for any share. Under `S3` they are ignored and the grants decide instead."
         ),
     )
     enabled: bool = Field(default=True, description="Whether the bucket is served. Toggling restarts the S3 service.")
     owner: NonEmptyString = Field(
         description=(
             "Account that owns the bucket and bypasses its grants, owns the `s3data` directory when the S3 "
-            "service creates it, and owns every object under the `S3_BUCKET_OWNER_ENFORCED` permissions model. "
+            "service creates it, and owns every object written under the `BUCKET_OWNER_ENFORCED` object "
+            "ownership setting. "
             "Given by name, held by uid: the name is resolved when set and again whenever the "
             "bucket is read, so a renamed account reads as its new name, a reused name never inherits the bucket, "
             "and an account that no longer exists reads as its uid. Changing the owner later moves the grants, not "
@@ -324,16 +339,36 @@ class SharingS3Entry(BaseModel):
     )
     owner_uid: int = Field(description="The uid that owns the bucket.")
     grants: list[S3GrantEntry] = Field(default=[], description="Who may access the bucket and how, beyond its owner.")
-    permissions_model: Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"] = Field(
+    permissions_model: S3PermissionsModel = Field(
         default="S3",
         description=(
-            "Whose account the S3 service touches the dataset under. `S3` when only the S3 service writes it: "
-            "the grants alone decide a read, and every object is written under the account that put it. "
-            "`MULTIPROTOCOL` when other protocols share the tree: a read is also subject to the file permissions "
-            "those protocols set. `S3_BUCKET_OWNER_ENFORCED` when only the S3 service writes it and every object "
-            "is to be `owner`'s: every read and write runs as the owner, so the grants are the whole of the "
-            "bucket's access control and a grantee needs no permissions on the `s3data` directory. A request is "
-            "still authorized and audited as the account that made it."
+            "How the S3 service treats the filesystem permissions on the bucket's tree. `S3` when the S3 "
+            "service is the only door: those permissions are ignored in their entirety, and access is decided "
+            "by the bucket's grants and, where `object_ownership` supports them, its S3 ACLs. `MULTIPROTOCOL` "
+            "when SMB or NFS share the tree: the filesystem ACL is enforced as well as the grants, so an ACL "
+            "set on the tree governs S3 callers too and narrowing it takes effect for them immediately. S3 ACLs "
+            "are not supported on such a bucket at all, whatever `object_ownership` says, since no stored S3 "
+            "record may decide what a write from another protocol could contradict. Which account an S3 "
+            "operation runs as is `object_ownership`'s answer, not this one's."
+        ),
+    )
+    object_ownership: S3ObjectOwnership = Field(
+        default="BUCKET_OWNER_ENFORCED",
+        description=(
+            "S3 Object Ownership, the bucket-level setting that controls ownership of objects uploaded to the "
+            "bucket and disables or enables ACLs, and what `GetBucketOwnershipControls` reports. "
+            "`BUCKET_OWNER_ENFORCED` (the default): ACLs are disabled, and the bucket owner automatically owns "
+            "and has full control over every object in the bucket. ACLs no longer affect permissions to data in "
+            "the bucket, and the bucket uses its grants to define access control. Requests to set or update "
+            "ACLs fail with `AccessControlListNotSupported`; requests to read ACLs are supported. Only uploads "
+            "with bucket owner full control ACLs, or uploads that do not specify an ACL, are accepted. "
+            "`BUCKET_OWNER_PREFERRED`: the bucket owner owns and has full control over new objects that other "
+            "accounts write to the bucket with the `bucket-owner-full-control` canned ACL. Objects uploaded "
+            "with other ACLs are owned by the writing account. ACLs can be updated and can grant permissions. "
+            "`OBJECT_WRITER`: the account that uploads an object owns the object, has full control over it, and "
+            "can grant other users access to it through ACLs. "
+            "A `MULTIPROTOCOL` bucket is always `OBJECT_WRITER` whatever is given here, and its ACLs stay "
+            "disabled: the other protocols' users own the filesystem permissions on the tree."
         ),
     )
     versioning: Literal["OFF", "ENABLED", "SUSPENDED"] = Field(default="OFF", description="Bucket versioning state.")

--- a/src/middlewared/middlewared/etc_files/truenas_s3/buckets.conf.mako
+++ b/src/middlewared/middlewared/etc_files/truenas_s3/buckets.conf.mako
@@ -54,6 +54,11 @@ path = ${bucket.mountpoint}
 owner = ${b.owner}
 owner_id = ${b.owner_uid}
 permissions_model = ${b.permissions_model.lower()}
+## the row states both halves of the pair: the model is only ever s3 or
+## multiprotocol here, the third value the API takes having been resolved
+## into the two before it was stored, so the file can carry no
+## contradiction for the daemon to refuse
+object_ownership = ${b.object_ownership.lower()}
 versioning = ${b.versioning.lower()}
 ## a selection of none is the key omitted, never rendered empty; the cap
 ## is inert without a selection, so it rides beside one

--- a/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
@@ -14,7 +14,7 @@ import errno
 import ipaddress
 import string
 import typing
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -53,6 +53,10 @@ __all__ = ("SharingS3Service", "S3FSAttachmentDelegate")
 AUDIT_ACTIONS: tuple[str, ...] = typing.get_args(S3AuditAction)
 
 
+# a whole bucket row, whichever of the two shapes the caller sent one in
+EntryT = TypeVar("EntryT", bound=SharingS3Entry)
+
+
 def bucket_dataset_properties() -> ZFSResourceCreateProperties:
     """What the S3 on-disk format requires of a bucket's dataset. A fresh
     instance per call, since the create rules write into the one they are
@@ -89,6 +93,7 @@ class SharingS3Model(sa.Model):
     owner_uid = sa.Column(sa.Integer())
     grants = sa.Column(sa.JSON(list))
     permissions_model = sa.Column(sa.String(32))
+    object_ownership = sa.Column(sa.String(32))
     versioning = sa.Column(sa.String(16))
     snapshot_versions = sa.Column(sa.JSON(list))
     snapshot_versions_max = sa.Column(sa.Integer())
@@ -208,6 +213,47 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         await validate_grants(self.middleware, f"{schema}.grants", data.grants, verrors)
 
     @private
+    def normalize_ownership(
+        self, data: EntryT, given: set[str], schema: str, verrors: ValidationErrors
+    ) -> EntryT:
+        """The pair a row is stored as.
+
+        `permissions_model` and `object_ownership` are one axis each:
+        the first says how the S3 service treats the filesystem
+        permissions on the tree, the second which account an S3
+        operation runs as and whether the bucket supports S3 ACLs.
+        Neither is always stored as it was given.
+
+        The undocumented `S3_BUCKET_OWNER_ENFORCED` is the pair spelled
+        as one value and is stored as `S3` with `BUCKET_OWNER_ENFORCED`.
+        It carries the last API consumer over and goes when that
+        consumer does. Naming it beside a different `object_ownership`
+        in the same call is refused rather than resolved: picking one
+        silently would serve a bucket under a gate the caller did not
+        ask for.
+
+        A `MULTIPROTOCOL` row folds to `OBJECT_WRITER` whatever it was
+        given, as the S3 service does with it: the other protocols'
+        users own the filesystem permissions, so the caller's own uid is
+        the only one that may act, and such a row supports no S3 ACLs
+        under any value. Folded rather than refused, so that a shared
+        bucket may be created without restating the default, and stored
+        folded so the row reads back as the service runs it.
+        """
+        model, ownership = data.permissions_model, data.object_ownership
+        if model == "S3_BUCKET_OWNER_ENFORCED":
+            if "object_ownership" in given and ownership != "BUCKET_OWNER_ENFORCED":
+                verrors.add(
+                    f"{schema}.object_ownership",
+                    "The S3_BUCKET_OWNER_ENFORCED permissions model is the S3 model with BUCKET_OWNER_ENFORCED "
+                    "object ownership, so it cannot be given beside another ownership setting.",
+                )
+            model, ownership = "S3", "BUCKET_OWNER_ENFORCED"
+        elif model == "MULTIPROTOCOL":
+            ownership = "OBJECT_WRITER"
+        return data.model_copy(update={"permissions_model": model, "object_ownership": ownership})
+
+    @private
     async def resolve_owner(self, schema: str, username: str, verrors: ValidationErrors) -> int | None:
         """The owner's uid."""
         try:
@@ -286,16 +332,19 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         The bucket's dataset is created here, with the properties the S3
         service requires, and must not exist beforehand. Objects live in its
         ``s3data`` directory, which the S3 service creates on its next start
-        owned by ``owner``. Under the ``S3`` and ``MULTIPROTOCOL`` permissions
-        models every object is written under the account that put it, so a
-        grantee other than the owner can write only where that directory's
-        permissions let the account write; set an ACL on it as for any share,
-        or choose ``S3_BUCKET_OWNER_ENFORCED``, under which every object is
-        written as the owner and the grants alone decide. Grants may be given
-        in the same call. Registering a bucket restarts the S3 service,
-        draining in-flight requests for up to 30 seconds.
+        owned by ``owner``. Under the ``S3`` permissions model the filesystem
+        permissions on that tree are ignored and the bucket's grants decide;
+        under ``MULTIPROTOCOL`` they are enforced as well, so a grantee other
+        than the owner reaches only what they allow and an ACL is set on the
+        directory as for any share. Which account a write is recorded as is
+        ``object_ownership``'s answer: the owner under
+        ``BUCKET_OWNER_ENFORCED``, which is the default and supports no S3
+        ACLs, and the account that put the object under the other two values.
+        Grants may be given in the same call. Registering a bucket restarts
+        the S3 service, draining in-flight requests for up to 30 seconds.
         """
         verrors = ValidationErrors()
+        data = self.normalize_ownership(data, data.model_fields_set, "sharing_s3_create", verrors)
         await self.validate(data, "sharing_s3_create", verrors)
         owner_uid = await self.resolve_owner("sharing_s3_create", data.owner, verrors)
         if await self.query([["dataset", "=", data.dataset]], {"select": ["id"]}):
@@ -333,6 +382,10 @@ class SharingS3Service(SharingService[SharingS3Entry]):
 
         new = old.updated(data)
         verrors = ValidationErrors()
+        # the pair is resolved against the fields *this* call named: a
+        # stored row never holds the folded-away model value, so naming it
+        # here is what makes it a statement about both halves
+        new = self.normalize_ownership(new, data.model_fields_set, "sharing_s3_update", verrors)
         await self.validate(new, "sharing_s3_update", verrors, old)
         # an owner given by name is compared by the uid it resolves to: a
         # renamed account is the same owner, a deleted and recreated one

--- a/tests/api2/test_s3_bucket.py
+++ b/tests/api2/test_s3_bucket.py
@@ -47,21 +47,6 @@ def running_service():
         call("service.control", "STOP", SERVICE, {"silent": False}, job=True)
 
 
-# the ACL a deployment puts on the share root when more than the owner is
-# to write into it, as it would for any share: every write is published
-# under the requesting account, and the daemon leaves the directory it
-# created at 0755 owned by the owner
-OPEN_ACL = [
-    {"tag": "owner@", "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}},
-    {"tag": "group@", "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}},
-    {"tag": "everyone@", "type": "ALLOW", "perms": {"BASIC": "MODIFY"}, "flags": {"BASIC": "INHERIT"}},
-]
-
-
-def open_share_root(uid, gid):
-    call("filesystem.setacl", {"path": f"/mnt/{DATASET}/s3data", "dacl": OPEN_ACL, "uid": uid, "gid": gid}, job=True)
-
-
 @pytest.fixture(scope="module")
 def owner():
     with user(
@@ -137,6 +122,7 @@ def test_create_owns_the_dataset(owner):
             "owner": OWNER,
             "owner_id": str(owner["uid"]),
             "permissions_model": "s3",
+            "object_ownership": "bucket_owner_enforced",
             "versioning": "off",
             "multipart_etag": "composite",
             "object_lock": "off",
@@ -231,6 +217,36 @@ def test_grants_live_on_the_bucket(owner):
     assert parse(POLICIES_CONF) == {}
 
 
+def test_object_ownership_is_its_own_key(owner):
+    """`permissions_model` and `object_ownership` are one axis each: the
+    first says how the S3 service treats the filesystem permissions on
+    the tree, the second which account an S3 operation runs as and
+    whether the bucket supports S3 ACLs. A shared tree folds to the one
+    uid it can run as."""
+    with bucket() as b:
+        assert (b["permissions_model"], b["object_ownership"]) == ("S3", "BUCKET_OWNER_ENFORCED")
+        call("etc.generate", "truenas_s3")
+        row = parse(BUCKETS_CONF)['bucket "test-bucket"']
+        assert (row["permissions_model"], row["object_ownership"]) == ("s3", "bucket_owner_enforced")
+
+        updated = call("sharing.s3.update", b["id"], {"object_ownership": "BUCKET_OWNER_PREFERRED"})
+        assert (updated["permissions_model"], updated["object_ownership"]) == ("S3", "BUCKET_OWNER_PREFERRED")
+        call("etc.generate", "truenas_s3")
+        assert parse(BUCKETS_CONF)['bucket "test-bucket"']["object_ownership"] == "bucket_owner_preferred"
+
+        # a shared tree runs as the caller whatever it is given: the other
+        # protocols' users own the filesystem permissions there
+        updated = call(
+            "sharing.s3.update",
+            b["id"],
+            {"permissions_model": "MULTIPROTOCOL", "object_ownership": "BUCKET_OWNER_ENFORCED"},
+        )
+        assert (updated["permissions_model"], updated["object_ownership"]) == ("MULTIPROTOCOL", "OBJECT_WRITER")
+        call("etc.generate", "truenas_s3")
+        row = parse(BUCKETS_CONF)['bucket "test-bucket"']
+        assert (row["permissions_model"], row["object_ownership"]) == ("multiprotocol", "object_writer")
+
+
 def test_object_lock_rules(owner):
     for bad, field in (
         ({"object_lock": True}, "versioning"),
@@ -271,19 +287,20 @@ def test_object_lock_rules(owner):
         assert field in ve.value.errors[0].attribute
 
     # the period is days, however long: the daemon's years are 365 days
-    # each, so the one field spells every rule it could. Either S3-only
-    # model may carry a lock; only a shared tree may not
+    # each, so the one field spells every rule it could. Only a shared
+    # tree may not carry a lock, whatever the bucket's object ownership
     with bucket(
         name="locked",
         versioning="ENABLED",
-        permissions_model="S3_BUCKET_OWNER_ENFORCED",
+        object_ownership="OBJECT_WRITER",
         object_lock=True,
         object_lock_default_mode="COMPLIANCE",
         object_lock_default_days=365,
     ):
         call("etc.generate", "truenas_s3")
         row = parse(BUCKETS_CONF)['bucket "locked"']
-        assert row["permissions_model"] == "s3_bucket_owner_enforced"
+        assert row["permissions_model"] == "s3"
+        assert row["object_ownership"] == "object_writer"
         assert row["versioning"] == "enabled"
         assert row["object_lock"] == "enabled"
         assert row["object_lock_default_mode"] == "compliance"
@@ -443,29 +460,33 @@ def md5_of(path):
 def test_boto3_roundtrip(owner):
     """The whole chain: a bucket with grants, access keys for the grantees,
     and clients that put and get objects through the daemon. Two grantees,
-    because every write is published under the requester's own uid: the
-    second one writing into a prefix the first created, and over the
-    first's object, is what an inheritable ACL on the share root is for,
-    and without one the second grantee is refused at the root: the daemon
-    makes the directory the owner's and every write is the requester's."""
+    because under `OBJECT_WRITER` every write is published under the
+    requester's own uid, and the second one writing into a prefix the
+    first created, and over the first's object, is what proves the `S3`
+    permissions model ignores the modes those writes leave behind: the
+    daemon makes the share root the owner's at 0755, nothing is opened on
+    it, and neither grantee is fenced by it."""
     with (
         grantee("s3client") as (grant_a, key_a),
         grantee("s3client2") as (
             grant_b,
             key_b,
         ),
-        bucket(grants=[grant_a, grant_b]),
+        bucket(grants=[grant_a, grant_b], object_ownership="OBJECT_WRITER"),
     ):
         assert call("service.control", "START", SERVICE, {"silent": False}, job=True)
         try:
             a, b = client(key_a), client(key_b)
             assert [x["Name"] for x in a.list_buckets()["Buckets"]] == ["test-bucket"]
-            with pytest.raises(Exception, match="AccessDenied"):
-                a.put_object(Bucket="test-bucket", Key="pfx/hello.txt", Body=b"from a")
-            open_share_root(owner["uid"], owner["group"]["bsdgrp_gid"])
+            root = call("filesystem.stat", f"/mnt/{DATASET}/s3data")
+            assert (root["uid"], root["mode"] & 0o777) == (owner["uid"], 0o755), "left as the daemon made it"
+
             a.put_object(Bucket="test-bucket", Key="pfx/hello.txt", Body=b"from a")
             assert a.get_object(Bucket="test-bucket", Key="pfx/hello.txt")["Body"].read() == b"from a"
             assert ssh(f"cat /mnt/{DATASET}/s3data/pfx/hello.txt") == "from a"
+            # OBJECT_WRITER: the publish records the account that made it
+            on_disk = call("filesystem.stat", f"/mnt/{DATASET}/s3data/pfx/hello.txt")
+            assert on_disk["uid"] == grant_a["xid"]
 
             b.put_object(Bucket="test-bucket", Key="pfx/other.txt", Body=b"from b")
             b.put_object(Bucket="test-bucket", Key="pfx/hello.txt", Body=b"b over a")
@@ -477,21 +498,22 @@ def test_boto3_roundtrip(owner):
 
 
 def test_bucket_owner_enforced_writes_as_the_owner(owner):
-    """Under `S3_BUCKET_OWNER_ENFORCED` the grants are the whole of the
-    access control: the same two grantees write into the share root the
-    daemon made the owner's, and over each other, with nothing opened on
-    it, and everything they publish lands on disk as the owner's rather
-    than the writer's. A key with no grant is still refused, since the
-    model moves the uid the kernel sees and not who is authorized."""
+    """Under `BUCKET_OWNER_ENFORCED` object ownership the grants are the
+    whole of the access control: the same two grantees write into the
+    share root the daemon made the owner's, and over each other, and
+    everything they publish lands on disk as the owner's rather than the
+    writer's. A key with no grant is still refused, since the value moves
+    the uid the kernel sees and not who is authorized."""
     with (
         grantee("s3client") as (grant_a, key_a),
         grantee("s3client2") as (grant_b, key_b),
         grantee("s3stranger") as (_ungranted, key_c),
-        bucket(grants=[grant_a, grant_b], permissions_model="S3_BUCKET_OWNER_ENFORCED"),
+        bucket(grants=[grant_a, grant_b], object_ownership="BUCKET_OWNER_ENFORCED"),
         running_service(),
     ):
         call("etc.generate", "truenas_s3")
-        assert parse(BUCKETS_CONF)['bucket "test-bucket"']["permissions_model"] == "s3_bucket_owner_enforced"
+        row = parse(BUCKETS_CONF)['bucket "test-bucket"']
+        assert (row["permissions_model"], row["object_ownership"]) == ("s3", "bucket_owner_enforced")
 
         a, b, stranger = client(key_a), client(key_b), client(key_c)
         a.put_object(Bucket="test-bucket", Key="pfx/hello.txt", Body=b"from a")
@@ -649,7 +671,10 @@ def test_a_file_survives_the_round_trip(owner, size, threshold, parts, multipart
     source, expected = random_file(size)
     fetched = source + ".down"
     try:
-        with grantee("s3client") as (_grant, key), bucket(owner="s3client", multipart_etag=multipart_etag):
+        with (
+            grantee("s3client") as (_grant, key),
+            bucket(owner="s3client", multipart_etag=multipart_etag, object_ownership="OBJECT_WRITER"),
+        ):
             assert call("service.control", "START", SERVICE, {"silent": False}, job=True)
             try:
                 s3 = client(key)


### PR DESCRIPTION
Initially, `permissions_model` determined whether the permissions should attempt to be compatible with other processes and the S3 ownership model (AWS-style per-bucket Object Ownership). This commit moves the object ownership question into its own API field for bckets. It becomes object_ownership, defaulting to BUCKET_OWNER_ENFORCED, and the model keeps S3 and MULTIPROTOCOL alone. A MULTIPROTOCOL row folds to OBJECT_WRITER, as the S3 service does with it.

S3_BUCKET_OWNER_ENFORCED stays spellable and stores as the pair it always meant. It is undocumented and goes with its last consumer.

test_boto3_roundtrip no longer expects a POSIX refusal on an S3 bucket: that model ignores the filesystem permissions entirely.

Original PR: https://github.com/truenas/middleware/pull/19658
