### PR TITLE
NAS-142893 / 26.0.0 / Make `filesystem.file_tail_follow` tail the file on repeated connect (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v26_0_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v26_0_0/filesystem.py
@@ -465,7 +465,12 @@ class FilesystemPutResult(BaseModel):
 
 class FileFollowTailEventSourceArgs(BaseModel):
     path: str = Field(description="Path to the file to follow/tail.")
-    tail_lines: int = Field(default=3, description="Number of log lines to tail from the end of the log.")
+    tail_lines: int = Field(
+        default=3,
+        ge=1,
+        le=1000,
+        description="Number of log lines to tail from the end of the log.",
+    )
 
 
 @single_argument_result

--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -150,8 +150,7 @@ class EventSourceManager:
         try:
             await instance.send_initial_state(subscriber)
         except Exception:
-            self.middleware.logger.error("EventSource %r:%r send_initial_state() failed", name, arg,
-                                         exc_info=True)
+            self.middleware.logger.exception("EventSource %r:%r send_initial_state() failed", name, arg)
 
     async def unsubscribe(self, ident: str, error: Exception | None = None):
         ident_data = self.idents.pop(ident, None)

--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -129,9 +129,9 @@ class EventSourceManager:
         self.idents[ident] = IdentData(subscriber, name, arg)
         self.subscriptions[name][arg].add(ident)
 
-        if arg not in self.instances[name]:
+        if (instance := self.instances[name].get(arg)) is None:
             self.middleware.logger.trace("Creating new instance of event source %r:%r", name, arg)
-            self.instances[name][arg] = self.event_sources[name](
+            instance = self.instances[name][arg] = self.event_sources[name](
                 self.middleware, name, arg,
                 functools.partial(self._send_event, name, arg),
                 functools.partial(self._unsubscribe_all, name, arg),
@@ -141,10 +141,17 @@ class EventSourceManager:
                 await self.instances[name][arg].validate_arg()
             except ValidationErrors as e:
                 await self.unsubscribe(ident, e)
+                return
             else:
                 self.middleware.create_task(self.instances[name][arg].process())
         else:
             self.middleware.logger.trace("Re-using existing instance of event source %r:%r", name, arg)
+
+        try:
+            await instance.send_initial_state(subscriber)
+        except Exception:
+            self.middleware.logger.error("EventSource %r:%r send_initial_state() failed", name, arg,
+                                         exc_info=True)
 
     async def unsubscribe(self, ident: str, error: Exception | None = None):
         ident_data = self.idents.pop(ident, None)

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -8,6 +8,7 @@ from middlewared.role import RoleManager
 from middlewared.service import ValidationErrors
 if typing.TYPE_CHECKING:
     from middlewared.api.base import BaseModel
+    from middlewared.common.event_source.manager import Subscriber
     from middlewared.main import Middleware
     from middlewared.utils.types import EventType
 
@@ -131,6 +132,9 @@ class EventSource:
 
     def run_sync(self):
         raise NotImplementedError('run_sync() method not implemented')
+
+    async def send_initial_state(self, subscriber: 'Subscriber') -> None:
+        pass
 
     async def cancel(self):
         self._canceled = True

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -28,6 +28,7 @@ from middlewared.api.current import (
     FilesystemPutArgs, FilesystemPutResult,
     FileFollowTailEventSourceArgs, FileFollowTailEventSourceEvent,
 )
+from middlewared.common.event_source.manager import Subscriber
 from middlewared.event import EventSource
 from middlewared.utils.pwenc import PWENC_FILE_SECRET
 from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
@@ -72,6 +73,19 @@ class FileFollowTailEventSource(EventSource):
     args = FileFollowTailEventSourceArgs
     event = FileFollowTailEventSourceEvent
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._buffer: list[str] = []
+
+    async def send_initial_state(self, subscriber: Subscriber) -> None:
+        if buffer := self._buffer:
+            subscriber.send_event('ADDED', fields={'data': ''.join(buffer)})
+
+    def send_lines(self, lines: list[str]) -> None:
+        buffer = self._buffer + lines
+        self._buffer = buffer[max(len(buffer) - self.arg['tail_lines'], 0):]
+        self.send_event('ADDED', fields={'data': ''.join(lines)})
+
     def run_sync(self):
         path, lines = self.arg['path'], self.arg['tail_lines']
 
@@ -95,11 +109,11 @@ class FileFollowTailEventSource(EventSource):
                 if len(data) >= lines or f.tell() == 0:
                     break
 
-            self.send_event('ADDED', fields={'data': ''.join(data[-lines:])})
+            self.send_lines(data[-lines:])
             f.seek(fsize)
 
-            for data in self._follow_path(path, f):
-                self.send_event('ADDED', fields={'data': data})
+            for chunk in self._follow_path(path, f):
+                self.send_lines(chunk)
 
     def _follow_path(self, path, f):
         queue = []
@@ -109,7 +123,7 @@ class FileFollowTailEventSource(EventSource):
 
         data = f.read()
         if data:
-            yield data
+            yield data.splitlines(keepends=True)
 
         last_sent_at = time.monotonic()
         interval = 0.5  # For performance reasons do not send websocket events more than twice a second
@@ -117,9 +131,8 @@ class FileFollowTailEventSource(EventSource):
             notifier.process_events()
 
             if time.monotonic() - last_sent_at >= interval:
-                data = "".join(queue)
-                if data:
-                    yield data
+                if queue:
+                    yield queue[:]
                 queue[:] = []
                 last_sent_at = time.monotonic()
 
@@ -131,7 +144,7 @@ class FileFollowTailEventSource(EventSource):
     def _follow_callback(self, queue, f, event):
         data = f.read()
         if data:
-            queue.append(data)
+            queue.extend(data.splitlines(keepends=True))
 
 
 class FilesystemService(Service):

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -65,6 +65,18 @@ class FilesystemReceiveFileResult(BaseModel):
     result: Literal[True]
 
 
+MAX_LINE_LENGTH = 1024
+
+
+def splitlines_maxlen(data: str, maxlen: int) -> list[str]:
+    """Split `data` into lines, also splitting lines longer than `maxlen` characters."""
+    return [
+        line[i:i + maxlen]
+        for line in data.splitlines(keepends=True)
+        for i in range(0, len(line), maxlen)
+    ]
+
+
 class FileFollowTailEventSource(EventSource):
     """
     Retrieve last ``tail_lines`` lines specified as an integer argument for a specified ``path`` and then
@@ -93,21 +105,17 @@ class FileFollowTailEventSource(EventSource):
             # FIXME: Error?
             return
 
-        bufsize = 8192
         fsize = os.stat(path).st_size
-        if fsize < bufsize:
-            bufsize = fsize
-        i = 0
         with safe_open(path, encoding='utf-8', errors='ignore') as f:
-            data = []
+            read_back = lines * 100  # average log file line length
             while True:
-                i += 1
-                if bufsize * i > fsize:
+                offset = max(fsize - read_back, 0)
+                f.seek(offset)
+                data = splitlines_maxlen(f.read(), MAX_LINE_LENGTH)
+                # The first line read is incomplete unless we are at the very beginning of the file
+                if len(data) > lines or offset == 0:
                     break
-                f.seek(fsize - bufsize * i)
-                data.extend(f.readlines())
-                if len(data) >= lines or f.tell() == 0:
-                    break
+                read_back *= 2
 
             self.send_lines(data[-lines:])
             f.seek(fsize)
@@ -123,7 +131,7 @@ class FileFollowTailEventSource(EventSource):
 
         data = f.read()
         if data:
-            yield data.splitlines(keepends=True)
+            yield splitlines_maxlen(data, MAX_LINE_LENGTH)
 
         last_sent_at = time.monotonic()
         interval = 0.5  # For performance reasons do not send websocket events more than twice a second
@@ -144,7 +152,7 @@ class FileFollowTailEventSource(EventSource):
     def _follow_callback(self, queue, f, event):
         data = f.read()
         if data:
-            queue.extend(data.splitlines(keepends=True))
+            queue.extend(splitlines_maxlen(data, MAX_LINE_LENGTH))
 
 
 class FilesystemService(Service):

--- a/tests/api2/test_filesystem__file_tail_follow.py
+++ b/tests/api2/test_filesystem__file_tail_follow.py
@@ -1,14 +1,8 @@
-import os
-import sys
 import time
 
 import pytest
 
 from middlewared.test.integration.utils import client, ssh
-
-
-apifolder = os.getcwd()
-sys.path.append(apifolder)
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=5)
@@ -33,7 +27,7 @@ def test_filesystem__file_tail_follow__grouping():
         assert 4 <= len(received) <= 6, str(received)
         # All blocks should have been received uniformly in time
         assert all(0.4 <= b2[0] - b1[0] <= 1.0 for b1, b2 in zip(received[:-1], received[1:])), str(received)
-        # All blocks should contain more or less same amount of data
+        # All blocks should contain more or less same amount of data: (0.5s grouping / 0.01s interval) <= 60
         assert all(len(block[1].split("\n")) <= 60 for block in received[:-1]), str(received)
 
         # One single send
@@ -44,3 +38,42 @@ def test_filesystem__file_tail_follow__grouping():
 
         # Make sure we can cleanly end the subscription
         c.unsubscribe(sub_id)
+
+
+def test_filesystem__file_tail_follow__shared_instance_initial_tail():
+    ssh("seq 1 10 > /tmp/file_tail_follow2.txt")
+
+    name = 'filesystem.file_tail_follow:{"path": "/tmp/file_tail_follow2.txt", "tail_lines": 5}'
+    with client() as c1, client() as c2:
+        received1 = []
+        received2 = []
+
+        c1.subscribe(name, lambda type, **kwargs: received1.append(kwargs["fields"]["data"]))
+        time.sleep(2)
+        assert received1 and received1[0] == "6\n7\n8\n9\n10\n", str(received1)
+
+        # An identical subscription re-uses the already running event source instance but must still
+        # receive the initial tail
+        sub_id2 = c2.subscribe(name, lambda type, **kwargs: received2.append(kwargs["fields"]["data"]))
+        time.sleep(2)
+        assert received2 and received2[0] == "6\n7\n8\n9\n10\n", str(received2)
+
+        # Both subscribers receive newly appended data
+        ssh("echo 11 >> /tmp/file_tail_follow2.txt")
+        time.sleep(2)
+        assert received1[-1] == "11\n", str(received1)
+        assert received2[-1] == "11\n", str(received2)
+
+        # Removing one subscriber must not affect the other one
+        c2.unsubscribe(sub_id2)
+        ssh("echo 12 >> /tmp/file_tail_follow2.txt")
+        time.sleep(2)
+        assert received1[-1] == "12\n", str(received1)
+        assert received2[-1] == "11\n", str(received2)
+
+        # A client that connects later receives the tail with the lines appended in the meantime
+        with client() as c3:
+            received3 = []
+            c3.subscribe(name, lambda type, **kwargs: received3.append(kwargs["fields"]["data"]))
+            time.sleep(2)
+            assert received3 and received3[0] == "8\n9\n10\n11\n12\n", str(received3)


### PR DESCRIPTION
Previously, if one browser tab is already connected to this event source and a second tab is opened, the second tab does not receive anything from `filesystem.file_tail_follow` source (it is re-used).

Now, the last N read lines are buffered in RAM, so newly connected tab will also receive last N files.

The buffer is capped: it is not possible to request more than 1000 lines (currently, UI requests 500), and each line is no longer than 1024 characters (otherwise, it is counted as `len(line) // 1024` lines).

Original PR: https://github.com/truenas/middleware/pull/19595
