### PR TITLE
NAS-143526 / 26.0.0 / Mock VM and container queries in bridge validation unit tests

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/test_interface.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_interface.py
@@ -114,6 +114,8 @@ async def test__interfaces_service__create_bridge_invalid_ports():
     m['interface.query'] = Mock(return_value=INTERFACES)
     m['datastore.query'] = Mock(return_value=[])
     m['network.common.check_failover_disabled'] = Mock()
+    m['vm.query'] = Mock(return_value=[])
+    m['container.query'] = Mock(return_value=[])
 
     with pytest.raises(ValidationErrors) as ve:
         await create_service(m, InterfaceService).do_create({
@@ -130,6 +132,8 @@ async def test__interfaces_service__create_bridge_invalid_ports_used():
     m['interface.query'] = Mock(return_value=INTERFACES_WITH_BRIDGE)
     m['datastore.query'] = Mock(return_value=[])
     m['network.common.check_failover_disabled'] = Mock()
+    m['vm.query'] = Mock(return_value=[])
+    m['container.query'] = Mock(return_value=[])
 
     with pytest.raises(ValidationErrors) as ve:
         await create_service(m, InterfaceService).do_create({


### PR DESCRIPTION
## Problem
The two bridge unit tests in `test_interface.py` fail with `KeyError: 'vm.query'`. BRIDGE validation now calls `nic_attach_users()` whenever `bridge_members` is set, which queries VMs and containers to find NICs attached directly to a member, but the mock middleware in those tests only stubs `interface.query`, `datastore.query` and `network.common.check_failover_disabled`.

## Solution
Stub `vm.query` and `container.query` with empty results in both tests, so validation reaches the member checks the tests actually assert on.