### PR TITLE
NAS-143511 / 26.0.0 / Make OTP Auth QR code reference TrueNAS (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -50,7 +50,7 @@ class UserService(Service):
         ).provisioning_uri(
             f'{username}-{await self.middleware.call("system.hostname")}'
             f'@{ProductName.PRODUCT_NAME}',
-            'iXsystems'
+            'TrueNAS'
         )
 
     @api_method(UserProvisioningUriArgs, UserProvisioningUriResult, private=True)


### PR DESCRIPTION
The logo is already there
<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/d25e10a9-0bfc-4efd-8003-bea936b5a2db" />


Original PR: https://github.com/truenas/middleware/pull/19679
