### PR TITLE
NAS-143037 / 27.0.0-BETA.1 / Log full git output to its own log file

### DIFF
--- a/src/freenas/etc/logrotate.d/syslog-ng-truenas
+++ b/src/freenas/etc/logrotate.d/syslog-ng-truenas
@@ -24,6 +24,7 @@
 /var/log/debug
 /var/log/messages
 /var/log/error
+/var/log/git.log
 {
 	rotate 3
 	size 10M

--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -66,6 +66,7 @@ APP_MIGRATION_LOGFILE = '/var/log/app_migrations.log'
 AUDIT_HANDLER_LOGFILE = '/var/log/audit/audit_handler.log'
 DOCKER_IMAGE_LOGFILE = '/var/log/docker_image.log'
 FAILOVER_LOGFILE = '/var/log/failover.log'
+GIT_LOGFILE = '/var/log/git.log'
 LOGFILE = '/var/log/middlewared.log'
 DEFAULT_LOGFORMAT = '[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s'
 FALLBACK_LOGFILE = '/var/log/fallback-middlewared.log'
@@ -117,6 +118,7 @@ ALL_LOG_FILES = (
     TNLog('audit_handler', AUDIT_HANDLER_LOGFILE),
     TNLog('docker_image', DOCKER_IMAGE_LOGFILE),
     TNLog('failover', FAILOVER_LOGFILE),
+    TNLog('git', GIT_LOGFILE),
     TNLog('netdata_api', NETDATA_API_LOGFILE),
     TNLog('truenas_connect', TRUENAS_CONNECT_LOGFILE),
     TNLog('zettarepl', ZETTAREPL_LOGFILE, ZETTAREPL_LOGFORMAT),

--- a/src/middlewared/middlewared/plugins/catalog/git_utils.py
+++ b/src/middlewared/middlewared/plugins/catalog/git_utils.py
@@ -7,7 +7,7 @@ from middlewared.service import CallError
 from middlewared.utils.git import checkout_repository, clone_repository, update_repo, validate_git_repo
 
 GIT_LOCK: defaultdict[str, threading.Lock] = defaultdict(threading.Lock)
-logger = logging.getLogger('catalog_utils')
+logger = logging.getLogger('git')
 
 
 def convert_repository_to_path(git_repository_uri: str, branch: str) -> str:
@@ -26,12 +26,10 @@ def pull_clone_repository(repository_uri: str, destination: str, branch: str, de
                 checkout_repository(destination, branch)
                 update_repo(destination, branch)
             except CallError:
+                logger.warning('%s: refresh failed, re-cloning from %r', destination, repository_uri)
                 clone_repo = True
 
         if clone_repo:
-            try:
-                clone_repository(repository_uri, destination, branch, depth)
-            except CallError as e:
-                raise CallError(f'Failed to clone {repository_uri!r} repository at {destination!r} destination: {e}')
+            clone_repository(repository_uri, destination, branch, depth)
 
         return True

--- a/src/middlewared/middlewared/pytest/unit/utils/test_git.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_git.py
@@ -1,0 +1,42 @@
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from middlewared.utils import git
+
+
+@pytest.mark.parametrize(
+    "stderr,returncode,reason",
+    [
+        (
+            b"Cloning into '/mnt/.ix-apps/truenas_catalog'...\n"
+            b"remote: Invalid username or token.\n"
+            b"fatal: Authentication failed for 'https://github.com/truenas/apps/'\n",
+            128,
+            "fatal: Authentication failed for 'https://github.com/truenas/apps/'",
+        ),
+        (
+            b"fatal: ambiguous argument 'origin/master': unknown revision or path not in the working tree.\n"
+            b"Use '--' to separate paths from revisions, like this:\n"
+            b"'git <command> [<revision>...] -- [<file>...]'\n",
+            128,
+            "fatal: ambiguous argument 'origin/master': unknown revision or path not in the working tree.",
+        ),
+        (
+            b"error: Your local changes to the following files would be overwritten by merge:\n"
+            b"\tix-dev/charts/plex/questions.yaml\n"
+            b"Aborting\n",
+            1,
+            "error: Your local changes to the following files would be overwritten by merge:",
+        ),
+        (b"Some unprefixed failure\n", 1, "Some unprefixed failure"),
+        (b"", -9, "git exited with code -9"),
+    ],
+)
+@patch("middlewared.utils.git.logger")
+def test__failure_names_the_cause(logger, stderr, returncode, reason):
+    cp = subprocess.CompletedProcess(args=[], returncode=returncode, stdout=b"", stderr=stderr)
+
+    expected = f"Failed to clone: {reason}. See /var/log/git.log for full git output"
+    assert git._failure(cp, "Failed to clone").errmsg == expected

--- a/src/middlewared/middlewared/utils/git.py
+++ b/src/middlewared/middlewared/utils/git.py
@@ -1,17 +1,29 @@
 import logging
 import shutil
 import subprocess
-import textwrap
 
 from middlewared.service import CallError
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('git')
 
 CLONE_TIMEOUT = 900
 PULL_TIMEOUT = 600
 RESET_TIMEOUT = 120
 CHECKOUT_TIMEOUT = 120
 STATUS_TIMEOUT = 30
+
+
+def _failure(cp: subprocess.CompletedProcess[bytes], what: str) -> CallError:
+    stderr = cp.stderr.decode(errors='replace')
+    logger.error('%s:\n%s', what, stderr[-8192:].strip() or '<no output>')
+
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    # `fatal:` is not always last: reset on a bad ref ends with usage boilerplate.
+    reason = next(
+        (line for prefix in ('fatal:', 'error:') for line in reversed(lines) if line.startswith(prefix)),
+        lines[-1] if lines else f'git exited with code {cp.returncode}',
+    )
+    return CallError(f'{what}: {reason}. See /var/log/git.log for full git output')
 
 
 def clone_repository(
@@ -38,10 +50,7 @@ def clone_repository(
         )
 
     if cp.returncode:
-        error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
-        raise CallError(
-            f'Failed to clone {repository_uri!r} repository at {destination!r} destination: {error_message}'
-        )
+        raise _failure(cp, f'Failed to clone {repository_uri!r} repository at {destination!r} destination')
 
 
 def checkout_repository(destination: str, branch: str) -> None:
@@ -56,10 +65,7 @@ def checkout_repository(destination: str, branch: str) -> None:
         )
 
     if cp.returncode:
-        error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
-        raise CallError(
-            f'Failed to checkout {branch!r} branch for {destination!r} repository: {error_message}'
-        )
+        raise _failure(cp, f'Failed to checkout {branch!r} branch for {destination!r} repository')
 
 
 def update_repo(destination: str, branch: str) -> None:
@@ -74,10 +80,7 @@ def update_repo(destination: str, branch: str) -> None:
         raise CallError(f'Timed out after {RESET_TIMEOUT} seconds resetting {destination!r} repository')
 
     if cp.returncode:
-        error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
-        raise CallError(
-            f'Failed to reset {destination!r} repository: {error_message}'
-        )
+        raise _failure(cp, f'Failed to reset {destination!r} repository')
 
     try:
         cp = subprocess.run(
@@ -87,10 +90,7 @@ def update_repo(destination: str, branch: str) -> None:
         raise CallError(f'Timed out after {PULL_TIMEOUT} seconds updating {destination!r} repository')
 
     if cp.returncode:
-        error_message = textwrap.shorten(cp.stderr.decode(), width=50, placeholder='...')
-        raise CallError(
-            f'Failed to update {destination!r} repository: {error_message}'
-        )
+        raise _failure(cp, f'Failed to update {destination!r} repository')
 
 
 def validate_git_repo(destination: str) -> bool:


### PR DESCRIPTION
## Problem
`utils/git.py` shortened git's stderr to 50 characters before putting it into the `CallError`, and `textwrap.shorten` collapses newlines before it truncates. `git clone` always opens stderr with `Cloning into '/mnt/.ix-apps/truenas_catalog'...`, which is 47 characters by itself, so every clone failure produced the byte-identical message and the `fatal:` line saying what actually went wrong was discarded every time. Bad credentials, DNS, TLS, a proxy and a missing branch were indistinguishable in the UI, in the logs and in a debug bundle, and git's stderr was preserved nowhere else.

## Solution
- **A dedicated `git` log file.** The tail of git's output goes to `/var/log/git.log` rather than back into `middlewared.log`, which is what the original shortening was trying to keep clean. The syslog-ng filter and destination generate themselves from `ALL_LOG_FILES`, so `logger.py` is the only place that needed touching, plus a line in the existing logrotate stanza.
- **The raised message names the cause.** The last `fatal:` line is preferred, then the last `error:` line, then whatever git printed last. Position alone is not reliable because `reset --hard` on a bad ref prints usage boilerplate after the `fatal:` line. The message stays a single line because it is stored as the job error and rendered into the catalog sync alert, and it points at the log file for the rest.
- **Stopped discarding two other git errors.** A failed checkout or pull was caught, silently dropped and turned into a re-clone, so a repository that stopped being usable left no record of why. The clone error was also re-raised behind a second copy of the prefix `clone_repository` had already produced, which pushed the real error further right in every alert and dropped the inner errno.