### PR TITLE
NAS-141987 / 26.0.0 / Rework snapshot rollback with batched destroys (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/pool_snapshot.py
+++ b/src/middlewared/middlewared/api/v26_0_0/pool_snapshot.py
@@ -152,7 +152,7 @@ class PoolSnapshotReleaseOptions(BaseModel):
 class PoolSnapshotRollbackOptions(BaseModel):
     recursive: bool = Field(
         default=False,
-        description="Destroy any snapshots and bookmarks more recent than the one specified.",
+        description="Destroy any snapshots more recent than the one specified.",
     )
     recursive_clones: bool = Field(default=False, description="Just like `recursive`, but also destroy any clones.")
     force: bool = Field(default=False, description="Force unmount of any clones.")

--- a/src/middlewared/middlewared/api/v26_0_0/zfs_resource_snapshot.py
+++ b/src/middlewared/middlewared/api/v26_0_0/zfs_resource_snapshot.py
@@ -388,7 +388,7 @@ class ZFSResourceSnapshotRollbackQuery(BaseModel):
     path: NonEmptyString = Field(description="Snapshot path to rollback to (e.g., 'pool/dataset@snapshot').")
     recursive: bool = Field(
         default=False,
-        description="Destroy any snapshots and bookmarks more recent than the one specified.",
+        description="Destroy any snapshots more recent than the one specified.",
     )
     recursive_clones: bool = Field(default=False, description="Like recursive, but also destroy any clones.")
     force: bool = Field(default=False, description="Force unmount of any clones.")

--- a/src/middlewared/middlewared/plugins/pool_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot.py
@@ -29,7 +29,12 @@ from middlewared.api.current import (
     ZFSResourceSnapshotQuery,
 )
 from middlewared.service import CRUDService, filterable_api_method, InstanceNotFound, ValidationError
-from middlewared.plugins.zfs.exceptions import ZFSPathAlreadyExistsException, ZFSPathNotFoundException
+from middlewared.plugins.zfs.exceptions import (
+    ZFSPathAlreadyExistsException,
+    ZFSPathNotASnapshotException,
+    ZFSPathNotFoundException,
+    ZFSRollbackConflictException,
+)
 from middlewared.utils.filter_list import filter_list
 
 
@@ -60,10 +65,17 @@ class PoolSnapshotService(CRUDService):
         roles=['SNAPSHOT_WRITE', 'POOL_WRITE']
     )
     def rollback(self, id_, options):
-        self.call_sync2(self.s.zfs.resource.snapshot.rollback_impl, ZFSResourceSnapshotRollbackQuery(
-            path=id_,
-            **options,
-        ))
+        try:
+            self.call_sync2(self.s.zfs.resource.snapshot.rollback_impl, ZFSResourceSnapshotRollbackQuery(
+                path=id_,
+                **options,
+            ))
+        except ZFSPathNotFoundException as e:
+            raise ValidationError('pool.snapshot.rollback', e.message, errno.ENOENT)
+        except ZFSPathNotASnapshotException as e:
+            raise ValidationError('pool.snapshot.rollback', e.message, errno.EINVAL)
+        except ZFSRollbackConflictException as e:
+            raise ValidationError('pool.snapshot.rollback', e.message, errno.EINVAL)
 
     @api_method(PoolSnapshotHoldArgs, PoolSnapshotHoldResult, roles=['SNAPSHOT_WRITE'])
     def hold(self, id_, options):

--- a/src/middlewared/middlewared/plugins/zfs/exceptions.py
+++ b/src/middlewared/middlewared/plugins/zfs/exceptions.py
@@ -1,13 +1,18 @@
-from typing import Iterable
+from typing import Iterable, Sequence
 
 __all__ = (
     "ZFSKeyAlreadyLoadedException",
     "ZFSNotEncryptedException",
     "ZFSPathAlreadyExistsException",
+    "ZFSPathHasClonesException",
+    "ZFSPathHasHoldsException",
     "ZFSPathInvalidException",
     "ZFSPathNotASnapshotException",
     "ZFSPathNotFoundException",
     "ZFSPathNotProvidedException",
+    "ZFSRollbackBlockedException",
+    "ZFSRollbackConflictException",
+    "ZFSRollbackFailedException",
 )
 
 
@@ -41,6 +46,51 @@ class ZFSPathHasHoldsException(Exception):
     def __init__(self, path: str, holds: Iterable[str]):
         self.message = f"{path!r} has the following holds: {','.join(holds)}"
         super().__init__(self.message)
+
+
+class ZFSRollbackBlockedException(Exception):
+    """Snapshots newer than the rollback target have holds, or clones that may not be destroyed."""
+
+    def __init__(self, path: str, blockers: Sequence[str]):
+        self.path = path
+        self.blockers = tuple(blockers)
+        self.message = (
+            f"Cannot rollback to {path!r}: the following snapshots must be destroyed first, but are blocked:\n"
+            + "\n".join(f"  {blocker}" for blocker in self.blockers)
+        )
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ZFSRollbackConflictException(Exception):
+    """Snapshots newer than the rollback target exist and may not be destroyed."""
+
+    def __init__(self, path: str, conflicts: Sequence[str]):
+        self.path = path
+        self.conflicts = tuple(conflicts)
+        self.message = (
+            "Cannot rollback: more recent snapshots exist. Please pass `recursive: true` to "
+            "delete the following snapshots recursively:\n" +
+            "\n".join(f"  {conflict}" for conflict in self.conflicts)
+        )
+        super().__init__(path, self.conflicts)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ZFSRollbackFailedException(Exception):
+    """A rollback, or a destroy the rollback depends on, failed for an operational reason."""
+
+    def __init__(self, message: str, errnum: int):
+        self.errnum = errnum
+        self.message = message
+        super().__init__(message, errnum)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class ZFSPathInvalidException(Exception):

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_crud.py
@@ -1,6 +1,8 @@
 import errno
 from typing import Any
 
+import truenas_pylibzfs
+
 from middlewared.api import api_method
 from middlewared.api.current import (
     ZFSResourceSnapshotEntry,
@@ -37,7 +39,7 @@ from middlewared.api.current import (
     ZFSResourceSnapshotRollbackResult,
 )
 from middlewared.service import Service, private
-from middlewared.service_exception import ValidationError
+from middlewared.service_exception import CallError, ValidationError
 from middlewared.service.decorators import pass_thread_local_storage
 
 from .destroy_impl import destroy_impl
@@ -47,6 +49,9 @@ from .exceptions import (
     ZFSPathHasHoldsException,
     ZFSPathNotASnapshotException,
     ZFSPathNotFoundException,
+    ZFSRollbackBlockedException,
+    ZFSRollbackConflictException,
+    ZFSRollbackFailedException,
 )
 from .rename_promote_clone_impl import clone_impl, rename_impl
 from .snapshot_count_impl import count_snapshots_impl
@@ -760,14 +765,21 @@ class ZFSResourceSnapshotService(Service):
             if has_internal_path(check_path):
                 raise ValidationError(schema, f"{data.path!r} is a protected path.", errno.EACCES)
 
-        return rollback_impl(
-            tls,
-            path=data.path,
-            recursive=data.recursive,
-            recursive_clones=data.recursive_clones,
-            force=data.force,
-            recursive_rollback=data.recursive_rollback,
-        )
+        try:
+            return rollback_impl(
+                tls,
+                path=data.path,
+                recursive=data.recursive,
+                recursive_clones=data.recursive_clones,
+                force=data.force,
+                recursive_rollback=data.recursive_rollback,
+            )
+        except truenas_pylibzfs.ZFSException as e:
+            raise CallError(f"Failed to rollback {data.path!r}: {e}")
+        except ZFSRollbackBlockedException as e:
+            raise CallError(e.message, errno.EBUSY)
+        except ZFSRollbackFailedException as e:
+            raise CallError(e.message, e.errnum)
 
     @api_method(
         ZFSResourceSnapshotRollbackArgs,
@@ -785,7 +797,7 @@ class ZFSResourceSnapshotService(Service):
         Args:
             data: Rollback parameters containing:
                 - path: Snapshot path to rollback to (e.g., 'pool/dataset@snapshot').
-                - recursive: Destroy any snapshots and bookmarks more recent than the one specified.
+                - recursive: Destroy any snapshots more recent than the one specified.
                 - recursive_clones: Like recursive, but also destroy any clones.
                 - force: Force unmount of any clones.
                 - recursive_rollback: Do a complete recursive rollback of each child snapshot.
@@ -794,7 +806,12 @@ class ZFSResourceSnapshotService(Service):
             None on success.
 
         Raises:
-            ValidationError: If snapshot not found or rollback fails.
+            ValidationError: If `path` is not a snapshot path, the snapshot (or a child's snapshot)
+                does not exist, snapshots more recent than `path` exist and neither `recursive` nor
+                `recursive_clones` was passed, or `path` is protected.
+            CallError: If a snapshot that has to be destroyed first has holds, or has clones and
+                `recursive_clones` was not passed (errno EBUSY), or if a destroy or the rollback
+                itself failed, with the errno the kernel reported.
 
         Examples:
             # Basic rollback
@@ -806,18 +823,19 @@ class ZFSResourceSnapshotService(Service):
             # Rollback all child datasets
             rollback({"path": "tank@backup", "recursive_rollback": True})
         """
-        # Validate path is a snapshot
-        if "@" not in data.path:
-            raise ValidationError(
-                "zfs.resource.snapshot.rollback",
-                "path must be a snapshot path (containing '@').",
-            )
-
         try:
             self.call_sync2(self.s.zfs.resource.snapshot.rollback_impl, data)
         except ZFSPathNotFoundException as e:
             raise ValidationError(
                 "zfs.resource.snapshot.rollback", e.message, errno.ENOENT
+            )
+        except ZFSPathNotASnapshotException as e:
+            raise ValidationError(
+                "zfs.resource.snapshot.rollback", e.message, errno.EINVAL
+            )
+        except ZFSRollbackConflictException as e:
+            raise ValidationError(
+                "zfs.resource.snapshot.rollback", e.message, errno.EINVAL
             )
         except ValueError as e:
             raise ValidationError(

--- a/src/middlewared/middlewared/plugins/zfs/snapshot_rollback_impl.py
+++ b/src/middlewared/middlewared/plugins/zfs/snapshot_rollback_impl.py
@@ -1,9 +1,20 @@
+from collections.abc import Sequence
 import dataclasses
+import errno
+import os
 from typing import Any
 
 import truenas_pylibzfs
 
-from .exceptions import ZFSPathNotFoundException, ZFSPathNotASnapshotException
+from .destroy_impl import destroy_impl
+from .exceptions import (
+    ZFSPathNotASnapshotException,
+    ZFSPathNotFoundException,
+    ZFSRollbackBlockedException,
+    ZFSRollbackConflictException,
+    ZFSRollbackFailedException,
+)
+from .utils import open_resource
 
 __all__ = ("rollback_impl",)
 
@@ -22,38 +33,111 @@ def __collect_child_datasets_callback(child_hdl: Any, state: list[str]) -> bool:
     return True
 
 
-def _collect_child_datasets(ds_hdl: Any, datasets: list[str]) -> None:
-    """Recursively collect all child dataset names."""
-    ds_hdl.iter_filesystems(callback=__collect_child_datasets_callback, state=datasets)
-
-
 def __collect_newer_snapshots_callback(snap_hdl: Any, state: CollectNewerSnapshotsState) -> bool:
     """Callback for collecting snapshots newer than target."""
     props = snap_hdl.get_properties(properties={truenas_pylibzfs.ZFSProperty.CREATETXG})
-    snap_txg = int(props.createtxg.value)
-    if snap_txg > state.target_txg:
+    if int(props.createtxg.value) > state.target_txg:
         state.snaps.append(snap_hdl.name)
     return True
 
 
-def _rollback_single(dataset: str, snap_name: str) -> str:
-    """Execute rollback for a single dataset.
-
-    Args:
-        dataset: Dataset path (e.g., 'pool/dataset')
-        snap_name: Snapshot name (e.g., 'snap1')
-
-    Returns:
-        Name of snapshot rolled back to
+def _collect_newer_snapshots(tls: Any, dataset: str, snap_name: str) -> list[str]:
+    """Return the snapshots of ``dataset`` newer than ``snap_name``, oldest first.
 
     Raises:
-        FileExistsError: If more recent snapshots exist
-        FileNotFoundError: If snapshot doesn't exist
+        ZFSPathNotFoundException: ``dataset`` has no ``snap_name``.
     """
-    return truenas_pylibzfs.lzc.rollback(
-        resource_name=dataset,
-        snapshot_name=snap_name,
+    target_txg = int(open_resource(tls, f"{dataset}@{snap_name}").createtxg)
+    state = CollectNewerSnapshotsState(target_txg=target_txg, snaps=[])
+    open_resource(tls, dataset).iter_snapshots(
+        callback=__collect_newer_snapshots_callback,
+        state=state,
+        min_transaction_group=target_txg,
+        order_by_transaction_group=True,
     )
+    return state.snaps
+
+
+def _collect_blockers(tls: Any, newer_snaps: Sequence[str], destroy_clones: bool) -> list[str]:
+    """Describe each of ``newer_snaps`` that cannot be destroyed, and why."""
+    blockers = []
+    for snap_path in newer_snaps:
+        try:
+            snap_rsrc = open_resource(tls, snap_path)
+        except ZFSPathNotFoundException:
+            continue
+
+        if holds := snap_rsrc.get_holds():
+            blockers.append(f"{snap_path!r} has holds: {', '.join(holds)}. Release them before rolling back.")
+        if (clones := snap_rsrc.get_clones()) and not destroy_clones:
+            blockers.append(
+                f"{snap_path!r} has dependent clones: {', '.join(clones)}. "
+                "Pass `recursive_clones: true` to destroy them."
+            )
+    return blockers
+
+
+def _destroy_clones_of(tls: Any, snap_path: str, force: bool) -> None:
+    """Destroy the clones of ``snap_path``, descendants included, so that the snapshot itself can be destroyed.
+
+    Matches ``zfs rollback -R``, which destroys a clone's own children and snapshots along with it.
+    """
+    try:
+        clones = open_resource(tls, snap_path).get_clones()
+    except ZFSPathNotFoundException:
+        return
+
+    for clone in clones:
+        try:
+            clone_rsrc = open_resource(tls, clone)
+        except ZFSPathNotFoundException:
+            continue
+
+        if force and clone_rsrc.type == truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM:
+            # The recursive destroy unmounts the clone tree itself, but never forcibly.
+            try:
+                clone_rsrc.unmount(force=True, recursive=True, unload_encryption_key=False)
+            except truenas_pylibzfs.ZFSException:
+                pass  # The destroy below reports why the unmount was needed.
+
+        failed, errnum = destroy_impl(tls, clone, recursive=True, all_snapshots=False, bypass=True, defer=False)
+        if failed:
+            raise ZFSRollbackFailedException(
+                f"{failed}. It is a clone of {snap_path!r}, which has to be destroyed for the rollback.",
+                errnum or errno.EFAULT,
+            )
+
+
+def _destroy_newer_snapshots(
+    tls: Any, dataset: str, snap_name: str, newer_snaps: Sequence[str], destroy_clones: bool, force: bool
+) -> None:
+    """Destroy ``newer_snaps`` in one ioctl, so the kernel either destroys all of them or none."""
+    if destroy_clones:
+        for snap_path in newer_snaps:
+            _destroy_clones_of(tls, snap_path, force)
+
+    try:
+        truenas_pylibzfs.lzc.destroy_snapshots(snapshot_names=newer_snaps, defer_destroy=False)
+    except truenas_pylibzfs.lzc.ZFSCoreException as e:
+        details = "; ".join(f"{name}: {os.strerror(err)}" for name, err in e.errors or ()) or str(e)
+        raise ZFSRollbackFailedException(
+            f"Failed to destroy the snapshots newer than {snap_name!r} on {dataset!r}: {details}", e.code
+        ) from None
+
+
+def _rollback(dataset: str, snap_name: str) -> None:
+    """Roll ``dataset`` back to ``snap_name``."""
+    try:
+        truenas_pylibzfs.lzc.rollback(resource_name=dataset, snapshot_name=snap_name)
+    except OSError as e:
+        errnum = e.errno or errno.EFAULT
+        message = f"Failed to rollback to {dataset}@{snap_name}: {os.strerror(errnum)}."
+        if errnum == errno.EEXIST:
+            message += (
+                " Something newer than the snapshot still exists. Bookmarks are not destroyed by this "
+                f"operation; remove one with `zfs destroy {dataset}#<bookmark>` and try again."
+            )
+        raise ZFSRollbackFailedException(message, errnum) from None
 
 
 def rollback_impl(
@@ -72,134 +156,42 @@ def rollback_impl(
     Args:
         tls: Thread local storage containing lzh (libzfs handle)
         path: Snapshot path to rollback to (e.g., 'pool/dataset@snapshot').
-        recursive: Destroy any snapshots and bookmarks more recent than the one specified.
+        recursive: Destroy any snapshots more recent than the one specified.
         recursive_clones: Like recursive, but also destroy any clones.
         force: Force unmount of any clones.
         recursive_rollback: Do a complete recursive rollback of each child snapshot.
 
     Raises:
-        ZFSPathNotFoundException: If the snapshot doesn't exist
         ZFSPathNotASnapshotException: If path is not a snapshot path
-        ValueError: If rollback fails
+        ZFSPathNotFoundException: If the snapshot, or a child's snapshot, doesn't exist
+        ZFSRollbackConflictException: If newer snapshots exist and no flag allows destroying them
+        ZFSRollbackBlockedException: If a newer snapshot has holds, or clones that may not be destroyed
+        ZFSRollbackFailedException: If a destroy or the rollback itself failed
+        truenas_pylibzfs.ZFSException: If a resource could not be opened or walked
     """
-
-    # Parse snapshot path
     if "@" not in path:
         raise ZFSPathNotASnapshotException(path)
 
     dataset, snap_name = path.rsplit("@", 1)
+    if not dataset or not snap_name or "@" in dataset:
+        raise ZFSPathNotASnapshotException(path)
 
-    # Verify snapshot exists
-    try:
-        tls.lzh.open_resource(name=path)
-    except truenas_pylibzfs.ZFSException as e:
-        if truenas_pylibzfs.ZFSError(e.code) == truenas_pylibzfs.ZFSError.EZFS_NOENT:
-            raise ZFSPathNotFoundException(path)
-        raise
-
-    # Collect datasets to rollback
+    datasets = [dataset]
     if recursive_rollback:
-        try:
-            ds_hdl = tls.lzh.open_resource(name=dataset)
-        except truenas_pylibzfs.ZFSException as e:
-            if truenas_pylibzfs.ZFSError(e.code) == truenas_pylibzfs.ZFSError.EZFS_NOENT:
-                raise ZFSPathNotFoundException(dataset)
-            raise
+        open_resource(tls, dataset).iter_filesystems(callback=__collect_child_datasets_callback, state=datasets)
 
-        datasets = [dataset]
-        _collect_child_datasets(ds_hdl, datasets)
-    else:
-        datasets = [dataset]
+    # Enumerated for the whole tree before anything is touched: a blocker found lazily on a
+    # child would only surface once the parent had already been rolled back.
+    newer = [(ds, _collect_newer_snapshots(tls, ds, snap_name)) for ds in datasets]
 
-    # Rollback each dataset
-    for ds in datasets:
-        snap_path = f"{ds}@{snap_name}"
+    destroy_newer = recursive or recursive_clones
+    if not destroy_newer:
+        if conflicts := [snap for _, snaps in newer for snap in snaps]:
+            raise ZFSRollbackConflictException(path, conflicts)
+    elif blockers := [b for _, snaps in newer for b in _collect_blockers(tls, snaps, recursive_clones)]:
+        raise ZFSRollbackBlockedException(path, blockers)
 
-        # For recursive_rollback, verify each child snapshot exists
-        if recursive_rollback and ds != dataset:
-            try:
-                tls.lzh.open_resource(name=snap_path)
-            except truenas_pylibzfs.ZFSException as e:
-                if truenas_pylibzfs.ZFSError(e.code) == truenas_pylibzfs.ZFSError.EZFS_NOENT:
-                    raise ZFSPathNotFoundException(snap_path)
-                raise
-
-        # If recursive, destroy more recent snapshots first
-        if recursive or recursive_clones:
-            _destroy_newer_snapshots(tls, ds, snap_name, recursive_clones, force)
-
-        try:
-            _rollback_single(ds, snap_name)
-        except FileNotFoundError:
-            raise ZFSPathNotFoundException(snap_path)
-        except FileExistsError:
-            conflicts = _collect_newer_snapshots(tls, ds, snap_name)
-            raise ValueError(
-                "Cannot rollback: more recent snapshots or bookmarks exist. Please pass `recursive: true` to "
-                "delete the following snapshots and bookmarks recursively:\n" +
-                "\n".join([f"  {snapshot}" for snapshot in conflicts])
-            )
-        except (ValueError, OSError, PermissionError, RuntimeError) as e:
-            raise ValueError(f"Failed to rollback snapshot: {e}")
-
-
-def _collect_newer_snapshots(tls: Any, dataset: str, target_snap: str) -> list[str]:
-    """Return the snapshots of ``dataset`` that are newer than ``target_snap``.
-
-    The names are ordered by ascending creation transaction group, matching the
-    order ``zfs rollback -r`` reports the snapshots it would force-delete.
-    Returns an empty list if the target or dataset can no longer be opened.
-    """
-    target_path = f"{dataset}@{target_snap}"
-    try:
-        target_rsrc = tls.lzh.open_resource(name=target_path)
-        target_txg = int(target_rsrc.createtxg)
-        ds_hdl = tls.lzh.open_resource(name=dataset)
-    except truenas_pylibzfs.ZFSException:
-        return []
-
-    state = CollectNewerSnapshotsState(target_txg=target_txg, snaps=[])
-    ds_hdl.iter_snapshots(
-        callback=__collect_newer_snapshots_callback,
-        state=state,
-        min_transaction_group=target_txg,
-        order_by_transaction_group=True,
-    )
-    return state.snaps
-
-
-def _destroy_newer_snapshots(tls: Any, dataset: str, target_snap: str, destroy_clones: bool, force: bool) -> None:
-    """Destroy snapshots newer than the target snapshot.
-
-    Args:
-        tls: Thread local storage containing lzh (libzfs handle)
-        dataset: Dataset path
-        target_snap: Target snapshot name to rollback to
-        destroy_clones: Also destroy clones of newer snapshots
-        force: Force unmount
-    """
-    # Collect snapshots newer than target (ordered oldest-first)
-    newer_snaps = _collect_newer_snapshots(tls, dataset, target_snap)
-
-    # Destroy newer snapshots (in reverse order - newest first)
-    for snap_path in reversed(newer_snaps):
-        try:
-            if destroy_clones:
-                # Destroy any clones of this snapshot first. get_clones()
-                # returns an empty tuple when there are none.
-                snap_rsrc = tls.lzh.open_resource(name=snap_path)
-                for clone in snap_rsrc.get_clones():
-                    try:
-                        clone_rsrc = tls.lzh.open_resource(name=clone)
-                        if force:
-                            clone_rsrc.unmount(force=True)
-                        clone_rsrc.destroy()
-                    except truenas_pylibzfs.ZFSException:
-                        pass
-
-            truenas_pylibzfs.lzc.destroy_snapshots(
-                snapshot_names=(snap_path,),
-                defer_destroy=False,
-            )
-        except truenas_pylibzfs.ZFSException:
-            pass  # Continue with other snapshots
+    for ds, newer_snaps in newer:
+        if newer_snaps:
+            _destroy_newer_snapshots(tls, ds, snap_name, newer_snaps, recursive_clones, force)
+        _rollback(ds, snap_name)

--- a/tests/api2/test_pool_snapshot_rollback.py
+++ b/tests/api2/test_pool_snapshot_rollback.py
@@ -1,0 +1,38 @@
+import errno
+
+import pytest
+
+from middlewared.service_exception import ValidationError
+from middlewared.test.integration.assets.pool import dataset, snapshot
+from middlewared.test.integration.utils import call
+
+
+def test_pool_snapshot_rollback_recursive():
+    """Options are passed through: `recursive` destroys the newer snapshot and the rollback succeeds"""
+    with dataset("test_pool_snap_rollback") as ds:
+        with snapshot(ds, "snap1"), snapshot(ds, "snap2"):
+            call("pool.snapshot.rollback", f"{ds}@snap1", {"recursive": True})
+
+            result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+            assert [snap["snapshot_name"] for snap in result] == ["snap1"]
+
+
+def test_pool_snapshot_rollback_input_errors_are_validation_errors():
+    """The wrapper translates the input problems of the underlying rollback into its own schema"""
+    with dataset("test_pool_snap_rollback_errors") as ds:
+        with pytest.raises(ValidationError) as ve:
+            call("pool.snapshot.rollback", ds)
+        assert ve.value.errno == errno.EINVAL
+        assert "must be a snapshot path" in ve.value.errmsg
+
+        with pytest.raises(ValidationError) as ve:
+            call("pool.snapshot.rollback", f"{ds}@nonexistent")
+        assert ve.value.errno == errno.ENOENT
+        assert ve.value.errmsg == f"'{ds}@nonexistent' not found"
+
+        with snapshot(ds, "snap1"), snapshot(ds, "snap2"):
+            with pytest.raises(ValidationError) as ve:
+                call("pool.snapshot.rollback", f"{ds}@snap1")
+            assert ve.value.errno == errno.EINVAL
+            assert "more recent snapshots exist" in ve.value.errmsg
+            assert f"{ds}@snap2" in ve.value.errmsg

--- a/tests/api2/test_zfs_resource_snapshot_rollback.py
+++ b/tests/api2/test_zfs_resource_snapshot_rollback.py
@@ -1,7 +1,10 @@
+import errno
+
 import pytest
 
+from middlewared.service_exception import CallError, ValidationError
 from middlewared.test.integration.assets.pool import dataset, snapshot
-from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils import call, pool, ssh
 
 
 def test_zfs_resource_snapshot_rollback_basic():
@@ -41,17 +44,39 @@ def test_zfs_resource_snapshot_rollback_more_recent_snapshots():
         # non-recursive rollback to snap1
         with snapshot(ds, "snap1"), snapshot(ds, "snap2"), snapshot(ds, "snap3"):
             # Rollback to snap1 without recursive should fail
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(ValidationError) as ve:
                 call(
                     "zfs.resource.snapshot.rollback",
                     {"path": f"{ds}@snap1"},
                 )
 
-            err = str(exc_info.value)
-            assert "Cannot rollback: more recent snapshots or bookmarks exist" in err
+            assert ve.value.errno == errno.EINVAL
+            assert "Cannot rollback: more recent snapshots exist" in ve.value.errmsg
             # The error must list the snapshots that prevent the rollback
-            assert f"{ds}@snap2" in err
-            assert f"{ds}@snap3" in err
+            assert f"{ds}@snap2" in ve.value.errmsg
+            assert f"{ds}@snap3" in ve.value.errmsg
+
+            result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+            assert {snap["snapshot_name"] for snap in result} == {"snap1", "snap2", "snap3"}
+
+
+def test_zfs_resource_snapshot_rollback_newer_bookmark_fails_after_snapshots_are_destroyed():
+    """`recursive` destroys the newer snapshots first, so a newer bookmark fails a committed destroy"""
+    with dataset("test_snap_rollback_bookmark_destroyed") as ds:
+        ssh(f"zfs snapshot {ds}@snap1")
+        ssh(f"zfs snapshot {ds}@snap2")
+        ssh(f"zfs bookmark {ds}@snap2 {ds}#bm2")
+
+        with pytest.raises(CallError) as ce:
+            call(
+                "zfs.resource.snapshot.rollback",
+                {"path": f"{ds}@snap1", "recursive": True},
+            )
+
+        assert ce.value.errno == errno.EEXIST
+        assert f"zfs destroy {ds}#<bookmark>" in ce.value.errmsg
+        result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+        assert [snap["snapshot_name"] for snap in result] == ["snap1"]
 
 
 def test_zfs_resource_snapshot_rollback_path_validation():
@@ -61,6 +86,13 @@ def test_zfs_resource_snapshot_rollback_path_validation():
         with pytest.raises(Exception) as exc_info:
             call("zfs.resource.snapshot.rollback", {"path": ds})
         assert "must be a snapshot path" in str(exc_info.value).lower()
+
+        # These must be refused as invalid input, not surface a raw ZFS open failure.
+        for bad_path in (f"{ds}@", "@snap1", f"{ds}@a@b"):
+            with pytest.raises(ValidationError) as ve:
+                call("zfs.resource.snapshot.rollback", {"path": bad_path})
+            assert ve.value.errno == errno.EINVAL
+            assert "must be a snapshot path" in ve.value.errmsg
 
 
 def test_zfs_resource_snapshot_rollback_nonexistent():
@@ -86,3 +118,149 @@ def test_zfs_resource_snapshot_rollback_protected_path():
             {"path": "boot-pool@test"},
         )
     assert "protected" in str(exc_info.value).lower()
+
+
+def test_zfs_resource_snapshot_rollback_recursive_clones_without_force_destroys_mounted_clone():
+    """A mounted clone is unmounted and destroyed with its own descendants, even when `force` is not passed"""
+    with dataset("test_snap_rollback_clone_noforce") as ds:
+        clone = f"{ds}/clone1"
+        with snapshot(ds, "snap1"), snapshot(ds, "snap2"):
+            ssh(f"zfs clone {ds}@snap2 {clone}")
+            # A child and a snapshot of its own, which a non-recursive destroy would refuse
+            ssh(f"zfs create {clone}/child")
+            ssh(f"zfs snapshot {clone}@c1")
+            # The clone has to actually be mounted for this test to mean anything
+            assert ssh(f"mountpoint -q /mnt/{clone}", check=False, complete_response=True)["result"] is True
+
+            call(
+                "zfs.resource.snapshot.rollback",
+                {"path": f"{ds}@snap1", "recursive_clones": True},
+            )
+
+            assert ssh(f"zfs list -H -o name {clone}", check=False, complete_response=True)["result"] is False
+            # Destroying the clone takes its mountpoint directory with it, so the
+            # name stays free for a later create
+            assert ssh(f"test -d /mnt/{clone}", check=False, complete_response=True)["result"] is False
+            result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+            assert [snap["snapshot_name"] for snap in result] == ["snap1"]
+
+
+def test_zfs_resource_snapshot_rollback_recursive_rollback_child_blocker_leaves_parent_intact():
+    """A blocker on a child dataset must be found before the parent is rolled back"""
+    with dataset("test_snap_rollback_child_blocker") as ds:
+        child = f"{ds}/child"
+        # The clone lives outside the dataset on purpose: one inside it would be
+        # collected as a child of the recursive rollback and rejected for not
+        # having the target snapshot, which is not what this test is about
+        clone = f"{pool}/test_snap_rollback_child_blocker_clone"
+        try:
+            ssh(f"zfs create {child}")
+            ssh(f"zfs snapshot -r {ds}@snap1")
+            ssh(f"touch /mnt/{ds}/marker")
+            ssh(f"zfs snapshot {child}@snap2")
+            ssh(f"zfs clone {child}@snap2 {clone}")
+
+            with pytest.raises(CallError) as ce:
+                call(
+                    "zfs.resource.snapshot.rollback",
+                    {"path": f"{ds}@snap1", "recursive": True, "recursive_rollback": True},
+                )
+
+            assert ce.value.errno == errno.EBUSY
+            assert f"{child}@snap2" in ce.value.errmsg
+            assert clone in ce.value.errmsg
+
+            ssh(f"test -f /mnt/{ds}/marker")
+        finally:
+            ssh(f"zfs destroy -r {clone} || true")
+
+
+def test_zfs_resource_snapshot_rollback_reports_every_blocker_at_once():
+    """A clone and a hold on newer snapshots block `recursive`, are all reported at once, and destroy nothing"""
+    with dataset("test_snap_rollback_multi_blocker") as ds:
+        # The clone lives under the dataset, so it is reaped by its recursive delete
+        clone = f"{ds}/clone1"
+        with snapshot(ds, "snap1"), snapshot(ds, "snap2"), snapshot(ds, "snap3"):
+            ssh(f"zfs clone {ds}@snap2 {clone}")
+            ssh(f"zfs hold truenas {ds}@snap3")
+
+            with pytest.raises(CallError) as ce:
+                call(
+                    "zfs.resource.snapshot.rollback",
+                    {"path": f"{ds}@snap1", "recursive": True},
+                )
+
+            assert ce.value.errno == errno.EBUSY
+            assert f"{ds}@snap2" in ce.value.errmsg
+            assert clone in ce.value.errmsg
+            assert "recursive_clones" in ce.value.errmsg
+            assert f"{ds}@snap3" in ce.value.errmsg
+            assert "truenas" in ce.value.errmsg
+
+            result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+            assert {snap["snapshot_name"] for snap in result} == {"snap1", "snap2", "snap3"}
+
+
+def test_zfs_resource_snapshot_rollback_recursive_rollback_rolls_back_children():
+    """`recursive_rollback` rolls the child datasets back, not only the parent"""
+    with dataset("test_snap_rollback_recursive_children") as ds:
+        child = f"{ds}/child"
+        ssh(f"zfs create {child}")
+        ssh(f"zfs snapshot -r {ds}@snap1")
+        ssh(f"touch /mnt/{ds}/parent_marker /mnt/{child}/child_marker")
+
+        call(
+            "zfs.resource.snapshot.rollback",
+            {"path": f"{ds}@snap1", "recursive_rollback": True},
+        )
+
+        assert ssh(f"test -f /mnt/{ds}/parent_marker", check=False, complete_response=True)["result"] is False
+        assert ssh(f"test -f /mnt/{child}/child_marker", check=False, complete_response=True)["result"] is False
+
+
+def test_zfs_resource_snapshot_rollback_recursive_rollback_missing_child_snapshot():
+    """A child that lacks the target snapshot is caught before anything is rolled back"""
+    with dataset("test_snap_rollback_missing_child") as ds:
+        child = f"{ds}/child"
+        ssh(f"zfs create {child}")
+        # Deliberately not recursive, so the child never gets snap1
+        ssh(f"zfs snapshot {ds}@snap1")
+        ssh(f"touch /mnt/{ds}/marker")
+
+        with pytest.raises(ValidationError) as ve:
+            call(
+                "zfs.resource.snapshot.rollback",
+                {"path": f"{ds}@snap1", "recursive_rollback": True},
+            )
+
+        assert ve.value.errno == errno.ENOENT
+        assert f"{child}@snap1" in ve.value.errmsg
+
+        ssh(f"test -f /mnt/{ds}/marker")
+
+
+def test_zfs_resource_snapshot_rollback_app_flag_combination():
+    """The flag combination app rollbacks send must still complete with a clone present"""
+    with dataset("test_snap_rollback_app_flags") as ds:
+        clone = f"{pool}/test_snap_rollback_app_flags_clone"
+        try:
+            ssh(f"zfs snapshot {ds}@snap1")
+            ssh(f"zfs snapshot {ds}@snap2")
+            ssh(f"zfs clone {ds}@snap2 {clone}")
+
+            call(
+                "zfs.resource.snapshot.rollback",
+                {
+                    "path": f"{ds}@snap1",
+                    "recursive": True,
+                    "recursive_clones": True,
+                    "recursive_rollback": True,
+                    "force": True,
+                },
+            )
+
+            assert ssh(f"zfs list -H -o name {clone}", check=False, complete_response=True)["result"] is False
+            result = call("zfs.resource.snapshot.query", {"paths": [ds]})
+            assert [snap["snapshot_name"] for snap in result] == ["snap1"]
+        finally:
+            ssh(f"zfs destroy -r {clone} || true")


### PR DESCRIPTION
## Problem
Rolling back past a snapshot that has a dependent clone crashed: the "no safety check" path called a `destroy()` method that does not exist on the pylibzfs dataset object, and the "newer clone" path skipped the safety check and let the kernel refuse with a raw EEXIST after some newer snapshots were already destroyed one at a time. With `recursive_rollback`, a blocked child was only discovered after the parent had already been rolled back, and every kernel error was flattened into `ValidationError(EINVAL)` with a raw strerror.

## Solution
- **Enumerate once, up front, for the whole tree.** Newer snapshots are collected for every affected dataset before anything is touched. Without `recursive`, the rollback is refused with every conflicting snapshot named; with it, holds and clones are checked first and the rollback is refused before any destroy, naming each blocker. A missing child snapshot fails the whole tree before the parent moves.
- **Destroy the newer snapshots in one ioctl per dataset**, so the kernel either destroys all of them or none, and a failure names the snapshots from the kernel's own error list.
- **Clones are always unmounted before being destroyed** - `force` only selects how forcefully - and destroyed via `destroy_resource()`.
- **Error model.** Input problems (bad path, missing snapshot, newer snapshots without a destroy flag) stay `ValidationError`; blockers and operational failures surface as `CallError` with the kernel's errno. A newer bookmark still fails the rollback with EEXIST, since bookmarks are not managed here; the error says so and names the manual remedy.


Original PR: https://github.com/truenas/middleware/pull/19518
