### PR TITLE
NAS-143516 / 27.0.0-BETA.1 / rename the s3 service from truenas_s3 to s3 (by anodos325)

### DIFF
--- a/src/freenas/etc/logrotate.d/truenas_s3
+++ b/src/freenas/etc/logrotate.d/truenas_s3
@@ -1,0 +1,12 @@
+/var/log/truenas_s3.log
+{
+	rotate 3
+	size 3M
+	missingok
+	notifempty
+	compress
+	delaycompress
+	postrotate
+		invoke-rc.d syslog-ng reload > /dev/null
+	endscript
+}

--- a/src/middlewared/middlewared/alembic/versions/26.0/2026-09-09_21-00_s3_service_name.py
+++ b/src/middlewared/middlewared/alembic/versions/26.0/2026-09-09_21-00_s3_service_name.py
@@ -1,0 +1,34 @@
+"""Name the S3 service s3 rather than truenas_s3
+
+Revision ID: 98358f332844
+Revises: b7e3f1a92c48
+Create Date: 2026-09-09 21:00:00.000000+00:00
+
+"""
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = '98358f332844'
+down_revision = 'b7e3f1a92c48'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # The row is what service.query reports and what every service name
+    # is looked up against, so it has to move with ServiceInterface.name.
+    # A row left under the old name matches no registered service:
+    # service.systemd_units raises MatchNotFound for it, which drops the
+    # service out of the systemd etc render and out of a configuration
+    # upload's enable/disable pass without an error either place.
+    #
+    # The daemon keeps the old name. Its systemd unit, its /etc directory
+    # and the services_truenas_s3 table are the truenas_s3 package's, not
+    # the API's, and none of them is what a caller names.
+    op.execute(text("UPDATE services_services SET srv_service = 's3' WHERE srv_service = 'truenas_s3'"))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/27.0/2026-09-10_11-32_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/27.0/2026-09-10_11-32_merge.py
@@ -1,0 +1,22 @@
+"""Merge migration for the S3 service rename (revision 98358f332844)
+
+Revision ID: 09cc64d01835
+Revises: 96ac58d1fefc, 98358f332844
+Create Date: 2026-09-10 11:32:00.000000+00:00
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '09cc64d01835'
+down_revision = ('96ac58d1fefc', '98358f332844')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -64,6 +64,13 @@ filter f_scst {
 filter f_discovery {
   program("truenas-discoveryd");
 };
+## the S3 daemon's own messages. It never opens /dev/log: under systemd it
+## writes journal-native datagrams carrying SYSLOG_IDENTIFIER=s3d, which
+## the system() source reads back as $PROGRAM. Its audit records are a
+## separate path, arriving on s_tn_auditd as TNAUDIT_S3
+filter f_truenas_s3 {
+  program("s3d");
+};
 
 # TrueNAS middleware filters
 % for tnlog in ALL_LOG_FILES:
@@ -77,7 +84,8 @@ filter f_truenas_exclude {
   not filter(f_tnaudit_all) and
   not filter(f_ctdb) and
   not filter(f_scst) and
-  not filter(f_discovery);
+  not filter(f_discovery) and
+  not filter(f_truenas_s3);
 };
 
 #####################

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -150,6 +150,13 @@ log {
   flags(final);
 };
 
+log {
+  source(s_src);
+  filter(f_truenas_s3);
+  destination { file("/var/log/truenas_s3.log"); };
+  flags(final);
+};
+
 #######################
 # Middlewared-related log files
 ########################

--- a/src/middlewared/middlewared/plugins/service/services/all.py
+++ b/src/middlewared/middlewared/plugins/service/services/all.py
@@ -34,11 +34,11 @@ from .pseudo.misc import (
     TimeservicesService,
     UserService,
 )
+from .s3 import TrueNASS3Service
 from .snmp import SNMPService
 from .ssh import SSHService
 from .sssd import SSSDService
 from .truecommand import TruecommandService
-from .truenas_s3 import TrueNASS3Service
 from .truenas_zfstierd import TruenasZfstierdService
 from .truesearch import TruesearchService
 from .ups import UPSService

--- a/src/middlewared/middlewared/plugins/service/services/s3.py
+++ b/src/middlewared/middlewared/plugins/service/services/s3.py
@@ -2,7 +2,7 @@ from .base import SimpleService
 
 
 class TrueNASS3Service(SimpleService):
-    name = "truenas_s3"
+    name = "s3"
     etc = ["truenas_s3"]
     reloadable = True
     restartable = True

--- a/src/middlewared/middlewared/plugins/service/utils.py
+++ b/src/middlewared/middlewared/plugins/service/utils.py
@@ -15,7 +15,7 @@ class ServiceWriteRole(enum.Enum):
     ISCSITARGET = 'SHARING_ISCSI_WRITE'
     FTP = 'SHARING_FTP_WRITE'
     NVMET = 'SHARING_NVME_TARGET_WRITE'
-    TRUENAS_S3 = 'SHARING_S3_WRITE'
+    S3 = 'SHARING_S3_WRITE'
 
 
 def app_has_write_privilege_for_service(app: App | None, service: str) -> bool:

--- a/src/middlewared/middlewared/plugins/truenas_s3/accesskey_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/accesskey_crud.py
@@ -199,6 +199,17 @@ class S3AccesskeyServicePart(CRUDServicePart[S3AccesskeyEntry]):
         users = await self.middleware.call("user.query", [["username", "=", data.username]])
         if not users:
             verrors.add("s3_accesskey_create.username", "User does not exist.")
+        elif users[0]["uid"] == 0:
+            # the S3 service runs a signed request as the account the key
+            # belongs to, and uid 0 is the account no filesystem permission
+            # and no bucket grant restrains. Such a key reaches every object
+            # on the appliance whatever its bucket allows, and every object
+            # it writes lands owned by root
+            verrors.add(
+                "s3_accesskey_create.username",
+                "An access key may not belong to root. Give the key an account that owns only what it should "
+                "reach.",
+            )
 
         if data.access_key is not None and await self.middleware.call(
             "datastore.query", self._datastore, [["access_key", "=", data.access_key]]

--- a/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
@@ -243,13 +243,23 @@ class SharingS3Service(SharingService[SharingS3Entry]):
 
     @private
     async def resolve_owner(self, schema: str, username: str, verrors: ValidationErrors) -> int | None:
-        """The owner's uid."""
+        """The owner's uid, refusing root.
+
+        The owner bypasses the bucket's grants, owns the `s3data`
+        directory the service creates, and owns every object written
+        under `BUCKET_OWNER_ENFORCED`. As uid 0 that is an owner the
+        filesystem does not restrain either, which leaves the bucket's
+        access control stating nothing about what its owner reaches.
+        """
         try:
             user = await self.middleware.call("user.get_user_obj", {"username": username})
         except KeyError:
             verrors.add(f"{schema}.owner", f"User {username!r} does not exist.")
             return None
         uid: int = user["pw_uid"]
+        if uid == 0:
+            verrors.add(f"{schema}.owner", "A bucket may not be owned by root.")
+            return None
         return uid
 
     @private
@@ -513,7 +523,7 @@ class SharingS3Service(SharingService[SharingS3Entry]):
 class S3FSAttachmentDelegate(LockableFSAttachmentDelegate[SharingS3Entry]):
     name = "s3"
     title = "S3 Bucket"
-    service = "truenas_s3"
+    service = "s3"
     service_class = SharingS3Service
 
     async def remove_alert(self, attachment: SharingS3Entry) -> None:

--- a/src/middlewared/middlewared/plugins/truenas_s3/config.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/config.py
@@ -136,7 +136,7 @@ def _rendered_grants(grants: Sequence[S3GrantEntry], bucket: str) -> list[Render
 class S3ConfigPart(SystemServicePart[S3Entry]):
     _datastore = "services.truenas_s3"
     _entry = S3Entry
-    _service = "truenas_s3"
+    _service = "s3"
 
     async def config(self) -> S3Entry:
         # the base get-or-insert creates the row the identities are stored in
@@ -373,7 +373,7 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
 
 class S3Service(SystemServiceService[S3Entry]):
     class Config:
-        service = "truenas_s3"
+        service = "s3"
         service_verb = "reload"
         datastore = "services.truenas_s3"
         cli_namespace = "service.s3"

--- a/src/middlewared/middlewared/plugins/truenas_s3/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/lifecycle.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from middlewared.api.current import ServiceEntry
     from middlewared.main import Middleware
 
-SERVICE = "truenas_s3"
+SERVICE = "s3"
 ETC_GROUP = "truenas_s3"
 MISSING_ALERT = "S3BucketDatasetMissing"
 CONTROL_SOCKET = "/run/truenas_s3/control"

--- a/tests/api2/test_s3_accesskey.py
+++ b/tests/api2/test_s3_accesskey.py
@@ -122,6 +122,17 @@ def test_unknown_user_is_refused():
     assert "User does not exist" in ve.value.errors[0].errmsg
 
 
+def test_root_may_not_hold_an_access_key():
+    """The S3 service runs a signed request as the account the key belongs
+    to, and uid 0 is the account no bucket grant and no filesystem
+    permission restrains."""
+    with pytest.raises(ValidationErrors) as ve:
+        call("s3.accesskey.create", {"name": "root key", "username": "root"})
+    assert "username" in ve.value.errors[0].attribute
+    assert "root" in ve.value.errors[0].errmsg
+    assert not call("s3.accesskey.query", [["name", "=", "root key"]])
+
+
 def test_access_key_never_authenticates_to_the_api(accesskey):
     """Nothing in the API authentication path reads this table."""
     with client(auth=None) as c:

--- a/tests/api2/test_s3_bucket.py
+++ b/tests/api2/test_s3_bucket.py
@@ -16,7 +16,7 @@ from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.pool import dataset, pool
 from middlewared.test.integration.utils import call, ssh
 
-SERVICE = "truenas_s3"
+SERVICE = "s3"
 BUCKETS_CONF = "/etc/truenas_s3/buckets.conf"
 POLICIES_CONF = "/etc/truenas_s3/policies.conf"
 OWNER = "s3bucketowner"
@@ -229,6 +229,25 @@ def test_unknown_owner_is_refused():
         )
     assert "does not exist" in ve.value.errors[0].errmsg
     assert zfs_props(DATASET, ["mountpoint"]) is None, "nothing was created"
+
+
+def test_root_may_not_own_a_bucket(owner):
+    """The owner bypasses the bucket's grants and owns every object written
+    under `BUCKET_OWNER_ENFORCED`, and uid 0 is an owner the filesystem
+    does not restrain either. Refused on both paths that set one."""
+    with pytest.raises(ValidationErrors) as ve:
+        call(
+            "sharing.s3.create",
+            {"name": "root-owned", "dataset": DATASET, "owner": "root"},
+        )
+    assert "owner" in ve.value.errors[0].attribute
+    assert zfs_props(DATASET, ["mountpoint"]) is None, "nothing was created"
+
+    with bucket() as b:
+        with pytest.raises(ValidationErrors) as ve:
+            call("sharing.s3.update", b["id"], {"owner": "root"})
+        assert "owner" in ve.value.errors[0].attribute
+        assert call("sharing.s3.get_instance", b["id"])["owner"] == OWNER
 
 
 def test_grants_live_on_the_bucket(owner):

--- a/tests/api2/test_s3_config.py
+++ b/tests/api2/test_s3_config.py
@@ -12,7 +12,7 @@ from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.utils import call, ssh
 
-SERVICE = "truenas_s3"
+SERVICE = "s3"
 BUCKETS_CONF = "/etc/truenas_s3/buckets.conf"
 POLICIES_CONF = "/etc/truenas_s3/policies.conf"
 CREDENTIALS_CONF = "/etc/truenas_s3/credentials.conf"


### PR DESCRIPTION
service.query reported it as truenas_s3, the daemon's name rather than the protocol's. The services_services row has to move with ServiceInterface.name or nothing resolves it, so a migration renames it; ServiceWriteRole is keyed by the name upper-cased and moves too.

Root is refused as an access key account and as a bucket owner. Both run as uid 0, which no bucket grant and no file mode restrains.

The daemon's own messages get /var/log/truenas_s3.log, filtered on the journal identifier it writes, s3d, and rotated the way scst and truenas-discoveryd are. Its audit records are a separate path and are untouched.

The systemd unit, the etc group and the tables keep the truenas_s3 name: they are the daemon's, and nothing outside middleware names them.

Original PR: https://github.com/truenas/middleware/pull/19672
