### PR TITLE
NAS-143506 / 27.0.0-BETA.1 / Refuse to export VM disks without 512 byte sectors to VHDX, VDI or VMDK

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_device_convert.py
@@ -145,7 +145,7 @@ def validate_convert_disk_image(
 
 def validate_convert_zvol(
     context: ServiceContext, zvp: str, schema: str,
-) -> tuple[dict[str, Any], str]:
+) -> tuple[dict[str, Any], str, int | None]:
     ptn = zvp.removeprefix('/dev/zvol/').replace('+', ' ')
     ntp = os.path.join('/dev/zvol', ptn.replace(' ', '+'))
     zv = context.call_sync2(
@@ -161,11 +161,14 @@ def validate_convert_zvol(
     elif not os.path.exists(ntp):
         raise ValidationError(schema, f'{ntp!r} does not exist', errno.ENOENT)
 
+    logical_sectorsize = None
     for device in context.call_sync2(context.s.vm.device.query, [['attributes.dtype', '=', 'DISK']]):
         if not isinstance(device.attributes, VMDiskDevice):
             continue
         vmzv = device.attributes.path
         if vmzv and vmzv == ntp:
+            if device.attributes.logical_sectorsize not in (None, 512):
+                logical_sectorsize = device.attributes.logical_sectorsize
             try:
                 vm = context.call_sync2(context.s.vm.get_instance, device.vm)
                 if vm.status.state in ACTIVE_STATES:
@@ -178,7 +181,7 @@ def validate_convert_zvol(
             except InstanceNotFound:
                 pass
 
-    return zv[0], ntp
+    return zv[0], ntp, logical_sectorsize
 
 
 def convert_disk(context: ServiceContext, job: Job, data: VMDeviceConvert) -> bool:
@@ -208,7 +211,7 @@ def convert_disk(context: ServiceContext, job: Job, data: VMDeviceConvert) -> bo
         progress_desc = "Convert to disk image progress"
 
     st = validate_convert_disk_image(context, source_image, schema, converting_from_image_to_zvol)
-    zv, abs_zvolpath = validate_convert_zvol(context, zvol, schema)
+    zv, abs_zvolpath, logical_sectorsize = validate_convert_zvol(context, zvol, schema)
     cmd_args = ['qemu-img', 'convert', '-p']
     if converting_from_image_to_zvol:
         assert st is not None
@@ -227,6 +230,13 @@ def convert_disk(context: ServiceContext, job: Job, data: VMDeviceConvert) -> bo
         dl = data.destination.lower()
         for fmt in VALID_DISK_FORMATS:
             if dl.endswith(f'.{fmt}'):
+                if logical_sectorsize not in (None, 512) and fmt in ('vdi', 'vhdx', 'vmdk'):
+                    raise ValidationError(
+                        schema,
+                        f'{fmt.upper()} images only support 512 byte sectors but {zv["name"]} is attached to a VM '
+                        f'using {logical_sectorsize} byte sectors. Export to RAW or QCOW2 instead.',
+                        errno.EINVAL
+                    )
                 cmd_args.extend(['-f', 'raw', '-O', fmt, abs_zvolpath, source_image])
                 break
         else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
@@ -7,7 +7,9 @@ import pytest
 from middlewared.api.current import VMDeviceConvert, VMDiskDevice
 from middlewared.plugins.vm import vm_device_convert
 from middlewared.plugins.vm.vm_device_convert import (
-    convert_disk, validate_convert_disk_image, validate_convert_zvol,
+    convert_disk,
+    validate_convert_disk_image,
+    validate_convert_zvol,
 )
 from middlewared.service import CallError
 from middlewared.service_exception import ValidationError

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from middlewared.api.current import VMDiskDevice
+from middlewared.api.current import VMDeviceConvert, VMDiskDevice
 from middlewared.plugins.vm import vm_device_convert
-from middlewared.plugins.vm.vm_device_convert import validate_convert_disk_image, validate_convert_zvol
+from middlewared.plugins.vm.vm_device_convert import (
+    convert_disk, validate_convert_disk_image, validate_convert_zvol,
+)
 from middlewared.service import CallError
 from middlewared.service_exception import ValidationError
 
@@ -68,9 +70,12 @@ def test_zvol_to_image_internal_dataset_destination_is_rejected():
 # validate_convert_zvol blocks conversion of any active VM's zvol
 
 
-def _zvol_context(state):
+def _zvol_context(state, logical_sectorsize=None):
     zv = [{"type": "VOLUME", "name": "tank/foo", "properties": {"volsize": {"value": 1024**3}}}]
-    device = SimpleNamespace(attributes=VMDiskDevice(dtype="DISK", path="/dev/zvol/tank/foo"), vm=1)
+    device = SimpleNamespace(
+        attributes=VMDiskDevice(dtype="DISK", path="/dev/zvol/tank/foo", logical_sectorsize=logical_sectorsize),
+        vm=1,
+    )
     vm = SimpleNamespace(name="myvm", status=SimpleNamespace(state=state))
 
     context = Mock()
@@ -99,9 +104,34 @@ def test_convert_zvol_blocked_for_active_vm(state):
     assert state.lower() in exc.value.errmsg
 
 
-def test_convert_zvol_allowed_for_stopped_vm():
-    context = _zvol_context("STOPPED")
+@pytest.mark.parametrize("sectorsize,expected", [(None, None), (512, None), (4096, 4096)])
+def test_convert_zvol_allowed_for_stopped_vm(sectorsize, expected):
+    context = _zvol_context("STOPPED", sectorsize)
     with patch.object(vm_device_convert.os.path, "exists", return_value=True):
-        zv, ntp = validate_convert_zvol(context, "/dev/zvol/tank/foo", SCHEMA)
+        zv, ntp, logical_sectorsize = validate_convert_zvol(context, "/dev/zvol/tank/foo", SCHEMA)
     assert zv["type"] == "VOLUME"
     assert ntp == "/dev/zvol/tank/foo"
+    assert logical_sectorsize == expected
+
+
+# convert_disk refuses formats that can only store 512 byte sectors
+
+
+@pytest.mark.parametrize("sectorsize,raises", [(None, False), (512, False), (4096, True)])
+def test_convert_disk_rejects_non_512_sectors_for_vhdx(sectorsize, raises):
+    context = _zvol_context("STOPPED", sectorsize)
+    data = VMDeviceConvert(source="/dev/zvol/tank/foo", destination="/mnt/tank/foo.vhdx")
+    with (
+        patch.object(vm_device_convert.os.path, "exists", return_value=True),
+        patch.object(vm_device_convert, "validate_convert_disk_image", return_value=None),
+        patch.object(vm_device_convert, "run_convert_cmd") as run_cmd,
+    ):
+        if raises:
+            with pytest.raises(ValidationError) as exc:
+                convert_disk(context, Mock(), data)
+            assert exc.value.errno == errno.EINVAL
+            assert "VHDX" in exc.value.errmsg
+            run_cmd.assert_not_called()
+        else:
+            assert convert_disk(context, Mock(), data) is True
+            run_cmd.assert_called_once()


### PR DESCRIPTION
qemu-img can only write 512 byte sectors for these formats. If the VM disk was set up with a different sector size the guest laid out its partitions that way, so the exported image looks empty to any hypervisor and will not boot. Raise a validation error and point the user at RAW or QCOW2, which do not record a sector size.