### PR TITLE
NAS-143133 / 26.0.0 / Change client IP detection method for `test_system_general_ui_allowlist` (by themylogin)

### DIFF
--- a/tests/api2/test_system_general_ui_allowlist.py
+++ b/tests/api2/test_system_general_ui_allowlist.py
@@ -1,16 +1,14 @@
-import socket
 import time
 
 import requests
 import websocket
 
-from middlewared.test.integration.utils import call, host, mock, ssh, url, websocket_url
+from middlewared.test.integration.utils import call, mock, ssh, url, websocket_url
 
 
 def test_system_general_ui_allowlist():
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect((host().ip, 1))  # connect() for UDP doesn't send packets
-    local_ip = s.getsockname()[0]
+    my_session = call("auth.sessions", [["current", "=", True]], {"get": True})
+    local_ip = my_session["origin"].split(":")[0]
 
     with mock("vm.query", return_value=[
         {"id": 1, "name": ""},


### PR DESCRIPTION
This test fails frequently because the IP nginx sees is not the IP `s.getsockname()[0]` returns (there might be NAT on the way or something).

Binding to our session IP as seen by the middleware will be more reliable.

Original PR: https://github.com/truenas/middleware/pull/19619
