### PR TITLE
NAS-142566 / 27.0.0-BETA.1 / Stop passing middlewared's environment to init/shutdown scripts

### DIFF
--- a/src/middlewared/middlewared/plugins/init_shutdown_script/task.py
+++ b/src/middlewared/middlewared/plugins/init_shutdown_script/task.py
@@ -15,6 +15,17 @@ if typing.TYPE_CHECKING:
 
 WHEN_ARG = typing.Literal['PREINIT', 'POSTINIT', 'SHUTDOWN']
 
+# User scripts must not inherit middlewared's environment
+SCRIPT_ENV = (
+    'LANG',
+    'PATH',
+    'REQUESTS_CA_BUNDLE',
+    'TZ',
+    'USER',
+    'http_proxy',
+    'https_proxy',
+)
+
 
 def get_cmd(task: InitShutdownScriptEntry) -> str | None:
     if task.type == 'COMMAND':
@@ -31,7 +42,8 @@ async def execute_task(context: ServiceContext, task: InitShutdownScriptEntry) -
         return
 
     try:
-        proc = await run(['sh', '-c', cmd], stderr=subprocess.STDOUT, check=False)
+        env = {k: v for k, v in os.environ.items() if k in SCRIPT_ENV}
+        proc = await run(['sh', '-c', cmd], env=env, stderr=subprocess.STDOUT, check=False)
         if proc.returncode:
             context.logger.debug('Failed to execute %r with error %r', cmd, proc.stdout.decode())
     except Exception:


### PR DESCRIPTION
## Problem
User scripts were spawned with middlewared's entire environment, including `NOTIFY_SOCKET`. Since our unit sets `NotifyAccess=all`, a daemon a script leaves behind can send `MAINPID=` and be adopted as the unit's main process, so systemd tears middlewared down when that daemon later exits. A user hit this with a POSTINIT script starting a NUT driver: the driver was killed as a duplicate on every boot, middlewared went down with it.

## Solution
Pass a curated set of names instead of inheriting: `PATH`, `TZ`, `LANG`, `USER`, the proxy variables and `REQUESTS_CA_BUNDLE`, all of which existing scripts may reasonably depend on. Allowlisted rather than denylisted so that whatever systemd or a plugin sets next stays out of user scripts too.