### PR TITLE
NAS-143506 / 26.0.0 / Refuse to export VM disks without 512 byte sectors to VHDX, VDI or VMDK (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -201,9 +201,12 @@ class VMDeviceService(CRUDService, DeviceMixin):
         elif not os.path.exists(ntp):
             raise ValidationError(schema, f'{ntp!r} does not exist', errno.ENOENT)
 
+        logical_sectorsize = None
         for i in self.middleware.call_sync('vm.device.query', [['attributes.dtype', '=', 'DISK']]):
             vmzv = i['attributes'].get('path')
             if vmzv and vmzv == ntp:
+                if i['attributes'].get('logical_sectorsize') not in (None, 512):
+                    logical_sectorsize = i['attributes']['logical_sectorsize']
                 try:
                     vm = self.middleware.call_sync('vm.get_instance', i['vm'])
                     if vm['status']['state'] in ACTIVE_STATES:
@@ -216,7 +219,7 @@ class VMDeviceService(CRUDService, DeviceMixin):
                 except InstanceNotFound:
                     pass
 
-        return zv[0], ntp
+        return zv[0], ntp, logical_sectorsize
 
     @api_method(
         VMDeviceVirtualSizeArgs,
@@ -278,7 +281,7 @@ class VMDeviceService(CRUDService, DeviceMixin):
             progress_desc = "Convert to disk image progress"
 
         st = self.validate_convert_disk_image(source_image, schema, converting_from_image_to_zvol)
-        zv, abs_zvolpath = self.validate_convert_zvol(zvol, schema)
+        zv, abs_zvolpath, logical_sectorsize = self.validate_convert_zvol(zvol, schema)
         cmd_args = ['qemu-img', 'convert', '-p']
         if converting_from_image_to_zvol:
             virtual_size = self.virtual_size_impl(schema, st['realpath'])
@@ -296,6 +299,13 @@ class VMDeviceService(CRUDService, DeviceMixin):
             dl = data['destination'].lower()
             for fmt in VALID_DISK_FORMATS:
                 if dl.endswith(f'.{fmt}'):
+                    if logical_sectorsize not in (None, 512) and fmt in ('vdi', 'vhdx', 'vmdk'):
+                        raise ValidationError(
+                            schema,
+                            f'{fmt.upper()} images only support 512 byte sectors but {zv["name"]} is attached to '
+                            f'a VM using {logical_sectorsize} byte sectors. Export to RAW or QCOW2 instead.',
+                            errno.EINVAL
+                        )
                     cmd_args.extend(['-f', 'raw', '-O', fmt, abs_zvolpath, source_image])
                     break
             else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_convert_validation.py
@@ -1,4 +1,5 @@
 import errno
+from functools import partial
 from unittest.mock import Mock, patch
 
 import pytest
@@ -66,9 +67,12 @@ def test_zvol_to_image_internal_dataset_destination_is_rejected():
 # validate_convert_zvol blocks conversion of any active VM's zvol
 
 
-def _zvol_service(state):
+def _zvol_service(state, logical_sectorsize=None):
     zv = [{"type": "VOLUME", "name": "tank/foo", "properties": {"volsize": {"value": 1024**3}}}]
-    device = {"attributes": {"dtype": "DISK", "path": "/dev/zvol/tank/foo"}, "vm": 1}
+    device = {
+        "attributes": {"dtype": "DISK", "path": "/dev/zvol/tank/foo", "logical_sectorsize": logical_sectorsize},
+        "vm": 1,
+    }
     vm = {"name": "myvm", "status": {"state": state}}
 
     svc = Mock()
@@ -101,9 +105,32 @@ def test_convert_zvol_blocked_for_active_vm(state):
     assert state.lower() in exc.value.errmsg
 
 
-def test_convert_zvol_allowed_for_stopped_vm():
-    svc = _zvol_service("STOPPED")
+@pytest.mark.parametrize("sectorsize,expected", [(None, None), (512, None), (4096, 4096)])
+def test_convert_zvol_allowed_for_stopped_vm(sectorsize, expected):
+    svc = _zvol_service("STOPPED", sectorsize)
     with patch.object(vm_devices.os.path, "exists", return_value=True):
-        zv, ntp = VMDeviceService.validate_convert_zvol(svc, "/dev/zvol/tank/foo", SCHEMA)
+        zv, ntp, logical_sectorsize = VMDeviceService.validate_convert_zvol(svc, "/dev/zvol/tank/foo", SCHEMA)
     assert zv["type"] == "VOLUME"
     assert ntp == "/dev/zvol/tank/foo"
+    assert logical_sectorsize == expected
+
+
+# convert refuses formats that can only store 512 byte sectors
+
+
+@pytest.mark.parametrize("sectorsize,raises", [(None, False), (512, False), (4096, True)])
+def test_convert_rejects_non_512_sectors_for_vhdx(sectorsize, raises):
+    svc = _zvol_service("STOPPED", sectorsize)
+    svc.validate_convert_disk_image = Mock(return_value=None)
+    svc.validate_convert_zvol = partial(VMDeviceService.validate_convert_zvol, svc)
+    data = {"source": "/dev/zvol/tank/foo", "destination": "/mnt/tank/foo.vhdx"}
+    with patch.object(vm_devices.os.path, "exists", return_value=True):
+        if raises:
+            with pytest.raises(ValidationError) as exc:
+                VMDeviceService.convert(svc, Mock(), data)
+            assert exc.value.errno == errno.EINVAL
+            assert "VHDX" in exc.value.errmsg
+            svc.run_convert_cmd.assert_not_called()
+        else:
+            assert VMDeviceService.convert(svc, Mock(), data) is True
+            svc.run_convert_cmd.assert_called_once()


### PR DESCRIPTION
qemu-img can only write 512 byte sectors for these formats. If the VM disk was set up with a different sector size the guest laid out its partitions that way, so the exported image looks empty to any hypervisor and will not boot. Raise a validation error and point the user at RAW or QCOW2, which do not record a sector size.

Original PR: https://github.com/truenas/middleware/pull/19692
