### PR TITLE
NAS-143382 / 27.0.0-BETA.1 / Fix rsync extra arguments quoting (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync/task.py
+++ b/src/middlewared/middlewared/plugins/rsync/task.py
@@ -12,7 +12,7 @@ from middlewared.alert.source.rsync import RsyncFailedAlert, RsyncSuccessAlert
 from middlewared.service import CallError, ServiceContext
 from middlewared.utils.user_context import run_command_with_user_context
 
-from .utils import get_host_key_file_contents_from_ssh_credentials
+from .utils import get_host_key_file_contents_from_ssh_credentials, quote_extra_args
 
 if TYPE_CHECKING:
     from middlewared.job import Job
@@ -74,7 +74,7 @@ def build_commandline(context: ServiceContext, id_: int) -> Iterator[str]:
             if getattr(rsync, name):
                 line.append(flag)
         if rsync.extra:
-            line.extend(shlex.quote(arg) for arg in rsync.extra)
+            line.extend(quote_extra_args(rsync.extra))
 
         remote_username = remote_host = ""
         if not rsync.ssh_credentials:

--- a/src/middlewared/middlewared/plugins/rsync/utils.py
+++ b/src/middlewared/middlewared/plugins/rsync/utils.py
@@ -1,3 +1,5 @@
+import shlex
+
 from middlewared.api.current import SSHCredentials
 
 
@@ -13,3 +15,14 @@ def get_host_key_file_contents_from_ssh_credentials(credentials: SSHCredentials)
             if host_key.strip() and not host_key.strip().startswith("#")
         ]
     )
+
+
+def quote_extra_args(extra: list[str]) -> list[str]:
+    args = []
+    for arg in extra:
+        try:
+            args.extend(shlex.split(arg))
+        except ValueError:
+            args.append(arg)
+
+    return [shlex.quote(arg) for arg in args]

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
@@ -1,0 +1,56 @@
+import pytest
+
+from middlewared.plugins.rsync_.utils import quote_extra_args
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (['--rsync-path="sudo rsync"'], ["'--rsync-path=sudo rsync'"]),
+        (["--rsync-path='sudo rsync'"], ["'--rsync-path=sudo rsync'"]),
+        (['--rsync-path="/usr/bin/env rsync"'], ["'--rsync-path=/usr/bin/env rsync'"]),
+        (['--exclude="my file"'], ["'--exclude=my file'"]),
+        (
+            ['--rsync-path="sudo rsync"', '--exclude="my file"'],
+            ["'--rsync-path=sudo rsync'", "'--exclude=my file'"],
+        ),
+    ],
+)
+def test_quoted_value_is_regrouped(extra, expected):
+    """The user's quotes group the value; they must not survive into the argument itself."""
+    assert quote_extra_args(extra) == expected
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (["-avz"], ["-avz"]),
+        (["--rsync-path=/usr/bin/rsync"], ["--rsync-path=/usr/bin/rsync"]),
+        (['--rsync-path="/usr/bin/rsync"'], ["--rsync-path=/usr/bin/rsync"]),
+        (["--exclude", "excluded_file"], ["--exclude", "excluded_file"]),
+        ([], []),
+    ],
+)
+def test_options_needing_no_grouping(extra, expected):
+    assert quote_extra_args(extra) == expected
+
+
+def test_glob_is_quoted_against_the_local_shell():
+    """The command line is run through a shell, so patterns rsync expands itself must stay unexpanded."""
+    assert quote_extra_args(["--bwlimit=1000", "--exclude", "*.tmp"]) == [
+        "--bwlimit=1000",
+        "--exclude",
+        "'*.tmp'",
+    ]
+
+
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        (['"'], ["'\"'"]),
+        (["--exclude", '"unclosed'], ["--exclude", "'\"unclosed'"]),
+    ],
+)
+def test_unbalanced_quotes_are_passed_through(extra, expected):
+    """A misconfigured value stored by an older version has no grouping to resolve, so it is left alone."""
+    assert quote_extra_args(extra) == expected

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_rsync_extra_args.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.plugins.rsync_.utils import quote_extra_args
+from middlewared.plugins.rsync.utils import quote_extra_args
 
 
 @pytest.mark.parametrize(
@@ -49,6 +49,10 @@ def test_glob_is_quoted_against_the_local_shell():
     [
         (['"'], ["'\"'"]),
         (["--exclude", '"unclosed'], ["--exclude", "'\"unclosed'"]),
+        (
+            ['--rsync-path="sudo rsync"', "--exclude=foo\\"],
+            ["'--rsync-path=sudo rsync'", "'--exclude=foo\\'"],
+        ),
     ],
 )
 def test_unbalanced_quotes_are_passed_through(extra, expected):

--- a/tests/api2/test_rsync_ssh_authentication.py
+++ b/tests/api2/test_rsync_ssh_authentication.py
@@ -811,6 +811,27 @@ def test_run_with_extra_options(cleanup, localuser, remoteuser, src, dst, ssh_cr
     assert "excluded_file" not in files
 
 
+def test_run_with_quoted_multiword_rsync_path(cleanup, localuser, remoteuser, src, dst, ssh_credentials):
+    """A quoted multi-word ``--rsync-path`` (e.g. ``"sudo rsync"``) must reach rsync without its quotes.
+
+    Quoting the value verbatim makes rsync ask the remote shell for a single word named
+    ``/usr/bin/env rsync``, which fails with ``command not found``.
+    """
+    with task({
+        "path": f"{src}/",
+        "user": "localuser",
+        "ssh_credentials": ssh_credentials["credentials"]["id"],
+        "mode": "SSH",
+        "remotepath": dst,
+        "extra": ['--rsync-path="/usr/bin/env rsync"'],
+    }) as t:
+        assert t["extra"] == ['--rsync-path="/usr/bin/env rsync"']
+
+        run_task(t)
+
+    assert ssh(f"ls -1 {dst}") == "test\n"
+
+
 def test_run_quiet(cleanup, localuser, remoteuser, src, dst, ssh_credentials):
     with task({
         "path": f"{src}/",


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/19496 introduced a regression: the user had `--rsync-path="sudo rsync"` in their `extra` args, and the argument value was used literally, causing `bash: line 1: sudo rsync: command not found` error (it tried to launch `sudo rsync` binary which didn't exist).

This is a 25.10.7 bug that didn't exist in 25.10.6, so, if we're ever publishing 25.10.8, it should be backported there.

Original PR: https://github.com/truenas/middleware/pull/19655
