### PR TITLE
NAS-143046 / 27.0.0-BETA.1 / Exempt TNC_SUB from the product matrix completeness check

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_entitlements.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_entitlements.py
@@ -91,9 +91,12 @@ def test_live_policy_shape():
     assert not [rule for rule in POLICY.values() if isinstance(rule, LegacyRule)]
 
 
+MATRIXLESS_FEATURES = frozenset({LicenseFeature.TNC_SUB})
+
+
 # Completeness: adding a flag must not silently skip a site.
 def test_target_vectors_cover_every_license_feature():
-    assert set(LicenseFeature) == set(TARGET_VECTORS)
+    assert set(LicenseFeature) - MATRIXLESS_FEATURES == set(TARGET_VECTORS)
 
 
 def test_policy_keys_are_known_vocabulary():


### PR DESCRIPTION
This commit adds changes to keep the target vector completeness assertion passing now that TNC_SUB exists in the LicenseFeature enum. TNC_SUB reports a TrueNAS Connect account tier rather than a product matrix row, so there is no HW/CE column that could grant or withhold it and giving it a vector would add a row nothing ever consults.