### PR TITLE
NAS-143512 / 26.0.0 / Gate S3 auditing on appliance hardware (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/s3.py
+++ b/src/middlewared/middlewared/api/v26_0_0/s3.py
@@ -280,7 +280,7 @@ class S3Entry(BaseModel):
         default=[],
         description=(
             "Actions audited on every bucket that does not set its own `audit`, or `ALL`. An empty list audits "
-            "nothing. Requires an Enterprise license."
+            "nothing. Requires TrueNAS Enterprise appliance hardware."
         ),
     )
     default_audit_overflow: S3AuditOverflow = Field(
@@ -440,7 +440,7 @@ class SharingS3Entry(BaseModel):
         default=None,
         description=(
             "Actions audited on this bucket, `ALL`, or an empty list to audit nothing. `null` inherits the service's "
-            "`default_audit`. Requires an Enterprise license."
+            "`default_audit`. Requires TrueNAS Enterprise appliance hardware."
         ),
     )
     audit_overflow: S3AuditOverflow | None = Field(

--- a/src/middlewared/middlewared/etc_files/truenas_s3/buckets.conf.mako
+++ b/src/middlewared/middlewared/etc_files/truenas_s3/buckets.conf.mako
@@ -36,7 +36,7 @@ region = ${config.region}
 host_id = ${data.host_id}
 owner_id_seed = ${data.owner_id_seed}
 log_level = ${config.log_level.lower()}
-% if data.audit_licensed:
+% if data.audit_supported:
 % if config.default_audit:
 default_audit = ${audit_value(config.default_audit)}
 % endif
@@ -72,7 +72,7 @@ object_lock_default_mode = ${b.object_lock_default_mode.lower()}
 % if b.object_lock_default_days:
 object_lock_default_days = ${b.object_lock_default_days}
 % endif
-% if data.audit_licensed:
+% if data.audit_supported:
 ## None inherits the server default by omission; an empty list is the
 ## empty mask, rendered so it shadows the default
 % if b.audit is not None:

--- a/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/bucket_crud.py
@@ -207,9 +207,11 @@ class SharingS3Service(SharingService[SharingS3Entry]):
                 verrors.add(f"{schema}.object_lock_default_days", "A default retention rule needs a period.")
 
         if (data.audit is not None or data.audit_overflow is not None) and not await self.middleware.call(
-            "s3.audit_licensed"
+            "s3.audit_supported"
         ):
-            verrors.add(f"{schema}.audit", "Auditing the S3 service requires an Enterprise license.")
+            verrors.add(
+                f"{schema}.audit", "Auditing the S3 service requires TrueNAS Enterprise appliance hardware."
+            )
 
         await validate_grants(self.middleware, f"{schema}.grants", data.grants, verrors)
 
@@ -506,7 +508,7 @@ class SharingS3Service(SharingService[SharingS3Entry]):
     async def audited_bucket_names(self) -> list[str]:
         """Enabled buckets whose effective audit mask is not empty, for
         `audit.config`."""
-        if not await self.middleware.call("s3.audit_licensed"):
+        if not await self.middleware.call("s3.audit_supported"):
             return []
         config: S3Entry = await self.middleware.call("s3.config")
         buckets: list[SharingS3Entry] = await self.middleware.call("sharing.s3.query", [["enabled", "=", True]])

--- a/src/middlewared/middlewared/plugins/truenas_s3/config.py
+++ b/src/middlewared/middlewared/plugins/truenas_s3/config.py
@@ -26,6 +26,7 @@ from middlewared.plugins.zfs.exceptions import ZFSPathNotFoundException
 from middlewared.service import SystemServicePart, SystemServiceService, ValidationErrors, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils.crypto import generate_token, ssl_uuid4
+from middlewared.utils.hardware import get_hardware_class
 
 from .accesskey_crud import S3AccesskeyService
 from .grants import grant_label, grant_principals, label_grants, principal_names, validate_grants
@@ -96,7 +97,7 @@ class RenderData:
     global_grants: list[RenderedGrant]
     buckets: list[RenderedBucket]
     accesskeys: list[S3AccesskeyEntry]
-    audit_licensed: bool
+    audit_supported: bool
 
 
 def _listen_text(listeners: Sequence[S3Listener]) -> tuple[str, str]:
@@ -228,8 +229,11 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
                 )
             )
 
-        if (new.default_audit or new.default_audit_overflow != "DROP") and not await self.audit_licensed():
-            verrors.add("s3_update.default_audit", "Auditing the S3 service requires an Enterprise license.")
+        if (new.default_audit or new.default_audit_overflow != "DROP") and not await self.audit_supported():
+            verrors.add(
+                "s3_update.default_audit",
+                "Auditing the S3 service requires TrueNAS Enterprise appliance hardware.",
+            )
 
         if new.managed_root_dataset:
             await self._validate_managed_root(new.managed_root_dataset, verrors)
@@ -271,8 +275,15 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
         elif rows[0]["type"] != "FILESYSTEM":
             verrors.add(field, f"{dataset!r} is a volume, not a dataset.")
 
-    async def audit_licensed(self) -> bool:
-        return await self.middleware.call("system.license") is not None
+    async def audit_supported(self) -> bool:
+        """Whether S3 requests are audited on this machine.
+
+        Read from the chassis rather than the license: the audit records
+        land in the same database the kernel audit handler feeds, which is
+        gated on the hardware class too, so both halves of the audit trail
+        have to answer to the same thing.
+        """
+        return get_hardware_class().is_appliance
 
     async def effective_certificate(self, cert_id: int | None) -> int | None:
         """The certificate the TLS listeners serve: the chosen one, or the
@@ -364,7 +375,7 @@ class S3ConfigPart(SystemServicePart[S3Entry]):
             global_grants=_rendered_grants(config.global_grants, "*"),
             buckets=rendered_buckets,
             accesskeys=accesskeys,
-            audit_licensed=await self.audit_licensed(),
+            audit_supported=await self.audit_supported(),
         )
 
 
@@ -411,8 +422,8 @@ class S3Service(SystemServiceService[S3Entry]):
         return await self._svc_part.render_data()
 
     @private
-    async def audit_licensed(self) -> bool:
-        return await self._svc_part.audit_licensed()
+    async def audit_supported(self) -> bool:
+        return await self._svc_part.audit_supported()
 
     @private
     async def effective_certificate(self, cert_id: int | None) -> int | None:

--- a/tests/api2/test_s3_config.py
+++ b/tests/api2/test_s3_config.py
@@ -28,8 +28,9 @@ def service():
     return call("service.query", [["service", "=", SERVICE]], {"get": True})
 
 
-def audit_licensed():
-    return call("system.license") is not None
+@pytest.fixture(scope="module")
+def audit_supported():
+    return call("system.product_type") == "ENTERPRISE"
 
 
 @contextlib.contextmanager
@@ -206,22 +207,29 @@ def test_global_grants_render_as_wildcard_rows():
             assert message in ve.value.errors[0].errmsg
 
 
-def test_audit_follows_the_license():
-    if audit_licensed():
-        with config(
-            default_audit=["GetObject", "PutObject"],
-            default_audit_overflow="BACKPRESSURE",
-        ):
-            call("etc.generate", "truenas_s3")
-            server = parse(BUCKETS_CONF)["server"]
-            assert server["default_audit"] == "GetObject,PutObject"
-            assert server["default_audit_overflow"] == "backpressure"
-    else:
-        with pytest.raises(ValidationErrors) as ve:
-            call("s3.update", {"default_audit": "ALL"})
-        assert "Enterprise license" in ve.value.errors[0].errmsg
+def test_audit_renders_on_appliance_hardware(audit_supported):
+    if not audit_supported:
+        pytest.skip("S3 auditing is gated on appliance hardware, which this system is not")
+
+    with config(
+        default_audit=["GetObject", "PutObject"],
+        default_audit_overflow="BACKPRESSURE",
+    ):
         call("etc.generate", "truenas_s3")
-        assert "default_audit" not in parse(BUCKETS_CONF)["server"]
+        server = parse(BUCKETS_CONF)["server"]
+        assert server["default_audit"] == "GetObject,PutObject"
+        assert server["default_audit_overflow"] == "backpressure"
+
+
+def test_audit_refused_off_appliance_hardware(audit_supported):
+    if audit_supported:
+        pytest.skip("This system is appliance hardware, where S3 auditing is allowed")
+
+    with pytest.raises(ValidationErrors) as ve:
+        call("s3.update", {"default_audit": "ALL"})
+    assert "appliance hardware" in ve.value.errors[0].errmsg
+    call("etc.generate", "truenas_s3")
+    assert "default_audit" not in parse(BUCKETS_CONF)["server"]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This commit adds changes to decide whether the S3 service audits requests from the hardware class rather than from the license, so it matches the gate the kernel audit handler already uses -- both halves of the audit trail land in the same database, so both have to answer to the same thing. The check is renamed audit_supported since it no longer reads a license, and the validation messages and API field descriptions say appliance hardware instead of Enterprise license.

Original PR: https://github.com/truenas/middleware/pull/19668
