### PR TITLE
NAS-143505 / 27.0.0-BETA.1 / Let the S3 protocol create and delete buckets (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-09-09_12-00_truenas_s3_protocol_buckets.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-09-09_12-00_truenas_s3_protocol_buckets.py
@@ -1,0 +1,33 @@
+"""Add what the S3 protocol needs to create and delete buckets
+
+Revision ID: b7e3f1a92c48
+Revises: e4b8d2f6a1c3
+Create Date: 2026-09-09 12:00:00.000000+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7e3f1a92c48'
+down_revision = 'e4b8d2f6a1c3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_truenas_s3', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('managed_root_dataset', sa.String(length=255), nullable=False, server_default='')
+        )
+
+    with op.batch_alter_table('truenas_s3_accesskey', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('last_used', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.add_column(
+            sa.Column('manage_buckets', sa.Boolean(), nullable=False, server_default='0')
+        )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-09-09_20-00_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-09-09_20-00_merge.py
@@ -1,0 +1,22 @@
+"""Merge migration for S3 protocol bucket support (revision b7e3f1a92c48)
+
+Revision ID: 96ac58d1fefc
+Revises: fdc00a666e90, b7e3f1a92c48
+Create Date: 2026-09-09 20:00:00.000000+00:00
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '96ac58d1fefc'
+down_revision = ('fdc00a666e90', 'b7e3f1a92c48')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v26_0_0/s3.py
+++ b/src/middlewared/middlewared/api/v26_0_0/s3.py
@@ -76,11 +76,7 @@ S3AuditOverflow = Literal["DROP", "BACKPRESSURE"]
 S3Access = Literal["READONLY", "WRITEONLY", "READWRITE", "DENY"]
 S3PrincipalType = Literal["USER", "GROUP", "EVERYONE"]
 
-# `S3_BUCKET_OWNER_ENFORCED` is accepted and stored as `S3` beside an
-# `object_ownership` of `BUCKET_OWNER_ENFORCED`, undocumented on purpose:
-# it carries the last API consumer over and goes when that consumer does,
-# with `SharingS3Service.normalize_ownership`'s handling of it.
-S3PermissionsModel = Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"]
+S3PermissionsModel = Literal["S3", "MULTIPROTOCOL"]
 """How the S3 service treats the filesystem permissions on a bucket's
 tree."""
 
@@ -128,6 +124,23 @@ class S3AccesskeyEntry(BaseModel):
         description="Expiration timestamp for the access key or `null` for no expiration.",
     )
     created_at: datetime = Field(description="Timestamp when the access key was created.")
+    last_used_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Time the S3 service last accepted a request signed with this key, or `null` if the key has never "
+            "been used. The S3 service reports this at intervals, so a recent request can be absent for a short "
+            "time. This field is read-only."
+        ),
+    )
+    manage_buckets: bool = Field(
+        default=False,
+        description=(
+            "Whether this access key may create and delete buckets through the S3 protocol. Setting it requires "
+            "the account that owns the key to hold the `SHARING_S3_WRITE` role, checked when a call turns it on. "
+            "It scopes the key, not the account: an account may hold several access keys, and leaving this off on "
+            "one of them affects neither its other keys nor its own access to `sharing.s3.create`."
+        ),
+    )
     status: S3AccesskeyStatus = Field(
         description=(
             "Effective state of the access key. Only `ENABLED` keys are usable. `DISABLED` was set by an "
@@ -154,6 +167,7 @@ class S3AccesskeyCreate(S3AccesskeyEntry):
     )
     enabled: bool = Field(default=True, description="Whether the access key may be used.")
     created_at: Excluded = excluded_field()
+    last_used_at: Excluded = excluded_field()
     status: Excluded = excluded_field()
 
 
@@ -281,6 +295,14 @@ class S3Entry(BaseModel):
         description=(
             "Grants that apply to every bucket. A `DENY` here suspends the principal everywhere, outranking every "
             "bucket grant. Listing buckets never needs one of these."
+        ),
+    )
+    managed_root_dataset: str = Field(
+        default="",
+        description=(
+            "Path where datasets for S3 buckets created through S3 protocol CreateBucket requests are created, "
+            "for example `tank/s3`. The path is a dataset name, not a mount point, and the dataset must already "
+            "exist. If this field is empty (the default), S3 protocol CreateBucket requests are refused."
         ),
     )
 
@@ -431,6 +453,15 @@ class SharingS3Entry(BaseModel):
 class SharingS3Create(SharingS3Entry):
     id: Excluded = excluded_field()
     owner_uid: Excluded = excluded_field()
+    dataset: NonEmptyString | None = Field(
+        default=None,
+        description=(
+            "ZFS dataset for the bucket, created by this method. If you give no value, the dataset is created "
+            "under the S3 service's `managed_root_dataset` and takes the name of the bucket. An S3 protocol "
+            "CreateBucket request always uses that default. If that name is in use, a `_N` suffix is added. An "
+            "existing dataset is never used: `sharing.s3.delete` keeps the dataset and its objects."
+        ),
+    )
     grants: list[S3Grant] = Field(default=[], description="Who may access the bucket and how, beyond its owner.")
     locked: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/api/v27_0_0/s3.py
+++ b/src/middlewared/middlewared/api/v27_0_0/s3.py
@@ -76,11 +76,7 @@ S3AuditOverflow = Literal["DROP", "BACKPRESSURE"]
 S3Access = Literal["READONLY", "WRITEONLY", "READWRITE", "DENY"]
 S3PrincipalType = Literal["USER", "GROUP", "EVERYONE"]
 
-# `S3_BUCKET_OWNER_ENFORCED` is accepted and stored as `S3` beside an
-# `object_ownership` of `BUCKET_OWNER_ENFORCED`, undocumented on purpose:
-# it carries the last API consumer over and goes when that consumer does,
-# with `SharingS3Service.normalize_ownership`'s handling of it.
-S3PermissionsModel = Literal["S3", "MULTIPROTOCOL", "S3_BUCKET_OWNER_ENFORCED"]
+S3PermissionsModel = Literal["S3", "MULTIPROTOCOL"]
 """How the S3 service treats the filesystem permissions on a bucket's
 tree."""
 
@@ -128,6 +124,23 @@ class S3AccesskeyEntry(BaseModel):
         description="Expiration timestamp for the access key or `null` for no expiration.",
     )
     created_at: datetime = Field(description="Timestamp when the access key was created.")
+    last_used_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Time the S3 service last accepted a request signed with this key, or `null` if the key has never "
+            "been used. The S3 service reports this at intervals, so a recent request can be absent for a short "
+            "time. This field is read-only."
+        ),
+    )
+    manage_buckets: bool = Field(
+        default=False,
+        description=(
+            "Whether this access key may create and delete buckets through the S3 protocol. Setting it requires "
+            "the account that owns the key to hold the `SHARING_S3_WRITE` role, checked when a call turns it on. "
+            "It scopes the key, not the account: an account may hold several access keys, and leaving this off on "
+            "one of them affects neither its other keys nor its own access to `sharing.s3.create`."
+        ),
+    )
     status: S3AccesskeyStatus = Field(
         description=(
             "Effective state of the access key. Only `ENABLED` keys are usable. `DISABLED` was set by an "
@@ -154,6 +167,7 @@ class S3AccesskeyCreate(S3AccesskeyEntry):
     )
     enabled: bool = Field(default=True, description="Whether the access key may be used.")
     created_at: Excluded = excluded_field()
+    last_used_at: Excluded = excluded_field()
     status: Excluded = excluded_field()
 
 
@@ -281,6 +295,14 @@ class S3Entry(BaseModel):
         description=(
             "Grants that apply to every bucket. A `DENY` here suspends the principal everywhere, outranking every "
             "bucket grant. Listing buckets never needs one of these."
+        ),
+    )
+    managed_root_dataset: str = Field(
+        default="",
+        description=(
+            "Path where datasets for S3 buckets created through S3 protocol CreateBucket requests are created, "
+            "for example `tank/s3`. The path is a dataset name, not a mount point, and the dataset must already "
+            "exist. If this field is empty (the default), S3 protocol CreateBucket requests are refused."
         ),
     )
 
@@ -431,6 +453,15 @@ class SharingS3Entry(BaseModel):
 class SharingS3Create(SharingS3Entry):
     id: Excluded = excluded_field()
     owner_uid: Excluded = excluded_field()
+    dataset: NonEmptyString | None = Field(
+        default=None,
+        description=(
+            "ZFS dataset for the bucket, created by this method. If you give no value, the dataset is created "
+            "under the S3 service's `managed_root_dataset` and takes the name of the bucket. An S3 protocol "
+            "CreateBucket request always uses that default. If that name is in use, a `_N` suffix is added. An "
+            "existing dataset is never used: `sharing.s3.delete` keeps the dataset and its objects."
+        ),
+    )
     grants: list[S3Grant] = Field(default=[], description="Who may access the bucket and how, beyond its owner.")
     locked: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/etc_files/truenas_s3/credentials.conf.mako
+++ b/src/middlewared/middlewared/etc_files/truenas_s3/credentials.conf.mako
@@ -14,5 +14,8 @@ secret_key = ${key.secret.get_secret_value()}
 user = ${key.username}
 % endif
 enabled = ${"true" if key.status == "ENABLED" else "false"}
+% if key.manage_buckets:
+manage_buckets = true
+% endif
 
 % endfor

--- a/src/middlewared/middlewared/plugins/truenas_s3/accesskey_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/accesskey_crud.py
@@ -43,6 +43,10 @@ class S3AccesskeyModel(sa.Model):
     enabled = sa.Column(sa.Boolean())
     expiry = sa.Column(sa.Integer())
     created_at = sa.Column(sa.DateTime())
+    # unix seconds, like expiry: the S3 service reports it over JSON-RPC
+    # and an integer needs no agreement about timezones. 0 is never used
+    last_used = sa.Column(sa.Integer(), default=0)
+    manage_buckets = sa.Column(sa.Boolean(), default=False)
 
 
 class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
@@ -81,8 +85,11 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
     async def extend(self, data: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
         user_identifier = data["user_identifier"]
         expiry = data.pop("expiry")
+        last_used = data.pop("last_used")
 
         data.update({"username": None, "local": True, "expires_at": None})
+        # 0 is a key the S3 service has never accepted a request for
+        data["last_used_at"] = datetime.fromtimestamp(last_used, UTC) if last_used else None
         if user_identifier.isdigit():
             data["user_identifier"] = int(user_identifier)
             # Ids at or above the synthetic base belong to directory services accounts.
@@ -131,7 +138,11 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
         if isinstance(out.get("user_identifier"), int):
             out["user_identifier"] = str(out["user_identifier"])
 
-        for key in ("username", "local", "status", "rotate"):
+        # `last_used_at` is on the entry, so an update model-dumps it back
+        # here. Dropped rather than converted: only `report_usage` moves
+        # it, and writing back what the update read would undo a flush
+        # that landed in between.
+        for key in ("username", "local", "status", "rotate", "last_used_at"):
             out.pop(key, None)
 
         return out
@@ -150,6 +161,37 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
         if expires_at is not None and utc_now(naive=False) > expires_at:
             verrors.add(f"{schema_name}.expires_at", "Expiration date is in the past")
 
+    async def _validate_manage_buckets(self, schema_name: str, username: str | None, verrors: ValidationErrors) -> None:
+        """The account must hold the role the flag lets its key spend.
+
+        `manage_buckets` lets a key ask middleware to create and delete
+        buckets, and middleware answers as the account the key belongs
+        to. Setting it for an account without `SHARING_S3_WRITE` builds
+        a key whose every bucket call is refused, so it is refused here
+        instead, where the administrator can read why.
+
+        Roles come from `privilege.roles_for_user`, which resolves group
+        membership through NSS: `user.query` reports an empty role list
+        for every directory services account, so a check against that
+        would pass a key it should refuse. The composed list already
+        expands what a role includes, so an account holding
+        `SHARING_WRITE`, `SHARING_ADMIN` or `FULL_ADMIN` reads as
+        holding this one.
+        """
+        if username is None:
+            verrors.add(
+                f"{schema_name}.manage_buckets",
+                "This access key belongs to an account that no longer exists, so it cannot manage buckets.",
+            )
+            return
+        roles = await self.middleware.call("privilege.roles_for_user", username)
+        if "SHARING_S3_WRITE" not in roles:
+            verrors.add(
+                f"{schema_name}.manage_buckets",
+                f"Account {username!r} does not hold the SHARING_S3_WRITE role, so a key of theirs cannot manage "
+                "buckets. Grant the account a privilege that includes it, or leave manage_buckets off.",
+            )
+
     async def do_create(self, data: S3AccesskeyCreate) -> S3AccesskeyEntry:
         verrors = ValidationErrors()
         await self._validate("s3_accesskey_create", data.name, data.expires_at, verrors)
@@ -162,6 +204,9 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
             "datastore.query", self._datastore, [["access_key", "=", data.access_key]]
         ):
             verrors.add("s3_accesskey_create.access_key", "access_key must be unique")
+
+        if data.manage_buckets:
+            await self._validate_manage_buckets("s3_accesskey_create", data.username, verrors)
 
         verrors.check()
 
@@ -189,6 +234,7 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
                 "enabled": data.enabled,
                 "expires_at": data.expires_at,
                 "created_at": utc_now(),
+                "manage_buckets": data.manage_buckets,
             }
         )
 
@@ -201,6 +247,13 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
 
         verrors = ValidationErrors()
         await self._validate("s3_accesskey_update", new.name, new.expires_at, verrors, id_=id_)
+        # Checked when this call turns it on, not whenever the row holds
+        # it: an account may lose the role afterwards, and re-checking on
+        # every update would fail an unrelated rename for a reason the
+        # caller did not ask about. A stale flag grants nothing on its
+        # own — middleware refuses the bucket call the key makes with it.
+        if "manage_buckets" in data.model_fields_set and new.manage_buckets:
+            await self._validate_manage_buckets("s3_accesskey_update", old.username, verrors)
         verrors.check()
 
         update = new.model_dump(expose_secrets=True, exclude={"id", "created_at"})
@@ -291,3 +344,38 @@ class S3AccesskeyService(GenericCRUDService[S3AccesskeyEntry]):
     @private
     async def delete_for_user(self, user_id: int) -> list[int]:
         return await self._svc_part.delete_for_user(user_id)
+
+    @private
+    async def report_usage(self, used: list[dict[str, Any]]) -> int:
+        """Record when each access key was last used. Returns the number
+        of rows changed.
+
+        **Consumed by the truenas_s3 daemon and by nothing else.** The
+        daemon counts uses in memory and calls this at intervals over the
+        unix socket as root. It is private because no administrator has a
+        reason to report usage, and because it deliberately skips the
+        config render: a timestamp changes no file the daemon reads, so a
+        reload for one would be pure cost.
+
+        Each entry is `{"access_key": str, "last_used": <unix seconds>}`.
+        Seconds rather than a timestamp string: the daemon is the only
+        caller, and an integer needs no agreement about timezones or
+        formats across that boundary. A stored value only moves forward,
+        so a flush that arrives late or repeats after a restart cannot
+        move a key backwards. An access key the table no longer holds is
+        skipped: deleting a key between its use and this call is ordinary.
+        """
+        rows = await self.middleware.call(
+            "datastore.query", self._svc_part._datastore, [], {"select": ["id", "access_key", "last_used"]}
+        )
+        by_key = {row["access_key"]: row for row in rows}
+        changed = 0
+        for entry in used:
+            row = by_key.get(entry["access_key"])
+            if row is None or row["last_used"] >= entry["last_used"]:
+                continue
+            await self.middleware.call(
+                "datastore.update", self._svc_part._datastore, row["id"], {"last_used": entry["last_used"]}
+            )
+            changed += 1
+        return changed

--- a/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
@@ -56,6 +56,12 @@ AUDIT_ACTIONS: tuple[str, ...] = typing.get_args(S3AuditAction)
 # a whole bucket row, whichever of the two shapes the caller sent one in
 EntryT = TypeVar("EntryT", bound=SharingS3Entry)
 
+MANAGED_NAME_MAX_SUFFIX = 10
+"""Highest `_N` suffix a derived dataset name uses. The names tried under the
+managed root are the name of the bucket, then that name with `_1` to `_10`.
+The limit stops an endless loop and gives an error the administrator can
+read."""
+
 
 def bucket_dataset_properties() -> ZFSResourceCreateProperties:
     """What the S3 on-disk format requires of a bucket's dataset. A fresh
@@ -213,9 +219,7 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         await validate_grants(self.middleware, f"{schema}.grants", data.grants, verrors)
 
     @private
-    def normalize_ownership(
-        self, data: EntryT, given: set[str], schema: str, verrors: ValidationErrors
-    ) -> EntryT:
+    def normalize_ownership(self, data: EntryT) -> EntryT:
         """The pair a row is stored as.
 
         `permissions_model` and `object_ownership` are one axis each:
@@ -223,14 +227,6 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         permissions on the tree, the second which account an S3
         operation runs as and whether the bucket supports S3 ACLs.
         Neither is always stored as it was given.
-
-        The undocumented `S3_BUCKET_OWNER_ENFORCED` is the pair spelled
-        as one value and is stored as `S3` with `BUCKET_OWNER_ENFORCED`.
-        It carries the last API consumer over and goes when that
-        consumer does. Naming it beside a different `object_ownership`
-        in the same call is refused rather than resolved: picking one
-        silently would serve a bucket under a gate the caller did not
-        ask for.
 
         A `MULTIPROTOCOL` row folds to `OBJECT_WRITER` whatever it was
         given, as the S3 service does with it: the other protocols'
@@ -241,15 +237,7 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         folded so the row reads back as the service runs it.
         """
         model, ownership = data.permissions_model, data.object_ownership
-        if model == "S3_BUCKET_OWNER_ENFORCED":
-            if "object_ownership" in given and ownership != "BUCKET_OWNER_ENFORCED":
-                verrors.add(
-                    f"{schema}.object_ownership",
-                    "The S3_BUCKET_OWNER_ENFORCED permissions model is the S3 model with BUCKET_OWNER_ENFORCED "
-                    "object ownership, so it cannot be given beside another ownership setting.",
-                )
-            model, ownership = "S3", "BUCKET_OWNER_ENFORCED"
-        elif model == "MULTIPROTOCOL":
+        if model == "MULTIPROTOCOL":
             ownership = "OBJECT_WRITER"
         return data.model_copy(update={"permissions_model": model, "object_ownership": ownership})
 
@@ -281,6 +269,76 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         )
         mountpoint = rows[0]["properties"]["mountpoint"]["value"] if rows else None
         return mountpoint if mountpoint and mountpoint.startswith("/") else None
+
+    @private
+    async def derive_dataset(self, schema: str, name: str, verrors: ValidationErrors) -> str | None:
+        """Select the dataset for a bucket that gives no `dataset` value.
+
+        This service decides the location, not the S3 daemon. An S3
+        client sends only a bucket name. The parent is the S3 service's
+        `managed_root_dataset` and the leaf is the name of the bucket.
+
+        If the leaf is in use, add a `_N` suffix. Do not use the existing
+        dataset and do not remove it. `sharing.s3.delete` keeps the
+        dataset and its objects. A new bucket with an old name must get a
+        new dataset. If it does not, it serves the objects of the old
+        bucket.
+
+        The separator is an underscore because a bucket name cannot
+        contain one. ZFS also permits `A-Z`, `:` and space, but an
+        underscore has no other meaning in a path, a shell or a ZFS user
+        property. The suffix is therefore unambiguous: `backups_1` is
+        always the second dataset for the bucket `backups`. A hyphen is
+        ambiguous, because `backups-1` is also the dataset for a bucket
+        named `backups-1`.
+        """
+        root = (await self.middleware.call("s3.config")).managed_root_dataset
+        if not root:
+            verrors.add(
+                f"{schema}.dataset",
+                "This bucket named no dataset, and the S3 service has no managed_root_dataset to put one under.",
+            )
+            return None
+        try:
+            rows = await self.call2(
+                self.s.zfs.resource.query_impl,
+                ZFSResourceQuery(paths=[root], properties=None, max_depth=1),
+            )
+        except ZFSPathNotFoundException:
+            rows = []
+        if not rows:
+            # `s3.update` refuses a root that does not exist, so the root
+            # was removed after that check. Reported here to name the
+            # setting. The create below would name the derived dataset
+            # and report a missing parent instead.
+            verrors.add(
+                f"{schema}.dataset",
+                f"The S3 service's managed_root_dataset {root!r} does not exist.",
+                errno.ENOENT,
+            )
+            return None
+        taken = {row["name"] for row in rows}
+        # A bucket row keeps its dataset name even when the dataset is
+        # gone. The column is unique, so a derived name that matches one
+        # fails the insert instead of giving a validation error.
+        taken |= {
+            row["dataset"]
+            for row in await self.middleware.call(
+                "datastore.query", self._config.datastore, [], {"select": ["dataset"]}
+            )
+        }
+        for suffix in range(MANAGED_NAME_MAX_SUFFIX + 1):
+            leaf = name if suffix == 0 else f"{name}_{suffix}"
+            candidate = f"{root}/{leaf}"
+            if candidate not in taken:
+                return candidate
+        verrors.add(
+            f"{schema}.dataset",
+            f"{root!r} already holds a dataset named {name!r} and every suffix to "
+            f"_{MANAGED_NAME_MAX_SUFFIX}. Remove an unused dataset, or give a dataset value.",
+            errno.EEXIST,
+        )
+        return None
 
     @private
     async def create_dataset(self, schema: str, name: str) -> None:
@@ -330,7 +388,11 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         Create an S3 bucket.
 
         The bucket's dataset is created here, with the properties the S3
-        service requires, and must not exist beforehand. Objects live in its
+        service requires, and must not exist beforehand. If you omit
+        ``dataset``, the dataset is created under the S3 service's
+        ``managed_root_dataset`` and takes the name of the bucket, with a
+        ``_N`` suffix if that name is in use. A bucket created through the S3
+        protocol always uses that default. Objects live in its
         ``s3data`` directory, which the S3 service creates on its next start
         owned by ``owner``. Under the ``S3`` permissions model the filesystem
         permissions on that tree are ignored and the bucket's grants decide;
@@ -344,13 +406,16 @@ class SharingS3Service(SharingService[SharingS3Entry]):
         the S3 service, draining in-flight requests for up to 30 seconds.
         """
         verrors = ValidationErrors()
-        data = self.normalize_ownership(data, data.model_fields_set, "sharing_s3_create", verrors)
+        data = self.normalize_ownership(data)
         await self.validate(data, "sharing_s3_create", verrors)
         owner_uid = await self.resolve_owner("sharing_s3_create", data.owner, verrors)
-        if await self.query([["dataset", "=", data.dataset]], {"select": ["id"]}):
+        if data.dataset is None:
+            data.dataset = await self.derive_dataset("sharing_s3_create", data.name, verrors)
+        elif await self.query([["dataset", "=", data.dataset]], {"select": ["id"]}):
             verrors.add("sharing_s3_create.dataset", "Another bucket already uses this dataset.")
         verrors.check()
         assert owner_uid is not None
+        assert data.dataset is not None
 
         await self.create_dataset("sharing_s3_create", data.dataset)
         try:
@@ -382,10 +447,7 @@ class SharingS3Service(SharingService[SharingS3Entry]):
 
         new = old.updated(data)
         verrors = ValidationErrors()
-        # the pair is resolved against the fields *this* call named: a
-        # stored row never holds the folded-away model value, so naming it
-        # here is what makes it a statement about both halves
-        new = self.normalize_ownership(new, data.model_fields_set, "sharing_s3_update", verrors)
+        new = self.normalize_ownership(new)
         await self.validate(new, "sharing_s3_update", verrors, old)
         # an owner given by name is compared by the uid it resolves to: a
         # renamed account is the same owner, a deleted and recreated one

--- a/src/middlewared/middlewared/plugins/truenas_s3/config.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/config.py
@@ -23,6 +23,7 @@ from middlewared.api.current import (
     SharingS3Entry,
     ZFSResourceQuery,
 )
+from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
 from middlewared.service import SystemServicePart, SystemServiceService, ValidationErrors, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils.crypto import generate_token, ssl_uuid4
@@ -58,6 +59,7 @@ class S3Model(sa.Model):
     default_audit = sa.Column(sa.JSON(list), default=[])
     default_audit_overflow = sa.Column(sa.String(16), default="DROP")
     global_grants = sa.Column(sa.JSON(list), default=[])
+    managed_root_dataset = sa.Column(sa.String(255), default="")
     # the two per-appliance identities the daemon wants stated once and never
     # moved. Generated on the first read and never exposed through the API.
     host_id = sa.Column(sa.String(64), default="")
@@ -230,6 +232,9 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
         if (new.default_audit or new.default_audit_overflow != "DROP") and not await self.audit_licensed():
             verrors.add("s3_update.default_audit", "Auditing the S3 service requires an Enterprise license.")
 
+        if new.managed_root_dataset:
+            await self._validate_managed_root(new.managed_root_dataset, verrors)
+
         await validate_grants(self.middleware, "s3_update.global_grants", new.global_grants, verrors)
         verrors.check()
 
@@ -243,6 +248,29 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
         await self.middleware.call("datastore.update", self._datastore, old.id, update)
         await render_and_apply(self.middleware)
         return await self.config()
+
+    async def _validate_managed_root(self, dataset: str, verrors: ValidationErrors) -> None:
+        """Check the parent dataset for buckets created through S3.
+
+        Checked at update time, not at create time. An S3 client cannot
+        correct this setting. The administrator who sets it gets one
+        error here, instead of one error for each bucket create.
+
+        The dataset must exist. This method does not create it: a typed
+        name can be a typo, and a new dataset would have no owner, no
+        quota and no chosen properties.
+        """
+        field = "s3_update.managed_root_dataset"
+        try:
+            rows = await self.call2(
+                self.s.zfs.resource.query_impl, ZFSResourceQuery(paths=[dataset], properties=None)
+            )
+        except ZFSPathNotFoundException:
+            rows = []
+        if not rows:
+            verrors.add(field, f"{dataset!r} does not exist.")
+        elif rows[0]["type"] != "FILESYSTEM":
+            verrors.add(field, f"{dataset!r} is a volume, not a dataset.")
 
     async def audit_licensed(self) -> bool:
         return await self.middleware.call("system.license") is not None

--- a/tests/api2/test_s3_accesskey.py
+++ b/tests/api2/test_s3_accesskey.py
@@ -3,6 +3,7 @@ serves. They live in their own table, linked to local or directory
 services accounts the way API keys are, and nothing in the TrueNAS API
 authentication path ever reads them."""
 
+import json
 from datetime import UTC, datetime, timedelta
 import re
 from time import sleep
@@ -11,12 +12,13 @@ import pytest
 
 from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.test.integration.assets.account import unprivileged_user_client, user
-from middlewared.test.integration.utils import call, client
+from middlewared.test.integration.utils import call, client, ssh
 
 S3_USER = "s3keyuser"
 ACCESS_KEY_RE = re.compile(r"^[A-Z0-9]{20}$")
 SECRET_RE = re.compile(r"^[A-Za-z0-9]{40}$")
 REDACTED = "********"
+CREDENTIALS_CONF = "/etc/truenas_s3/credentials.conf"
 
 
 @pytest.fixture(scope="module")
@@ -228,3 +230,135 @@ def test_lost_secret_flips_the_status(accesskey):
     rotated = call("s3.accesskey.update", accesskey["id"], {"rotate": True})
     assert rotated["status"] == "ENABLED"
     assert SECRET_RE.match(rotated["secret"])
+
+
+def report_usage(entries):
+    """Call the private reporting method the way the S3 daemon does.
+
+    `midclt` runs locally as root with an unset loginuid, which is the
+    origin `_can_call_private_methods` admits. The daemon reaches it the
+    same way over the unix socket, so the test exercises the path that
+    ships instead of one the API layer only tolerates.
+    """
+    payload = json.dumps(entries).replace("'", "'\\''")
+    return int(ssh(f"midclt call s3.accesskey.report_usage '{payload}'").strip())
+
+
+def test_a_new_key_manages_no_buckets_and_has_no_use(accesskey):
+    """Both fields start closed. `manage_buckets` must default to false,
+    or an upgrade would widen every key that already exists."""
+    assert accesskey["manage_buckets"] is False
+    assert accesskey["last_used_at"] is None
+
+
+def test_manage_buckets_is_settable_and_rendered(accesskey):
+    """The S3 service reads the flag from the credentials file, so the
+    render is the only way it reaches the daemon."""
+    updated = call("s3.accesskey.update", accesskey["id"], {"manage_buckets": True})
+    assert updated["manage_buckets"] is True
+
+    call("etc.generate", "truenas_s3")
+    rendered = ssh(f"cat {CREDENTIALS_CONF}")
+    assert "manage_buckets = true" in rendered
+
+    call("s3.accesskey.update", accesskey["id"], {"manage_buckets": False})
+    call("etc.generate", "truenas_s3")
+    assert "manage_buckets" not in ssh(f"cat {CREDENTIALS_CONF}")
+
+
+def test_reported_usage_only_moves_forward(accesskey):
+    """The daemon reports what it has seen since its last call. A flush
+    that arrives late, or repeats after a restart, must not move a key
+    backwards."""
+    key = accesskey["access_key"]
+    later = int(datetime.now(UTC).timestamp())
+    earlier = later - 3600
+
+    assert report_usage([{"access_key": key, "last_used": later}]) == 1
+    first = call("s3.accesskey.get_instance", accesskey["id"])["last_used_at"]
+    assert first is not None
+
+    assert report_usage([{"access_key": key, "last_used": earlier}]) == 0
+    assert call("s3.accesskey.get_instance", accesskey["id"])["last_used_at"] == first
+
+
+def test_manage_buckets_needs_the_write_role(s3_user):
+    """The flag lets a key ask middleware to create buckets, and
+    middleware answers as the account the key belongs to. An account
+    without the role would have every such call refused, so the key is
+    refused here instead. The module's user deliberately holds no roles."""
+    with pytest.raises(ValidationErrors) as ve:
+        call(
+            "s3.accesskey.create",
+            {"name": "would-be admin", "username": S3_USER, "manage_buckets": True},
+        )
+    assert "manage_buckets" in ve.value.errors[0].attribute
+    assert "SHARING_S3_WRITE" in ve.value.errors[0].errmsg
+    assert not call("s3.accesskey.query", [["name", "=", "would-be admin"]])
+
+
+@pytest.mark.parametrize("role", ["SHARING_S3_WRITE", "SHARING_WRITE"])
+def test_manage_buckets_is_allowed_for_a_role_holder(role):
+    """`SHARING_WRITE` includes `SHARING_S3_WRITE`, and the composed role
+    list is what the check reads, so a role that merely includes it
+    passes."""
+    with unprivileged_user_client(roles=[role]) as c:
+        key = call(
+            "s3.accesskey.create",
+            {"name": f"admin key {role}", "username": c.username, "manage_buckets": True},
+        )
+        try:
+            assert key["manage_buckets"] is True
+        finally:
+            call("s3.accesskey.delete", key["id"])
+
+
+def test_turning_manage_buckets_on_is_checked_too(accesskey):
+    """The update path takes the same check, so a key cannot reach the
+    flag by being created without it and edited afterwards."""
+    with pytest.raises(ValidationErrors) as ve:
+        call("s3.accesskey.update", accesskey["id"], {"manage_buckets": True})
+    assert "manage_buckets" in ve.value.errors[0].attribute
+    assert call("s3.accesskey.get_instance", accesskey["id"])["manage_buckets"] is False
+
+
+def test_update_cannot_set_the_usage_timestamp(accesskey):
+    """`last_used_at` is the S3 service's to move and nobody else's. The
+    entry model excludes it from the update shape, and the base model
+    forbids extra fields, so naming it is a validation error rather than
+    a value that is quietly dropped."""
+    with pytest.raises(ValidationErrors):
+        call(
+            "s3.accesskey.update",
+            accesskey["id"],
+            {"last_used_at": datetime.now(UTC).isoformat()},
+        )
+
+
+def test_an_ordinary_update_does_not_disturb_the_usage_timestamp(accesskey):
+    """An update model-dumps the whole entry, so the stored timestamp
+    travels back through compress. It must be dropped there: writing back
+    what the update read would undo a flush that landed in between."""
+    used = int(datetime.now(UTC).timestamp())
+    assert report_usage([{"access_key": accesskey["access_key"], "last_used": used}]) == 1
+    before = call("s3.accesskey.get_instance", accesskey["id"])["last_used_at"]
+    assert before is not None
+
+    renamed = call("s3.accesskey.update", accesskey["id"], {"name": "renamed key"})
+    assert renamed["name"] == "renamed key"
+    assert renamed["last_used_at"] == before
+
+
+def test_reported_usage_skips_a_key_that_is_gone(accesskey):
+    """A key deleted between its use and the next flush is ordinary, so
+    it is skipped rather than failing the whole batch."""
+    assert (
+        report_usage(
+            [
+                {"access_key": "AKIAGONEGONEGONEGONE", "last_used": int(datetime.now(UTC).timestamp())},
+                {"access_key": accesskey["access_key"], "last_used": int(datetime.now(UTC).timestamp())},
+            ]
+        )
+        == 1
+    )
+    assert call("s3.accesskey.get_instance", accesskey["id"])["last_used_at"] is not None

--- a/tests/api2/test_s3_bucket.py
+++ b/tests/api2/test_s3_bucket.py
@@ -147,6 +147,67 @@ def test_delete_keeps_the_dataset(owner):
         call("zfs.resource.destroy", {"path": DATASET, "recursive": True})
 
 
+@contextlib.contextmanager
+def managed_root(value):
+    """Set `value` as the S3 service's managed root, then restore the old
+    value. A bucket created without a `dataset` goes under this root."""
+    was = call("s3.config")["managed_root_dataset"]
+    call("s3.update", {"managed_root_dataset": value})
+    try:
+        yield value
+    finally:
+        call("s3.update", {"managed_root_dataset": was})
+
+
+def test_a_bucket_with_no_dataset_lands_under_the_managed_root(owner):
+    """An S3 client sends only a bucket name, so the service selects the
+    dataset."""
+    with dataset("s3-managed-root") as root, managed_root(root):
+        entry = call("sharing.s3.create", {"name": "derived", "owner": OWNER})
+        try:
+            assert entry["dataset"] == f"{root}/derived"
+            # the derived dataset is the bucket's own, with the same
+            # properties an explicitly named one gets
+            assert zfs_props(entry["dataset"], ["xattr", "acltype"]) == {
+                "xattr": "sa",
+                "acltype": "nfsv4",
+            }
+        finally:
+            call("sharing.s3.delete", entry["id"])
+
+
+def test_a_recreated_bucket_does_not_land_on_the_old_data(owner):
+    """`sharing.s3.delete` keeps the dataset and its objects. A second
+    bucket with the same name must get a new dataset. If it does not, it
+    serves the objects of the first bucket."""
+    with dataset("s3-managed-reuse") as root, managed_root(root):
+        first = call("sharing.s3.create", {"name": "recycled", "owner": OWNER})
+        assert first["dataset"] == f"{root}/recycled"
+        call("sharing.s3.delete", first["id"])
+        assert zfs_props(first["dataset"], ["mountpoint"]) is not None, "the dataset is kept"
+
+        second = call("sharing.s3.create", {"name": "recycled", "owner": OWNER})
+        try:
+            assert second["dataset"] == f"{root}/recycled_1"
+        finally:
+            call("sharing.s3.delete", second["id"])
+
+
+def test_no_managed_root_refuses_a_bucket_with_no_dataset(owner):
+    with managed_root(""):
+        with pytest.raises(ValidationErrors) as ve:
+            call("sharing.s3.create", {"name": "nowhere", "owner": OWNER})
+        assert "dataset" in ve.value.errors[0].attribute
+        assert not call("sharing.s3.query", [["name", "=", "nowhere"]])
+
+
+def test_the_managed_root_must_exist():
+    with pytest.raises(ValidationErrors) as ve:
+        call("s3.update", {"managed_root_dataset": f"{pool}/s3-no-such-root"})
+    assert "managed_root_dataset" in ve.value.errors[0].attribute
+    assert call("s3.config")["managed_root_dataset"] != f"{pool}/s3-no-such-root"
+
+
 def test_existing_dataset_is_refused(owner):
     with dataset("s3-preexisting") as ds:
         with pytest.raises(ValidationErrors):


### PR DESCRIPTION
An S3 client creating a bucket sends a name and nothing about placement, so something has to decide where the dataset goes. That decision is this service's: the S3 daemon holds no ZFS layout, and a daemon that composed a dataset name would be holding half of a policy whose other half it cannot see.

The S3 service gains managed_root_dataset and sharing.s3.create's dataset becomes optional. Omitted, the dataset is created under that root and named after the bucket. Empty is the default and refuses a bucket that named no dataset, which is what an appliance whose administrator has not chosen a location should do rather than picking one. The root must exist and is never created: a service that made a dataset out of a string typed into its configuration would make one out of a typo just as readily. It is checked at s3.update, because a create is the wrong place to learn the service is misconfigured - the client that provoked it can do nothing about it.

A leaf already taken gets a _N suffix. It is not adopted and what stands there is not removed: deleting a bucket keeps its dataset and every object in it, so a bucket recreated under a name used before must land somewhere new or it would serve the old bucket's objects as its own. A name is taken if ZFS holds it or if a bucket row claims it - a row whose dataset was destroyed out of band still owns the name, the column being unique. The separator is an underscore because a bucket name cannot hold one, so backups_1 is always the second dataset for bucket backups, where backups-1 would equally be what a bucket named backups-1 derives.

An access key gains two fields. manage_buckets says whether the key may ask for those operations at all: an account may hold several keys, and one given to a backup product does not need what an administrator's key reaches. It defaults to false, or an upgrade would widen every existing key, and it is refused for an account without SHARING_S3_WRITE - a key set that way is one whose every bucket call middleware refuses. Roles come from privilege.roles_for_user, the endpoint api_key.create uses, because user.query reports no roles at all for directory services accounts. Checked when a call turns the flag on rather than whenever the row holds it, so losing the role later does not fail an unrelated rename; a stale flag grants nothing, middleware still deciding.

last_used_at is when the S3 service last accepted a request signed with the key, so a key can be retired knowing whether anything still uses it. The service counts uses in memory and reports them through s3.accesskey.report_usage, which is private: no administrator has a reason to report usage, and the write skips the config render because a timestamp changes no file the daemon reads. Stored as unix seconds, like expiry, since the reporter is the daemon and an integer needs no agreement about timezones. Only that endpoint may move it - the update shape excludes the field, the base model forbids extra ones, and compress drops it, because an update model-dumps the whole entry and writing back what it read would undo a flush that landed in between.

The S3_BUCKET_OWNER_ENFORCED permissions model goes with all this. It was the pair spelled as one value, kept to carry the last API consumer over, and the UI has removed the option. Nothing stored held it: normalize_ownership resolved it before compress on both paths, so removing it refuses a caller that names it and cannot fail a row read back. That function loses three arguments with it, which existed for the one validation the fold needed.

Original PR: https://github.com/truenas/middleware/pull/19665
